### PR TITLE
Improve metadata: licenses, source URL, field descriptions, country_code schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Residential property price statistics from different countries. Contains propert
 
 ## Data
 
- This data comes from [Bank For International Settlements BIS](http://www.bis.org/statistics/pp.htm).
+ This data comes from [Bank For International Settlements BIS](https://www.bis.org/statistics/dataportal/pp.htm).
  There are several series of data on the BIS site:
    - detailed data set. Format: xlsx
    - [source of this repo] selected series (nominal and real). Format: xlsx, csv. 
@@ -14,7 +14,7 @@ Residential property price statistics from different countries. Contains propert
 Here we use *Selected series* set, reasons are: 
 
  - 'Selected series' dataset covers most of the countries
- - has the csv source https://www.bis.org/statistics/full_bis_selected_pp_csv.zip  
+ - has the csv source https://www.bis.org/statistics/full_spp_csv.zip  
  - facilitates access for users and enhance comparability.
 
 #### Data format
@@ -27,19 +27,25 @@ Output is four files with different metrics:
 
 Each file structure is like this:
 ```
-date,country,price
-2012-06-30,Philippines,114.5
-2012-06-30,Poland,97.36
-2012-06-30,Portugal,88.15
-2012-06-30,Romania,84.61
-2012-06-30,Serbia,96.48
-2012-06-30,Russia,89.81
-2012-06-30,Sweden,103.47
+date,country_code,country,price
+2012-06-30,PH,Philippines,114.5
+2012-06-30,PL,Poland,97.36
+2012-06-30,PT,Portugal,88.15
+2012-06-30,RO,Romania,84.61
+2012-06-30,RS,Serbia,96.48
+2012-06-30,RU,Russia,89.81
+2012-06-30,SE,Sweden,103.47
 ```
 
 #### Detailed Data Description:
 
-Contains data for 59 countries at a quarterly frequency (real series are the nominal price series deflated by the consumer price index), both in levels and in growth rates (ie four series per country). These indicators have been selected from the detailed data set to facilitate access for users and enhance comparability. The BIS has made the selection based on the Handbook on Residential Property Prices and the experience and metadata of central banks. An analysis based on these selected indicators is also released on a quarterly basis, with a particular focus on longer-term developments in the May release.
+Contains data for 60+ countries and regions at a quarterly frequency (real series are the nominal price series deflated by the consumer price index), both in levels and in growth rates (ie four series per country). These indicators have been selected from the detailed data set to facilitate access for users and enhance comparability. The BIS has made the selection based on the Handbook on Residential Property Prices and the experience and metadata of central banks. An analysis based on these selected indicators is also released on a quarterly basis, with a particular focus on longer-term developments in the May release.
+
+#### Data quirks
+
+- **Dates** are the last day of each quarter (e.g. `2023-09-30` for Q3 2023).
+- **`country_code`** uses ISO 3166-1 alpha-2 codes for individual countries plus BIS aggregate codes: `XM` (Euro area), `XW` (World), `4T` (Emerging market economies), `5R` (Advanced economies).
+- **Early rows** (roughly pre-1970 for most countries) have an empty `price` field because source data does not extend that far back; the BIS source file contains columns for all quarters from 1927 onward.
 
 ## Preparation
 
@@ -49,7 +55,7 @@ You will need `python` and `pip` installed to run the data downloading and proce
 # if you don't have "git" you can download and unzip the datapackage directly from this page.
 git clone https://github.com/datasets/house-prices-global.git
 
-pip -r scripts/requirements.txt
+pip install -r scripts/requirements.txt
 python scripts/process.py
 ```
 
@@ -59,7 +65,7 @@ Up-to-date (auto-updates every month) house-prices-global dataset could be found
 
 ## License
 
-The data source is National sources, Bank for International Settlements ("BIS") Residential Property Price database, www.bis.org/statistics/pp.htm.  
-You can use this data following BIS rules:  
+The data source is National sources, Bank for International Settlements ("BIS") Residential Property Price database, https://www.bis.org/statistics/dataportal/pp.htm.  
+You can use this data following BIS rules (attribution to BIS as source is required):  
 https://www.bis.org/terms_conditions.htm#Copyright_and_Permissions  
 https://www.bis.org/terms_statistics.htm

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,7 +1,21 @@
 {
-  "Frequency": "Quarterly",
-  "description": "Contain data for 59 countries at a quarterly frequency (real series are the nominal price series deflated by the consumer price index), both in levels and in growth rates (ie four series per country). These indicators have been selected from the detailed data set to facilitate access for users and enhance comparability. The BIS has made the selection based on the Handbook on Residential Property Prices and the experience and metadata of central banks. An analysis based on these selected indicators is also released on a quarterly basis, with a particular focus on longer-term developments in the May release.",
   "name": "house-prices-global",
+  "title": "Residential property price statistics from different countries",
+  "description": "Residential property price statistics for 60+ countries and regions at quarterly frequency, published by the Bank for International Settlements (BIS). Covers nominal and real price index levels (base year 2010 = 100) and year-on-year percentage changes. Real series are the nominal price series deflated by the consumer price index. Indicators are selected from the detailed BIS dataset to facilitate access and enhance comparability.",
+  "licenses": [
+    {
+      "name": "BIS-terms",
+      "title": "BIS Terms of Permitted Use of Statistics (Attribution Required)",
+      "path": "https://www.bis.org/terms_statistics.htm"
+    }
+  ],
+  "sources": [
+    {
+      "name": "bis-selected-property-prices",
+      "title": "BIS Selected Residential Property Prices",
+      "path": "https://www.bis.org/statistics/full_spp_csv.zip"
+    }
+  ],
   "resources": [
     {
       "encoding": "utf-8",
@@ -9,23 +23,30 @@
       "mediatype": "text/csv",
       "name": "nominal-index",
       "path": "data/nominal_index.csv",
+      "description": "Nominal residential property price index for selected countries and regions at quarterly frequency, base year 2010 = 100.",
       "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "format": "default",
+            "description": "Last day of the reference quarter in ISO 8601 format (YYYY-MM-DD). For example, 2023-09-30 represents Q3 2023."
           },
           {
-            "format": "default",
+            "name": "country_code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code or BIS regional aggregate code (e.g. XM = Euro area, XW = World, 4T = Emerging market economies, 5R = Advanced economies)."
+          },
+          {
             "name": "country",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the country or regional aggregate."
           },
           {
-            "format": "default",
             "name": "price",
-            "type": "string"
+            "type": "number",
+            "description": "Nominal residential property price index value (base year 2010 = 100). Empty for periods where no data is available."
           }
         ],
         "missingValues": [
@@ -39,23 +60,30 @@
       "mediatype": "text/csv",
       "name": "nominal-year",
       "path": "data/nominal_year.csv",
+      "description": "Nominal residential property price year-on-year percentage changes for selected countries and regions at quarterly frequency.",
       "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "format": "default",
+            "description": "Last day of the reference quarter in ISO 8601 format (YYYY-MM-DD). For example, 2023-09-30 represents Q3 2023."
           },
           {
-            "format": "default",
+            "name": "country_code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code or BIS regional aggregate code (e.g. XM = Euro area, XW = World, 4T = Emerging market economies, 5R = Advanced economies)."
+          },
+          {
             "name": "country",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the country or regional aggregate."
           },
           {
-            "format": "default",
             "name": "price",
-            "type": "string"
+            "type": "number",
+            "description": "Nominal residential property price year-on-year change, in per cent. Empty for periods where no data is available."
           }
         ],
         "missingValues": [
@@ -69,23 +97,30 @@
       "mediatype": "text/csv",
       "name": "real-index",
       "path": "data/real_index.csv",
+      "description": "Real residential property price index for selected countries and regions at quarterly frequency, base year 2010 = 100. Deflated by the consumer price index.",
       "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "format": "default",
+            "description": "Last day of the reference quarter in ISO 8601 format (YYYY-MM-DD). For example, 2023-09-30 represents Q3 2023."
           },
           {
-            "format": "default",
+            "name": "country_code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code or BIS regional aggregate code (e.g. XM = Euro area, XW = World, 4T = Emerging market economies, 5R = Advanced economies)."
+          },
+          {
             "name": "country",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the country or regional aggregate."
           },
           {
-            "format": "default",
             "name": "price",
-            "type": "string"
+            "type": "number",
+            "description": "Real residential property price index value (base year 2010 = 100), deflated by the consumer price index. Empty for periods where no data is available."
           }
         ],
         "missingValues": [
@@ -99,23 +134,30 @@
       "mediatype": "text/csv",
       "name": "real-year",
       "path": "data/real_year.csv",
+      "description": "Real residential property price year-on-year percentage changes for selected countries and regions at quarterly frequency. Deflated by the consumer price index.",
       "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "date",
-            "type": "date"
+            "type": "date",
+            "format": "default",
+            "description": "Last day of the reference quarter in ISO 8601 format (YYYY-MM-DD). For example, 2023-09-30 represents Q3 2023."
           },
           {
-            "format": "default",
+            "name": "country_code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code or BIS regional aggregate code (e.g. XM = Euro area, XW = World, 4T = Emerging market economies, 5R = Advanced economies)."
+          },
+          {
             "name": "country",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the country or regional aggregate."
           },
           {
-            "format": "default",
             "name": "price",
-            "type": "string"
+            "type": "number",
+            "description": "Real residential property price year-on-year change, in per cent, deflated by the consumer price index. Empty for periods where no data is available."
           }
         ],
         "missingValues": [
@@ -124,13 +166,5 @@
       }
     }
   ],
-  "sources": [
-    {
-      "name": "Bank For International Settlements BIS",
-      "title": "BIS Selected property prices",
-      "path": "https://www.bis.org/statistics/full_bis_selected_pp_csv.zip"
-    }
-  ],
-  "title": "Residential property price statistics from different countries",
   "collection": "property-prices"
 }


### PR DESCRIPTION
## Summary

- **Fix broken source URL**: `sources[0].path` was `full_bis_selected_pp_csv.zip` (404); corrected to `full_spp_csv.zip` (the URL the script actually fetches, returns 200)
- **Add `licenses` entry**: BIS terms require attribution; added entry pointing to `https://www.bis.org/terms_statistics.htm`
- **Add `country_code` field to all 4 resource schemas**: the script writes `date,country_code,country,price` but the schema only declared `date,country,price` — schema now matches the actual CSV columns
- **Fix `price` field type**: was `string`, corrected to `number` (values are decimals)
- **Add `description` to all resources and all fields**: every resource now has a description; every field (`date`, `country_code`, `country`, `price`) has a description including date format notes and missing-value notes
- **README fixes**: `pip -r` → `pip install -r`; updated BIS page URL from dead redirect; documented `country_code` aggregate codes and empty early-row prices; updated license section with attribution note

No data files were modified in this PR.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>