### PR TITLE
Add quarterly GitHub Actions workflow to auto-update data

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,34 @@
+name: Update data
+
+on:
+  schedule:
+    - cron: "0 6 5 1,4,7,10 *"  # 06:00 UTC on the 5th of Jan, Apr, Jul, Oct
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt
+
+      - name: Fetch and process data
+        run: python scripts/process.py
+
+      - name: Commit updated data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/
+          git diff --cached --quiet || git commit -m "Update data ($(date -u +%Y-%m-%d))"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update.yml` that runs quarterly (Jan 5, Apr 5, Jul 5, Oct 5 at 06:00 UTC), timed to follow each BIS quarterly release
- Also supports manual trigger via `workflow_dispatch`
- Installs dependencies, runs `scripts/process.py`, then commits and pushes updated `data/` files only if they changed

## Notes

- The `workflow_dispatch` trigger lets you kick off a manual refresh immediately (e.g. to backfill the current ~20-month data gap)
- Requires no secrets — uses the default `GITHUB_TOKEN` with `contents: write` permission

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>