### PR TITLE
Fix stale source: switch to BIS SDMX API, regenerate data through Q4 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Residential property price statistics from different countries. Contains propert
  This data comes from [Bank For International Settlements BIS](https://www.bis.org/statistics/dataportal/pp.htm).
  There are several series of data on the BIS site:
    - detailed data set. Format: xlsx
-   - [source of this repo] selected series (nominal and real). Format: xlsx, csv. 
+   - [source of this repo] selected series (nominal and real), available via the BIS SDMX REST API
    - long series. Formats: xlsx, csv
    - Commercial property price series. Format: xlsx
  
 Here we use *Selected series* set, reasons are: 
 
  - 'Selected series' dataset covers most of the countries
- - has the csv source https://www.bis.org/statistics/full_spp_csv.zip  
+ - available via the BIS SDMX API: https://stats.bis.org/api/v2/data/dataflow/BIS/WS_SPP/1.0
  - facilitates access for users and enhance comparability.
 
 #### Data format
@@ -55,7 +55,6 @@ You will need `python` and `pip` installed to run the data downloading and proce
 # if you don't have "git" you can download and unzip the datapackage directly from this page.
 git clone https://github.com/datasets/house-prices-global.git
 
-pip install -r scripts/requirements.txt
 python scripts/process.py
 ```
 

--- a/data/nominal_index.csv
+++ b/data/nominal_index.csv
@@ -1,20105 +1,4716 @@
 date,country_code,country,price
-1927-03-31,4T,Emerging market economies (aggregate),
-1927-03-31,5R,Advanced economies,
-1927-03-31,AE,United Arab Emirates,
-1927-03-31,AT,Austria,
-1927-03-31,AU,Australia,
-1927-03-31,BE,Belgium,
-1927-03-31,BG,Bulgaria,
-1927-03-31,BR,Brazil,
-1927-03-31,CA,Canada,
-1927-03-31,CH,Switzerland,
-1927-03-31,CL,Chile,
-1927-03-31,CN,China,
-1927-03-31,CO,Colombia,
-1927-03-31,CY,Cyprus,
-1927-03-31,CZ,Czechia,
-1927-03-31,DE,Germany,
-1927-03-31,DK,Denmark,
-1927-03-31,EE,Estonia,
-1927-03-31,ES,Spain,
-1927-03-31,FI,Finland,
-1927-03-31,FR,France,
-1927-03-31,GB,United Kingdom,
-1927-03-31,GR,Greece,
-1927-03-31,HK,Hong Kong SAR,
-1927-03-31,HR,Croatia,
-1927-03-31,HU,Hungary,
-1927-03-31,ID,Indonesia,
-1927-03-31,IE,Ireland,
-1927-03-31,IL,Israel,
-1927-03-31,IN,India,
-1927-03-31,IS,Iceland,
 1927-03-31,IT,Italy,0.0189
-1927-03-31,JP,Japan,
-1927-03-31,KR,Korea,
-1927-03-31,LT,Lithuania,
-1927-03-31,LU,Luxembourg,
-1927-03-31,LV,Latvia,
-1927-03-31,MA,Morocco,
-1927-03-31,MK,North Macedonia,
-1927-03-31,MT,Malta,
-1927-03-31,MX,Mexico,
-1927-03-31,MY,Malaysia,
-1927-03-31,NL,Netherlands,
-1927-03-31,NO,Norway,
-1927-03-31,NZ,New Zealand,
-1927-03-31,PE,Peru,
-1927-03-31,PH,Philippines,
-1927-03-31,PL,Poland,
-1927-03-31,PT,Portugal,
-1927-03-31,RO,Romania,
-1927-03-31,RS,Serbia,
-1927-03-31,RU,Russia,
-1927-03-31,SE,Sweden,
-1927-03-31,SG,Singapore,
-1927-03-31,SI,Slovenia,
-1927-03-31,SK,Slovak Republic,
-1927-03-31,TH,Thailand,
-1927-03-31,TR,Türkiye,
-1927-03-31,US,United States,
-1927-03-31,XM,Euro area,
-1927-03-31,XW,World,
-1927-03-31,ZA,South Africa,
-1927-06-30,4T,Emerging market economies (aggregate),
-1927-06-30,5R,Advanced economies,
-1927-06-30,AE,United Arab Emirates,
-1927-06-30,AT,Austria,
-1927-06-30,AU,Australia,
-1927-06-30,BE,Belgium,
-1927-06-30,BG,Bulgaria,
-1927-06-30,BR,Brazil,
-1927-06-30,CA,Canada,
-1927-06-30,CH,Switzerland,
-1927-06-30,CL,Chile,
-1927-06-30,CN,China,
-1927-06-30,CO,Colombia,
-1927-06-30,CY,Cyprus,
-1927-06-30,CZ,Czechia,
-1927-06-30,DE,Germany,
-1927-06-30,DK,Denmark,
-1927-06-30,EE,Estonia,
-1927-06-30,ES,Spain,
-1927-06-30,FI,Finland,
-1927-06-30,FR,France,
-1927-06-30,GB,United Kingdom,
-1927-06-30,GR,Greece,
-1927-06-30,HK,Hong Kong SAR,
-1927-06-30,HR,Croatia,
-1927-06-30,HU,Hungary,
-1927-06-30,ID,Indonesia,
-1927-06-30,IE,Ireland,
-1927-06-30,IL,Israel,
-1927-06-30,IN,India,
-1927-06-30,IS,Iceland,
 1927-06-30,IT,Italy,0.0188
-1927-06-30,JP,Japan,
-1927-06-30,KR,Korea,
-1927-06-30,LT,Lithuania,
-1927-06-30,LU,Luxembourg,
-1927-06-30,LV,Latvia,
-1927-06-30,MA,Morocco,
-1927-06-30,MK,North Macedonia,
-1927-06-30,MT,Malta,
-1927-06-30,MX,Mexico,
-1927-06-30,MY,Malaysia,
-1927-06-30,NL,Netherlands,
-1927-06-30,NO,Norway,
-1927-06-30,NZ,New Zealand,
-1927-06-30,PE,Peru,
-1927-06-30,PH,Philippines,
-1927-06-30,PL,Poland,
-1927-06-30,PT,Portugal,
-1927-06-30,RO,Romania,
-1927-06-30,RS,Serbia,
-1927-06-30,RU,Russia,
-1927-06-30,SE,Sweden,
-1927-06-30,SG,Singapore,
-1927-06-30,SI,Slovenia,
-1927-06-30,SK,Slovak Republic,
-1927-06-30,TH,Thailand,
-1927-06-30,TR,Türkiye,
-1927-06-30,US,United States,
-1927-06-30,XM,Euro area,
-1927-06-30,XW,World,
-1927-06-30,ZA,South Africa,
-1927-09-30,4T,Emerging market economies (aggregate),
-1927-09-30,5R,Advanced economies,
-1927-09-30,AE,United Arab Emirates,
-1927-09-30,AT,Austria,
-1927-09-30,AU,Australia,
-1927-09-30,BE,Belgium,
-1927-09-30,BG,Bulgaria,
-1927-09-30,BR,Brazil,
-1927-09-30,CA,Canada,
-1927-09-30,CH,Switzerland,
-1927-09-30,CL,Chile,
-1927-09-30,CN,China,
-1927-09-30,CO,Colombia,
-1927-09-30,CY,Cyprus,
-1927-09-30,CZ,Czechia,
-1927-09-30,DE,Germany,
-1927-09-30,DK,Denmark,
-1927-09-30,EE,Estonia,
-1927-09-30,ES,Spain,
-1927-09-30,FI,Finland,
-1927-09-30,FR,France,
-1927-09-30,GB,United Kingdom,
-1927-09-30,GR,Greece,
-1927-09-30,HK,Hong Kong SAR,
-1927-09-30,HR,Croatia,
-1927-09-30,HU,Hungary,
-1927-09-30,ID,Indonesia,
-1927-09-30,IE,Ireland,
-1927-09-30,IL,Israel,
-1927-09-30,IN,India,
-1927-09-30,IS,Iceland,
 1927-09-30,IT,Italy,0.0187
-1927-09-30,JP,Japan,
-1927-09-30,KR,Korea,
-1927-09-30,LT,Lithuania,
-1927-09-30,LU,Luxembourg,
-1927-09-30,LV,Latvia,
-1927-09-30,MA,Morocco,
-1927-09-30,MK,North Macedonia,
-1927-09-30,MT,Malta,
-1927-09-30,MX,Mexico,
-1927-09-30,MY,Malaysia,
-1927-09-30,NL,Netherlands,
-1927-09-30,NO,Norway,
-1927-09-30,NZ,New Zealand,
-1927-09-30,PE,Peru,
-1927-09-30,PH,Philippines,
-1927-09-30,PL,Poland,
-1927-09-30,PT,Portugal,
-1927-09-30,RO,Romania,
-1927-09-30,RS,Serbia,
-1927-09-30,RU,Russia,
-1927-09-30,SE,Sweden,
-1927-09-30,SG,Singapore,
-1927-09-30,SI,Slovenia,
-1927-09-30,SK,Slovak Republic,
-1927-09-30,TH,Thailand,
-1927-09-30,TR,Türkiye,
-1927-09-30,US,United States,
-1927-09-30,XM,Euro area,
-1927-09-30,XW,World,
-1927-09-30,ZA,South Africa,
-1927-12-31,4T,Emerging market economies (aggregate),
-1927-12-31,5R,Advanced economies,
-1927-12-31,AE,United Arab Emirates,
-1927-12-31,AT,Austria,
-1927-12-31,AU,Australia,
-1927-12-31,BE,Belgium,
-1927-12-31,BG,Bulgaria,
-1927-12-31,BR,Brazil,
-1927-12-31,CA,Canada,
-1927-12-31,CH,Switzerland,
-1927-12-31,CL,Chile,
-1927-12-31,CN,China,
-1927-12-31,CO,Colombia,
-1927-12-31,CY,Cyprus,
-1927-12-31,CZ,Czechia,
-1927-12-31,DE,Germany,
-1927-12-31,DK,Denmark,
-1927-12-31,EE,Estonia,
-1927-12-31,ES,Spain,
-1927-12-31,FI,Finland,
-1927-12-31,FR,France,
-1927-12-31,GB,United Kingdom,
-1927-12-31,GR,Greece,
-1927-12-31,HK,Hong Kong SAR,
-1927-12-31,HR,Croatia,
-1927-12-31,HU,Hungary,
-1927-12-31,ID,Indonesia,
-1927-12-31,IE,Ireland,
-1927-12-31,IL,Israel,
-1927-12-31,IN,India,
-1927-12-31,IS,Iceland,
 1927-12-31,IT,Italy,0.0186
-1927-12-31,JP,Japan,
-1927-12-31,KR,Korea,
-1927-12-31,LT,Lithuania,
-1927-12-31,LU,Luxembourg,
-1927-12-31,LV,Latvia,
-1927-12-31,MA,Morocco,
-1927-12-31,MK,North Macedonia,
-1927-12-31,MT,Malta,
-1927-12-31,MX,Mexico,
-1927-12-31,MY,Malaysia,
-1927-12-31,NL,Netherlands,
-1927-12-31,NO,Norway,
-1927-12-31,NZ,New Zealand,
-1927-12-31,PE,Peru,
-1927-12-31,PH,Philippines,
-1927-12-31,PL,Poland,
-1927-12-31,PT,Portugal,
-1927-12-31,RO,Romania,
-1927-12-31,RS,Serbia,
-1927-12-31,RU,Russia,
-1927-12-31,SE,Sweden,
-1927-12-31,SG,Singapore,
-1927-12-31,SI,Slovenia,
-1927-12-31,SK,Slovak Republic,
-1927-12-31,TH,Thailand,
-1927-12-31,TR,Türkiye,
-1927-12-31,US,United States,
-1927-12-31,XM,Euro area,
-1927-12-31,XW,World,
-1927-12-31,ZA,South Africa,
-1928-03-31,4T,Emerging market economies (aggregate),
-1928-03-31,5R,Advanced economies,
-1928-03-31,AE,United Arab Emirates,
-1928-03-31,AT,Austria,
-1928-03-31,AU,Australia,
-1928-03-31,BE,Belgium,
-1928-03-31,BG,Bulgaria,
-1928-03-31,BR,Brazil,
-1928-03-31,CA,Canada,
-1928-03-31,CH,Switzerland,
-1928-03-31,CL,Chile,
-1928-03-31,CN,China,
-1928-03-31,CO,Colombia,
-1928-03-31,CY,Cyprus,
-1928-03-31,CZ,Czechia,
-1928-03-31,DE,Germany,
-1928-03-31,DK,Denmark,
-1928-03-31,EE,Estonia,
-1928-03-31,ES,Spain,
-1928-03-31,FI,Finland,
-1928-03-31,FR,France,
-1928-03-31,GB,United Kingdom,
-1928-03-31,GR,Greece,
-1928-03-31,HK,Hong Kong SAR,
-1928-03-31,HR,Croatia,
-1928-03-31,HU,Hungary,
-1928-03-31,ID,Indonesia,
-1928-03-31,IE,Ireland,
-1928-03-31,IL,Israel,
-1928-03-31,IN,India,
-1928-03-31,IS,Iceland,
 1928-03-31,IT,Italy,0.0186
-1928-03-31,JP,Japan,
-1928-03-31,KR,Korea,
-1928-03-31,LT,Lithuania,
-1928-03-31,LU,Luxembourg,
-1928-03-31,LV,Latvia,
-1928-03-31,MA,Morocco,
-1928-03-31,MK,North Macedonia,
-1928-03-31,MT,Malta,
-1928-03-31,MX,Mexico,
-1928-03-31,MY,Malaysia,
-1928-03-31,NL,Netherlands,
-1928-03-31,NO,Norway,
-1928-03-31,NZ,New Zealand,
-1928-03-31,PE,Peru,
-1928-03-31,PH,Philippines,
-1928-03-31,PL,Poland,
-1928-03-31,PT,Portugal,
-1928-03-31,RO,Romania,
-1928-03-31,RS,Serbia,
-1928-03-31,RU,Russia,
-1928-03-31,SE,Sweden,
-1928-03-31,SG,Singapore,
-1928-03-31,SI,Slovenia,
-1928-03-31,SK,Slovak Republic,
-1928-03-31,TH,Thailand,
-1928-03-31,TR,Türkiye,
-1928-03-31,US,United States,
-1928-03-31,XM,Euro area,
-1928-03-31,XW,World,
-1928-03-31,ZA,South Africa,
-1928-06-30,4T,Emerging market economies (aggregate),
-1928-06-30,5R,Advanced economies,
-1928-06-30,AE,United Arab Emirates,
-1928-06-30,AT,Austria,
-1928-06-30,AU,Australia,
-1928-06-30,BE,Belgium,
-1928-06-30,BG,Bulgaria,
-1928-06-30,BR,Brazil,
-1928-06-30,CA,Canada,
-1928-06-30,CH,Switzerland,
-1928-06-30,CL,Chile,
-1928-06-30,CN,China,
-1928-06-30,CO,Colombia,
-1928-06-30,CY,Cyprus,
-1928-06-30,CZ,Czechia,
-1928-06-30,DE,Germany,
-1928-06-30,DK,Denmark,
-1928-06-30,EE,Estonia,
-1928-06-30,ES,Spain,
-1928-06-30,FI,Finland,
-1928-06-30,FR,France,
-1928-06-30,GB,United Kingdom,
-1928-06-30,GR,Greece,
-1928-06-30,HK,Hong Kong SAR,
-1928-06-30,HR,Croatia,
-1928-06-30,HU,Hungary,
-1928-06-30,ID,Indonesia,
-1928-06-30,IE,Ireland,
-1928-06-30,IL,Israel,
-1928-06-30,IN,India,
-1928-06-30,IS,Iceland,
 1928-06-30,IT,Italy,0.0185
-1928-06-30,JP,Japan,
-1928-06-30,KR,Korea,
-1928-06-30,LT,Lithuania,
-1928-06-30,LU,Luxembourg,
-1928-06-30,LV,Latvia,
-1928-06-30,MA,Morocco,
-1928-06-30,MK,North Macedonia,
-1928-06-30,MT,Malta,
-1928-06-30,MX,Mexico,
-1928-06-30,MY,Malaysia,
-1928-06-30,NL,Netherlands,
-1928-06-30,NO,Norway,
-1928-06-30,NZ,New Zealand,
-1928-06-30,PE,Peru,
-1928-06-30,PH,Philippines,
-1928-06-30,PL,Poland,
-1928-06-30,PT,Portugal,
-1928-06-30,RO,Romania,
-1928-06-30,RS,Serbia,
-1928-06-30,RU,Russia,
-1928-06-30,SE,Sweden,
-1928-06-30,SG,Singapore,
-1928-06-30,SI,Slovenia,
-1928-06-30,SK,Slovak Republic,
-1928-06-30,TH,Thailand,
-1928-06-30,TR,Türkiye,
-1928-06-30,US,United States,
-1928-06-30,XM,Euro area,
-1928-06-30,XW,World,
-1928-06-30,ZA,South Africa,
-1928-09-30,4T,Emerging market economies (aggregate),
-1928-09-30,5R,Advanced economies,
-1928-09-30,AE,United Arab Emirates,
-1928-09-30,AT,Austria,
-1928-09-30,AU,Australia,
-1928-09-30,BE,Belgium,
-1928-09-30,BG,Bulgaria,
-1928-09-30,BR,Brazil,
-1928-09-30,CA,Canada,
-1928-09-30,CH,Switzerland,
-1928-09-30,CL,Chile,
-1928-09-30,CN,China,
-1928-09-30,CO,Colombia,
-1928-09-30,CY,Cyprus,
-1928-09-30,CZ,Czechia,
-1928-09-30,DE,Germany,
-1928-09-30,DK,Denmark,
-1928-09-30,EE,Estonia,
-1928-09-30,ES,Spain,
-1928-09-30,FI,Finland,
-1928-09-30,FR,France,
-1928-09-30,GB,United Kingdom,
-1928-09-30,GR,Greece,
-1928-09-30,HK,Hong Kong SAR,
-1928-09-30,HR,Croatia,
-1928-09-30,HU,Hungary,
-1928-09-30,ID,Indonesia,
-1928-09-30,IE,Ireland,
-1928-09-30,IL,Israel,
-1928-09-30,IN,India,
-1928-09-30,IS,Iceland,
 1928-09-30,IT,Italy,0.0183
-1928-09-30,JP,Japan,
-1928-09-30,KR,Korea,
-1928-09-30,LT,Lithuania,
-1928-09-30,LU,Luxembourg,
-1928-09-30,LV,Latvia,
-1928-09-30,MA,Morocco,
-1928-09-30,MK,North Macedonia,
-1928-09-30,MT,Malta,
-1928-09-30,MX,Mexico,
-1928-09-30,MY,Malaysia,
-1928-09-30,NL,Netherlands,
-1928-09-30,NO,Norway,
-1928-09-30,NZ,New Zealand,
-1928-09-30,PE,Peru,
-1928-09-30,PH,Philippines,
-1928-09-30,PL,Poland,
-1928-09-30,PT,Portugal,
-1928-09-30,RO,Romania,
-1928-09-30,RS,Serbia,
-1928-09-30,RU,Russia,
-1928-09-30,SE,Sweden,
-1928-09-30,SG,Singapore,
-1928-09-30,SI,Slovenia,
-1928-09-30,SK,Slovak Republic,
-1928-09-30,TH,Thailand,
-1928-09-30,TR,Türkiye,
-1928-09-30,US,United States,
-1928-09-30,XM,Euro area,
-1928-09-30,XW,World,
-1928-09-30,ZA,South Africa,
-1928-12-31,4T,Emerging market economies (aggregate),
-1928-12-31,5R,Advanced economies,
-1928-12-31,AE,United Arab Emirates,
-1928-12-31,AT,Austria,
-1928-12-31,AU,Australia,
-1928-12-31,BE,Belgium,
-1928-12-31,BG,Bulgaria,
-1928-12-31,BR,Brazil,
-1928-12-31,CA,Canada,
-1928-12-31,CH,Switzerland,
-1928-12-31,CL,Chile,
-1928-12-31,CN,China,
-1928-12-31,CO,Colombia,
-1928-12-31,CY,Cyprus,
-1928-12-31,CZ,Czechia,
-1928-12-31,DE,Germany,
-1928-12-31,DK,Denmark,
-1928-12-31,EE,Estonia,
-1928-12-31,ES,Spain,
-1928-12-31,FI,Finland,
-1928-12-31,FR,France,
-1928-12-31,GB,United Kingdom,
-1928-12-31,GR,Greece,
-1928-12-31,HK,Hong Kong SAR,
-1928-12-31,HR,Croatia,
-1928-12-31,HU,Hungary,
-1928-12-31,ID,Indonesia,
-1928-12-31,IE,Ireland,
-1928-12-31,IL,Israel,
-1928-12-31,IN,India,
-1928-12-31,IS,Iceland,
 1928-12-31,IT,Italy,0.0182
-1928-12-31,JP,Japan,
-1928-12-31,KR,Korea,
-1928-12-31,LT,Lithuania,
-1928-12-31,LU,Luxembourg,
-1928-12-31,LV,Latvia,
-1928-12-31,MA,Morocco,
-1928-12-31,MK,North Macedonia,
-1928-12-31,MT,Malta,
-1928-12-31,MX,Mexico,
-1928-12-31,MY,Malaysia,
-1928-12-31,NL,Netherlands,
-1928-12-31,NO,Norway,
-1928-12-31,NZ,New Zealand,
-1928-12-31,PE,Peru,
-1928-12-31,PH,Philippines,
-1928-12-31,PL,Poland,
-1928-12-31,PT,Portugal,
-1928-12-31,RO,Romania,
-1928-12-31,RS,Serbia,
-1928-12-31,RU,Russia,
-1928-12-31,SE,Sweden,
-1928-12-31,SG,Singapore,
-1928-12-31,SI,Slovenia,
-1928-12-31,SK,Slovak Republic,
-1928-12-31,TH,Thailand,
-1928-12-31,TR,Türkiye,
-1928-12-31,US,United States,
-1928-12-31,XM,Euro area,
-1928-12-31,XW,World,
-1928-12-31,ZA,South Africa,
-1929-03-31,4T,Emerging market economies (aggregate),
-1929-03-31,5R,Advanced economies,
-1929-03-31,AE,United Arab Emirates,
-1929-03-31,AT,Austria,
-1929-03-31,AU,Australia,
-1929-03-31,BE,Belgium,
-1929-03-31,BG,Bulgaria,
-1929-03-31,BR,Brazil,
-1929-03-31,CA,Canada,
-1929-03-31,CH,Switzerland,
-1929-03-31,CL,Chile,
-1929-03-31,CN,China,
-1929-03-31,CO,Colombia,
-1929-03-31,CY,Cyprus,
-1929-03-31,CZ,Czechia,
-1929-03-31,DE,Germany,
-1929-03-31,DK,Denmark,
-1929-03-31,EE,Estonia,
-1929-03-31,ES,Spain,
-1929-03-31,FI,Finland,
-1929-03-31,FR,France,
-1929-03-31,GB,United Kingdom,
-1929-03-31,GR,Greece,
-1929-03-31,HK,Hong Kong SAR,
-1929-03-31,HR,Croatia,
-1929-03-31,HU,Hungary,
-1929-03-31,ID,Indonesia,
-1929-03-31,IE,Ireland,
-1929-03-31,IL,Israel,
-1929-03-31,IN,India,
-1929-03-31,IS,Iceland,
 1929-03-31,IT,Italy,0.018
-1929-03-31,JP,Japan,
-1929-03-31,KR,Korea,
-1929-03-31,LT,Lithuania,
-1929-03-31,LU,Luxembourg,
-1929-03-31,LV,Latvia,
-1929-03-31,MA,Morocco,
-1929-03-31,MK,North Macedonia,
-1929-03-31,MT,Malta,
-1929-03-31,MX,Mexico,
-1929-03-31,MY,Malaysia,
-1929-03-31,NL,Netherlands,
-1929-03-31,NO,Norway,
-1929-03-31,NZ,New Zealand,
-1929-03-31,PE,Peru,
-1929-03-31,PH,Philippines,
-1929-03-31,PL,Poland,
-1929-03-31,PT,Portugal,
-1929-03-31,RO,Romania,
-1929-03-31,RS,Serbia,
-1929-03-31,RU,Russia,
-1929-03-31,SE,Sweden,
-1929-03-31,SG,Singapore,
-1929-03-31,SI,Slovenia,
-1929-03-31,SK,Slovak Republic,
-1929-03-31,TH,Thailand,
-1929-03-31,TR,Türkiye,
-1929-03-31,US,United States,
-1929-03-31,XM,Euro area,
-1929-03-31,XW,World,
-1929-03-31,ZA,South Africa,
-1929-06-30,4T,Emerging market economies (aggregate),
-1929-06-30,5R,Advanced economies,
-1929-06-30,AE,United Arab Emirates,
-1929-06-30,AT,Austria,
-1929-06-30,AU,Australia,
-1929-06-30,BE,Belgium,
-1929-06-30,BG,Bulgaria,
-1929-06-30,BR,Brazil,
-1929-06-30,CA,Canada,
-1929-06-30,CH,Switzerland,
-1929-06-30,CL,Chile,
-1929-06-30,CN,China,
-1929-06-30,CO,Colombia,
-1929-06-30,CY,Cyprus,
-1929-06-30,CZ,Czechia,
-1929-06-30,DE,Germany,
-1929-06-30,DK,Denmark,
-1929-06-30,EE,Estonia,
-1929-06-30,ES,Spain,
-1929-06-30,FI,Finland,
-1929-06-30,FR,France,
-1929-06-30,GB,United Kingdom,
-1929-06-30,GR,Greece,
-1929-06-30,HK,Hong Kong SAR,
-1929-06-30,HR,Croatia,
-1929-06-30,HU,Hungary,
-1929-06-30,ID,Indonesia,
-1929-06-30,IE,Ireland,
-1929-06-30,IL,Israel,
-1929-06-30,IN,India,
-1929-06-30,IS,Iceland,
 1929-06-30,IT,Italy,0.0178
-1929-06-30,JP,Japan,
-1929-06-30,KR,Korea,
-1929-06-30,LT,Lithuania,
-1929-06-30,LU,Luxembourg,
-1929-06-30,LV,Latvia,
-1929-06-30,MA,Morocco,
-1929-06-30,MK,North Macedonia,
-1929-06-30,MT,Malta,
-1929-06-30,MX,Mexico,
-1929-06-30,MY,Malaysia,
-1929-06-30,NL,Netherlands,
-1929-06-30,NO,Norway,
-1929-06-30,NZ,New Zealand,
-1929-06-30,PE,Peru,
-1929-06-30,PH,Philippines,
-1929-06-30,PL,Poland,
-1929-06-30,PT,Portugal,
-1929-06-30,RO,Romania,
-1929-06-30,RS,Serbia,
-1929-06-30,RU,Russia,
-1929-06-30,SE,Sweden,
-1929-06-30,SG,Singapore,
-1929-06-30,SI,Slovenia,
-1929-06-30,SK,Slovak Republic,
-1929-06-30,TH,Thailand,
-1929-06-30,TR,Türkiye,
-1929-06-30,US,United States,
-1929-06-30,XM,Euro area,
-1929-06-30,XW,World,
-1929-06-30,ZA,South Africa,
-1929-09-30,4T,Emerging market economies (aggregate),
-1929-09-30,5R,Advanced economies,
-1929-09-30,AE,United Arab Emirates,
-1929-09-30,AT,Austria,
-1929-09-30,AU,Australia,
-1929-09-30,BE,Belgium,
-1929-09-30,BG,Bulgaria,
-1929-09-30,BR,Brazil,
-1929-09-30,CA,Canada,
-1929-09-30,CH,Switzerland,
-1929-09-30,CL,Chile,
-1929-09-30,CN,China,
-1929-09-30,CO,Colombia,
-1929-09-30,CY,Cyprus,
-1929-09-30,CZ,Czechia,
-1929-09-30,DE,Germany,
-1929-09-30,DK,Denmark,
-1929-09-30,EE,Estonia,
-1929-09-30,ES,Spain,
-1929-09-30,FI,Finland,
-1929-09-30,FR,France,
-1929-09-30,GB,United Kingdom,
-1929-09-30,GR,Greece,
-1929-09-30,HK,Hong Kong SAR,
-1929-09-30,HR,Croatia,
-1929-09-30,HU,Hungary,
-1929-09-30,ID,Indonesia,
-1929-09-30,IE,Ireland,
-1929-09-30,IL,Israel,
-1929-09-30,IN,India,
-1929-09-30,IS,Iceland,
 1929-09-30,IT,Italy,0.0175
-1929-09-30,JP,Japan,
-1929-09-30,KR,Korea,
-1929-09-30,LT,Lithuania,
-1929-09-30,LU,Luxembourg,
-1929-09-30,LV,Latvia,
-1929-09-30,MA,Morocco,
-1929-09-30,MK,North Macedonia,
-1929-09-30,MT,Malta,
-1929-09-30,MX,Mexico,
-1929-09-30,MY,Malaysia,
-1929-09-30,NL,Netherlands,
-1929-09-30,NO,Norway,
-1929-09-30,NZ,New Zealand,
-1929-09-30,PE,Peru,
-1929-09-30,PH,Philippines,
-1929-09-30,PL,Poland,
-1929-09-30,PT,Portugal,
-1929-09-30,RO,Romania,
-1929-09-30,RS,Serbia,
-1929-09-30,RU,Russia,
-1929-09-30,SE,Sweden,
-1929-09-30,SG,Singapore,
-1929-09-30,SI,Slovenia,
-1929-09-30,SK,Slovak Republic,
-1929-09-30,TH,Thailand,
-1929-09-30,TR,Türkiye,
-1929-09-30,US,United States,
-1929-09-30,XM,Euro area,
-1929-09-30,XW,World,
-1929-09-30,ZA,South Africa,
-1929-12-31,4T,Emerging market economies (aggregate),
-1929-12-31,5R,Advanced economies,
-1929-12-31,AE,United Arab Emirates,
-1929-12-31,AT,Austria,
-1929-12-31,AU,Australia,
-1929-12-31,BE,Belgium,
-1929-12-31,BG,Bulgaria,
-1929-12-31,BR,Brazil,
-1929-12-31,CA,Canada,
-1929-12-31,CH,Switzerland,
-1929-12-31,CL,Chile,
-1929-12-31,CN,China,
-1929-12-31,CO,Colombia,
-1929-12-31,CY,Cyprus,
-1929-12-31,CZ,Czechia,
-1929-12-31,DE,Germany,
-1929-12-31,DK,Denmark,
-1929-12-31,EE,Estonia,
-1929-12-31,ES,Spain,
-1929-12-31,FI,Finland,
-1929-12-31,FR,France,
-1929-12-31,GB,United Kingdom,
-1929-12-31,GR,Greece,
-1929-12-31,HK,Hong Kong SAR,
-1929-12-31,HR,Croatia,
-1929-12-31,HU,Hungary,
-1929-12-31,ID,Indonesia,
-1929-12-31,IE,Ireland,
-1929-12-31,IL,Israel,
-1929-12-31,IN,India,
-1929-12-31,IS,Iceland,
 1929-12-31,IT,Italy,0.0172
-1929-12-31,JP,Japan,
-1929-12-31,KR,Korea,
-1929-12-31,LT,Lithuania,
-1929-12-31,LU,Luxembourg,
-1929-12-31,LV,Latvia,
-1929-12-31,MA,Morocco,
-1929-12-31,MK,North Macedonia,
-1929-12-31,MT,Malta,
-1929-12-31,MX,Mexico,
-1929-12-31,MY,Malaysia,
-1929-12-31,NL,Netherlands,
-1929-12-31,NO,Norway,
-1929-12-31,NZ,New Zealand,
-1929-12-31,PE,Peru,
-1929-12-31,PH,Philippines,
-1929-12-31,PL,Poland,
-1929-12-31,PT,Portugal,
-1929-12-31,RO,Romania,
-1929-12-31,RS,Serbia,
-1929-12-31,RU,Russia,
-1929-12-31,SE,Sweden,
-1929-12-31,SG,Singapore,
-1929-12-31,SI,Slovenia,
-1929-12-31,SK,Slovak Republic,
-1929-12-31,TH,Thailand,
-1929-12-31,TR,Türkiye,
-1929-12-31,US,United States,
-1929-12-31,XM,Euro area,
-1929-12-31,XW,World,
-1929-12-31,ZA,South Africa,
-1930-03-31,4T,Emerging market economies (aggregate),
-1930-03-31,5R,Advanced economies,
-1930-03-31,AE,United Arab Emirates,
-1930-03-31,AT,Austria,
-1930-03-31,AU,Australia,
-1930-03-31,BE,Belgium,
-1930-03-31,BG,Bulgaria,
-1930-03-31,BR,Brazil,
-1930-03-31,CA,Canada,
-1930-03-31,CH,Switzerland,
-1930-03-31,CL,Chile,
-1930-03-31,CN,China,
-1930-03-31,CO,Colombia,
-1930-03-31,CY,Cyprus,
-1930-03-31,CZ,Czechia,
-1930-03-31,DE,Germany,
-1930-03-31,DK,Denmark,
-1930-03-31,EE,Estonia,
-1930-03-31,ES,Spain,
-1930-03-31,FI,Finland,
-1930-03-31,FR,France,
-1930-03-31,GB,United Kingdom,
-1930-03-31,GR,Greece,
-1930-03-31,HK,Hong Kong SAR,
-1930-03-31,HR,Croatia,
-1930-03-31,HU,Hungary,
-1930-03-31,ID,Indonesia,
-1930-03-31,IE,Ireland,
-1930-03-31,IL,Israel,
-1930-03-31,IN,India,
-1930-03-31,IS,Iceland,
 1930-03-31,IT,Italy,0.0169
-1930-03-31,JP,Japan,
-1930-03-31,KR,Korea,
-1930-03-31,LT,Lithuania,
-1930-03-31,LU,Luxembourg,
-1930-03-31,LV,Latvia,
-1930-03-31,MA,Morocco,
-1930-03-31,MK,North Macedonia,
-1930-03-31,MT,Malta,
-1930-03-31,MX,Mexico,
-1930-03-31,MY,Malaysia,
-1930-03-31,NL,Netherlands,
-1930-03-31,NO,Norway,
-1930-03-31,NZ,New Zealand,
-1930-03-31,PE,Peru,
-1930-03-31,PH,Philippines,
-1930-03-31,PL,Poland,
-1930-03-31,PT,Portugal,
-1930-03-31,RO,Romania,
-1930-03-31,RS,Serbia,
-1930-03-31,RU,Russia,
-1930-03-31,SE,Sweden,
-1930-03-31,SG,Singapore,
-1930-03-31,SI,Slovenia,
-1930-03-31,SK,Slovak Republic,
-1930-03-31,TH,Thailand,
-1930-03-31,TR,Türkiye,
-1930-03-31,US,United States,
-1930-03-31,XM,Euro area,
-1930-03-31,XW,World,
-1930-03-31,ZA,South Africa,
-1930-06-30,4T,Emerging market economies (aggregate),
-1930-06-30,5R,Advanced economies,
-1930-06-30,AE,United Arab Emirates,
-1930-06-30,AT,Austria,
-1930-06-30,AU,Australia,
-1930-06-30,BE,Belgium,
-1930-06-30,BG,Bulgaria,
-1930-06-30,BR,Brazil,
-1930-06-30,CA,Canada,
-1930-06-30,CH,Switzerland,
-1930-06-30,CL,Chile,
-1930-06-30,CN,China,
-1930-06-30,CO,Colombia,
-1930-06-30,CY,Cyprus,
-1930-06-30,CZ,Czechia,
-1930-06-30,DE,Germany,
-1930-06-30,DK,Denmark,
-1930-06-30,EE,Estonia,
-1930-06-30,ES,Spain,
-1930-06-30,FI,Finland,
-1930-06-30,FR,France,
-1930-06-30,GB,United Kingdom,
-1930-06-30,GR,Greece,
-1930-06-30,HK,Hong Kong SAR,
-1930-06-30,HR,Croatia,
-1930-06-30,HU,Hungary,
-1930-06-30,ID,Indonesia,
-1930-06-30,IE,Ireland,
-1930-06-30,IL,Israel,
-1930-06-30,IN,India,
-1930-06-30,IS,Iceland,
 1930-06-30,IT,Italy,0.0165
-1930-06-30,JP,Japan,
-1930-06-30,KR,Korea,
-1930-06-30,LT,Lithuania,
-1930-06-30,LU,Luxembourg,
-1930-06-30,LV,Latvia,
-1930-06-30,MA,Morocco,
-1930-06-30,MK,North Macedonia,
-1930-06-30,MT,Malta,
-1930-06-30,MX,Mexico,
-1930-06-30,MY,Malaysia,
-1930-06-30,NL,Netherlands,
-1930-06-30,NO,Norway,
-1930-06-30,NZ,New Zealand,
-1930-06-30,PE,Peru,
-1930-06-30,PH,Philippines,
-1930-06-30,PL,Poland,
-1930-06-30,PT,Portugal,
-1930-06-30,RO,Romania,
-1930-06-30,RS,Serbia,
-1930-06-30,RU,Russia,
-1930-06-30,SE,Sweden,
-1930-06-30,SG,Singapore,
-1930-06-30,SI,Slovenia,
-1930-06-30,SK,Slovak Republic,
-1930-06-30,TH,Thailand,
-1930-06-30,TR,Türkiye,
-1930-06-30,US,United States,
-1930-06-30,XM,Euro area,
-1930-06-30,XW,World,
-1930-06-30,ZA,South Africa,
-1930-09-30,4T,Emerging market economies (aggregate),
-1930-09-30,5R,Advanced economies,
-1930-09-30,AE,United Arab Emirates,
-1930-09-30,AT,Austria,
-1930-09-30,AU,Australia,
-1930-09-30,BE,Belgium,
-1930-09-30,BG,Bulgaria,
-1930-09-30,BR,Brazil,
-1930-09-30,CA,Canada,
-1930-09-30,CH,Switzerland,
-1930-09-30,CL,Chile,
-1930-09-30,CN,China,
-1930-09-30,CO,Colombia,
-1930-09-30,CY,Cyprus,
-1930-09-30,CZ,Czechia,
-1930-09-30,DE,Germany,
-1930-09-30,DK,Denmark,
-1930-09-30,EE,Estonia,
-1930-09-30,ES,Spain,
-1930-09-30,FI,Finland,
-1930-09-30,FR,France,
-1930-09-30,GB,United Kingdom,
-1930-09-30,GR,Greece,
-1930-09-30,HK,Hong Kong SAR,
-1930-09-30,HR,Croatia,
-1930-09-30,HU,Hungary,
-1930-09-30,ID,Indonesia,
-1930-09-30,IE,Ireland,
-1930-09-30,IL,Israel,
-1930-09-30,IN,India,
-1930-09-30,IS,Iceland,
 1930-09-30,IT,Italy,0.0162
-1930-09-30,JP,Japan,
-1930-09-30,KR,Korea,
-1930-09-30,LT,Lithuania,
-1930-09-30,LU,Luxembourg,
-1930-09-30,LV,Latvia,
-1930-09-30,MA,Morocco,
-1930-09-30,MK,North Macedonia,
-1930-09-30,MT,Malta,
-1930-09-30,MX,Mexico,
-1930-09-30,MY,Malaysia,
-1930-09-30,NL,Netherlands,
-1930-09-30,NO,Norway,
-1930-09-30,NZ,New Zealand,
-1930-09-30,PE,Peru,
-1930-09-30,PH,Philippines,
-1930-09-30,PL,Poland,
-1930-09-30,PT,Portugal,
-1930-09-30,RO,Romania,
-1930-09-30,RS,Serbia,
-1930-09-30,RU,Russia,
-1930-09-30,SE,Sweden,
-1930-09-30,SG,Singapore,
-1930-09-30,SI,Slovenia,
-1930-09-30,SK,Slovak Republic,
-1930-09-30,TH,Thailand,
-1930-09-30,TR,Türkiye,
-1930-09-30,US,United States,
-1930-09-30,XM,Euro area,
-1930-09-30,XW,World,
-1930-09-30,ZA,South Africa,
-1930-12-31,4T,Emerging market economies (aggregate),
-1930-12-31,5R,Advanced economies,
-1930-12-31,AE,United Arab Emirates,
-1930-12-31,AT,Austria,
-1930-12-31,AU,Australia,
-1930-12-31,BE,Belgium,
-1930-12-31,BG,Bulgaria,
-1930-12-31,BR,Brazil,
-1930-12-31,CA,Canada,
-1930-12-31,CH,Switzerland,
-1930-12-31,CL,Chile,
-1930-12-31,CN,China,
-1930-12-31,CO,Colombia,
-1930-12-31,CY,Cyprus,
-1930-12-31,CZ,Czechia,
-1930-12-31,DE,Germany,
-1930-12-31,DK,Denmark,
-1930-12-31,EE,Estonia,
-1930-12-31,ES,Spain,
-1930-12-31,FI,Finland,
-1930-12-31,FR,France,
-1930-12-31,GB,United Kingdom,
-1930-12-31,GR,Greece,
-1930-12-31,HK,Hong Kong SAR,
-1930-12-31,HR,Croatia,
-1930-12-31,HU,Hungary,
-1930-12-31,ID,Indonesia,
-1930-12-31,IE,Ireland,
-1930-12-31,IL,Israel,
-1930-12-31,IN,India,
-1930-12-31,IS,Iceland,
 1930-12-31,IT,Italy,0.0157
-1930-12-31,JP,Japan,
-1930-12-31,KR,Korea,
-1930-12-31,LT,Lithuania,
-1930-12-31,LU,Luxembourg,
-1930-12-31,LV,Latvia,
-1930-12-31,MA,Morocco,
-1930-12-31,MK,North Macedonia,
-1930-12-31,MT,Malta,
-1930-12-31,MX,Mexico,
-1930-12-31,MY,Malaysia,
-1930-12-31,NL,Netherlands,
-1930-12-31,NO,Norway,
-1930-12-31,NZ,New Zealand,
-1930-12-31,PE,Peru,
-1930-12-31,PH,Philippines,
-1930-12-31,PL,Poland,
-1930-12-31,PT,Portugal,
-1930-12-31,RO,Romania,
-1930-12-31,RS,Serbia,
-1930-12-31,RU,Russia,
-1930-12-31,SE,Sweden,
-1930-12-31,SG,Singapore,
-1930-12-31,SI,Slovenia,
-1930-12-31,SK,Slovak Republic,
-1930-12-31,TH,Thailand,
-1930-12-31,TR,Türkiye,
-1930-12-31,US,United States,
-1930-12-31,XM,Euro area,
-1930-12-31,XW,World,
-1930-12-31,ZA,South Africa,
-1931-03-31,4T,Emerging market economies (aggregate),
-1931-03-31,5R,Advanced economies,
-1931-03-31,AE,United Arab Emirates,
-1931-03-31,AT,Austria,
-1931-03-31,AU,Australia,
-1931-03-31,BE,Belgium,
-1931-03-31,BG,Bulgaria,
-1931-03-31,BR,Brazil,
-1931-03-31,CA,Canada,
-1931-03-31,CH,Switzerland,
-1931-03-31,CL,Chile,
-1931-03-31,CN,China,
-1931-03-31,CO,Colombia,
-1931-03-31,CY,Cyprus,
-1931-03-31,CZ,Czechia,
-1931-03-31,DE,Germany,
-1931-03-31,DK,Denmark,
-1931-03-31,EE,Estonia,
-1931-03-31,ES,Spain,
-1931-03-31,FI,Finland,
-1931-03-31,FR,France,
-1931-03-31,GB,United Kingdom,
-1931-03-31,GR,Greece,
-1931-03-31,HK,Hong Kong SAR,
-1931-03-31,HR,Croatia,
-1931-03-31,HU,Hungary,
-1931-03-31,ID,Indonesia,
-1931-03-31,IE,Ireland,
-1931-03-31,IL,Israel,
-1931-03-31,IN,India,
-1931-03-31,IS,Iceland,
 1931-03-31,IT,Italy,0.0153
-1931-03-31,JP,Japan,
-1931-03-31,KR,Korea,
-1931-03-31,LT,Lithuania,
-1931-03-31,LU,Luxembourg,
-1931-03-31,LV,Latvia,
-1931-03-31,MA,Morocco,
-1931-03-31,MK,North Macedonia,
-1931-03-31,MT,Malta,
-1931-03-31,MX,Mexico,
-1931-03-31,MY,Malaysia,
-1931-03-31,NL,Netherlands,
-1931-03-31,NO,Norway,
-1931-03-31,NZ,New Zealand,
-1931-03-31,PE,Peru,
-1931-03-31,PH,Philippines,
-1931-03-31,PL,Poland,
-1931-03-31,PT,Portugal,
-1931-03-31,RO,Romania,
-1931-03-31,RS,Serbia,
-1931-03-31,RU,Russia,
-1931-03-31,SE,Sweden,
-1931-03-31,SG,Singapore,
-1931-03-31,SI,Slovenia,
-1931-03-31,SK,Slovak Republic,
-1931-03-31,TH,Thailand,
-1931-03-31,TR,Türkiye,
-1931-03-31,US,United States,
-1931-03-31,XM,Euro area,
-1931-03-31,XW,World,
-1931-03-31,ZA,South Africa,
-1931-06-30,4T,Emerging market economies (aggregate),
-1931-06-30,5R,Advanced economies,
-1931-06-30,AE,United Arab Emirates,
-1931-06-30,AT,Austria,
-1931-06-30,AU,Australia,
-1931-06-30,BE,Belgium,
-1931-06-30,BG,Bulgaria,
-1931-06-30,BR,Brazil,
-1931-06-30,CA,Canada,
-1931-06-30,CH,Switzerland,
-1931-06-30,CL,Chile,
-1931-06-30,CN,China,
-1931-06-30,CO,Colombia,
-1931-06-30,CY,Cyprus,
-1931-06-30,CZ,Czechia,
-1931-06-30,DE,Germany,
-1931-06-30,DK,Denmark,
-1931-06-30,EE,Estonia,
-1931-06-30,ES,Spain,
-1931-06-30,FI,Finland,
-1931-06-30,FR,France,
-1931-06-30,GB,United Kingdom,
-1931-06-30,GR,Greece,
-1931-06-30,HK,Hong Kong SAR,
-1931-06-30,HR,Croatia,
-1931-06-30,HU,Hungary,
-1931-06-30,ID,Indonesia,
-1931-06-30,IE,Ireland,
-1931-06-30,IL,Israel,
-1931-06-30,IN,India,
-1931-06-30,IS,Iceland,
 1931-06-30,IT,Italy,0.0148
-1931-06-30,JP,Japan,
-1931-06-30,KR,Korea,
-1931-06-30,LT,Lithuania,
-1931-06-30,LU,Luxembourg,
-1931-06-30,LV,Latvia,
-1931-06-30,MA,Morocco,
-1931-06-30,MK,North Macedonia,
-1931-06-30,MT,Malta,
-1931-06-30,MX,Mexico,
-1931-06-30,MY,Malaysia,
-1931-06-30,NL,Netherlands,
-1931-06-30,NO,Norway,
-1931-06-30,NZ,New Zealand,
-1931-06-30,PE,Peru,
-1931-06-30,PH,Philippines,
-1931-06-30,PL,Poland,
-1931-06-30,PT,Portugal,
-1931-06-30,RO,Romania,
-1931-06-30,RS,Serbia,
-1931-06-30,RU,Russia,
-1931-06-30,SE,Sweden,
-1931-06-30,SG,Singapore,
-1931-06-30,SI,Slovenia,
-1931-06-30,SK,Slovak Republic,
-1931-06-30,TH,Thailand,
-1931-06-30,TR,Türkiye,
-1931-06-30,US,United States,
-1931-06-30,XM,Euro area,
-1931-06-30,XW,World,
-1931-06-30,ZA,South Africa,
-1931-09-30,4T,Emerging market economies (aggregate),
-1931-09-30,5R,Advanced economies,
-1931-09-30,AE,United Arab Emirates,
-1931-09-30,AT,Austria,
-1931-09-30,AU,Australia,
-1931-09-30,BE,Belgium,
-1931-09-30,BG,Bulgaria,
-1931-09-30,BR,Brazil,
-1931-09-30,CA,Canada,
-1931-09-30,CH,Switzerland,
-1931-09-30,CL,Chile,
-1931-09-30,CN,China,
-1931-09-30,CO,Colombia,
-1931-09-30,CY,Cyprus,
-1931-09-30,CZ,Czechia,
-1931-09-30,DE,Germany,
-1931-09-30,DK,Denmark,
-1931-09-30,EE,Estonia,
-1931-09-30,ES,Spain,
-1931-09-30,FI,Finland,
-1931-09-30,FR,France,
-1931-09-30,GB,United Kingdom,
-1931-09-30,GR,Greece,
-1931-09-30,HK,Hong Kong SAR,
-1931-09-30,HR,Croatia,
-1931-09-30,HU,Hungary,
-1931-09-30,ID,Indonesia,
-1931-09-30,IE,Ireland,
-1931-09-30,IL,Israel,
-1931-09-30,IN,India,
-1931-09-30,IS,Iceland,
 1931-09-30,IT,Italy,0.0144
-1931-09-30,JP,Japan,
-1931-09-30,KR,Korea,
-1931-09-30,LT,Lithuania,
-1931-09-30,LU,Luxembourg,
-1931-09-30,LV,Latvia,
-1931-09-30,MA,Morocco,
-1931-09-30,MK,North Macedonia,
-1931-09-30,MT,Malta,
-1931-09-30,MX,Mexico,
-1931-09-30,MY,Malaysia,
-1931-09-30,NL,Netherlands,
-1931-09-30,NO,Norway,
-1931-09-30,NZ,New Zealand,
-1931-09-30,PE,Peru,
-1931-09-30,PH,Philippines,
-1931-09-30,PL,Poland,
-1931-09-30,PT,Portugal,
-1931-09-30,RO,Romania,
-1931-09-30,RS,Serbia,
-1931-09-30,RU,Russia,
-1931-09-30,SE,Sweden,
-1931-09-30,SG,Singapore,
-1931-09-30,SI,Slovenia,
-1931-09-30,SK,Slovak Republic,
-1931-09-30,TH,Thailand,
-1931-09-30,TR,Türkiye,
-1931-09-30,US,United States,
-1931-09-30,XM,Euro area,
-1931-09-30,XW,World,
-1931-09-30,ZA,South Africa,
-1931-12-31,4T,Emerging market economies (aggregate),
-1931-12-31,5R,Advanced economies,
-1931-12-31,AE,United Arab Emirates,
-1931-12-31,AT,Austria,
-1931-12-31,AU,Australia,
-1931-12-31,BE,Belgium,
-1931-12-31,BG,Bulgaria,
-1931-12-31,BR,Brazil,
-1931-12-31,CA,Canada,
-1931-12-31,CH,Switzerland,
-1931-12-31,CL,Chile,
-1931-12-31,CN,China,
-1931-12-31,CO,Colombia,
-1931-12-31,CY,Cyprus,
-1931-12-31,CZ,Czechia,
-1931-12-31,DE,Germany,
-1931-12-31,DK,Denmark,
-1931-12-31,EE,Estonia,
-1931-12-31,ES,Spain,
-1931-12-31,FI,Finland,
-1931-12-31,FR,France,
-1931-12-31,GB,United Kingdom,
-1931-12-31,GR,Greece,
-1931-12-31,HK,Hong Kong SAR,
-1931-12-31,HR,Croatia,
-1931-12-31,HU,Hungary,
-1931-12-31,ID,Indonesia,
-1931-12-31,IE,Ireland,
-1931-12-31,IL,Israel,
-1931-12-31,IN,India,
-1931-12-31,IS,Iceland,
 1931-12-31,IT,Italy,0.014
-1931-12-31,JP,Japan,
-1931-12-31,KR,Korea,
-1931-12-31,LT,Lithuania,
-1931-12-31,LU,Luxembourg,
-1931-12-31,LV,Latvia,
-1931-12-31,MA,Morocco,
-1931-12-31,MK,North Macedonia,
-1931-12-31,MT,Malta,
-1931-12-31,MX,Mexico,
-1931-12-31,MY,Malaysia,
-1931-12-31,NL,Netherlands,
-1931-12-31,NO,Norway,
-1931-12-31,NZ,New Zealand,
-1931-12-31,PE,Peru,
-1931-12-31,PH,Philippines,
-1931-12-31,PL,Poland,
-1931-12-31,PT,Portugal,
-1931-12-31,RO,Romania,
-1931-12-31,RS,Serbia,
-1931-12-31,RU,Russia,
-1931-12-31,SE,Sweden,
-1931-12-31,SG,Singapore,
-1931-12-31,SI,Slovenia,
-1931-12-31,SK,Slovak Republic,
-1931-12-31,TH,Thailand,
-1931-12-31,TR,Türkiye,
-1931-12-31,US,United States,
-1931-12-31,XM,Euro area,
-1931-12-31,XW,World,
-1931-12-31,ZA,South Africa,
-1932-03-31,4T,Emerging market economies (aggregate),
-1932-03-31,5R,Advanced economies,
-1932-03-31,AE,United Arab Emirates,
-1932-03-31,AT,Austria,
-1932-03-31,AU,Australia,
-1932-03-31,BE,Belgium,
-1932-03-31,BG,Bulgaria,
-1932-03-31,BR,Brazil,
-1932-03-31,CA,Canada,
-1932-03-31,CH,Switzerland,
-1932-03-31,CL,Chile,
-1932-03-31,CN,China,
-1932-03-31,CO,Colombia,
-1932-03-31,CY,Cyprus,
-1932-03-31,CZ,Czechia,
-1932-03-31,DE,Germany,
-1932-03-31,DK,Denmark,
-1932-03-31,EE,Estonia,
-1932-03-31,ES,Spain,
-1932-03-31,FI,Finland,
-1932-03-31,FR,France,
-1932-03-31,GB,United Kingdom,
-1932-03-31,GR,Greece,
-1932-03-31,HK,Hong Kong SAR,
-1932-03-31,HR,Croatia,
-1932-03-31,HU,Hungary,
-1932-03-31,ID,Indonesia,
-1932-03-31,IE,Ireland,
-1932-03-31,IL,Israel,
-1932-03-31,IN,India,
-1932-03-31,IS,Iceland,
 1932-03-31,IT,Italy,0.0136
-1932-03-31,JP,Japan,
-1932-03-31,KR,Korea,
-1932-03-31,LT,Lithuania,
-1932-03-31,LU,Luxembourg,
-1932-03-31,LV,Latvia,
-1932-03-31,MA,Morocco,
-1932-03-31,MK,North Macedonia,
-1932-03-31,MT,Malta,
-1932-03-31,MX,Mexico,
-1932-03-31,MY,Malaysia,
-1932-03-31,NL,Netherlands,
-1932-03-31,NO,Norway,
-1932-03-31,NZ,New Zealand,
-1932-03-31,PE,Peru,
-1932-03-31,PH,Philippines,
-1932-03-31,PL,Poland,
-1932-03-31,PT,Portugal,
-1932-03-31,RO,Romania,
-1932-03-31,RS,Serbia,
-1932-03-31,RU,Russia,
-1932-03-31,SE,Sweden,
-1932-03-31,SG,Singapore,
-1932-03-31,SI,Slovenia,
-1932-03-31,SK,Slovak Republic,
-1932-03-31,TH,Thailand,
-1932-03-31,TR,Türkiye,
-1932-03-31,US,United States,
-1932-03-31,XM,Euro area,
-1932-03-31,XW,World,
-1932-03-31,ZA,South Africa,
-1932-06-30,4T,Emerging market economies (aggregate),
-1932-06-30,5R,Advanced economies,
-1932-06-30,AE,United Arab Emirates,
-1932-06-30,AT,Austria,
-1932-06-30,AU,Australia,
-1932-06-30,BE,Belgium,
-1932-06-30,BG,Bulgaria,
-1932-06-30,BR,Brazil,
-1932-06-30,CA,Canada,
-1932-06-30,CH,Switzerland,
-1932-06-30,CL,Chile,
-1932-06-30,CN,China,
-1932-06-30,CO,Colombia,
-1932-06-30,CY,Cyprus,
-1932-06-30,CZ,Czechia,
-1932-06-30,DE,Germany,
-1932-06-30,DK,Denmark,
-1932-06-30,EE,Estonia,
-1932-06-30,ES,Spain,
-1932-06-30,FI,Finland,
-1932-06-30,FR,France,
-1932-06-30,GB,United Kingdom,
-1932-06-30,GR,Greece,
-1932-06-30,HK,Hong Kong SAR,
-1932-06-30,HR,Croatia,
-1932-06-30,HU,Hungary,
-1932-06-30,ID,Indonesia,
-1932-06-30,IE,Ireland,
-1932-06-30,IL,Israel,
-1932-06-30,IN,India,
-1932-06-30,IS,Iceland,
 1932-06-30,IT,Italy,0.0132
-1932-06-30,JP,Japan,
-1932-06-30,KR,Korea,
-1932-06-30,LT,Lithuania,
-1932-06-30,LU,Luxembourg,
-1932-06-30,LV,Latvia,
-1932-06-30,MA,Morocco,
-1932-06-30,MK,North Macedonia,
-1932-06-30,MT,Malta,
-1932-06-30,MX,Mexico,
-1932-06-30,MY,Malaysia,
-1932-06-30,NL,Netherlands,
-1932-06-30,NO,Norway,
-1932-06-30,NZ,New Zealand,
-1932-06-30,PE,Peru,
-1932-06-30,PH,Philippines,
-1932-06-30,PL,Poland,
-1932-06-30,PT,Portugal,
-1932-06-30,RO,Romania,
-1932-06-30,RS,Serbia,
-1932-06-30,RU,Russia,
-1932-06-30,SE,Sweden,
-1932-06-30,SG,Singapore,
-1932-06-30,SI,Slovenia,
-1932-06-30,SK,Slovak Republic,
-1932-06-30,TH,Thailand,
-1932-06-30,TR,Türkiye,
-1932-06-30,US,United States,
-1932-06-30,XM,Euro area,
-1932-06-30,XW,World,
-1932-06-30,ZA,South Africa,
-1932-09-30,4T,Emerging market economies (aggregate),
-1932-09-30,5R,Advanced economies,
-1932-09-30,AE,United Arab Emirates,
-1932-09-30,AT,Austria,
-1932-09-30,AU,Australia,
-1932-09-30,BE,Belgium,
-1932-09-30,BG,Bulgaria,
-1932-09-30,BR,Brazil,
-1932-09-30,CA,Canada,
-1932-09-30,CH,Switzerland,
-1932-09-30,CL,Chile,
-1932-09-30,CN,China,
-1932-09-30,CO,Colombia,
-1932-09-30,CY,Cyprus,
-1932-09-30,CZ,Czechia,
-1932-09-30,DE,Germany,
-1932-09-30,DK,Denmark,
-1932-09-30,EE,Estonia,
-1932-09-30,ES,Spain,
-1932-09-30,FI,Finland,
-1932-09-30,FR,France,
-1932-09-30,GB,United Kingdom,
-1932-09-30,GR,Greece,
-1932-09-30,HK,Hong Kong SAR,
-1932-09-30,HR,Croatia,
-1932-09-30,HU,Hungary,
-1932-09-30,ID,Indonesia,
-1932-09-30,IE,Ireland,
-1932-09-30,IL,Israel,
-1932-09-30,IN,India,
-1932-09-30,IS,Iceland,
 1932-09-30,IT,Italy,0.0129
-1932-09-30,JP,Japan,
-1932-09-30,KR,Korea,
-1932-09-30,LT,Lithuania,
-1932-09-30,LU,Luxembourg,
-1932-09-30,LV,Latvia,
-1932-09-30,MA,Morocco,
-1932-09-30,MK,North Macedonia,
-1932-09-30,MT,Malta,
-1932-09-30,MX,Mexico,
-1932-09-30,MY,Malaysia,
-1932-09-30,NL,Netherlands,
-1932-09-30,NO,Norway,
-1932-09-30,NZ,New Zealand,
-1932-09-30,PE,Peru,
-1932-09-30,PH,Philippines,
-1932-09-30,PL,Poland,
-1932-09-30,PT,Portugal,
-1932-09-30,RO,Romania,
-1932-09-30,RS,Serbia,
-1932-09-30,RU,Russia,
-1932-09-30,SE,Sweden,
-1932-09-30,SG,Singapore,
-1932-09-30,SI,Slovenia,
-1932-09-30,SK,Slovak Republic,
-1932-09-30,TH,Thailand,
-1932-09-30,TR,Türkiye,
-1932-09-30,US,United States,
-1932-09-30,XM,Euro area,
-1932-09-30,XW,World,
-1932-09-30,ZA,South Africa,
-1932-12-31,4T,Emerging market economies (aggregate),
-1932-12-31,5R,Advanced economies,
-1932-12-31,AE,United Arab Emirates,
-1932-12-31,AT,Austria,
-1932-12-31,AU,Australia,
-1932-12-31,BE,Belgium,
-1932-12-31,BG,Bulgaria,
-1932-12-31,BR,Brazil,
-1932-12-31,CA,Canada,
-1932-12-31,CH,Switzerland,
-1932-12-31,CL,Chile,
-1932-12-31,CN,China,
-1932-12-31,CO,Colombia,
-1932-12-31,CY,Cyprus,
-1932-12-31,CZ,Czechia,
-1932-12-31,DE,Germany,
-1932-12-31,DK,Denmark,
-1932-12-31,EE,Estonia,
-1932-12-31,ES,Spain,
-1932-12-31,FI,Finland,
-1932-12-31,FR,France,
-1932-12-31,GB,United Kingdom,
-1932-12-31,GR,Greece,
-1932-12-31,HK,Hong Kong SAR,
-1932-12-31,HR,Croatia,
-1932-12-31,HU,Hungary,
-1932-12-31,ID,Indonesia,
-1932-12-31,IE,Ireland,
-1932-12-31,IL,Israel,
-1932-12-31,IN,India,
-1932-12-31,IS,Iceland,
 1932-12-31,IT,Italy,0.0128
-1932-12-31,JP,Japan,
-1932-12-31,KR,Korea,
-1932-12-31,LT,Lithuania,
-1932-12-31,LU,Luxembourg,
-1932-12-31,LV,Latvia,
-1932-12-31,MA,Morocco,
-1932-12-31,MK,North Macedonia,
-1932-12-31,MT,Malta,
-1932-12-31,MX,Mexico,
-1932-12-31,MY,Malaysia,
-1932-12-31,NL,Netherlands,
-1932-12-31,NO,Norway,
-1932-12-31,NZ,New Zealand,
-1932-12-31,PE,Peru,
-1932-12-31,PH,Philippines,
-1932-12-31,PL,Poland,
-1932-12-31,PT,Portugal,
-1932-12-31,RO,Romania,
-1932-12-31,RS,Serbia,
-1932-12-31,RU,Russia,
-1932-12-31,SE,Sweden,
-1932-12-31,SG,Singapore,
-1932-12-31,SI,Slovenia,
-1932-12-31,SK,Slovak Republic,
-1932-12-31,TH,Thailand,
-1932-12-31,TR,Türkiye,
-1932-12-31,US,United States,
-1932-12-31,XM,Euro area,
-1932-12-31,XW,World,
-1932-12-31,ZA,South Africa,
-1933-03-31,4T,Emerging market economies (aggregate),
-1933-03-31,5R,Advanced economies,
-1933-03-31,AE,United Arab Emirates,
-1933-03-31,AT,Austria,
-1933-03-31,AU,Australia,
-1933-03-31,BE,Belgium,
-1933-03-31,BG,Bulgaria,
-1933-03-31,BR,Brazil,
-1933-03-31,CA,Canada,
-1933-03-31,CH,Switzerland,
-1933-03-31,CL,Chile,
-1933-03-31,CN,China,
-1933-03-31,CO,Colombia,
-1933-03-31,CY,Cyprus,
-1933-03-31,CZ,Czechia,
-1933-03-31,DE,Germany,
-1933-03-31,DK,Denmark,
-1933-03-31,EE,Estonia,
-1933-03-31,ES,Spain,
-1933-03-31,FI,Finland,
-1933-03-31,FR,France,
-1933-03-31,GB,United Kingdom,
-1933-03-31,GR,Greece,
-1933-03-31,HK,Hong Kong SAR,
-1933-03-31,HR,Croatia,
-1933-03-31,HU,Hungary,
-1933-03-31,ID,Indonesia,
-1933-03-31,IE,Ireland,
-1933-03-31,IL,Israel,
-1933-03-31,IN,India,
-1933-03-31,IS,Iceland,
 1933-03-31,IT,Italy,0.0126
-1933-03-31,JP,Japan,
-1933-03-31,KR,Korea,
-1933-03-31,LT,Lithuania,
-1933-03-31,LU,Luxembourg,
-1933-03-31,LV,Latvia,
-1933-03-31,MA,Morocco,
-1933-03-31,MK,North Macedonia,
-1933-03-31,MT,Malta,
-1933-03-31,MX,Mexico,
-1933-03-31,MY,Malaysia,
-1933-03-31,NL,Netherlands,
-1933-03-31,NO,Norway,
-1933-03-31,NZ,New Zealand,
-1933-03-31,PE,Peru,
-1933-03-31,PH,Philippines,
-1933-03-31,PL,Poland,
-1933-03-31,PT,Portugal,
-1933-03-31,RO,Romania,
-1933-03-31,RS,Serbia,
-1933-03-31,RU,Russia,
-1933-03-31,SE,Sweden,
-1933-03-31,SG,Singapore,
-1933-03-31,SI,Slovenia,
-1933-03-31,SK,Slovak Republic,
-1933-03-31,TH,Thailand,
-1933-03-31,TR,Türkiye,
-1933-03-31,US,United States,
-1933-03-31,XM,Euro area,
-1933-03-31,XW,World,
-1933-03-31,ZA,South Africa,
-1933-06-30,4T,Emerging market economies (aggregate),
-1933-06-30,5R,Advanced economies,
-1933-06-30,AE,United Arab Emirates,
-1933-06-30,AT,Austria,
-1933-06-30,AU,Australia,
-1933-06-30,BE,Belgium,
-1933-06-30,BG,Bulgaria,
-1933-06-30,BR,Brazil,
-1933-06-30,CA,Canada,
-1933-06-30,CH,Switzerland,
-1933-06-30,CL,Chile,
-1933-06-30,CN,China,
-1933-06-30,CO,Colombia,
-1933-06-30,CY,Cyprus,
-1933-06-30,CZ,Czechia,
-1933-06-30,DE,Germany,
-1933-06-30,DK,Denmark,
-1933-06-30,EE,Estonia,
-1933-06-30,ES,Spain,
-1933-06-30,FI,Finland,
-1933-06-30,FR,France,
-1933-06-30,GB,United Kingdom,
-1933-06-30,GR,Greece,
-1933-06-30,HK,Hong Kong SAR,
-1933-06-30,HR,Croatia,
-1933-06-30,HU,Hungary,
-1933-06-30,ID,Indonesia,
-1933-06-30,IE,Ireland,
-1933-06-30,IL,Israel,
-1933-06-30,IN,India,
-1933-06-30,IS,Iceland,
 1933-06-30,IT,Italy,0.0125
-1933-06-30,JP,Japan,
-1933-06-30,KR,Korea,
-1933-06-30,LT,Lithuania,
-1933-06-30,LU,Luxembourg,
-1933-06-30,LV,Latvia,
-1933-06-30,MA,Morocco,
-1933-06-30,MK,North Macedonia,
-1933-06-30,MT,Malta,
-1933-06-30,MX,Mexico,
-1933-06-30,MY,Malaysia,
-1933-06-30,NL,Netherlands,
-1933-06-30,NO,Norway,
-1933-06-30,NZ,New Zealand,
-1933-06-30,PE,Peru,
-1933-06-30,PH,Philippines,
-1933-06-30,PL,Poland,
-1933-06-30,PT,Portugal,
-1933-06-30,RO,Romania,
-1933-06-30,RS,Serbia,
-1933-06-30,RU,Russia,
-1933-06-30,SE,Sweden,
-1933-06-30,SG,Singapore,
-1933-06-30,SI,Slovenia,
-1933-06-30,SK,Slovak Republic,
-1933-06-30,TH,Thailand,
-1933-06-30,TR,Türkiye,
-1933-06-30,US,United States,
-1933-06-30,XM,Euro area,
-1933-06-30,XW,World,
-1933-06-30,ZA,South Africa,
-1933-09-30,4T,Emerging market economies (aggregate),
-1933-09-30,5R,Advanced economies,
-1933-09-30,AE,United Arab Emirates,
-1933-09-30,AT,Austria,
-1933-09-30,AU,Australia,
-1933-09-30,BE,Belgium,
-1933-09-30,BG,Bulgaria,
-1933-09-30,BR,Brazil,
-1933-09-30,CA,Canada,
-1933-09-30,CH,Switzerland,
-1933-09-30,CL,Chile,
-1933-09-30,CN,China,
-1933-09-30,CO,Colombia,
-1933-09-30,CY,Cyprus,
-1933-09-30,CZ,Czechia,
-1933-09-30,DE,Germany,
-1933-09-30,DK,Denmark,
-1933-09-30,EE,Estonia,
-1933-09-30,ES,Spain,
-1933-09-30,FI,Finland,
-1933-09-30,FR,France,
-1933-09-30,GB,United Kingdom,
-1933-09-30,GR,Greece,
-1933-09-30,HK,Hong Kong SAR,
-1933-09-30,HR,Croatia,
-1933-09-30,HU,Hungary,
-1933-09-30,ID,Indonesia,
-1933-09-30,IE,Ireland,
-1933-09-30,IL,Israel,
-1933-09-30,IN,India,
-1933-09-30,IS,Iceland,
 1933-09-30,IT,Italy,0.0123
-1933-09-30,JP,Japan,
-1933-09-30,KR,Korea,
-1933-09-30,LT,Lithuania,
-1933-09-30,LU,Luxembourg,
-1933-09-30,LV,Latvia,
-1933-09-30,MA,Morocco,
-1933-09-30,MK,North Macedonia,
-1933-09-30,MT,Malta,
-1933-09-30,MX,Mexico,
-1933-09-30,MY,Malaysia,
-1933-09-30,NL,Netherlands,
-1933-09-30,NO,Norway,
-1933-09-30,NZ,New Zealand,
-1933-09-30,PE,Peru,
-1933-09-30,PH,Philippines,
-1933-09-30,PL,Poland,
-1933-09-30,PT,Portugal,
-1933-09-30,RO,Romania,
-1933-09-30,RS,Serbia,
-1933-09-30,RU,Russia,
-1933-09-30,SE,Sweden,
-1933-09-30,SG,Singapore,
-1933-09-30,SI,Slovenia,
-1933-09-30,SK,Slovak Republic,
-1933-09-30,TH,Thailand,
-1933-09-30,TR,Türkiye,
-1933-09-30,US,United States,
-1933-09-30,XM,Euro area,
-1933-09-30,XW,World,
-1933-09-30,ZA,South Africa,
-1933-12-31,4T,Emerging market economies (aggregate),
-1933-12-31,5R,Advanced economies,
-1933-12-31,AE,United Arab Emirates,
-1933-12-31,AT,Austria,
-1933-12-31,AU,Australia,
-1933-12-31,BE,Belgium,
-1933-12-31,BG,Bulgaria,
-1933-12-31,BR,Brazil,
-1933-12-31,CA,Canada,
-1933-12-31,CH,Switzerland,
-1933-12-31,CL,Chile,
-1933-12-31,CN,China,
-1933-12-31,CO,Colombia,
-1933-12-31,CY,Cyprus,
-1933-12-31,CZ,Czechia,
-1933-12-31,DE,Germany,
-1933-12-31,DK,Denmark,
-1933-12-31,EE,Estonia,
-1933-12-31,ES,Spain,
-1933-12-31,FI,Finland,
-1933-12-31,FR,France,
-1933-12-31,GB,United Kingdom,
-1933-12-31,GR,Greece,
-1933-12-31,HK,Hong Kong SAR,
-1933-12-31,HR,Croatia,
-1933-12-31,HU,Hungary,
-1933-12-31,ID,Indonesia,
-1933-12-31,IE,Ireland,
-1933-12-31,IL,Israel,
-1933-12-31,IN,India,
-1933-12-31,IS,Iceland,
 1933-12-31,IT,Italy,0.0121
-1933-12-31,JP,Japan,
-1933-12-31,KR,Korea,
-1933-12-31,LT,Lithuania,
-1933-12-31,LU,Luxembourg,
-1933-12-31,LV,Latvia,
-1933-12-31,MA,Morocco,
-1933-12-31,MK,North Macedonia,
-1933-12-31,MT,Malta,
-1933-12-31,MX,Mexico,
-1933-12-31,MY,Malaysia,
-1933-12-31,NL,Netherlands,
-1933-12-31,NO,Norway,
-1933-12-31,NZ,New Zealand,
-1933-12-31,PE,Peru,
-1933-12-31,PH,Philippines,
-1933-12-31,PL,Poland,
-1933-12-31,PT,Portugal,
-1933-12-31,RO,Romania,
-1933-12-31,RS,Serbia,
-1933-12-31,RU,Russia,
-1933-12-31,SE,Sweden,
-1933-12-31,SG,Singapore,
-1933-12-31,SI,Slovenia,
-1933-12-31,SK,Slovak Republic,
-1933-12-31,TH,Thailand,
-1933-12-31,TR,Türkiye,
-1933-12-31,US,United States,
-1933-12-31,XM,Euro area,
-1933-12-31,XW,World,
-1933-12-31,ZA,South Africa,
-1934-03-31,4T,Emerging market economies (aggregate),
-1934-03-31,5R,Advanced economies,
-1934-03-31,AE,United Arab Emirates,
-1934-03-31,AT,Austria,
-1934-03-31,AU,Australia,
-1934-03-31,BE,Belgium,
-1934-03-31,BG,Bulgaria,
-1934-03-31,BR,Brazil,
-1934-03-31,CA,Canada,
-1934-03-31,CH,Switzerland,
-1934-03-31,CL,Chile,
-1934-03-31,CN,China,
-1934-03-31,CO,Colombia,
-1934-03-31,CY,Cyprus,
-1934-03-31,CZ,Czechia,
-1934-03-31,DE,Germany,
-1934-03-31,DK,Denmark,
-1934-03-31,EE,Estonia,
-1934-03-31,ES,Spain,
-1934-03-31,FI,Finland,
-1934-03-31,FR,France,
-1934-03-31,GB,United Kingdom,
-1934-03-31,GR,Greece,
-1934-03-31,HK,Hong Kong SAR,
-1934-03-31,HR,Croatia,
-1934-03-31,HU,Hungary,
-1934-03-31,ID,Indonesia,
-1934-03-31,IE,Ireland,
-1934-03-31,IL,Israel,
-1934-03-31,IN,India,
-1934-03-31,IS,Iceland,
 1934-03-31,IT,Italy,0.0118
-1934-03-31,JP,Japan,
-1934-03-31,KR,Korea,
-1934-03-31,LT,Lithuania,
-1934-03-31,LU,Luxembourg,
-1934-03-31,LV,Latvia,
-1934-03-31,MA,Morocco,
-1934-03-31,MK,North Macedonia,
-1934-03-31,MT,Malta,
-1934-03-31,MX,Mexico,
-1934-03-31,MY,Malaysia,
-1934-03-31,NL,Netherlands,
-1934-03-31,NO,Norway,
-1934-03-31,NZ,New Zealand,
-1934-03-31,PE,Peru,
-1934-03-31,PH,Philippines,
-1934-03-31,PL,Poland,
-1934-03-31,PT,Portugal,
-1934-03-31,RO,Romania,
-1934-03-31,RS,Serbia,
-1934-03-31,RU,Russia,
-1934-03-31,SE,Sweden,
-1934-03-31,SG,Singapore,
-1934-03-31,SI,Slovenia,
-1934-03-31,SK,Slovak Republic,
-1934-03-31,TH,Thailand,
-1934-03-31,TR,Türkiye,
-1934-03-31,US,United States,
-1934-03-31,XM,Euro area,
-1934-03-31,XW,World,
-1934-03-31,ZA,South Africa,
-1934-06-30,4T,Emerging market economies (aggregate),
-1934-06-30,5R,Advanced economies,
-1934-06-30,AE,United Arab Emirates,
-1934-06-30,AT,Austria,
-1934-06-30,AU,Australia,
-1934-06-30,BE,Belgium,
-1934-06-30,BG,Bulgaria,
-1934-06-30,BR,Brazil,
-1934-06-30,CA,Canada,
-1934-06-30,CH,Switzerland,
-1934-06-30,CL,Chile,
-1934-06-30,CN,China,
-1934-06-30,CO,Colombia,
-1934-06-30,CY,Cyprus,
-1934-06-30,CZ,Czechia,
-1934-06-30,DE,Germany,
-1934-06-30,DK,Denmark,
-1934-06-30,EE,Estonia,
-1934-06-30,ES,Spain,
-1934-06-30,FI,Finland,
-1934-06-30,FR,France,
-1934-06-30,GB,United Kingdom,
-1934-06-30,GR,Greece,
-1934-06-30,HK,Hong Kong SAR,
-1934-06-30,HR,Croatia,
-1934-06-30,HU,Hungary,
-1934-06-30,ID,Indonesia,
-1934-06-30,IE,Ireland,
-1934-06-30,IL,Israel,
-1934-06-30,IN,India,
-1934-06-30,IS,Iceland,
 1934-06-30,IT,Italy,0.0116
-1934-06-30,JP,Japan,
-1934-06-30,KR,Korea,
-1934-06-30,LT,Lithuania,
-1934-06-30,LU,Luxembourg,
-1934-06-30,LV,Latvia,
-1934-06-30,MA,Morocco,
-1934-06-30,MK,North Macedonia,
-1934-06-30,MT,Malta,
-1934-06-30,MX,Mexico,
-1934-06-30,MY,Malaysia,
-1934-06-30,NL,Netherlands,
-1934-06-30,NO,Norway,
-1934-06-30,NZ,New Zealand,
-1934-06-30,PE,Peru,
-1934-06-30,PH,Philippines,
-1934-06-30,PL,Poland,
-1934-06-30,PT,Portugal,
-1934-06-30,RO,Romania,
-1934-06-30,RS,Serbia,
-1934-06-30,RU,Russia,
-1934-06-30,SE,Sweden,
-1934-06-30,SG,Singapore,
-1934-06-30,SI,Slovenia,
-1934-06-30,SK,Slovak Republic,
-1934-06-30,TH,Thailand,
-1934-06-30,TR,Türkiye,
-1934-06-30,US,United States,
-1934-06-30,XM,Euro area,
-1934-06-30,XW,World,
-1934-06-30,ZA,South Africa,
-1934-09-30,4T,Emerging market economies (aggregate),
-1934-09-30,5R,Advanced economies,
-1934-09-30,AE,United Arab Emirates,
-1934-09-30,AT,Austria,
-1934-09-30,AU,Australia,
-1934-09-30,BE,Belgium,
-1934-09-30,BG,Bulgaria,
-1934-09-30,BR,Brazil,
-1934-09-30,CA,Canada,
-1934-09-30,CH,Switzerland,
-1934-09-30,CL,Chile,
-1934-09-30,CN,China,
-1934-09-30,CO,Colombia,
-1934-09-30,CY,Cyprus,
-1934-09-30,CZ,Czechia,
-1934-09-30,DE,Germany,
-1934-09-30,DK,Denmark,
-1934-09-30,EE,Estonia,
-1934-09-30,ES,Spain,
-1934-09-30,FI,Finland,
-1934-09-30,FR,France,
-1934-09-30,GB,United Kingdom,
-1934-09-30,GR,Greece,
-1934-09-30,HK,Hong Kong SAR,
-1934-09-30,HR,Croatia,
-1934-09-30,HU,Hungary,
-1934-09-30,ID,Indonesia,
-1934-09-30,IE,Ireland,
-1934-09-30,IL,Israel,
-1934-09-30,IN,India,
-1934-09-30,IS,Iceland,
 1934-09-30,IT,Italy,0.0115
-1934-09-30,JP,Japan,
-1934-09-30,KR,Korea,
-1934-09-30,LT,Lithuania,
-1934-09-30,LU,Luxembourg,
-1934-09-30,LV,Latvia,
-1934-09-30,MA,Morocco,
-1934-09-30,MK,North Macedonia,
-1934-09-30,MT,Malta,
-1934-09-30,MX,Mexico,
-1934-09-30,MY,Malaysia,
-1934-09-30,NL,Netherlands,
-1934-09-30,NO,Norway,
-1934-09-30,NZ,New Zealand,
-1934-09-30,PE,Peru,
-1934-09-30,PH,Philippines,
-1934-09-30,PL,Poland,
-1934-09-30,PT,Portugal,
-1934-09-30,RO,Romania,
-1934-09-30,RS,Serbia,
-1934-09-30,RU,Russia,
-1934-09-30,SE,Sweden,
-1934-09-30,SG,Singapore,
-1934-09-30,SI,Slovenia,
-1934-09-30,SK,Slovak Republic,
-1934-09-30,TH,Thailand,
-1934-09-30,TR,Türkiye,
-1934-09-30,US,United States,
-1934-09-30,XM,Euro area,
-1934-09-30,XW,World,
-1934-09-30,ZA,South Africa,
-1934-12-31,4T,Emerging market economies (aggregate),
-1934-12-31,5R,Advanced economies,
-1934-12-31,AE,United Arab Emirates,
-1934-12-31,AT,Austria,
-1934-12-31,AU,Australia,
-1934-12-31,BE,Belgium,
-1934-12-31,BG,Bulgaria,
-1934-12-31,BR,Brazil,
-1934-12-31,CA,Canada,
-1934-12-31,CH,Switzerland,
-1934-12-31,CL,Chile,
-1934-12-31,CN,China,
-1934-12-31,CO,Colombia,
-1934-12-31,CY,Cyprus,
-1934-12-31,CZ,Czechia,
-1934-12-31,DE,Germany,
-1934-12-31,DK,Denmark,
-1934-12-31,EE,Estonia,
-1934-12-31,ES,Spain,
-1934-12-31,FI,Finland,
-1934-12-31,FR,France,
-1934-12-31,GB,United Kingdom,
-1934-12-31,GR,Greece,
-1934-12-31,HK,Hong Kong SAR,
-1934-12-31,HR,Croatia,
-1934-12-31,HU,Hungary,
-1934-12-31,ID,Indonesia,
-1934-12-31,IE,Ireland,
-1934-12-31,IL,Israel,
-1934-12-31,IN,India,
-1934-12-31,IS,Iceland,
 1934-12-31,IT,Italy,0.0116
-1934-12-31,JP,Japan,
-1934-12-31,KR,Korea,
-1934-12-31,LT,Lithuania,
-1934-12-31,LU,Luxembourg,
-1934-12-31,LV,Latvia,
-1934-12-31,MA,Morocco,
-1934-12-31,MK,North Macedonia,
-1934-12-31,MT,Malta,
-1934-12-31,MX,Mexico,
-1934-12-31,MY,Malaysia,
-1934-12-31,NL,Netherlands,
-1934-12-31,NO,Norway,
-1934-12-31,NZ,New Zealand,
-1934-12-31,PE,Peru,
-1934-12-31,PH,Philippines,
-1934-12-31,PL,Poland,
-1934-12-31,PT,Portugal,
-1934-12-31,RO,Romania,
-1934-12-31,RS,Serbia,
-1934-12-31,RU,Russia,
-1934-12-31,SE,Sweden,
-1934-12-31,SG,Singapore,
-1934-12-31,SI,Slovenia,
-1934-12-31,SK,Slovak Republic,
-1934-12-31,TH,Thailand,
-1934-12-31,TR,Türkiye,
-1934-12-31,US,United States,
-1934-12-31,XM,Euro area,
-1934-12-31,XW,World,
-1934-12-31,ZA,South Africa,
-1935-03-31,4T,Emerging market economies (aggregate),
-1935-03-31,5R,Advanced economies,
-1935-03-31,AE,United Arab Emirates,
-1935-03-31,AT,Austria,
-1935-03-31,AU,Australia,
-1935-03-31,BE,Belgium,
-1935-03-31,BG,Bulgaria,
-1935-03-31,BR,Brazil,
-1935-03-31,CA,Canada,
-1935-03-31,CH,Switzerland,
-1935-03-31,CL,Chile,
-1935-03-31,CN,China,
-1935-03-31,CO,Colombia,
-1935-03-31,CY,Cyprus,
-1935-03-31,CZ,Czechia,
-1935-03-31,DE,Germany,
-1935-03-31,DK,Denmark,
-1935-03-31,EE,Estonia,
-1935-03-31,ES,Spain,
-1935-03-31,FI,Finland,
-1935-03-31,FR,France,
-1935-03-31,GB,United Kingdom,
-1935-03-31,GR,Greece,
-1935-03-31,HK,Hong Kong SAR,
-1935-03-31,HR,Croatia,
-1935-03-31,HU,Hungary,
-1935-03-31,ID,Indonesia,
-1935-03-31,IE,Ireland,
-1935-03-31,IL,Israel,
-1935-03-31,IN,India,
-1935-03-31,IS,Iceland,
 1935-03-31,IT,Italy,0.0117
-1935-03-31,JP,Japan,
-1935-03-31,KR,Korea,
-1935-03-31,LT,Lithuania,
-1935-03-31,LU,Luxembourg,
-1935-03-31,LV,Latvia,
-1935-03-31,MA,Morocco,
-1935-03-31,MK,North Macedonia,
-1935-03-31,MT,Malta,
-1935-03-31,MX,Mexico,
-1935-03-31,MY,Malaysia,
-1935-03-31,NL,Netherlands,
-1935-03-31,NO,Norway,
-1935-03-31,NZ,New Zealand,
-1935-03-31,PE,Peru,
-1935-03-31,PH,Philippines,
-1935-03-31,PL,Poland,
-1935-03-31,PT,Portugal,
-1935-03-31,RO,Romania,
-1935-03-31,RS,Serbia,
-1935-03-31,RU,Russia,
-1935-03-31,SE,Sweden,
-1935-03-31,SG,Singapore,
-1935-03-31,SI,Slovenia,
-1935-03-31,SK,Slovak Republic,
-1935-03-31,TH,Thailand,
-1935-03-31,TR,Türkiye,
-1935-03-31,US,United States,
-1935-03-31,XM,Euro area,
-1935-03-31,XW,World,
-1935-03-31,ZA,South Africa,
-1935-06-30,4T,Emerging market economies (aggregate),
-1935-06-30,5R,Advanced economies,
-1935-06-30,AE,United Arab Emirates,
-1935-06-30,AT,Austria,
-1935-06-30,AU,Australia,
-1935-06-30,BE,Belgium,
-1935-06-30,BG,Bulgaria,
-1935-06-30,BR,Brazil,
-1935-06-30,CA,Canada,
-1935-06-30,CH,Switzerland,
-1935-06-30,CL,Chile,
-1935-06-30,CN,China,
-1935-06-30,CO,Colombia,
-1935-06-30,CY,Cyprus,
-1935-06-30,CZ,Czechia,
-1935-06-30,DE,Germany,
-1935-06-30,DK,Denmark,
-1935-06-30,EE,Estonia,
-1935-06-30,ES,Spain,
-1935-06-30,FI,Finland,
-1935-06-30,FR,France,
-1935-06-30,GB,United Kingdom,
-1935-06-30,GR,Greece,
-1935-06-30,HK,Hong Kong SAR,
-1935-06-30,HR,Croatia,
-1935-06-30,HU,Hungary,
-1935-06-30,ID,Indonesia,
-1935-06-30,IE,Ireland,
-1935-06-30,IL,Israel,
-1935-06-30,IN,India,
-1935-06-30,IS,Iceland,
 1935-06-30,IT,Italy,0.0118
-1935-06-30,JP,Japan,
-1935-06-30,KR,Korea,
-1935-06-30,LT,Lithuania,
-1935-06-30,LU,Luxembourg,
-1935-06-30,LV,Latvia,
-1935-06-30,MA,Morocco,
-1935-06-30,MK,North Macedonia,
-1935-06-30,MT,Malta,
-1935-06-30,MX,Mexico,
-1935-06-30,MY,Malaysia,
-1935-06-30,NL,Netherlands,
-1935-06-30,NO,Norway,
-1935-06-30,NZ,New Zealand,
-1935-06-30,PE,Peru,
-1935-06-30,PH,Philippines,
-1935-06-30,PL,Poland,
-1935-06-30,PT,Portugal,
-1935-06-30,RO,Romania,
-1935-06-30,RS,Serbia,
-1935-06-30,RU,Russia,
-1935-06-30,SE,Sweden,
-1935-06-30,SG,Singapore,
-1935-06-30,SI,Slovenia,
-1935-06-30,SK,Slovak Republic,
-1935-06-30,TH,Thailand,
-1935-06-30,TR,Türkiye,
-1935-06-30,US,United States,
-1935-06-30,XM,Euro area,
-1935-06-30,XW,World,
-1935-06-30,ZA,South Africa,
-1935-09-30,4T,Emerging market economies (aggregate),
-1935-09-30,5R,Advanced economies,
-1935-09-30,AE,United Arab Emirates,
-1935-09-30,AT,Austria,
-1935-09-30,AU,Australia,
-1935-09-30,BE,Belgium,
-1935-09-30,BG,Bulgaria,
-1935-09-30,BR,Brazil,
-1935-09-30,CA,Canada,
-1935-09-30,CH,Switzerland,
-1935-09-30,CL,Chile,
-1935-09-30,CN,China,
-1935-09-30,CO,Colombia,
-1935-09-30,CY,Cyprus,
-1935-09-30,CZ,Czechia,
-1935-09-30,DE,Germany,
-1935-09-30,DK,Denmark,
-1935-09-30,EE,Estonia,
-1935-09-30,ES,Spain,
-1935-09-30,FI,Finland,
-1935-09-30,FR,France,
-1935-09-30,GB,United Kingdom,
-1935-09-30,GR,Greece,
-1935-09-30,HK,Hong Kong SAR,
-1935-09-30,HR,Croatia,
-1935-09-30,HU,Hungary,
-1935-09-30,ID,Indonesia,
-1935-09-30,IE,Ireland,
-1935-09-30,IL,Israel,
-1935-09-30,IN,India,
-1935-09-30,IS,Iceland,
 1935-09-30,IT,Italy,0.0119
-1935-09-30,JP,Japan,
-1935-09-30,KR,Korea,
-1935-09-30,LT,Lithuania,
-1935-09-30,LU,Luxembourg,
-1935-09-30,LV,Latvia,
-1935-09-30,MA,Morocco,
-1935-09-30,MK,North Macedonia,
-1935-09-30,MT,Malta,
-1935-09-30,MX,Mexico,
-1935-09-30,MY,Malaysia,
-1935-09-30,NL,Netherlands,
-1935-09-30,NO,Norway,
-1935-09-30,NZ,New Zealand,
-1935-09-30,PE,Peru,
-1935-09-30,PH,Philippines,
-1935-09-30,PL,Poland,
-1935-09-30,PT,Portugal,
-1935-09-30,RO,Romania,
-1935-09-30,RS,Serbia,
-1935-09-30,RU,Russia,
-1935-09-30,SE,Sweden,
-1935-09-30,SG,Singapore,
-1935-09-30,SI,Slovenia,
-1935-09-30,SK,Slovak Republic,
-1935-09-30,TH,Thailand,
-1935-09-30,TR,Türkiye,
-1935-09-30,US,United States,
-1935-09-30,XM,Euro area,
-1935-09-30,XW,World,
-1935-09-30,ZA,South Africa,
-1935-12-31,4T,Emerging market economies (aggregate),
-1935-12-31,5R,Advanced economies,
-1935-12-31,AE,United Arab Emirates,
-1935-12-31,AT,Austria,
-1935-12-31,AU,Australia,
-1935-12-31,BE,Belgium,
-1935-12-31,BG,Bulgaria,
-1935-12-31,BR,Brazil,
-1935-12-31,CA,Canada,
-1935-12-31,CH,Switzerland,
-1935-12-31,CL,Chile,
-1935-12-31,CN,China,
-1935-12-31,CO,Colombia,
-1935-12-31,CY,Cyprus,
-1935-12-31,CZ,Czechia,
-1935-12-31,DE,Germany,
-1935-12-31,DK,Denmark,
-1935-12-31,EE,Estonia,
-1935-12-31,ES,Spain,
-1935-12-31,FI,Finland,
-1935-12-31,FR,France,
-1935-12-31,GB,United Kingdom,
-1935-12-31,GR,Greece,
-1935-12-31,HK,Hong Kong SAR,
-1935-12-31,HR,Croatia,
-1935-12-31,HU,Hungary,
-1935-12-31,ID,Indonesia,
-1935-12-31,IE,Ireland,
-1935-12-31,IL,Israel,
-1935-12-31,IN,India,
-1935-12-31,IS,Iceland,
 1935-12-31,IT,Italy,0.0119
-1935-12-31,JP,Japan,
-1935-12-31,KR,Korea,
-1935-12-31,LT,Lithuania,
-1935-12-31,LU,Luxembourg,
-1935-12-31,LV,Latvia,
-1935-12-31,MA,Morocco,
-1935-12-31,MK,North Macedonia,
-1935-12-31,MT,Malta,
-1935-12-31,MX,Mexico,
-1935-12-31,MY,Malaysia,
-1935-12-31,NL,Netherlands,
-1935-12-31,NO,Norway,
-1935-12-31,NZ,New Zealand,
-1935-12-31,PE,Peru,
-1935-12-31,PH,Philippines,
-1935-12-31,PL,Poland,
-1935-12-31,PT,Portugal,
-1935-12-31,RO,Romania,
-1935-12-31,RS,Serbia,
-1935-12-31,RU,Russia,
-1935-12-31,SE,Sweden,
-1935-12-31,SG,Singapore,
-1935-12-31,SI,Slovenia,
-1935-12-31,SK,Slovak Republic,
-1935-12-31,TH,Thailand,
-1935-12-31,TR,Türkiye,
-1935-12-31,US,United States,
-1935-12-31,XM,Euro area,
-1935-12-31,XW,World,
-1935-12-31,ZA,South Africa,
-1936-03-31,4T,Emerging market economies (aggregate),
-1936-03-31,5R,Advanced economies,
-1936-03-31,AE,United Arab Emirates,
-1936-03-31,AT,Austria,
-1936-03-31,AU,Australia,
-1936-03-31,BE,Belgium,
-1936-03-31,BG,Bulgaria,
-1936-03-31,BR,Brazil,
-1936-03-31,CA,Canada,
-1936-03-31,CH,Switzerland,
-1936-03-31,CL,Chile,
-1936-03-31,CN,China,
-1936-03-31,CO,Colombia,
-1936-03-31,CY,Cyprus,
-1936-03-31,CZ,Czechia,
-1936-03-31,DE,Germany,
-1936-03-31,DK,Denmark,
-1936-03-31,EE,Estonia,
-1936-03-31,ES,Spain,
-1936-03-31,FI,Finland,
-1936-03-31,FR,France,
-1936-03-31,GB,United Kingdom,
-1936-03-31,GR,Greece,
-1936-03-31,HK,Hong Kong SAR,
-1936-03-31,HR,Croatia,
-1936-03-31,HU,Hungary,
-1936-03-31,ID,Indonesia,
-1936-03-31,IE,Ireland,
-1936-03-31,IL,Israel,
-1936-03-31,IN,India,
-1936-03-31,IS,Iceland,
 1936-03-31,IT,Italy,0.0119
-1936-03-31,JP,Japan,
-1936-03-31,KR,Korea,
-1936-03-31,LT,Lithuania,
-1936-03-31,LU,Luxembourg,
-1936-03-31,LV,Latvia,
-1936-03-31,MA,Morocco,
-1936-03-31,MK,North Macedonia,
-1936-03-31,MT,Malta,
-1936-03-31,MX,Mexico,
-1936-03-31,MY,Malaysia,
-1936-03-31,NL,Netherlands,
-1936-03-31,NO,Norway,
-1936-03-31,NZ,New Zealand,
-1936-03-31,PE,Peru,
-1936-03-31,PH,Philippines,
-1936-03-31,PL,Poland,
-1936-03-31,PT,Portugal,
-1936-03-31,RO,Romania,
-1936-03-31,RS,Serbia,
-1936-03-31,RU,Russia,
-1936-03-31,SE,Sweden,
-1936-03-31,SG,Singapore,
-1936-03-31,SI,Slovenia,
-1936-03-31,SK,Slovak Republic,
-1936-03-31,TH,Thailand,
-1936-03-31,TR,Türkiye,
-1936-03-31,US,United States,
-1936-03-31,XM,Euro area,
-1936-03-31,XW,World,
-1936-03-31,ZA,South Africa,
-1936-06-30,4T,Emerging market economies (aggregate),
-1936-06-30,5R,Advanced economies,
-1936-06-30,AE,United Arab Emirates,
-1936-06-30,AT,Austria,
-1936-06-30,AU,Australia,
-1936-06-30,BE,Belgium,
-1936-06-30,BG,Bulgaria,
-1936-06-30,BR,Brazil,
-1936-06-30,CA,Canada,
-1936-06-30,CH,Switzerland,
-1936-06-30,CL,Chile,
-1936-06-30,CN,China,
-1936-06-30,CO,Colombia,
-1936-06-30,CY,Cyprus,
-1936-06-30,CZ,Czechia,
-1936-06-30,DE,Germany,
-1936-06-30,DK,Denmark,
-1936-06-30,EE,Estonia,
-1936-06-30,ES,Spain,
-1936-06-30,FI,Finland,
-1936-06-30,FR,France,
-1936-06-30,GB,United Kingdom,
-1936-06-30,GR,Greece,
-1936-06-30,HK,Hong Kong SAR,
-1936-06-30,HR,Croatia,
-1936-06-30,HU,Hungary,
-1936-06-30,ID,Indonesia,
-1936-06-30,IE,Ireland,
-1936-06-30,IL,Israel,
-1936-06-30,IN,India,
-1936-06-30,IS,Iceland,
 1936-06-30,IT,Italy,0.012
-1936-06-30,JP,Japan,
-1936-06-30,KR,Korea,
-1936-06-30,LT,Lithuania,
-1936-06-30,LU,Luxembourg,
-1936-06-30,LV,Latvia,
-1936-06-30,MA,Morocco,
-1936-06-30,MK,North Macedonia,
-1936-06-30,MT,Malta,
-1936-06-30,MX,Mexico,
-1936-06-30,MY,Malaysia,
-1936-06-30,NL,Netherlands,
-1936-06-30,NO,Norway,
-1936-06-30,NZ,New Zealand,
-1936-06-30,PE,Peru,
-1936-06-30,PH,Philippines,
-1936-06-30,PL,Poland,
-1936-06-30,PT,Portugal,
-1936-06-30,RO,Romania,
-1936-06-30,RS,Serbia,
-1936-06-30,RU,Russia,
-1936-06-30,SE,Sweden,
-1936-06-30,SG,Singapore,
-1936-06-30,SI,Slovenia,
-1936-06-30,SK,Slovak Republic,
-1936-06-30,TH,Thailand,
-1936-06-30,TR,Türkiye,
-1936-06-30,US,United States,
-1936-06-30,XM,Euro area,
-1936-06-30,XW,World,
-1936-06-30,ZA,South Africa,
-1936-09-30,4T,Emerging market economies (aggregate),
-1936-09-30,5R,Advanced economies,
-1936-09-30,AE,United Arab Emirates,
-1936-09-30,AT,Austria,
-1936-09-30,AU,Australia,
-1936-09-30,BE,Belgium,
-1936-09-30,BG,Bulgaria,
-1936-09-30,BR,Brazil,
-1936-09-30,CA,Canada,
-1936-09-30,CH,Switzerland,
-1936-09-30,CL,Chile,
-1936-09-30,CN,China,
-1936-09-30,CO,Colombia,
-1936-09-30,CY,Cyprus,
-1936-09-30,CZ,Czechia,
-1936-09-30,DE,Germany,
-1936-09-30,DK,Denmark,
-1936-09-30,EE,Estonia,
-1936-09-30,ES,Spain,
-1936-09-30,FI,Finland,
-1936-09-30,FR,France,
-1936-09-30,GB,United Kingdom,
-1936-09-30,GR,Greece,
-1936-09-30,HK,Hong Kong SAR,
-1936-09-30,HR,Croatia,
-1936-09-30,HU,Hungary,
-1936-09-30,ID,Indonesia,
-1936-09-30,IE,Ireland,
-1936-09-30,IL,Israel,
-1936-09-30,IN,India,
-1936-09-30,IS,Iceland,
 1936-09-30,IT,Italy,0.012
-1936-09-30,JP,Japan,
-1936-09-30,KR,Korea,
-1936-09-30,LT,Lithuania,
-1936-09-30,LU,Luxembourg,
-1936-09-30,LV,Latvia,
-1936-09-30,MA,Morocco,
-1936-09-30,MK,North Macedonia,
-1936-09-30,MT,Malta,
-1936-09-30,MX,Mexico,
-1936-09-30,MY,Malaysia,
-1936-09-30,NL,Netherlands,
-1936-09-30,NO,Norway,
-1936-09-30,NZ,New Zealand,
-1936-09-30,PE,Peru,
-1936-09-30,PH,Philippines,
-1936-09-30,PL,Poland,
-1936-09-30,PT,Portugal,
-1936-09-30,RO,Romania,
-1936-09-30,RS,Serbia,
-1936-09-30,RU,Russia,
-1936-09-30,SE,Sweden,
-1936-09-30,SG,Singapore,
-1936-09-30,SI,Slovenia,
-1936-09-30,SK,Slovak Republic,
-1936-09-30,TH,Thailand,
-1936-09-30,TR,Türkiye,
-1936-09-30,US,United States,
-1936-09-30,XM,Euro area,
-1936-09-30,XW,World,
-1936-09-30,ZA,South Africa,
-1936-12-31,4T,Emerging market economies (aggregate),
-1936-12-31,5R,Advanced economies,
-1936-12-31,AE,United Arab Emirates,
-1936-12-31,AT,Austria,
-1936-12-31,AU,Australia,
-1936-12-31,BE,Belgium,
-1936-12-31,BG,Bulgaria,
-1936-12-31,BR,Brazil,
-1936-12-31,CA,Canada,
-1936-12-31,CH,Switzerland,
-1936-12-31,CL,Chile,
-1936-12-31,CN,China,
-1936-12-31,CO,Colombia,
-1936-12-31,CY,Cyprus,
-1936-12-31,CZ,Czechia,
-1936-12-31,DE,Germany,
-1936-12-31,DK,Denmark,
-1936-12-31,EE,Estonia,
-1936-12-31,ES,Spain,
-1936-12-31,FI,Finland,
-1936-12-31,FR,France,
-1936-12-31,GB,United Kingdom,
-1936-12-31,GR,Greece,
-1936-12-31,HK,Hong Kong SAR,
-1936-12-31,HR,Croatia,
-1936-12-31,HU,Hungary,
-1936-12-31,ID,Indonesia,
-1936-12-31,IE,Ireland,
-1936-12-31,IL,Israel,
-1936-12-31,IN,India,
-1936-12-31,IS,Iceland,
 1936-12-31,IT,Italy,0.0121
-1936-12-31,JP,Japan,
-1936-12-31,KR,Korea,
-1936-12-31,LT,Lithuania,
-1936-12-31,LU,Luxembourg,
-1936-12-31,LV,Latvia,
-1936-12-31,MA,Morocco,
-1936-12-31,MK,North Macedonia,
-1936-12-31,MT,Malta,
-1936-12-31,MX,Mexico,
-1936-12-31,MY,Malaysia,
-1936-12-31,NL,Netherlands,
-1936-12-31,NO,Norway,
-1936-12-31,NZ,New Zealand,
-1936-12-31,PE,Peru,
-1936-12-31,PH,Philippines,
-1936-12-31,PL,Poland,
-1936-12-31,PT,Portugal,
-1936-12-31,RO,Romania,
-1936-12-31,RS,Serbia,
-1936-12-31,RU,Russia,
-1936-12-31,SE,Sweden,
-1936-12-31,SG,Singapore,
-1936-12-31,SI,Slovenia,
-1936-12-31,SK,Slovak Republic,
-1936-12-31,TH,Thailand,
-1936-12-31,TR,Türkiye,
-1936-12-31,US,United States,
-1936-12-31,XM,Euro area,
-1936-12-31,XW,World,
-1936-12-31,ZA,South Africa,
-1937-03-31,4T,Emerging market economies (aggregate),
-1937-03-31,5R,Advanced economies,
-1937-03-31,AE,United Arab Emirates,
-1937-03-31,AT,Austria,
-1937-03-31,AU,Australia,
-1937-03-31,BE,Belgium,
-1937-03-31,BG,Bulgaria,
-1937-03-31,BR,Brazil,
-1937-03-31,CA,Canada,
-1937-03-31,CH,Switzerland,
-1937-03-31,CL,Chile,
-1937-03-31,CN,China,
-1937-03-31,CO,Colombia,
-1937-03-31,CY,Cyprus,
-1937-03-31,CZ,Czechia,
-1937-03-31,DE,Germany,
-1937-03-31,DK,Denmark,
-1937-03-31,EE,Estonia,
-1937-03-31,ES,Spain,
-1937-03-31,FI,Finland,
-1937-03-31,FR,France,
-1937-03-31,GB,United Kingdom,
-1937-03-31,GR,Greece,
-1937-03-31,HK,Hong Kong SAR,
-1937-03-31,HR,Croatia,
-1937-03-31,HU,Hungary,
-1937-03-31,ID,Indonesia,
-1937-03-31,IE,Ireland,
-1937-03-31,IL,Israel,
-1937-03-31,IN,India,
-1937-03-31,IS,Iceland,
 1937-03-31,IT,Italy,0.0122
-1937-03-31,JP,Japan,
-1937-03-31,KR,Korea,
-1937-03-31,LT,Lithuania,
-1937-03-31,LU,Luxembourg,
-1937-03-31,LV,Latvia,
-1937-03-31,MA,Morocco,
-1937-03-31,MK,North Macedonia,
-1937-03-31,MT,Malta,
-1937-03-31,MX,Mexico,
-1937-03-31,MY,Malaysia,
-1937-03-31,NL,Netherlands,
-1937-03-31,NO,Norway,
-1937-03-31,NZ,New Zealand,
-1937-03-31,PE,Peru,
-1937-03-31,PH,Philippines,
-1937-03-31,PL,Poland,
-1937-03-31,PT,Portugal,
-1937-03-31,RO,Romania,
-1937-03-31,RS,Serbia,
-1937-03-31,RU,Russia,
-1937-03-31,SE,Sweden,
-1937-03-31,SG,Singapore,
-1937-03-31,SI,Slovenia,
-1937-03-31,SK,Slovak Republic,
-1937-03-31,TH,Thailand,
-1937-03-31,TR,Türkiye,
-1937-03-31,US,United States,
-1937-03-31,XM,Euro area,
-1937-03-31,XW,World,
-1937-03-31,ZA,South Africa,
-1937-06-30,4T,Emerging market economies (aggregate),
-1937-06-30,5R,Advanced economies,
-1937-06-30,AE,United Arab Emirates,
-1937-06-30,AT,Austria,
-1937-06-30,AU,Australia,
-1937-06-30,BE,Belgium,
-1937-06-30,BG,Bulgaria,
-1937-06-30,BR,Brazil,
-1937-06-30,CA,Canada,
-1937-06-30,CH,Switzerland,
-1937-06-30,CL,Chile,
-1937-06-30,CN,China,
-1937-06-30,CO,Colombia,
-1937-06-30,CY,Cyprus,
-1937-06-30,CZ,Czechia,
-1937-06-30,DE,Germany,
-1937-06-30,DK,Denmark,
-1937-06-30,EE,Estonia,
-1937-06-30,ES,Spain,
-1937-06-30,FI,Finland,
-1937-06-30,FR,France,
-1937-06-30,GB,United Kingdom,
-1937-06-30,GR,Greece,
-1937-06-30,HK,Hong Kong SAR,
-1937-06-30,HR,Croatia,
-1937-06-30,HU,Hungary,
-1937-06-30,ID,Indonesia,
-1937-06-30,IE,Ireland,
-1937-06-30,IL,Israel,
-1937-06-30,IN,India,
-1937-06-30,IS,Iceland,
 1937-06-30,IT,Italy,0.0123
-1937-06-30,JP,Japan,
-1937-06-30,KR,Korea,
-1937-06-30,LT,Lithuania,
-1937-06-30,LU,Luxembourg,
-1937-06-30,LV,Latvia,
-1937-06-30,MA,Morocco,
-1937-06-30,MK,North Macedonia,
-1937-06-30,MT,Malta,
-1937-06-30,MX,Mexico,
-1937-06-30,MY,Malaysia,
-1937-06-30,NL,Netherlands,
-1937-06-30,NO,Norway,
-1937-06-30,NZ,New Zealand,
-1937-06-30,PE,Peru,
-1937-06-30,PH,Philippines,
-1937-06-30,PL,Poland,
-1937-06-30,PT,Portugal,
-1937-06-30,RO,Romania,
-1937-06-30,RS,Serbia,
-1937-06-30,RU,Russia,
-1937-06-30,SE,Sweden,
-1937-06-30,SG,Singapore,
-1937-06-30,SI,Slovenia,
-1937-06-30,SK,Slovak Republic,
-1937-06-30,TH,Thailand,
-1937-06-30,TR,Türkiye,
-1937-06-30,US,United States,
-1937-06-30,XM,Euro area,
-1937-06-30,XW,World,
-1937-06-30,ZA,South Africa,
-1937-09-30,4T,Emerging market economies (aggregate),
-1937-09-30,5R,Advanced economies,
-1937-09-30,AE,United Arab Emirates,
-1937-09-30,AT,Austria,
-1937-09-30,AU,Australia,
-1937-09-30,BE,Belgium,
-1937-09-30,BG,Bulgaria,
-1937-09-30,BR,Brazil,
-1937-09-30,CA,Canada,
-1937-09-30,CH,Switzerland,
-1937-09-30,CL,Chile,
-1937-09-30,CN,China,
-1937-09-30,CO,Colombia,
-1937-09-30,CY,Cyprus,
-1937-09-30,CZ,Czechia,
-1937-09-30,DE,Germany,
-1937-09-30,DK,Denmark,
-1937-09-30,EE,Estonia,
-1937-09-30,ES,Spain,
-1937-09-30,FI,Finland,
-1937-09-30,FR,France,
-1937-09-30,GB,United Kingdom,
-1937-09-30,GR,Greece,
-1937-09-30,HK,Hong Kong SAR,
-1937-09-30,HR,Croatia,
-1937-09-30,HU,Hungary,
-1937-09-30,ID,Indonesia,
-1937-09-30,IE,Ireland,
-1937-09-30,IL,Israel,
-1937-09-30,IN,India,
-1937-09-30,IS,Iceland,
 1937-09-30,IT,Italy,0.0124
-1937-09-30,JP,Japan,
-1937-09-30,KR,Korea,
-1937-09-30,LT,Lithuania,
-1937-09-30,LU,Luxembourg,
-1937-09-30,LV,Latvia,
-1937-09-30,MA,Morocco,
-1937-09-30,MK,North Macedonia,
-1937-09-30,MT,Malta,
-1937-09-30,MX,Mexico,
-1937-09-30,MY,Malaysia,
-1937-09-30,NL,Netherlands,
-1937-09-30,NO,Norway,
-1937-09-30,NZ,New Zealand,
-1937-09-30,PE,Peru,
-1937-09-30,PH,Philippines,
-1937-09-30,PL,Poland,
-1937-09-30,PT,Portugal,
-1937-09-30,RO,Romania,
-1937-09-30,RS,Serbia,
-1937-09-30,RU,Russia,
-1937-09-30,SE,Sweden,
-1937-09-30,SG,Singapore,
-1937-09-30,SI,Slovenia,
-1937-09-30,SK,Slovak Republic,
-1937-09-30,TH,Thailand,
-1937-09-30,TR,Türkiye,
-1937-09-30,US,United States,
-1937-09-30,XM,Euro area,
-1937-09-30,XW,World,
-1937-09-30,ZA,South Africa,
-1937-12-31,4T,Emerging market economies (aggregate),
-1937-12-31,5R,Advanced economies,
-1937-12-31,AE,United Arab Emirates,
-1937-12-31,AT,Austria,
-1937-12-31,AU,Australia,
-1937-12-31,BE,Belgium,
-1937-12-31,BG,Bulgaria,
-1937-12-31,BR,Brazil,
-1937-12-31,CA,Canada,
-1937-12-31,CH,Switzerland,
-1937-12-31,CL,Chile,
-1937-12-31,CN,China,
-1937-12-31,CO,Colombia,
-1937-12-31,CY,Cyprus,
-1937-12-31,CZ,Czechia,
-1937-12-31,DE,Germany,
-1937-12-31,DK,Denmark,
-1937-12-31,EE,Estonia,
-1937-12-31,ES,Spain,
-1937-12-31,FI,Finland,
-1937-12-31,FR,France,
-1937-12-31,GB,United Kingdom,
-1937-12-31,GR,Greece,
-1937-12-31,HK,Hong Kong SAR,
-1937-12-31,HR,Croatia,
-1937-12-31,HU,Hungary,
-1937-12-31,ID,Indonesia,
-1937-12-31,IE,Ireland,
-1937-12-31,IL,Israel,
-1937-12-31,IN,India,
-1937-12-31,IS,Iceland,
 1937-12-31,IT,Italy,0.0125
-1937-12-31,JP,Japan,
-1937-12-31,KR,Korea,
-1937-12-31,LT,Lithuania,
-1937-12-31,LU,Luxembourg,
-1937-12-31,LV,Latvia,
-1937-12-31,MA,Morocco,
-1937-12-31,MK,North Macedonia,
-1937-12-31,MT,Malta,
-1937-12-31,MX,Mexico,
-1937-12-31,MY,Malaysia,
-1937-12-31,NL,Netherlands,
-1937-12-31,NO,Norway,
-1937-12-31,NZ,New Zealand,
-1937-12-31,PE,Peru,
-1937-12-31,PH,Philippines,
-1937-12-31,PL,Poland,
-1937-12-31,PT,Portugal,
-1937-12-31,RO,Romania,
-1937-12-31,RS,Serbia,
-1937-12-31,RU,Russia,
-1937-12-31,SE,Sweden,
-1937-12-31,SG,Singapore,
-1937-12-31,SI,Slovenia,
-1937-12-31,SK,Slovak Republic,
-1937-12-31,TH,Thailand,
-1937-12-31,TR,Türkiye,
-1937-12-31,US,United States,
-1937-12-31,XM,Euro area,
-1937-12-31,XW,World,
-1937-12-31,ZA,South Africa,
-1938-03-31,4T,Emerging market economies (aggregate),
-1938-03-31,5R,Advanced economies,
-1938-03-31,AE,United Arab Emirates,
-1938-03-31,AT,Austria,
-1938-03-31,AU,Australia,
-1938-03-31,BE,Belgium,
-1938-03-31,BG,Bulgaria,
-1938-03-31,BR,Brazil,
-1938-03-31,CA,Canada,
-1938-03-31,CH,Switzerland,
-1938-03-31,CL,Chile,
-1938-03-31,CN,China,
-1938-03-31,CO,Colombia,
-1938-03-31,CY,Cyprus,
-1938-03-31,CZ,Czechia,
-1938-03-31,DE,Germany,
-1938-03-31,DK,Denmark,
-1938-03-31,EE,Estonia,
-1938-03-31,ES,Spain,
-1938-03-31,FI,Finland,
-1938-03-31,FR,France,
-1938-03-31,GB,United Kingdom,
-1938-03-31,GR,Greece,
-1938-03-31,HK,Hong Kong SAR,
-1938-03-31,HR,Croatia,
-1938-03-31,HU,Hungary,
-1938-03-31,ID,Indonesia,
-1938-03-31,IE,Ireland,
-1938-03-31,IL,Israel,
-1938-03-31,IN,India,
-1938-03-31,IS,Iceland,
 1938-03-31,IT,Italy,0.0126
-1938-03-31,JP,Japan,
-1938-03-31,KR,Korea,
-1938-03-31,LT,Lithuania,
-1938-03-31,LU,Luxembourg,
-1938-03-31,LV,Latvia,
-1938-03-31,MA,Morocco,
-1938-03-31,MK,North Macedonia,
-1938-03-31,MT,Malta,
-1938-03-31,MX,Mexico,
-1938-03-31,MY,Malaysia,
-1938-03-31,NL,Netherlands,
-1938-03-31,NO,Norway,
-1938-03-31,NZ,New Zealand,
-1938-03-31,PE,Peru,
-1938-03-31,PH,Philippines,
-1938-03-31,PL,Poland,
-1938-03-31,PT,Portugal,
-1938-03-31,RO,Romania,
-1938-03-31,RS,Serbia,
-1938-03-31,RU,Russia,
-1938-03-31,SE,Sweden,
-1938-03-31,SG,Singapore,
-1938-03-31,SI,Slovenia,
-1938-03-31,SK,Slovak Republic,
-1938-03-31,TH,Thailand,
-1938-03-31,TR,Türkiye,
-1938-03-31,US,United States,
-1938-03-31,XM,Euro area,
-1938-03-31,XW,World,
-1938-03-31,ZA,South Africa,
-1938-06-30,4T,Emerging market economies (aggregate),
-1938-06-30,5R,Advanced economies,
-1938-06-30,AE,United Arab Emirates,
-1938-06-30,AT,Austria,
-1938-06-30,AU,Australia,
-1938-06-30,BE,Belgium,
-1938-06-30,BG,Bulgaria,
-1938-06-30,BR,Brazil,
-1938-06-30,CA,Canada,
-1938-06-30,CH,Switzerland,
-1938-06-30,CL,Chile,
-1938-06-30,CN,China,
-1938-06-30,CO,Colombia,
-1938-06-30,CY,Cyprus,
-1938-06-30,CZ,Czechia,
-1938-06-30,DE,Germany,
-1938-06-30,DK,Denmark,
-1938-06-30,EE,Estonia,
-1938-06-30,ES,Spain,
-1938-06-30,FI,Finland,
-1938-06-30,FR,France,
-1938-06-30,GB,United Kingdom,
-1938-06-30,GR,Greece,
-1938-06-30,HK,Hong Kong SAR,
-1938-06-30,HR,Croatia,
-1938-06-30,HU,Hungary,
-1938-06-30,ID,Indonesia,
-1938-06-30,IE,Ireland,
-1938-06-30,IL,Israel,
-1938-06-30,IN,India,
-1938-06-30,IS,Iceland,
 1938-06-30,IT,Italy,0.0127
-1938-06-30,JP,Japan,
-1938-06-30,KR,Korea,
-1938-06-30,LT,Lithuania,
-1938-06-30,LU,Luxembourg,
-1938-06-30,LV,Latvia,
-1938-06-30,MA,Morocco,
-1938-06-30,MK,North Macedonia,
-1938-06-30,MT,Malta,
-1938-06-30,MX,Mexico,
-1938-06-30,MY,Malaysia,
-1938-06-30,NL,Netherlands,
-1938-06-30,NO,Norway,
-1938-06-30,NZ,New Zealand,
-1938-06-30,PE,Peru,
-1938-06-30,PH,Philippines,
-1938-06-30,PL,Poland,
-1938-06-30,PT,Portugal,
-1938-06-30,RO,Romania,
-1938-06-30,RS,Serbia,
-1938-06-30,RU,Russia,
-1938-06-30,SE,Sweden,
-1938-06-30,SG,Singapore,
-1938-06-30,SI,Slovenia,
-1938-06-30,SK,Slovak Republic,
-1938-06-30,TH,Thailand,
-1938-06-30,TR,Türkiye,
-1938-06-30,US,United States,
-1938-06-30,XM,Euro area,
-1938-06-30,XW,World,
-1938-06-30,ZA,South Africa,
-1938-09-30,4T,Emerging market economies (aggregate),
-1938-09-30,5R,Advanced economies,
-1938-09-30,AE,United Arab Emirates,
-1938-09-30,AT,Austria,
-1938-09-30,AU,Australia,
-1938-09-30,BE,Belgium,
-1938-09-30,BG,Bulgaria,
-1938-09-30,BR,Brazil,
-1938-09-30,CA,Canada,
-1938-09-30,CH,Switzerland,
-1938-09-30,CL,Chile,
-1938-09-30,CN,China,
-1938-09-30,CO,Colombia,
-1938-09-30,CY,Cyprus,
-1938-09-30,CZ,Czechia,
-1938-09-30,DE,Germany,
-1938-09-30,DK,Denmark,
-1938-09-30,EE,Estonia,
-1938-09-30,ES,Spain,
-1938-09-30,FI,Finland,
-1938-09-30,FR,France,
-1938-09-30,GB,United Kingdom,
-1938-09-30,GR,Greece,
-1938-09-30,HK,Hong Kong SAR,
-1938-09-30,HR,Croatia,
-1938-09-30,HU,Hungary,
-1938-09-30,ID,Indonesia,
-1938-09-30,IE,Ireland,
-1938-09-30,IL,Israel,
-1938-09-30,IN,India,
-1938-09-30,IS,Iceland,
 1938-09-30,IT,Italy,0.0128
-1938-09-30,JP,Japan,
-1938-09-30,KR,Korea,
-1938-09-30,LT,Lithuania,
-1938-09-30,LU,Luxembourg,
-1938-09-30,LV,Latvia,
-1938-09-30,MA,Morocco,
-1938-09-30,MK,North Macedonia,
-1938-09-30,MT,Malta,
-1938-09-30,MX,Mexico,
-1938-09-30,MY,Malaysia,
-1938-09-30,NL,Netherlands,
-1938-09-30,NO,Norway,
-1938-09-30,NZ,New Zealand,
-1938-09-30,PE,Peru,
-1938-09-30,PH,Philippines,
-1938-09-30,PL,Poland,
-1938-09-30,PT,Portugal,
-1938-09-30,RO,Romania,
-1938-09-30,RS,Serbia,
-1938-09-30,RU,Russia,
-1938-09-30,SE,Sweden,
-1938-09-30,SG,Singapore,
-1938-09-30,SI,Slovenia,
-1938-09-30,SK,Slovak Republic,
-1938-09-30,TH,Thailand,
-1938-09-30,TR,Türkiye,
-1938-09-30,US,United States,
-1938-09-30,XM,Euro area,
-1938-09-30,XW,World,
-1938-09-30,ZA,South Africa,
-1938-12-31,4T,Emerging market economies (aggregate),
-1938-12-31,5R,Advanced economies,
-1938-12-31,AE,United Arab Emirates,
-1938-12-31,AT,Austria,
-1938-12-31,AU,Australia,
-1938-12-31,BE,Belgium,
-1938-12-31,BG,Bulgaria,
-1938-12-31,BR,Brazil,
-1938-12-31,CA,Canada,
-1938-12-31,CH,Switzerland,
-1938-12-31,CL,Chile,
-1938-12-31,CN,China,
-1938-12-31,CO,Colombia,
-1938-12-31,CY,Cyprus,
-1938-12-31,CZ,Czechia,
-1938-12-31,DE,Germany,
-1938-12-31,DK,Denmark,
-1938-12-31,EE,Estonia,
-1938-12-31,ES,Spain,
-1938-12-31,FI,Finland,
-1938-12-31,FR,France,
-1938-12-31,GB,United Kingdom,
-1938-12-31,GR,Greece,
-1938-12-31,HK,Hong Kong SAR,
-1938-12-31,HR,Croatia,
-1938-12-31,HU,Hungary,
-1938-12-31,ID,Indonesia,
-1938-12-31,IE,Ireland,
-1938-12-31,IL,Israel,
-1938-12-31,IN,India,
-1938-12-31,IS,Iceland,
 1938-12-31,IT,Italy,0.0129
-1938-12-31,JP,Japan,
-1938-12-31,KR,Korea,
-1938-12-31,LT,Lithuania,
-1938-12-31,LU,Luxembourg,
-1938-12-31,LV,Latvia,
-1938-12-31,MA,Morocco,
-1938-12-31,MK,North Macedonia,
-1938-12-31,MT,Malta,
-1938-12-31,MX,Mexico,
-1938-12-31,MY,Malaysia,
-1938-12-31,NL,Netherlands,
-1938-12-31,NO,Norway,
-1938-12-31,NZ,New Zealand,
-1938-12-31,PE,Peru,
-1938-12-31,PH,Philippines,
-1938-12-31,PL,Poland,
-1938-12-31,PT,Portugal,
-1938-12-31,RO,Romania,
-1938-12-31,RS,Serbia,
-1938-12-31,RU,Russia,
-1938-12-31,SE,Sweden,
-1938-12-31,SG,Singapore,
-1938-12-31,SI,Slovenia,
-1938-12-31,SK,Slovak Republic,
-1938-12-31,TH,Thailand,
-1938-12-31,TR,Türkiye,
-1938-12-31,US,United States,
-1938-12-31,XM,Euro area,
-1938-12-31,XW,World,
-1938-12-31,ZA,South Africa,
-1939-03-31,4T,Emerging market economies (aggregate),
-1939-03-31,5R,Advanced economies,
-1939-03-31,AE,United Arab Emirates,
-1939-03-31,AT,Austria,
-1939-03-31,AU,Australia,
-1939-03-31,BE,Belgium,
-1939-03-31,BG,Bulgaria,
-1939-03-31,BR,Brazil,
-1939-03-31,CA,Canada,
-1939-03-31,CH,Switzerland,
-1939-03-31,CL,Chile,
-1939-03-31,CN,China,
-1939-03-31,CO,Colombia,
-1939-03-31,CY,Cyprus,
-1939-03-31,CZ,Czechia,
-1939-03-31,DE,Germany,
-1939-03-31,DK,Denmark,
-1939-03-31,EE,Estonia,
-1939-03-31,ES,Spain,
-1939-03-31,FI,Finland,
-1939-03-31,FR,France,
-1939-03-31,GB,United Kingdom,
-1939-03-31,GR,Greece,
-1939-03-31,HK,Hong Kong SAR,
-1939-03-31,HR,Croatia,
-1939-03-31,HU,Hungary,
-1939-03-31,ID,Indonesia,
-1939-03-31,IE,Ireland,
-1939-03-31,IL,Israel,
-1939-03-31,IN,India,
-1939-03-31,IS,Iceland,
 1939-03-31,IT,Italy,0.013
-1939-03-31,JP,Japan,
-1939-03-31,KR,Korea,
-1939-03-31,LT,Lithuania,
-1939-03-31,LU,Luxembourg,
-1939-03-31,LV,Latvia,
-1939-03-31,MA,Morocco,
-1939-03-31,MK,North Macedonia,
-1939-03-31,MT,Malta,
-1939-03-31,MX,Mexico,
-1939-03-31,MY,Malaysia,
-1939-03-31,NL,Netherlands,
-1939-03-31,NO,Norway,
-1939-03-31,NZ,New Zealand,
-1939-03-31,PE,Peru,
-1939-03-31,PH,Philippines,
-1939-03-31,PL,Poland,
-1939-03-31,PT,Portugal,
-1939-03-31,RO,Romania,
-1939-03-31,RS,Serbia,
-1939-03-31,RU,Russia,
-1939-03-31,SE,Sweden,
-1939-03-31,SG,Singapore,
-1939-03-31,SI,Slovenia,
-1939-03-31,SK,Slovak Republic,
-1939-03-31,TH,Thailand,
-1939-03-31,TR,Türkiye,
-1939-03-31,US,United States,
-1939-03-31,XM,Euro area,
-1939-03-31,XW,World,
-1939-03-31,ZA,South Africa,
-1939-06-30,4T,Emerging market economies (aggregate),
-1939-06-30,5R,Advanced economies,
-1939-06-30,AE,United Arab Emirates,
-1939-06-30,AT,Austria,
-1939-06-30,AU,Australia,
-1939-06-30,BE,Belgium,
-1939-06-30,BG,Bulgaria,
-1939-06-30,BR,Brazil,
-1939-06-30,CA,Canada,
-1939-06-30,CH,Switzerland,
-1939-06-30,CL,Chile,
-1939-06-30,CN,China,
-1939-06-30,CO,Colombia,
-1939-06-30,CY,Cyprus,
-1939-06-30,CZ,Czechia,
-1939-06-30,DE,Germany,
-1939-06-30,DK,Denmark,
-1939-06-30,EE,Estonia,
-1939-06-30,ES,Spain,
-1939-06-30,FI,Finland,
-1939-06-30,FR,France,
-1939-06-30,GB,United Kingdom,
-1939-06-30,GR,Greece,
-1939-06-30,HK,Hong Kong SAR,
-1939-06-30,HR,Croatia,
-1939-06-30,HU,Hungary,
-1939-06-30,ID,Indonesia,
-1939-06-30,IE,Ireland,
-1939-06-30,IL,Israel,
-1939-06-30,IN,India,
-1939-06-30,IS,Iceland,
 1939-06-30,IT,Italy,0.013
-1939-06-30,JP,Japan,
-1939-06-30,KR,Korea,
-1939-06-30,LT,Lithuania,
-1939-06-30,LU,Luxembourg,
-1939-06-30,LV,Latvia,
-1939-06-30,MA,Morocco,
-1939-06-30,MK,North Macedonia,
-1939-06-30,MT,Malta,
-1939-06-30,MX,Mexico,
-1939-06-30,MY,Malaysia,
-1939-06-30,NL,Netherlands,
-1939-06-30,NO,Norway,
-1939-06-30,NZ,New Zealand,
-1939-06-30,PE,Peru,
-1939-06-30,PH,Philippines,
-1939-06-30,PL,Poland,
-1939-06-30,PT,Portugal,
-1939-06-30,RO,Romania,
-1939-06-30,RS,Serbia,
-1939-06-30,RU,Russia,
-1939-06-30,SE,Sweden,
-1939-06-30,SG,Singapore,
-1939-06-30,SI,Slovenia,
-1939-06-30,SK,Slovak Republic,
-1939-06-30,TH,Thailand,
-1939-06-30,TR,Türkiye,
-1939-06-30,US,United States,
-1939-06-30,XM,Euro area,
-1939-06-30,XW,World,
-1939-06-30,ZA,South Africa,
-1939-09-30,4T,Emerging market economies (aggregate),
-1939-09-30,5R,Advanced economies,
-1939-09-30,AE,United Arab Emirates,
-1939-09-30,AT,Austria,
-1939-09-30,AU,Australia,
-1939-09-30,BE,Belgium,
-1939-09-30,BG,Bulgaria,
-1939-09-30,BR,Brazil,
-1939-09-30,CA,Canada,
-1939-09-30,CH,Switzerland,
-1939-09-30,CL,Chile,
-1939-09-30,CN,China,
-1939-09-30,CO,Colombia,
-1939-09-30,CY,Cyprus,
-1939-09-30,CZ,Czechia,
-1939-09-30,DE,Germany,
-1939-09-30,DK,Denmark,
-1939-09-30,EE,Estonia,
-1939-09-30,ES,Spain,
-1939-09-30,FI,Finland,
-1939-09-30,FR,France,
-1939-09-30,GB,United Kingdom,
-1939-09-30,GR,Greece,
-1939-09-30,HK,Hong Kong SAR,
-1939-09-30,HR,Croatia,
-1939-09-30,HU,Hungary,
-1939-09-30,ID,Indonesia,
-1939-09-30,IE,Ireland,
-1939-09-30,IL,Israel,
-1939-09-30,IN,India,
-1939-09-30,IS,Iceland,
 1939-09-30,IT,Italy,0.0132
-1939-09-30,JP,Japan,
-1939-09-30,KR,Korea,
-1939-09-30,LT,Lithuania,
-1939-09-30,LU,Luxembourg,
-1939-09-30,LV,Latvia,
-1939-09-30,MA,Morocco,
-1939-09-30,MK,North Macedonia,
-1939-09-30,MT,Malta,
-1939-09-30,MX,Mexico,
-1939-09-30,MY,Malaysia,
-1939-09-30,NL,Netherlands,
-1939-09-30,NO,Norway,
-1939-09-30,NZ,New Zealand,
-1939-09-30,PE,Peru,
-1939-09-30,PH,Philippines,
-1939-09-30,PL,Poland,
-1939-09-30,PT,Portugal,
-1939-09-30,RO,Romania,
-1939-09-30,RS,Serbia,
-1939-09-30,RU,Russia,
-1939-09-30,SE,Sweden,
-1939-09-30,SG,Singapore,
-1939-09-30,SI,Slovenia,
-1939-09-30,SK,Slovak Republic,
-1939-09-30,TH,Thailand,
-1939-09-30,TR,Türkiye,
-1939-09-30,US,United States,
-1939-09-30,XM,Euro area,
-1939-09-30,XW,World,
-1939-09-30,ZA,South Africa,
-1939-12-31,4T,Emerging market economies (aggregate),
-1939-12-31,5R,Advanced economies,
-1939-12-31,AE,United Arab Emirates,
-1939-12-31,AT,Austria,
-1939-12-31,AU,Australia,
-1939-12-31,BE,Belgium,
-1939-12-31,BG,Bulgaria,
-1939-12-31,BR,Brazil,
-1939-12-31,CA,Canada,
-1939-12-31,CH,Switzerland,
-1939-12-31,CL,Chile,
-1939-12-31,CN,China,
-1939-12-31,CO,Colombia,
-1939-12-31,CY,Cyprus,
-1939-12-31,CZ,Czechia,
-1939-12-31,DE,Germany,
-1939-12-31,DK,Denmark,
-1939-12-31,EE,Estonia,
-1939-12-31,ES,Spain,
-1939-12-31,FI,Finland,
-1939-12-31,FR,France,
-1939-12-31,GB,United Kingdom,
-1939-12-31,GR,Greece,
-1939-12-31,HK,Hong Kong SAR,
-1939-12-31,HR,Croatia,
-1939-12-31,HU,Hungary,
-1939-12-31,ID,Indonesia,
-1939-12-31,IE,Ireland,
-1939-12-31,IL,Israel,
-1939-12-31,IN,India,
-1939-12-31,IS,Iceland,
 1939-12-31,IT,Italy,0.0134
-1939-12-31,JP,Japan,
-1939-12-31,KR,Korea,
-1939-12-31,LT,Lithuania,
-1939-12-31,LU,Luxembourg,
-1939-12-31,LV,Latvia,
-1939-12-31,MA,Morocco,
-1939-12-31,MK,North Macedonia,
-1939-12-31,MT,Malta,
-1939-12-31,MX,Mexico,
-1939-12-31,MY,Malaysia,
-1939-12-31,NL,Netherlands,
-1939-12-31,NO,Norway,
-1939-12-31,NZ,New Zealand,
-1939-12-31,PE,Peru,
-1939-12-31,PH,Philippines,
-1939-12-31,PL,Poland,
-1939-12-31,PT,Portugal,
-1939-12-31,RO,Romania,
-1939-12-31,RS,Serbia,
-1939-12-31,RU,Russia,
-1939-12-31,SE,Sweden,
-1939-12-31,SG,Singapore,
-1939-12-31,SI,Slovenia,
-1939-12-31,SK,Slovak Republic,
-1939-12-31,TH,Thailand,
-1939-12-31,TR,Türkiye,
-1939-12-31,US,United States,
-1939-12-31,XM,Euro area,
-1939-12-31,XW,World,
-1939-12-31,ZA,South Africa,
-1940-03-31,4T,Emerging market economies (aggregate),
-1940-03-31,5R,Advanced economies,
-1940-03-31,AE,United Arab Emirates,
-1940-03-31,AT,Austria,
-1940-03-31,AU,Australia,
-1940-03-31,BE,Belgium,
-1940-03-31,BG,Bulgaria,
-1940-03-31,BR,Brazil,
-1940-03-31,CA,Canada,
-1940-03-31,CH,Switzerland,
-1940-03-31,CL,Chile,
-1940-03-31,CN,China,
-1940-03-31,CO,Colombia,
-1940-03-31,CY,Cyprus,
-1940-03-31,CZ,Czechia,
-1940-03-31,DE,Germany,
-1940-03-31,DK,Denmark,
-1940-03-31,EE,Estonia,
-1940-03-31,ES,Spain,
-1940-03-31,FI,Finland,
-1940-03-31,FR,France,
-1940-03-31,GB,United Kingdom,
-1940-03-31,GR,Greece,
-1940-03-31,HK,Hong Kong SAR,
-1940-03-31,HR,Croatia,
-1940-03-31,HU,Hungary,
-1940-03-31,ID,Indonesia,
-1940-03-31,IE,Ireland,
-1940-03-31,IL,Israel,
-1940-03-31,IN,India,
-1940-03-31,IS,Iceland,
 1940-03-31,IT,Italy,0.0136
-1940-03-31,JP,Japan,
-1940-03-31,KR,Korea,
-1940-03-31,LT,Lithuania,
-1940-03-31,LU,Luxembourg,
-1940-03-31,LV,Latvia,
-1940-03-31,MA,Morocco,
-1940-03-31,MK,North Macedonia,
-1940-03-31,MT,Malta,
-1940-03-31,MX,Mexico,
-1940-03-31,MY,Malaysia,
-1940-03-31,NL,Netherlands,
-1940-03-31,NO,Norway,
-1940-03-31,NZ,New Zealand,
-1940-03-31,PE,Peru,
-1940-03-31,PH,Philippines,
-1940-03-31,PL,Poland,
-1940-03-31,PT,Portugal,
-1940-03-31,RO,Romania,
-1940-03-31,RS,Serbia,
-1940-03-31,RU,Russia,
-1940-03-31,SE,Sweden,
-1940-03-31,SG,Singapore,
-1940-03-31,SI,Slovenia,
-1940-03-31,SK,Slovak Republic,
-1940-03-31,TH,Thailand,
-1940-03-31,TR,Türkiye,
-1940-03-31,US,United States,
-1940-03-31,XM,Euro area,
-1940-03-31,XW,World,
-1940-03-31,ZA,South Africa,
-1940-06-30,4T,Emerging market economies (aggregate),
-1940-06-30,5R,Advanced economies,
-1940-06-30,AE,United Arab Emirates,
-1940-06-30,AT,Austria,
-1940-06-30,AU,Australia,
-1940-06-30,BE,Belgium,
-1940-06-30,BG,Bulgaria,
-1940-06-30,BR,Brazil,
-1940-06-30,CA,Canada,
-1940-06-30,CH,Switzerland,
-1940-06-30,CL,Chile,
-1940-06-30,CN,China,
-1940-06-30,CO,Colombia,
-1940-06-30,CY,Cyprus,
-1940-06-30,CZ,Czechia,
-1940-06-30,DE,Germany,
-1940-06-30,DK,Denmark,
-1940-06-30,EE,Estonia,
-1940-06-30,ES,Spain,
-1940-06-30,FI,Finland,
-1940-06-30,FR,France,
-1940-06-30,GB,United Kingdom,
-1940-06-30,GR,Greece,
-1940-06-30,HK,Hong Kong SAR,
-1940-06-30,HR,Croatia,
-1940-06-30,HU,Hungary,
-1940-06-30,ID,Indonesia,
-1940-06-30,IE,Ireland,
-1940-06-30,IL,Israel,
-1940-06-30,IN,India,
-1940-06-30,IS,Iceland,
 1940-06-30,IT,Italy,0.0138
-1940-06-30,JP,Japan,
-1940-06-30,KR,Korea,
-1940-06-30,LT,Lithuania,
-1940-06-30,LU,Luxembourg,
-1940-06-30,LV,Latvia,
-1940-06-30,MA,Morocco,
-1940-06-30,MK,North Macedonia,
-1940-06-30,MT,Malta,
-1940-06-30,MX,Mexico,
-1940-06-30,MY,Malaysia,
-1940-06-30,NL,Netherlands,
-1940-06-30,NO,Norway,
-1940-06-30,NZ,New Zealand,
-1940-06-30,PE,Peru,
-1940-06-30,PH,Philippines,
-1940-06-30,PL,Poland,
-1940-06-30,PT,Portugal,
-1940-06-30,RO,Romania,
-1940-06-30,RS,Serbia,
-1940-06-30,RU,Russia,
-1940-06-30,SE,Sweden,
-1940-06-30,SG,Singapore,
-1940-06-30,SI,Slovenia,
-1940-06-30,SK,Slovak Republic,
-1940-06-30,TH,Thailand,
-1940-06-30,TR,Türkiye,
-1940-06-30,US,United States,
-1940-06-30,XM,Euro area,
-1940-06-30,XW,World,
-1940-06-30,ZA,South Africa,
-1940-09-30,4T,Emerging market economies (aggregate),
-1940-09-30,5R,Advanced economies,
-1940-09-30,AE,United Arab Emirates,
-1940-09-30,AT,Austria,
-1940-09-30,AU,Australia,
-1940-09-30,BE,Belgium,
-1940-09-30,BG,Bulgaria,
-1940-09-30,BR,Brazil,
-1940-09-30,CA,Canada,
-1940-09-30,CH,Switzerland,
-1940-09-30,CL,Chile,
-1940-09-30,CN,China,
-1940-09-30,CO,Colombia,
-1940-09-30,CY,Cyprus,
-1940-09-30,CZ,Czechia,
-1940-09-30,DE,Germany,
-1940-09-30,DK,Denmark,
-1940-09-30,EE,Estonia,
-1940-09-30,ES,Spain,
-1940-09-30,FI,Finland,
-1940-09-30,FR,France,
-1940-09-30,GB,United Kingdom,
-1940-09-30,GR,Greece,
-1940-09-30,HK,Hong Kong SAR,
-1940-09-30,HR,Croatia,
-1940-09-30,HU,Hungary,
-1940-09-30,ID,Indonesia,
-1940-09-30,IE,Ireland,
-1940-09-30,IL,Israel,
-1940-09-30,IN,India,
-1940-09-30,IS,Iceland,
 1940-09-30,IT,Italy,0.0142
-1940-09-30,JP,Japan,
-1940-09-30,KR,Korea,
-1940-09-30,LT,Lithuania,
-1940-09-30,LU,Luxembourg,
-1940-09-30,LV,Latvia,
-1940-09-30,MA,Morocco,
-1940-09-30,MK,North Macedonia,
-1940-09-30,MT,Malta,
-1940-09-30,MX,Mexico,
-1940-09-30,MY,Malaysia,
-1940-09-30,NL,Netherlands,
-1940-09-30,NO,Norway,
-1940-09-30,NZ,New Zealand,
-1940-09-30,PE,Peru,
-1940-09-30,PH,Philippines,
-1940-09-30,PL,Poland,
-1940-09-30,PT,Portugal,
-1940-09-30,RO,Romania,
-1940-09-30,RS,Serbia,
-1940-09-30,RU,Russia,
-1940-09-30,SE,Sweden,
-1940-09-30,SG,Singapore,
-1940-09-30,SI,Slovenia,
-1940-09-30,SK,Slovak Republic,
-1940-09-30,TH,Thailand,
-1940-09-30,TR,Türkiye,
-1940-09-30,US,United States,
-1940-09-30,XM,Euro area,
-1940-09-30,XW,World,
-1940-09-30,ZA,South Africa,
-1940-12-31,4T,Emerging market economies (aggregate),
-1940-12-31,5R,Advanced economies,
-1940-12-31,AE,United Arab Emirates,
-1940-12-31,AT,Austria,
-1940-12-31,AU,Australia,
-1940-12-31,BE,Belgium,
-1940-12-31,BG,Bulgaria,
-1940-12-31,BR,Brazil,
-1940-12-31,CA,Canada,
-1940-12-31,CH,Switzerland,
-1940-12-31,CL,Chile,
-1940-12-31,CN,China,
-1940-12-31,CO,Colombia,
-1940-12-31,CY,Cyprus,
-1940-12-31,CZ,Czechia,
-1940-12-31,DE,Germany,
-1940-12-31,DK,Denmark,
-1940-12-31,EE,Estonia,
-1940-12-31,ES,Spain,
-1940-12-31,FI,Finland,
-1940-12-31,FR,France,
-1940-12-31,GB,United Kingdom,
-1940-12-31,GR,Greece,
-1940-12-31,HK,Hong Kong SAR,
-1940-12-31,HR,Croatia,
-1940-12-31,HU,Hungary,
-1940-12-31,ID,Indonesia,
-1940-12-31,IE,Ireland,
-1940-12-31,IL,Israel,
-1940-12-31,IN,India,
-1940-12-31,IS,Iceland,
 1940-12-31,IT,Italy,0.0147
-1940-12-31,JP,Japan,
-1940-12-31,KR,Korea,
-1940-12-31,LT,Lithuania,
-1940-12-31,LU,Luxembourg,
-1940-12-31,LV,Latvia,
-1940-12-31,MA,Morocco,
-1940-12-31,MK,North Macedonia,
-1940-12-31,MT,Malta,
-1940-12-31,MX,Mexico,
-1940-12-31,MY,Malaysia,
-1940-12-31,NL,Netherlands,
-1940-12-31,NO,Norway,
-1940-12-31,NZ,New Zealand,
-1940-12-31,PE,Peru,
-1940-12-31,PH,Philippines,
-1940-12-31,PL,Poland,
-1940-12-31,PT,Portugal,
-1940-12-31,RO,Romania,
-1940-12-31,RS,Serbia,
-1940-12-31,RU,Russia,
-1940-12-31,SE,Sweden,
-1940-12-31,SG,Singapore,
-1940-12-31,SI,Slovenia,
-1940-12-31,SK,Slovak Republic,
-1940-12-31,TH,Thailand,
-1940-12-31,TR,Türkiye,
-1940-12-31,US,United States,
-1940-12-31,XM,Euro area,
-1940-12-31,XW,World,
-1940-12-31,ZA,South Africa,
-1941-03-31,4T,Emerging market economies (aggregate),
-1941-03-31,5R,Advanced economies,
-1941-03-31,AE,United Arab Emirates,
-1941-03-31,AT,Austria,
-1941-03-31,AU,Australia,
-1941-03-31,BE,Belgium,
-1941-03-31,BG,Bulgaria,
-1941-03-31,BR,Brazil,
-1941-03-31,CA,Canada,
-1941-03-31,CH,Switzerland,
-1941-03-31,CL,Chile,
-1941-03-31,CN,China,
-1941-03-31,CO,Colombia,
-1941-03-31,CY,Cyprus,
-1941-03-31,CZ,Czechia,
-1941-03-31,DE,Germany,
-1941-03-31,DK,Denmark,
-1941-03-31,EE,Estonia,
-1941-03-31,ES,Spain,
-1941-03-31,FI,Finland,
-1941-03-31,FR,France,
-1941-03-31,GB,United Kingdom,
-1941-03-31,GR,Greece,
-1941-03-31,HK,Hong Kong SAR,
-1941-03-31,HR,Croatia,
-1941-03-31,HU,Hungary,
-1941-03-31,ID,Indonesia,
-1941-03-31,IE,Ireland,
-1941-03-31,IL,Israel,
-1941-03-31,IN,India,
-1941-03-31,IS,Iceland,
 1941-03-31,IT,Italy,0.0153
-1941-03-31,JP,Japan,
-1941-03-31,KR,Korea,
-1941-03-31,LT,Lithuania,
-1941-03-31,LU,Luxembourg,
-1941-03-31,LV,Latvia,
-1941-03-31,MA,Morocco,
-1941-03-31,MK,North Macedonia,
-1941-03-31,MT,Malta,
-1941-03-31,MX,Mexico,
-1941-03-31,MY,Malaysia,
-1941-03-31,NL,Netherlands,
-1941-03-31,NO,Norway,
-1941-03-31,NZ,New Zealand,
-1941-03-31,PE,Peru,
-1941-03-31,PH,Philippines,
-1941-03-31,PL,Poland,
-1941-03-31,PT,Portugal,
-1941-03-31,RO,Romania,
-1941-03-31,RS,Serbia,
-1941-03-31,RU,Russia,
-1941-03-31,SE,Sweden,
-1941-03-31,SG,Singapore,
-1941-03-31,SI,Slovenia,
-1941-03-31,SK,Slovak Republic,
-1941-03-31,TH,Thailand,
-1941-03-31,TR,Türkiye,
-1941-03-31,US,United States,
-1941-03-31,XM,Euro area,
-1941-03-31,XW,World,
-1941-03-31,ZA,South Africa,
-1941-06-30,4T,Emerging market economies (aggregate),
-1941-06-30,5R,Advanced economies,
-1941-06-30,AE,United Arab Emirates,
-1941-06-30,AT,Austria,
-1941-06-30,AU,Australia,
-1941-06-30,BE,Belgium,
-1941-06-30,BG,Bulgaria,
-1941-06-30,BR,Brazil,
-1941-06-30,CA,Canada,
-1941-06-30,CH,Switzerland,
-1941-06-30,CL,Chile,
-1941-06-30,CN,China,
-1941-06-30,CO,Colombia,
-1941-06-30,CY,Cyprus,
-1941-06-30,CZ,Czechia,
-1941-06-30,DE,Germany,
-1941-06-30,DK,Denmark,
-1941-06-30,EE,Estonia,
-1941-06-30,ES,Spain,
-1941-06-30,FI,Finland,
-1941-06-30,FR,France,
-1941-06-30,GB,United Kingdom,
-1941-06-30,GR,Greece,
-1941-06-30,HK,Hong Kong SAR,
-1941-06-30,HR,Croatia,
-1941-06-30,HU,Hungary,
-1941-06-30,ID,Indonesia,
-1941-06-30,IE,Ireland,
-1941-06-30,IL,Israel,
-1941-06-30,IN,India,
-1941-06-30,IS,Iceland,
 1941-06-30,IT,Italy,0.0158
-1941-06-30,JP,Japan,
-1941-06-30,KR,Korea,
-1941-06-30,LT,Lithuania,
-1941-06-30,LU,Luxembourg,
-1941-06-30,LV,Latvia,
-1941-06-30,MA,Morocco,
-1941-06-30,MK,North Macedonia,
-1941-06-30,MT,Malta,
-1941-06-30,MX,Mexico,
-1941-06-30,MY,Malaysia,
-1941-06-30,NL,Netherlands,
-1941-06-30,NO,Norway,
-1941-06-30,NZ,New Zealand,
-1941-06-30,PE,Peru,
-1941-06-30,PH,Philippines,
-1941-06-30,PL,Poland,
-1941-06-30,PT,Portugal,
-1941-06-30,RO,Romania,
-1941-06-30,RS,Serbia,
-1941-06-30,RU,Russia,
-1941-06-30,SE,Sweden,
-1941-06-30,SG,Singapore,
-1941-06-30,SI,Slovenia,
-1941-06-30,SK,Slovak Republic,
-1941-06-30,TH,Thailand,
-1941-06-30,TR,Türkiye,
-1941-06-30,US,United States,
-1941-06-30,XM,Euro area,
-1941-06-30,XW,World,
-1941-06-30,ZA,South Africa,
-1941-09-30,4T,Emerging market economies (aggregate),
-1941-09-30,5R,Advanced economies,
-1941-09-30,AE,United Arab Emirates,
-1941-09-30,AT,Austria,
-1941-09-30,AU,Australia,
-1941-09-30,BE,Belgium,
-1941-09-30,BG,Bulgaria,
-1941-09-30,BR,Brazil,
-1941-09-30,CA,Canada,
-1941-09-30,CH,Switzerland,
-1941-09-30,CL,Chile,
-1941-09-30,CN,China,
-1941-09-30,CO,Colombia,
-1941-09-30,CY,Cyprus,
-1941-09-30,CZ,Czechia,
-1941-09-30,DE,Germany,
-1941-09-30,DK,Denmark,
-1941-09-30,EE,Estonia,
-1941-09-30,ES,Spain,
-1941-09-30,FI,Finland,
-1941-09-30,FR,France,
-1941-09-30,GB,United Kingdom,
-1941-09-30,GR,Greece,
-1941-09-30,HK,Hong Kong SAR,
-1941-09-30,HR,Croatia,
-1941-09-30,HU,Hungary,
-1941-09-30,ID,Indonesia,
-1941-09-30,IE,Ireland,
-1941-09-30,IL,Israel,
-1941-09-30,IN,India,
-1941-09-30,IS,Iceland,
 1941-09-30,IT,Italy,0.0162
-1941-09-30,JP,Japan,
-1941-09-30,KR,Korea,
-1941-09-30,LT,Lithuania,
-1941-09-30,LU,Luxembourg,
-1941-09-30,LV,Latvia,
-1941-09-30,MA,Morocco,
-1941-09-30,MK,North Macedonia,
-1941-09-30,MT,Malta,
-1941-09-30,MX,Mexico,
-1941-09-30,MY,Malaysia,
-1941-09-30,NL,Netherlands,
-1941-09-30,NO,Norway,
-1941-09-30,NZ,New Zealand,
-1941-09-30,PE,Peru,
-1941-09-30,PH,Philippines,
-1941-09-30,PL,Poland,
-1941-09-30,PT,Portugal,
-1941-09-30,RO,Romania,
-1941-09-30,RS,Serbia,
-1941-09-30,RU,Russia,
-1941-09-30,SE,Sweden,
-1941-09-30,SG,Singapore,
-1941-09-30,SI,Slovenia,
-1941-09-30,SK,Slovak Republic,
-1941-09-30,TH,Thailand,
-1941-09-30,TR,Türkiye,
-1941-09-30,US,United States,
-1941-09-30,XM,Euro area,
-1941-09-30,XW,World,
-1941-09-30,ZA,South Africa,
-1941-12-31,4T,Emerging market economies (aggregate),
-1941-12-31,5R,Advanced economies,
-1941-12-31,AE,United Arab Emirates,
-1941-12-31,AT,Austria,
-1941-12-31,AU,Australia,
-1941-12-31,BE,Belgium,
-1941-12-31,BG,Bulgaria,
-1941-12-31,BR,Brazil,
-1941-12-31,CA,Canada,
-1941-12-31,CH,Switzerland,
-1941-12-31,CL,Chile,
-1941-12-31,CN,China,
-1941-12-31,CO,Colombia,
-1941-12-31,CY,Cyprus,
-1941-12-31,CZ,Czechia,
-1941-12-31,DE,Germany,
-1941-12-31,DK,Denmark,
-1941-12-31,EE,Estonia,
-1941-12-31,ES,Spain,
-1941-12-31,FI,Finland,
-1941-12-31,FR,France,
-1941-12-31,GB,United Kingdom,
-1941-12-31,GR,Greece,
-1941-12-31,HK,Hong Kong SAR,
-1941-12-31,HR,Croatia,
-1941-12-31,HU,Hungary,
-1941-12-31,ID,Indonesia,
-1941-12-31,IE,Ireland,
-1941-12-31,IL,Israel,
-1941-12-31,IN,India,
-1941-12-31,IS,Iceland,
 1941-12-31,IT,Italy,0.0165
-1941-12-31,JP,Japan,
-1941-12-31,KR,Korea,
-1941-12-31,LT,Lithuania,
-1941-12-31,LU,Luxembourg,
-1941-12-31,LV,Latvia,
-1941-12-31,MA,Morocco,
-1941-12-31,MK,North Macedonia,
-1941-12-31,MT,Malta,
-1941-12-31,MX,Mexico,
-1941-12-31,MY,Malaysia,
-1941-12-31,NL,Netherlands,
-1941-12-31,NO,Norway,
-1941-12-31,NZ,New Zealand,
-1941-12-31,PE,Peru,
-1941-12-31,PH,Philippines,
-1941-12-31,PL,Poland,
-1941-12-31,PT,Portugal,
-1941-12-31,RO,Romania,
-1941-12-31,RS,Serbia,
-1941-12-31,RU,Russia,
-1941-12-31,SE,Sweden,
-1941-12-31,SG,Singapore,
-1941-12-31,SI,Slovenia,
-1941-12-31,SK,Slovak Republic,
-1941-12-31,TH,Thailand,
-1941-12-31,TR,Türkiye,
-1941-12-31,US,United States,
-1941-12-31,XM,Euro area,
-1941-12-31,XW,World,
-1941-12-31,ZA,South Africa,
-1942-03-31,4T,Emerging market economies (aggregate),
-1942-03-31,5R,Advanced economies,
-1942-03-31,AE,United Arab Emirates,
-1942-03-31,AT,Austria,
-1942-03-31,AU,Australia,
-1942-03-31,BE,Belgium,
-1942-03-31,BG,Bulgaria,
-1942-03-31,BR,Brazil,
-1942-03-31,CA,Canada,
-1942-03-31,CH,Switzerland,
-1942-03-31,CL,Chile,
-1942-03-31,CN,China,
-1942-03-31,CO,Colombia,
-1942-03-31,CY,Cyprus,
-1942-03-31,CZ,Czechia,
-1942-03-31,DE,Germany,
-1942-03-31,DK,Denmark,
-1942-03-31,EE,Estonia,
-1942-03-31,ES,Spain,
-1942-03-31,FI,Finland,
-1942-03-31,FR,France,
-1942-03-31,GB,United Kingdom,
-1942-03-31,GR,Greece,
-1942-03-31,HK,Hong Kong SAR,
-1942-03-31,HR,Croatia,
-1942-03-31,HU,Hungary,
-1942-03-31,ID,Indonesia,
-1942-03-31,IE,Ireland,
-1942-03-31,IL,Israel,
-1942-03-31,IN,India,
-1942-03-31,IS,Iceland,
 1942-03-31,IT,Italy,0.0168
-1942-03-31,JP,Japan,
-1942-03-31,KR,Korea,
-1942-03-31,LT,Lithuania,
-1942-03-31,LU,Luxembourg,
-1942-03-31,LV,Latvia,
-1942-03-31,MA,Morocco,
-1942-03-31,MK,North Macedonia,
-1942-03-31,MT,Malta,
-1942-03-31,MX,Mexico,
-1942-03-31,MY,Malaysia,
-1942-03-31,NL,Netherlands,
-1942-03-31,NO,Norway,
-1942-03-31,NZ,New Zealand,
-1942-03-31,PE,Peru,
-1942-03-31,PH,Philippines,
-1942-03-31,PL,Poland,
-1942-03-31,PT,Portugal,
-1942-03-31,RO,Romania,
-1942-03-31,RS,Serbia,
-1942-03-31,RU,Russia,
-1942-03-31,SE,Sweden,
-1942-03-31,SG,Singapore,
-1942-03-31,SI,Slovenia,
-1942-03-31,SK,Slovak Republic,
-1942-03-31,TH,Thailand,
-1942-03-31,TR,Türkiye,
-1942-03-31,US,United States,
-1942-03-31,XM,Euro area,
-1942-03-31,XW,World,
-1942-03-31,ZA,South Africa,
-1942-06-30,4T,Emerging market economies (aggregate),
-1942-06-30,5R,Advanced economies,
-1942-06-30,AE,United Arab Emirates,
-1942-06-30,AT,Austria,
-1942-06-30,AU,Australia,
-1942-06-30,BE,Belgium,
-1942-06-30,BG,Bulgaria,
-1942-06-30,BR,Brazil,
-1942-06-30,CA,Canada,
-1942-06-30,CH,Switzerland,
-1942-06-30,CL,Chile,
-1942-06-30,CN,China,
-1942-06-30,CO,Colombia,
-1942-06-30,CY,Cyprus,
-1942-06-30,CZ,Czechia,
-1942-06-30,DE,Germany,
-1942-06-30,DK,Denmark,
-1942-06-30,EE,Estonia,
-1942-06-30,ES,Spain,
-1942-06-30,FI,Finland,
-1942-06-30,FR,France,
-1942-06-30,GB,United Kingdom,
-1942-06-30,GR,Greece,
-1942-06-30,HK,Hong Kong SAR,
-1942-06-30,HR,Croatia,
-1942-06-30,HU,Hungary,
-1942-06-30,ID,Indonesia,
-1942-06-30,IE,Ireland,
-1942-06-30,IL,Israel,
-1942-06-30,IN,India,
-1942-06-30,IS,Iceland,
 1942-06-30,IT,Italy,0.0171
-1942-06-30,JP,Japan,
-1942-06-30,KR,Korea,
-1942-06-30,LT,Lithuania,
-1942-06-30,LU,Luxembourg,
-1942-06-30,LV,Latvia,
-1942-06-30,MA,Morocco,
-1942-06-30,MK,North Macedonia,
-1942-06-30,MT,Malta,
-1942-06-30,MX,Mexico,
-1942-06-30,MY,Malaysia,
-1942-06-30,NL,Netherlands,
-1942-06-30,NO,Norway,
-1942-06-30,NZ,New Zealand,
-1942-06-30,PE,Peru,
-1942-06-30,PH,Philippines,
-1942-06-30,PL,Poland,
-1942-06-30,PT,Portugal,
-1942-06-30,RO,Romania,
-1942-06-30,RS,Serbia,
-1942-06-30,RU,Russia,
-1942-06-30,SE,Sweden,
-1942-06-30,SG,Singapore,
-1942-06-30,SI,Slovenia,
-1942-06-30,SK,Slovak Republic,
-1942-06-30,TH,Thailand,
-1942-06-30,TR,Türkiye,
-1942-06-30,US,United States,
-1942-06-30,XM,Euro area,
-1942-06-30,XW,World,
-1942-06-30,ZA,South Africa,
-1942-09-30,4T,Emerging market economies (aggregate),
-1942-09-30,5R,Advanced economies,
-1942-09-30,AE,United Arab Emirates,
-1942-09-30,AT,Austria,
-1942-09-30,AU,Australia,
-1942-09-30,BE,Belgium,
-1942-09-30,BG,Bulgaria,
-1942-09-30,BR,Brazil,
-1942-09-30,CA,Canada,
-1942-09-30,CH,Switzerland,
-1942-09-30,CL,Chile,
-1942-09-30,CN,China,
-1942-09-30,CO,Colombia,
-1942-09-30,CY,Cyprus,
-1942-09-30,CZ,Czechia,
-1942-09-30,DE,Germany,
-1942-09-30,DK,Denmark,
-1942-09-30,EE,Estonia,
-1942-09-30,ES,Spain,
-1942-09-30,FI,Finland,
-1942-09-30,FR,France,
-1942-09-30,GB,United Kingdom,
-1942-09-30,GR,Greece,
-1942-09-30,HK,Hong Kong SAR,
-1942-09-30,HR,Croatia,
-1942-09-30,HU,Hungary,
-1942-09-30,ID,Indonesia,
-1942-09-30,IE,Ireland,
-1942-09-30,IL,Israel,
-1942-09-30,IN,India,
-1942-09-30,IS,Iceland,
 1942-09-30,IT,Italy,0.0178
-1942-09-30,JP,Japan,
-1942-09-30,KR,Korea,
-1942-09-30,LT,Lithuania,
-1942-09-30,LU,Luxembourg,
-1942-09-30,LV,Latvia,
-1942-09-30,MA,Morocco,
-1942-09-30,MK,North Macedonia,
-1942-09-30,MT,Malta,
-1942-09-30,MX,Mexico,
-1942-09-30,MY,Malaysia,
-1942-09-30,NL,Netherlands,
-1942-09-30,NO,Norway,
-1942-09-30,NZ,New Zealand,
-1942-09-30,PE,Peru,
-1942-09-30,PH,Philippines,
-1942-09-30,PL,Poland,
-1942-09-30,PT,Portugal,
-1942-09-30,RO,Romania,
-1942-09-30,RS,Serbia,
-1942-09-30,RU,Russia,
-1942-09-30,SE,Sweden,
-1942-09-30,SG,Singapore,
-1942-09-30,SI,Slovenia,
-1942-09-30,SK,Slovak Republic,
-1942-09-30,TH,Thailand,
-1942-09-30,TR,Türkiye,
-1942-09-30,US,United States,
-1942-09-30,XM,Euro area,
-1942-09-30,XW,World,
-1942-09-30,ZA,South Africa,
-1942-12-31,4T,Emerging market economies (aggregate),
-1942-12-31,5R,Advanced economies,
-1942-12-31,AE,United Arab Emirates,
-1942-12-31,AT,Austria,
-1942-12-31,AU,Australia,
-1942-12-31,BE,Belgium,
-1942-12-31,BG,Bulgaria,
-1942-12-31,BR,Brazil,
-1942-12-31,CA,Canada,
-1942-12-31,CH,Switzerland,
-1942-12-31,CL,Chile,
-1942-12-31,CN,China,
-1942-12-31,CO,Colombia,
-1942-12-31,CY,Cyprus,
-1942-12-31,CZ,Czechia,
-1942-12-31,DE,Germany,
-1942-12-31,DK,Denmark,
-1942-12-31,EE,Estonia,
-1942-12-31,ES,Spain,
-1942-12-31,FI,Finland,
-1942-12-31,FR,France,
-1942-12-31,GB,United Kingdom,
-1942-12-31,GR,Greece,
-1942-12-31,HK,Hong Kong SAR,
-1942-12-31,HR,Croatia,
-1942-12-31,HU,Hungary,
-1942-12-31,ID,Indonesia,
-1942-12-31,IE,Ireland,
-1942-12-31,IL,Israel,
-1942-12-31,IN,India,
-1942-12-31,IS,Iceland,
 1942-12-31,IT,Italy,0.0188
-1942-12-31,JP,Japan,
-1942-12-31,KR,Korea,
-1942-12-31,LT,Lithuania,
-1942-12-31,LU,Luxembourg,
-1942-12-31,LV,Latvia,
-1942-12-31,MA,Morocco,
-1942-12-31,MK,North Macedonia,
-1942-12-31,MT,Malta,
-1942-12-31,MX,Mexico,
-1942-12-31,MY,Malaysia,
-1942-12-31,NL,Netherlands,
-1942-12-31,NO,Norway,
-1942-12-31,NZ,New Zealand,
-1942-12-31,PE,Peru,
-1942-12-31,PH,Philippines,
-1942-12-31,PL,Poland,
-1942-12-31,PT,Portugal,
-1942-12-31,RO,Romania,
-1942-12-31,RS,Serbia,
-1942-12-31,RU,Russia,
-1942-12-31,SE,Sweden,
-1942-12-31,SG,Singapore,
-1942-12-31,SI,Slovenia,
-1942-12-31,SK,Slovak Republic,
-1942-12-31,TH,Thailand,
-1942-12-31,TR,Türkiye,
-1942-12-31,US,United States,
-1942-12-31,XM,Euro area,
-1942-12-31,XW,World,
-1942-12-31,ZA,South Africa,
-1943-03-31,4T,Emerging market economies (aggregate),
-1943-03-31,5R,Advanced economies,
-1943-03-31,AE,United Arab Emirates,
-1943-03-31,AT,Austria,
-1943-03-31,AU,Australia,
-1943-03-31,BE,Belgium,
-1943-03-31,BG,Bulgaria,
-1943-03-31,BR,Brazil,
-1943-03-31,CA,Canada,
-1943-03-31,CH,Switzerland,
-1943-03-31,CL,Chile,
-1943-03-31,CN,China,
-1943-03-31,CO,Colombia,
-1943-03-31,CY,Cyprus,
-1943-03-31,CZ,Czechia,
-1943-03-31,DE,Germany,
-1943-03-31,DK,Denmark,
-1943-03-31,EE,Estonia,
-1943-03-31,ES,Spain,
-1943-03-31,FI,Finland,
-1943-03-31,FR,France,
-1943-03-31,GB,United Kingdom,
-1943-03-31,GR,Greece,
-1943-03-31,HK,Hong Kong SAR,
-1943-03-31,HR,Croatia,
-1943-03-31,HU,Hungary,
-1943-03-31,ID,Indonesia,
-1943-03-31,IE,Ireland,
-1943-03-31,IL,Israel,
-1943-03-31,IN,India,
-1943-03-31,IS,Iceland,
 1943-03-31,IT,Italy,0.0199
-1943-03-31,JP,Japan,
-1943-03-31,KR,Korea,
-1943-03-31,LT,Lithuania,
-1943-03-31,LU,Luxembourg,
-1943-03-31,LV,Latvia,
-1943-03-31,MA,Morocco,
-1943-03-31,MK,North Macedonia,
-1943-03-31,MT,Malta,
-1943-03-31,MX,Mexico,
-1943-03-31,MY,Malaysia,
-1943-03-31,NL,Netherlands,
-1943-03-31,NO,Norway,
-1943-03-31,NZ,New Zealand,
-1943-03-31,PE,Peru,
-1943-03-31,PH,Philippines,
-1943-03-31,PL,Poland,
-1943-03-31,PT,Portugal,
-1943-03-31,RO,Romania,
-1943-03-31,RS,Serbia,
-1943-03-31,RU,Russia,
-1943-03-31,SE,Sweden,
-1943-03-31,SG,Singapore,
-1943-03-31,SI,Slovenia,
-1943-03-31,SK,Slovak Republic,
-1943-03-31,TH,Thailand,
-1943-03-31,TR,Türkiye,
-1943-03-31,US,United States,
-1943-03-31,XM,Euro area,
-1943-03-31,XW,World,
-1943-03-31,ZA,South Africa,
-1943-06-30,4T,Emerging market economies (aggregate),
-1943-06-30,5R,Advanced economies,
-1943-06-30,AE,United Arab Emirates,
-1943-06-30,AT,Austria,
-1943-06-30,AU,Australia,
-1943-06-30,BE,Belgium,
-1943-06-30,BG,Bulgaria,
-1943-06-30,BR,Brazil,
-1943-06-30,CA,Canada,
-1943-06-30,CH,Switzerland,
-1943-06-30,CL,Chile,
-1943-06-30,CN,China,
-1943-06-30,CO,Colombia,
-1943-06-30,CY,Cyprus,
-1943-06-30,CZ,Czechia,
-1943-06-30,DE,Germany,
-1943-06-30,DK,Denmark,
-1943-06-30,EE,Estonia,
-1943-06-30,ES,Spain,
-1943-06-30,FI,Finland,
-1943-06-30,FR,France,
-1943-06-30,GB,United Kingdom,
-1943-06-30,GR,Greece,
-1943-06-30,HK,Hong Kong SAR,
-1943-06-30,HR,Croatia,
-1943-06-30,HU,Hungary,
-1943-06-30,ID,Indonesia,
-1943-06-30,IE,Ireland,
-1943-06-30,IL,Israel,
-1943-06-30,IN,India,
-1943-06-30,IS,Iceland,
 1943-06-30,IT,Italy,0.021
-1943-06-30,JP,Japan,
-1943-06-30,KR,Korea,
-1943-06-30,LT,Lithuania,
-1943-06-30,LU,Luxembourg,
-1943-06-30,LV,Latvia,
-1943-06-30,MA,Morocco,
-1943-06-30,MK,North Macedonia,
-1943-06-30,MT,Malta,
-1943-06-30,MX,Mexico,
-1943-06-30,MY,Malaysia,
-1943-06-30,NL,Netherlands,
-1943-06-30,NO,Norway,
-1943-06-30,NZ,New Zealand,
-1943-06-30,PE,Peru,
-1943-06-30,PH,Philippines,
-1943-06-30,PL,Poland,
-1943-06-30,PT,Portugal,
-1943-06-30,RO,Romania,
-1943-06-30,RS,Serbia,
-1943-06-30,RU,Russia,
-1943-06-30,SE,Sweden,
-1943-06-30,SG,Singapore,
-1943-06-30,SI,Slovenia,
-1943-06-30,SK,Slovak Republic,
-1943-06-30,TH,Thailand,
-1943-06-30,TR,Türkiye,
-1943-06-30,US,United States,
-1943-06-30,XM,Euro area,
-1943-06-30,XW,World,
-1943-06-30,ZA,South Africa,
-1943-09-30,4T,Emerging market economies (aggregate),
-1943-09-30,5R,Advanced economies,
-1943-09-30,AE,United Arab Emirates,
-1943-09-30,AT,Austria,
-1943-09-30,AU,Australia,
-1943-09-30,BE,Belgium,
-1943-09-30,BG,Bulgaria,
-1943-09-30,BR,Brazil,
-1943-09-30,CA,Canada,
-1943-09-30,CH,Switzerland,
-1943-09-30,CL,Chile,
-1943-09-30,CN,China,
-1943-09-30,CO,Colombia,
-1943-09-30,CY,Cyprus,
-1943-09-30,CZ,Czechia,
-1943-09-30,DE,Germany,
-1943-09-30,DK,Denmark,
-1943-09-30,EE,Estonia,
-1943-09-30,ES,Spain,
-1943-09-30,FI,Finland,
-1943-09-30,FR,France,
-1943-09-30,GB,United Kingdom,
-1943-09-30,GR,Greece,
-1943-09-30,HK,Hong Kong SAR,
-1943-09-30,HR,Croatia,
-1943-09-30,HU,Hungary,
-1943-09-30,ID,Indonesia,
-1943-09-30,IE,Ireland,
-1943-09-30,IL,Israel,
-1943-09-30,IN,India,
-1943-09-30,IS,Iceland,
 1943-09-30,IT,Italy,0.0287
-1943-09-30,JP,Japan,
-1943-09-30,KR,Korea,
-1943-09-30,LT,Lithuania,
-1943-09-30,LU,Luxembourg,
-1943-09-30,LV,Latvia,
-1943-09-30,MA,Morocco,
-1943-09-30,MK,North Macedonia,
-1943-09-30,MT,Malta,
-1943-09-30,MX,Mexico,
-1943-09-30,MY,Malaysia,
-1943-09-30,NL,Netherlands,
-1943-09-30,NO,Norway,
-1943-09-30,NZ,New Zealand,
-1943-09-30,PE,Peru,
-1943-09-30,PH,Philippines,
-1943-09-30,PL,Poland,
-1943-09-30,PT,Portugal,
-1943-09-30,RO,Romania,
-1943-09-30,RS,Serbia,
-1943-09-30,RU,Russia,
-1943-09-30,SE,Sweden,
-1943-09-30,SG,Singapore,
-1943-09-30,SI,Slovenia,
-1943-09-30,SK,Slovak Republic,
-1943-09-30,TH,Thailand,
-1943-09-30,TR,Türkiye,
-1943-09-30,US,United States,
-1943-09-30,XM,Euro area,
-1943-09-30,XW,World,
-1943-09-30,ZA,South Africa,
-1943-12-31,4T,Emerging market economies (aggregate),
-1943-12-31,5R,Advanced economies,
-1943-12-31,AE,United Arab Emirates,
-1943-12-31,AT,Austria,
-1943-12-31,AU,Australia,
-1943-12-31,BE,Belgium,
-1943-12-31,BG,Bulgaria,
-1943-12-31,BR,Brazil,
-1943-12-31,CA,Canada,
-1943-12-31,CH,Switzerland,
-1943-12-31,CL,Chile,
-1943-12-31,CN,China,
-1943-12-31,CO,Colombia,
-1943-12-31,CY,Cyprus,
-1943-12-31,CZ,Czechia,
-1943-12-31,DE,Germany,
-1943-12-31,DK,Denmark,
-1943-12-31,EE,Estonia,
-1943-12-31,ES,Spain,
-1943-12-31,FI,Finland,
-1943-12-31,FR,France,
-1943-12-31,GB,United Kingdom,
-1943-12-31,GR,Greece,
-1943-12-31,HK,Hong Kong SAR,
-1943-12-31,HR,Croatia,
-1943-12-31,HU,Hungary,
-1943-12-31,ID,Indonesia,
-1943-12-31,IE,Ireland,
-1943-12-31,IL,Israel,
-1943-12-31,IN,India,
-1943-12-31,IS,Iceland,
 1943-12-31,IT,Italy,0.0435
-1943-12-31,JP,Japan,
-1943-12-31,KR,Korea,
-1943-12-31,LT,Lithuania,
-1943-12-31,LU,Luxembourg,
-1943-12-31,LV,Latvia,
-1943-12-31,MA,Morocco,
-1943-12-31,MK,North Macedonia,
-1943-12-31,MT,Malta,
-1943-12-31,MX,Mexico,
-1943-12-31,MY,Malaysia,
-1943-12-31,NL,Netherlands,
-1943-12-31,NO,Norway,
-1943-12-31,NZ,New Zealand,
-1943-12-31,PE,Peru,
-1943-12-31,PH,Philippines,
-1943-12-31,PL,Poland,
-1943-12-31,PT,Portugal,
-1943-12-31,RO,Romania,
-1943-12-31,RS,Serbia,
-1943-12-31,RU,Russia,
-1943-12-31,SE,Sweden,
-1943-12-31,SG,Singapore,
-1943-12-31,SI,Slovenia,
-1943-12-31,SK,Slovak Republic,
-1943-12-31,TH,Thailand,
-1943-12-31,TR,Türkiye,
-1943-12-31,US,United States,
-1943-12-31,XM,Euro area,
-1943-12-31,XW,World,
-1943-12-31,ZA,South Africa,
-1944-03-31,4T,Emerging market economies (aggregate),
-1944-03-31,5R,Advanced economies,
-1944-03-31,AE,United Arab Emirates,
-1944-03-31,AT,Austria,
-1944-03-31,AU,Australia,
-1944-03-31,BE,Belgium,
-1944-03-31,BG,Bulgaria,
-1944-03-31,BR,Brazil,
-1944-03-31,CA,Canada,
-1944-03-31,CH,Switzerland,
-1944-03-31,CL,Chile,
-1944-03-31,CN,China,
-1944-03-31,CO,Colombia,
-1944-03-31,CY,Cyprus,
-1944-03-31,CZ,Czechia,
-1944-03-31,DE,Germany,
-1944-03-31,DK,Denmark,
-1944-03-31,EE,Estonia,
-1944-03-31,ES,Spain,
-1944-03-31,FI,Finland,
-1944-03-31,FR,France,
-1944-03-31,GB,United Kingdom,
-1944-03-31,GR,Greece,
-1944-03-31,HK,Hong Kong SAR,
-1944-03-31,HR,Croatia,
-1944-03-31,HU,Hungary,
-1944-03-31,ID,Indonesia,
-1944-03-31,IE,Ireland,
-1944-03-31,IL,Israel,
-1944-03-31,IN,India,
-1944-03-31,IS,Iceland,
 1944-03-31,IT,Italy,0.0583
-1944-03-31,JP,Japan,
-1944-03-31,KR,Korea,
-1944-03-31,LT,Lithuania,
-1944-03-31,LU,Luxembourg,
-1944-03-31,LV,Latvia,
-1944-03-31,MA,Morocco,
-1944-03-31,MK,North Macedonia,
-1944-03-31,MT,Malta,
-1944-03-31,MX,Mexico,
-1944-03-31,MY,Malaysia,
-1944-03-31,NL,Netherlands,
-1944-03-31,NO,Norway,
-1944-03-31,NZ,New Zealand,
-1944-03-31,PE,Peru,
-1944-03-31,PH,Philippines,
-1944-03-31,PL,Poland,
-1944-03-31,PT,Portugal,
-1944-03-31,RO,Romania,
-1944-03-31,RS,Serbia,
-1944-03-31,RU,Russia,
-1944-03-31,SE,Sweden,
-1944-03-31,SG,Singapore,
-1944-03-31,SI,Slovenia,
-1944-03-31,SK,Slovak Republic,
-1944-03-31,TH,Thailand,
-1944-03-31,TR,Türkiye,
-1944-03-31,US,United States,
-1944-03-31,XM,Euro area,
-1944-03-31,XW,World,
-1944-03-31,ZA,South Africa,
-1944-06-30,4T,Emerging market economies (aggregate),
-1944-06-30,5R,Advanced economies,
-1944-06-30,AE,United Arab Emirates,
-1944-06-30,AT,Austria,
-1944-06-30,AU,Australia,
-1944-06-30,BE,Belgium,
-1944-06-30,BG,Bulgaria,
-1944-06-30,BR,Brazil,
-1944-06-30,CA,Canada,
-1944-06-30,CH,Switzerland,
-1944-06-30,CL,Chile,
-1944-06-30,CN,China,
-1944-06-30,CO,Colombia,
-1944-06-30,CY,Cyprus,
-1944-06-30,CZ,Czechia,
-1944-06-30,DE,Germany,
-1944-06-30,DK,Denmark,
-1944-06-30,EE,Estonia,
-1944-06-30,ES,Spain,
-1944-06-30,FI,Finland,
-1944-06-30,FR,France,
-1944-06-30,GB,United Kingdom,
-1944-06-30,GR,Greece,
-1944-06-30,HK,Hong Kong SAR,
-1944-06-30,HR,Croatia,
-1944-06-30,HU,Hungary,
-1944-06-30,ID,Indonesia,
-1944-06-30,IE,Ireland,
-1944-06-30,IL,Israel,
-1944-06-30,IN,India,
-1944-06-30,IS,Iceland,
 1944-06-30,IT,Italy,0.0729
-1944-06-30,JP,Japan,
-1944-06-30,KR,Korea,
-1944-06-30,LT,Lithuania,
-1944-06-30,LU,Luxembourg,
-1944-06-30,LV,Latvia,
-1944-06-30,MA,Morocco,
-1944-06-30,MK,North Macedonia,
-1944-06-30,MT,Malta,
-1944-06-30,MX,Mexico,
-1944-06-30,MY,Malaysia,
-1944-06-30,NL,Netherlands,
-1944-06-30,NO,Norway,
-1944-06-30,NZ,New Zealand,
-1944-06-30,PE,Peru,
-1944-06-30,PH,Philippines,
-1944-06-30,PL,Poland,
-1944-06-30,PT,Portugal,
-1944-06-30,RO,Romania,
-1944-06-30,RS,Serbia,
-1944-06-30,RU,Russia,
-1944-06-30,SE,Sweden,
-1944-06-30,SG,Singapore,
-1944-06-30,SI,Slovenia,
-1944-06-30,SK,Slovak Republic,
-1944-06-30,TH,Thailand,
-1944-06-30,TR,Türkiye,
-1944-06-30,US,United States,
-1944-06-30,XM,Euro area,
-1944-06-30,XW,World,
-1944-06-30,ZA,South Africa,
-1944-09-30,4T,Emerging market economies (aggregate),
-1944-09-30,5R,Advanced economies,
-1944-09-30,AE,United Arab Emirates,
-1944-09-30,AT,Austria,
-1944-09-30,AU,Australia,
-1944-09-30,BE,Belgium,
-1944-09-30,BG,Bulgaria,
-1944-09-30,BR,Brazil,
-1944-09-30,CA,Canada,
-1944-09-30,CH,Switzerland,
-1944-09-30,CL,Chile,
-1944-09-30,CN,China,
-1944-09-30,CO,Colombia,
-1944-09-30,CY,Cyprus,
-1944-09-30,CZ,Czechia,
-1944-09-30,DE,Germany,
-1944-09-30,DK,Denmark,
-1944-09-30,EE,Estonia,
-1944-09-30,ES,Spain,
-1944-09-30,FI,Finland,
-1944-09-30,FR,France,
-1944-09-30,GB,United Kingdom,
-1944-09-30,GR,Greece,
-1944-09-30,HK,Hong Kong SAR,
-1944-09-30,HR,Croatia,
-1944-09-30,HU,Hungary,
-1944-09-30,ID,Indonesia,
-1944-09-30,IE,Ireland,
-1944-09-30,IL,Israel,
-1944-09-30,IN,India,
-1944-09-30,IS,Iceland,
 1944-09-30,IT,Italy,0.1165
-1944-09-30,JP,Japan,
-1944-09-30,KR,Korea,
-1944-09-30,LT,Lithuania,
-1944-09-30,LU,Luxembourg,
-1944-09-30,LV,Latvia,
-1944-09-30,MA,Morocco,
-1944-09-30,MK,North Macedonia,
-1944-09-30,MT,Malta,
-1944-09-30,MX,Mexico,
-1944-09-30,MY,Malaysia,
-1944-09-30,NL,Netherlands,
-1944-09-30,NO,Norway,
-1944-09-30,NZ,New Zealand,
-1944-09-30,PE,Peru,
-1944-09-30,PH,Philippines,
-1944-09-30,PL,Poland,
-1944-09-30,PT,Portugal,
-1944-09-30,RO,Romania,
-1944-09-30,RS,Serbia,
-1944-09-30,RU,Russia,
-1944-09-30,SE,Sweden,
-1944-09-30,SG,Singapore,
-1944-09-30,SI,Slovenia,
-1944-09-30,SK,Slovak Republic,
-1944-09-30,TH,Thailand,
-1944-09-30,TR,Türkiye,
-1944-09-30,US,United States,
-1944-09-30,XM,Euro area,
-1944-09-30,XW,World,
-1944-09-30,ZA,South Africa,
-1944-12-31,4T,Emerging market economies (aggregate),
-1944-12-31,5R,Advanced economies,
-1944-12-31,AE,United Arab Emirates,
-1944-12-31,AT,Austria,
-1944-12-31,AU,Australia,
-1944-12-31,BE,Belgium,
-1944-12-31,BG,Bulgaria,
-1944-12-31,BR,Brazil,
-1944-12-31,CA,Canada,
-1944-12-31,CH,Switzerland,
-1944-12-31,CL,Chile,
-1944-12-31,CN,China,
-1944-12-31,CO,Colombia,
-1944-12-31,CY,Cyprus,
-1944-12-31,CZ,Czechia,
-1944-12-31,DE,Germany,
-1944-12-31,DK,Denmark,
-1944-12-31,EE,Estonia,
-1944-12-31,ES,Spain,
-1944-12-31,FI,Finland,
-1944-12-31,FR,France,
-1944-12-31,GB,United Kingdom,
-1944-12-31,GR,Greece,
-1944-12-31,HK,Hong Kong SAR,
-1944-12-31,HR,Croatia,
-1944-12-31,HU,Hungary,
-1944-12-31,ID,Indonesia,
-1944-12-31,IE,Ireland,
-1944-12-31,IL,Israel,
-1944-12-31,IN,India,
-1944-12-31,IS,Iceland,
 1944-12-31,IT,Italy,0.1903
-1944-12-31,JP,Japan,
-1944-12-31,KR,Korea,
-1944-12-31,LT,Lithuania,
-1944-12-31,LU,Luxembourg,
-1944-12-31,LV,Latvia,
-1944-12-31,MA,Morocco,
-1944-12-31,MK,North Macedonia,
-1944-12-31,MT,Malta,
-1944-12-31,MX,Mexico,
-1944-12-31,MY,Malaysia,
-1944-12-31,NL,Netherlands,
-1944-12-31,NO,Norway,
-1944-12-31,NZ,New Zealand,
-1944-12-31,PE,Peru,
-1944-12-31,PH,Philippines,
-1944-12-31,PL,Poland,
-1944-12-31,PT,Portugal,
-1944-12-31,RO,Romania,
-1944-12-31,RS,Serbia,
-1944-12-31,RU,Russia,
-1944-12-31,SE,Sweden,
-1944-12-31,SG,Singapore,
-1944-12-31,SI,Slovenia,
-1944-12-31,SK,Slovak Republic,
-1944-12-31,TH,Thailand,
-1944-12-31,TR,Türkiye,
-1944-12-31,US,United States,
-1944-12-31,XM,Euro area,
-1944-12-31,XW,World,
-1944-12-31,ZA,South Africa,
-1945-03-31,4T,Emerging market economies (aggregate),
-1945-03-31,5R,Advanced economies,
-1945-03-31,AE,United Arab Emirates,
-1945-03-31,AT,Austria,
-1945-03-31,AU,Australia,
-1945-03-31,BE,Belgium,
-1945-03-31,BG,Bulgaria,
-1945-03-31,BR,Brazil,
-1945-03-31,CA,Canada,
-1945-03-31,CH,Switzerland,
-1945-03-31,CL,Chile,
-1945-03-31,CN,China,
-1945-03-31,CO,Colombia,
-1945-03-31,CY,Cyprus,
-1945-03-31,CZ,Czechia,
-1945-03-31,DE,Germany,
-1945-03-31,DK,Denmark,
-1945-03-31,EE,Estonia,
-1945-03-31,ES,Spain,
-1945-03-31,FI,Finland,
-1945-03-31,FR,France,
-1945-03-31,GB,United Kingdom,
-1945-03-31,GR,Greece,
-1945-03-31,HK,Hong Kong SAR,
-1945-03-31,HR,Croatia,
-1945-03-31,HU,Hungary,
-1945-03-31,ID,Indonesia,
-1945-03-31,IE,Ireland,
-1945-03-31,IL,Israel,
-1945-03-31,IN,India,
-1945-03-31,IS,Iceland,
 1945-03-31,IT,Italy,0.2632
-1945-03-31,JP,Japan,
-1945-03-31,KR,Korea,
-1945-03-31,LT,Lithuania,
-1945-03-31,LU,Luxembourg,
-1945-03-31,LV,Latvia,
-1945-03-31,MA,Morocco,
-1945-03-31,MK,North Macedonia,
-1945-03-31,MT,Malta,
-1945-03-31,MX,Mexico,
-1945-03-31,MY,Malaysia,
-1945-03-31,NL,Netherlands,
-1945-03-31,NO,Norway,
-1945-03-31,NZ,New Zealand,
-1945-03-31,PE,Peru,
-1945-03-31,PH,Philippines,
-1945-03-31,PL,Poland,
-1945-03-31,PT,Portugal,
-1945-03-31,RO,Romania,
-1945-03-31,RS,Serbia,
-1945-03-31,RU,Russia,
-1945-03-31,SE,Sweden,
-1945-03-31,SG,Singapore,
-1945-03-31,SI,Slovenia,
-1945-03-31,SK,Slovak Republic,
-1945-03-31,TH,Thailand,
-1945-03-31,TR,Türkiye,
-1945-03-31,US,United States,
-1945-03-31,XM,Euro area,
-1945-03-31,XW,World,
-1945-03-31,ZA,South Africa,
-1945-06-30,4T,Emerging market economies (aggregate),
-1945-06-30,5R,Advanced economies,
-1945-06-30,AE,United Arab Emirates,
-1945-06-30,AT,Austria,
-1945-06-30,AU,Australia,
-1945-06-30,BE,Belgium,
-1945-06-30,BG,Bulgaria,
-1945-06-30,BR,Brazil,
-1945-06-30,CA,Canada,
-1945-06-30,CH,Switzerland,
-1945-06-30,CL,Chile,
-1945-06-30,CN,China,
-1945-06-30,CO,Colombia,
-1945-06-30,CY,Cyprus,
-1945-06-30,CZ,Czechia,
-1945-06-30,DE,Germany,
-1945-06-30,DK,Denmark,
-1945-06-30,EE,Estonia,
-1945-06-30,ES,Spain,
-1945-06-30,FI,Finland,
-1945-06-30,FR,France,
-1945-06-30,GB,United Kingdom,
-1945-06-30,GR,Greece,
-1945-06-30,HK,Hong Kong SAR,
-1945-06-30,HR,Croatia,
-1945-06-30,HU,Hungary,
-1945-06-30,ID,Indonesia,
-1945-06-30,IE,Ireland,
-1945-06-30,IL,Israel,
-1945-06-30,IN,India,
-1945-06-30,IS,Iceland,
 1945-06-30,IT,Italy,0.3357
-1945-06-30,JP,Japan,
-1945-06-30,KR,Korea,
-1945-06-30,LT,Lithuania,
-1945-06-30,LU,Luxembourg,
-1945-06-30,LV,Latvia,
-1945-06-30,MA,Morocco,
-1945-06-30,MK,North Macedonia,
-1945-06-30,MT,Malta,
-1945-06-30,MX,Mexico,
-1945-06-30,MY,Malaysia,
-1945-06-30,NL,Netherlands,
-1945-06-30,NO,Norway,
-1945-06-30,NZ,New Zealand,
-1945-06-30,PE,Peru,
-1945-06-30,PH,Philippines,
-1945-06-30,PL,Poland,
-1945-06-30,PT,Portugal,
-1945-06-30,RO,Romania,
-1945-06-30,RS,Serbia,
-1945-06-30,RU,Russia,
-1945-06-30,SE,Sweden,
-1945-06-30,SG,Singapore,
-1945-06-30,SI,Slovenia,
-1945-06-30,SK,Slovak Republic,
-1945-06-30,TH,Thailand,
-1945-06-30,TR,Türkiye,
-1945-06-30,US,United States,
-1945-06-30,XM,Euro area,
-1945-06-30,XW,World,
-1945-06-30,ZA,South Africa,
-1945-09-30,4T,Emerging market economies (aggregate),
-1945-09-30,5R,Advanced economies,
-1945-09-30,AE,United Arab Emirates,
-1945-09-30,AT,Austria,
-1945-09-30,AU,Australia,
-1945-09-30,BE,Belgium,
-1945-09-30,BG,Bulgaria,
-1945-09-30,BR,Brazil,
-1945-09-30,CA,Canada,
-1945-09-30,CH,Switzerland,
-1945-09-30,CL,Chile,
-1945-09-30,CN,China,
-1945-09-30,CO,Colombia,
-1945-09-30,CY,Cyprus,
-1945-09-30,CZ,Czechia,
-1945-09-30,DE,Germany,
-1945-09-30,DK,Denmark,
-1945-09-30,EE,Estonia,
-1945-09-30,ES,Spain,
-1945-09-30,FI,Finland,
-1945-09-30,FR,France,
-1945-09-30,GB,United Kingdom,
-1945-09-30,GR,Greece,
-1945-09-30,HK,Hong Kong SAR,
-1945-09-30,HR,Croatia,
-1945-09-30,HU,Hungary,
-1945-09-30,ID,Indonesia,
-1945-09-30,IE,Ireland,
-1945-09-30,IL,Israel,
-1945-09-30,IN,India,
-1945-09-30,IS,Iceland,
 1945-09-30,IT,Italy,0.3963
-1945-09-30,JP,Japan,
-1945-09-30,KR,Korea,
-1945-09-30,LT,Lithuania,
-1945-09-30,LU,Luxembourg,
-1945-09-30,LV,Latvia,
-1945-09-30,MA,Morocco,
-1945-09-30,MK,North Macedonia,
-1945-09-30,MT,Malta,
-1945-09-30,MX,Mexico,
-1945-09-30,MY,Malaysia,
-1945-09-30,NL,Netherlands,
-1945-09-30,NO,Norway,
-1945-09-30,NZ,New Zealand,
-1945-09-30,PE,Peru,
-1945-09-30,PH,Philippines,
-1945-09-30,PL,Poland,
-1945-09-30,PT,Portugal,
-1945-09-30,RO,Romania,
-1945-09-30,RS,Serbia,
-1945-09-30,RU,Russia,
-1945-09-30,SE,Sweden,
-1945-09-30,SG,Singapore,
-1945-09-30,SI,Slovenia,
-1945-09-30,SK,Slovak Republic,
-1945-09-30,TH,Thailand,
-1945-09-30,TR,Türkiye,
-1945-09-30,US,United States,
-1945-09-30,XM,Euro area,
-1945-09-30,XW,World,
-1945-09-30,ZA,South Africa,
-1945-12-31,4T,Emerging market economies (aggregate),
-1945-12-31,5R,Advanced economies,
-1945-12-31,AE,United Arab Emirates,
-1945-12-31,AT,Austria,
-1945-12-31,AU,Australia,
-1945-12-31,BE,Belgium,
-1945-12-31,BG,Bulgaria,
-1945-12-31,BR,Brazil,
-1945-12-31,CA,Canada,
-1945-12-31,CH,Switzerland,
-1945-12-31,CL,Chile,
-1945-12-31,CN,China,
-1945-12-31,CO,Colombia,
-1945-12-31,CY,Cyprus,
-1945-12-31,CZ,Czechia,
-1945-12-31,DE,Germany,
-1945-12-31,DK,Denmark,
-1945-12-31,EE,Estonia,
-1945-12-31,ES,Spain,
-1945-12-31,FI,Finland,
-1945-12-31,FR,France,
-1945-12-31,GB,United Kingdom,
-1945-12-31,GR,Greece,
-1945-12-31,HK,Hong Kong SAR,
-1945-12-31,HR,Croatia,
-1945-12-31,HU,Hungary,
-1945-12-31,ID,Indonesia,
-1945-12-31,IE,Ireland,
-1945-12-31,IL,Israel,
-1945-12-31,IN,India,
-1945-12-31,IS,Iceland,
 1945-12-31,IT,Italy,0.4436
-1945-12-31,JP,Japan,
-1945-12-31,KR,Korea,
-1945-12-31,LT,Lithuania,
-1945-12-31,LU,Luxembourg,
-1945-12-31,LV,Latvia,
-1945-12-31,MA,Morocco,
-1945-12-31,MK,North Macedonia,
-1945-12-31,MT,Malta,
-1945-12-31,MX,Mexico,
-1945-12-31,MY,Malaysia,
-1945-12-31,NL,Netherlands,
-1945-12-31,NO,Norway,
-1945-12-31,NZ,New Zealand,
-1945-12-31,PE,Peru,
-1945-12-31,PH,Philippines,
-1945-12-31,PL,Poland,
-1945-12-31,PT,Portugal,
-1945-12-31,RO,Romania,
-1945-12-31,RS,Serbia,
-1945-12-31,RU,Russia,
-1945-12-31,SE,Sweden,
-1945-12-31,SG,Singapore,
-1945-12-31,SI,Slovenia,
-1945-12-31,SK,Slovak Republic,
-1945-12-31,TH,Thailand,
-1945-12-31,TR,Türkiye,
-1945-12-31,US,United States,
-1945-12-31,XM,Euro area,
-1945-12-31,XW,World,
-1945-12-31,ZA,South Africa,
-1946-03-31,4T,Emerging market economies (aggregate),
-1946-03-31,5R,Advanced economies,
-1946-03-31,AE,United Arab Emirates,
-1946-03-31,AT,Austria,
-1946-03-31,AU,Australia,
-1946-03-31,BE,Belgium,
-1946-03-31,BG,Bulgaria,
-1946-03-31,BR,Brazil,
-1946-03-31,CA,Canada,
-1946-03-31,CH,Switzerland,
-1946-03-31,CL,Chile,
-1946-03-31,CN,China,
-1946-03-31,CO,Colombia,
-1946-03-31,CY,Cyprus,
-1946-03-31,CZ,Czechia,
-1946-03-31,DE,Germany,
-1946-03-31,DK,Denmark,
-1946-03-31,EE,Estonia,
-1946-03-31,ES,Spain,
-1946-03-31,FI,Finland,
-1946-03-31,FR,France,
-1946-03-31,GB,United Kingdom,
-1946-03-31,GR,Greece,
-1946-03-31,HK,Hong Kong SAR,
-1946-03-31,HR,Croatia,
-1946-03-31,HU,Hungary,
-1946-03-31,ID,Indonesia,
-1946-03-31,IE,Ireland,
-1946-03-31,IL,Israel,
-1946-03-31,IN,India,
-1946-03-31,IS,Iceland,
-1946-03-31,IT,Italy,0.4905
-1946-03-31,JP,Japan,
-1946-03-31,KR,Korea,
-1946-03-31,LT,Lithuania,
-1946-03-31,LU,Luxembourg,
-1946-03-31,LV,Latvia,
-1946-03-31,MA,Morocco,
-1946-03-31,MK,North Macedonia,
-1946-03-31,MT,Malta,
-1946-03-31,MX,Mexico,
-1946-03-31,MY,Malaysia,
-1946-03-31,NL,Netherlands,
-1946-03-31,NO,Norway,
-1946-03-31,NZ,New Zealand,
-1946-03-31,PE,Peru,
-1946-03-31,PH,Philippines,
-1946-03-31,PL,Poland,
-1946-03-31,PT,Portugal,
-1946-03-31,RO,Romania,
-1946-03-31,RS,Serbia,
-1946-03-31,RU,Russia,
-1946-03-31,SE,Sweden,
-1946-03-31,SG,Singapore,
-1946-03-31,SI,Slovenia,
-1946-03-31,SK,Slovak Republic,
-1946-03-31,TH,Thailand,
-1946-03-31,TR,Türkiye,
-1946-03-31,US,United States,
-1946-03-31,XM,Euro area,
-1946-03-31,XW,World,
-1946-03-31,ZA,South Africa,
-1946-06-30,4T,Emerging market economies (aggregate),
-1946-06-30,5R,Advanced economies,
-1946-06-30,AE,United Arab Emirates,
-1946-06-30,AT,Austria,
-1946-06-30,AU,Australia,
-1946-06-30,BE,Belgium,
-1946-06-30,BG,Bulgaria,
-1946-06-30,BR,Brazil,
-1946-06-30,CA,Canada,
-1946-06-30,CH,Switzerland,
-1946-06-30,CL,Chile,
-1946-06-30,CN,China,
-1946-06-30,CO,Colombia,
-1946-06-30,CY,Cyprus,
-1946-06-30,CZ,Czechia,
-1946-06-30,DE,Germany,
-1946-06-30,DK,Denmark,
-1946-06-30,EE,Estonia,
-1946-06-30,ES,Spain,
-1946-06-30,FI,Finland,
-1946-06-30,FR,France,
-1946-06-30,GB,United Kingdom,
-1946-06-30,GR,Greece,
-1946-06-30,HK,Hong Kong SAR,
-1946-06-30,HR,Croatia,
-1946-06-30,HU,Hungary,
-1946-06-30,ID,Indonesia,
-1946-06-30,IE,Ireland,
-1946-06-30,IL,Israel,
-1946-06-30,IN,India,
-1946-06-30,IS,Iceland,
+1946-03-31,IT,Italy,0.4904
 1946-06-30,IT,Italy,0.537
-1946-06-30,JP,Japan,
-1946-06-30,KR,Korea,
-1946-06-30,LT,Lithuania,
-1946-06-30,LU,Luxembourg,
-1946-06-30,LV,Latvia,
-1946-06-30,MA,Morocco,
-1946-06-30,MK,North Macedonia,
-1946-06-30,MT,Malta,
-1946-06-30,MX,Mexico,
-1946-06-30,MY,Malaysia,
-1946-06-30,NL,Netherlands,
-1946-06-30,NO,Norway,
-1946-06-30,NZ,New Zealand,
-1946-06-30,PE,Peru,
-1946-06-30,PH,Philippines,
-1946-06-30,PL,Poland,
-1946-06-30,PT,Portugal,
-1946-06-30,RO,Romania,
-1946-06-30,RS,Serbia,
-1946-06-30,RU,Russia,
-1946-06-30,SE,Sweden,
-1946-06-30,SG,Singapore,
-1946-06-30,SI,Slovenia,
-1946-06-30,SK,Slovak Republic,
-1946-06-30,TH,Thailand,
-1946-06-30,TR,Türkiye,
-1946-06-30,US,United States,
-1946-06-30,XM,Euro area,
-1946-06-30,XW,World,
-1946-06-30,ZA,South Africa,
-1946-09-30,4T,Emerging market economies (aggregate),
-1946-09-30,5R,Advanced economies,
-1946-09-30,AE,United Arab Emirates,
-1946-09-30,AT,Austria,
-1946-09-30,AU,Australia,
-1946-09-30,BE,Belgium,
-1946-09-30,BG,Bulgaria,
-1946-09-30,BR,Brazil,
-1946-09-30,CA,Canada,
-1946-09-30,CH,Switzerland,
-1946-09-30,CL,Chile,
-1946-09-30,CN,China,
-1946-09-30,CO,Colombia,
-1946-09-30,CY,Cyprus,
-1946-09-30,CZ,Czechia,
-1946-09-30,DE,Germany,
-1946-09-30,DK,Denmark,
-1946-09-30,EE,Estonia,
-1946-09-30,ES,Spain,
-1946-09-30,FI,Finland,
-1946-09-30,FR,France,
-1946-09-30,GB,United Kingdom,
-1946-09-30,GR,Greece,
-1946-09-30,HK,Hong Kong SAR,
-1946-09-30,HR,Croatia,
-1946-09-30,HU,Hungary,
-1946-09-30,ID,Indonesia,
-1946-09-30,IE,Ireland,
-1946-09-30,IL,Israel,
-1946-09-30,IN,India,
-1946-09-30,IS,Iceland,
 1946-09-30,IT,Italy,0.5998
-1946-09-30,JP,Japan,
-1946-09-30,KR,Korea,
-1946-09-30,LT,Lithuania,
-1946-09-30,LU,Luxembourg,
-1946-09-30,LV,Latvia,
-1946-09-30,MA,Morocco,
-1946-09-30,MK,North Macedonia,
-1946-09-30,MT,Malta,
-1946-09-30,MX,Mexico,
-1946-09-30,MY,Malaysia,
-1946-09-30,NL,Netherlands,
-1946-09-30,NO,Norway,
-1946-09-30,NZ,New Zealand,
-1946-09-30,PE,Peru,
-1946-09-30,PH,Philippines,
-1946-09-30,PL,Poland,
-1946-09-30,PT,Portugal,
-1946-09-30,RO,Romania,
-1946-09-30,RS,Serbia,
-1946-09-30,RU,Russia,
-1946-09-30,SE,Sweden,
-1946-09-30,SG,Singapore,
-1946-09-30,SI,Slovenia,
-1946-09-30,SK,Slovak Republic,
-1946-09-30,TH,Thailand,
-1946-09-30,TR,Türkiye,
-1946-09-30,US,United States,
-1946-09-30,XM,Euro area,
-1946-09-30,XW,World,
-1946-09-30,ZA,South Africa,
-1946-12-31,4T,Emerging market economies (aggregate),
-1946-12-31,5R,Advanced economies,
-1946-12-31,AE,United Arab Emirates,
-1946-12-31,AT,Austria,
-1946-12-31,AU,Australia,
-1946-12-31,BE,Belgium,
-1946-12-31,BG,Bulgaria,
-1946-12-31,BR,Brazil,
-1946-12-31,CA,Canada,
-1946-12-31,CH,Switzerland,
-1946-12-31,CL,Chile,
-1946-12-31,CN,China,
-1946-12-31,CO,Colombia,
-1946-12-31,CY,Cyprus,
-1946-12-31,CZ,Czechia,
-1946-12-31,DE,Germany,
-1946-12-31,DK,Denmark,
-1946-12-31,EE,Estonia,
-1946-12-31,ES,Spain,
-1946-12-31,FI,Finland,
-1946-12-31,FR,France,
-1946-12-31,GB,United Kingdom,
-1946-12-31,GR,Greece,
-1946-12-31,HK,Hong Kong SAR,
-1946-12-31,HR,Croatia,
-1946-12-31,HU,Hungary,
-1946-12-31,ID,Indonesia,
-1946-12-31,IE,Ireland,
-1946-12-31,IL,Israel,
-1946-12-31,IN,India,
-1946-12-31,IS,Iceland,
 1946-12-31,IT,Italy,0.6797
-1946-12-31,JP,Japan,
-1946-12-31,KR,Korea,
-1946-12-31,LT,Lithuania,
-1946-12-31,LU,Luxembourg,
-1946-12-31,LV,Latvia,
-1946-12-31,MA,Morocco,
-1946-12-31,MK,North Macedonia,
-1946-12-31,MT,Malta,
-1946-12-31,MX,Mexico,
-1946-12-31,MY,Malaysia,
-1946-12-31,NL,Netherlands,
-1946-12-31,NO,Norway,
-1946-12-31,NZ,New Zealand,
-1946-12-31,PE,Peru,
-1946-12-31,PH,Philippines,
-1946-12-31,PL,Poland,
-1946-12-31,PT,Portugal,
-1946-12-31,RO,Romania,
-1946-12-31,RS,Serbia,
-1946-12-31,RU,Russia,
-1946-12-31,SE,Sweden,
-1946-12-31,SG,Singapore,
-1946-12-31,SI,Slovenia,
-1946-12-31,SK,Slovak Republic,
-1946-12-31,TH,Thailand,
-1946-12-31,TR,Türkiye,
-1946-12-31,US,United States,
-1946-12-31,XM,Euro area,
-1946-12-31,XW,World,
-1946-12-31,ZA,South Africa,
-1947-03-31,4T,Emerging market economies (aggregate),
-1947-03-31,5R,Advanced economies,
-1947-03-31,AE,United Arab Emirates,
-1947-03-31,AT,Austria,
-1947-03-31,AU,Australia,
-1947-03-31,BE,Belgium,
-1947-03-31,BG,Bulgaria,
-1947-03-31,BR,Brazil,
-1947-03-31,CA,Canada,
-1947-03-31,CH,Switzerland,
-1947-03-31,CL,Chile,
-1947-03-31,CN,China,
-1947-03-31,CO,Colombia,
-1947-03-31,CY,Cyprus,
-1947-03-31,CZ,Czechia,
-1947-03-31,DE,Germany,
-1947-03-31,DK,Denmark,
-1947-03-31,EE,Estonia,
-1947-03-31,ES,Spain,
-1947-03-31,FI,Finland,
-1947-03-31,FR,France,
-1947-03-31,GB,United Kingdom,
-1947-03-31,GR,Greece,
-1947-03-31,HK,Hong Kong SAR,
-1947-03-31,HR,Croatia,
-1947-03-31,HU,Hungary,
-1947-03-31,ID,Indonesia,
-1947-03-31,IE,Ireland,
-1947-03-31,IL,Israel,
-1947-03-31,IN,India,
-1947-03-31,IS,Iceland,
 1947-03-31,IT,Italy,0.7587
-1947-03-31,JP,Japan,
-1947-03-31,KR,Korea,
-1947-03-31,LT,Lithuania,
-1947-03-31,LU,Luxembourg,
-1947-03-31,LV,Latvia,
-1947-03-31,MA,Morocco,
-1947-03-31,MK,North Macedonia,
-1947-03-31,MT,Malta,
-1947-03-31,MX,Mexico,
-1947-03-31,MY,Malaysia,
-1947-03-31,NL,Netherlands,
-1947-03-31,NO,Norway,
-1947-03-31,NZ,New Zealand,
-1947-03-31,PE,Peru,
-1947-03-31,PH,Philippines,
-1947-03-31,PL,Poland,
-1947-03-31,PT,Portugal,
-1947-03-31,RO,Romania,
-1947-03-31,RS,Serbia,
-1947-03-31,RU,Russia,
-1947-03-31,SE,Sweden,
-1947-03-31,SG,Singapore,
-1947-03-31,SI,Slovenia,
-1947-03-31,SK,Slovak Republic,
-1947-03-31,TH,Thailand,
-1947-03-31,TR,Türkiye,
-1947-03-31,US,United States,
-1947-03-31,XM,Euro area,
-1947-03-31,XW,World,
-1947-03-31,ZA,South Africa,
-1947-06-30,4T,Emerging market economies (aggregate),
-1947-06-30,5R,Advanced economies,
-1947-06-30,AE,United Arab Emirates,
-1947-06-30,AT,Austria,
-1947-06-30,AU,Australia,
-1947-06-30,BE,Belgium,
-1947-06-30,BG,Bulgaria,
-1947-06-30,BR,Brazil,
-1947-06-30,CA,Canada,
-1947-06-30,CH,Switzerland,
-1947-06-30,CL,Chile,
-1947-06-30,CN,China,
-1947-06-30,CO,Colombia,
-1947-06-30,CY,Cyprus,
-1947-06-30,CZ,Czechia,
-1947-06-30,DE,Germany,
-1947-06-30,DK,Denmark,
-1947-06-30,EE,Estonia,
-1947-06-30,ES,Spain,
-1947-06-30,FI,Finland,
-1947-06-30,FR,France,
-1947-06-30,GB,United Kingdom,
-1947-06-30,GR,Greece,
-1947-06-30,HK,Hong Kong SAR,
-1947-06-30,HR,Croatia,
-1947-06-30,HU,Hungary,
-1947-06-30,ID,Indonesia,
-1947-06-30,IE,Ireland,
-1947-06-30,IL,Israel,
-1947-06-30,IN,India,
-1947-06-30,IS,Iceland,
 1947-06-30,IT,Italy,0.8373
-1947-06-30,JP,Japan,
-1947-06-30,KR,Korea,
-1947-06-30,LT,Lithuania,
-1947-06-30,LU,Luxembourg,
-1947-06-30,LV,Latvia,
-1947-06-30,MA,Morocco,
-1947-06-30,MK,North Macedonia,
-1947-06-30,MT,Malta,
-1947-06-30,MX,Mexico,
-1947-06-30,MY,Malaysia,
-1947-06-30,NL,Netherlands,
-1947-06-30,NO,Norway,
-1947-06-30,NZ,New Zealand,
-1947-06-30,PE,Peru,
-1947-06-30,PH,Philippines,
-1947-06-30,PL,Poland,
-1947-06-30,PT,Portugal,
-1947-06-30,RO,Romania,
-1947-06-30,RS,Serbia,
-1947-06-30,RU,Russia,
-1947-06-30,SE,Sweden,
-1947-06-30,SG,Singapore,
-1947-06-30,SI,Slovenia,
-1947-06-30,SK,Slovak Republic,
-1947-06-30,TH,Thailand,
-1947-06-30,TR,Türkiye,
-1947-06-30,US,United States,
-1947-06-30,XM,Euro area,
-1947-06-30,XW,World,
-1947-06-30,ZA,South Africa,
-1947-09-30,4T,Emerging market economies (aggregate),
-1947-09-30,5R,Advanced economies,
-1947-09-30,AE,United Arab Emirates,
-1947-09-30,AT,Austria,
-1947-09-30,AU,Australia,
-1947-09-30,BE,Belgium,
-1947-09-30,BG,Bulgaria,
-1947-09-30,BR,Brazil,
-1947-09-30,CA,Canada,
-1947-09-30,CH,Switzerland,
-1947-09-30,CL,Chile,
-1947-09-30,CN,China,
-1947-09-30,CO,Colombia,
-1947-09-30,CY,Cyprus,
-1947-09-30,CZ,Czechia,
-1947-09-30,DE,Germany,
-1947-09-30,DK,Denmark,
-1947-09-30,EE,Estonia,
-1947-09-30,ES,Spain,
-1947-09-30,FI,Finland,
-1947-09-30,FR,France,
-1947-09-30,GB,United Kingdom,
-1947-09-30,GR,Greece,
-1947-09-30,HK,Hong Kong SAR,
-1947-09-30,HR,Croatia,
-1947-09-30,HU,Hungary,
-1947-09-30,ID,Indonesia,
-1947-09-30,IE,Ireland,
-1947-09-30,IL,Israel,
-1947-09-30,IN,India,
-1947-09-30,IS,Iceland,
 1947-09-30,IT,Italy,0.9007
-1947-09-30,JP,Japan,
-1947-09-30,KR,Korea,
-1947-09-30,LT,Lithuania,
-1947-09-30,LU,Luxembourg,
-1947-09-30,LV,Latvia,
-1947-09-30,MA,Morocco,
-1947-09-30,MK,North Macedonia,
-1947-09-30,MT,Malta,
-1947-09-30,MX,Mexico,
-1947-09-30,MY,Malaysia,
-1947-09-30,NL,Netherlands,
-1947-09-30,NO,Norway,
-1947-09-30,NZ,New Zealand,
-1947-09-30,PE,Peru,
-1947-09-30,PH,Philippines,
-1947-09-30,PL,Poland,
-1947-09-30,PT,Portugal,
-1947-09-30,RO,Romania,
-1947-09-30,RS,Serbia,
-1947-09-30,RU,Russia,
-1947-09-30,SE,Sweden,
-1947-09-30,SG,Singapore,
-1947-09-30,SI,Slovenia,
-1947-09-30,SK,Slovak Republic,
-1947-09-30,TH,Thailand,
-1947-09-30,TR,Türkiye,
-1947-09-30,US,United States,
-1947-09-30,XM,Euro area,
-1947-09-30,XW,World,
-1947-09-30,ZA,South Africa,
-1947-12-31,4T,Emerging market economies (aggregate),
-1947-12-31,5R,Advanced economies,
-1947-12-31,AE,United Arab Emirates,
-1947-12-31,AT,Austria,
-1947-12-31,AU,Australia,
-1947-12-31,BE,Belgium,
-1947-12-31,BG,Bulgaria,
-1947-12-31,BR,Brazil,
-1947-12-31,CA,Canada,
-1947-12-31,CH,Switzerland,
-1947-12-31,CL,Chile,
-1947-12-31,CN,China,
-1947-12-31,CO,Colombia,
-1947-12-31,CY,Cyprus,
-1947-12-31,CZ,Czechia,
-1947-12-31,DE,Germany,
-1947-12-31,DK,Denmark,
-1947-12-31,EE,Estonia,
-1947-12-31,ES,Spain,
-1947-12-31,FI,Finland,
-1947-12-31,FR,France,
-1947-12-31,GB,United Kingdom,
-1947-12-31,GR,Greece,
-1947-12-31,HK,Hong Kong SAR,
-1947-12-31,HR,Croatia,
-1947-12-31,HU,Hungary,
-1947-12-31,ID,Indonesia,
-1947-12-31,IE,Ireland,
-1947-12-31,IL,Israel,
-1947-12-31,IN,India,
-1947-12-31,IS,Iceland,
 1947-12-31,IT,Italy,0.9475
-1947-12-31,JP,Japan,
-1947-12-31,KR,Korea,
-1947-12-31,LT,Lithuania,
-1947-12-31,LU,Luxembourg,
-1947-12-31,LV,Latvia,
-1947-12-31,MA,Morocco,
-1947-12-31,MK,North Macedonia,
-1947-12-31,MT,Malta,
-1947-12-31,MX,Mexico,
-1947-12-31,MY,Malaysia,
-1947-12-31,NL,Netherlands,
-1947-12-31,NO,Norway,
-1947-12-31,NZ,New Zealand,
-1947-12-31,PE,Peru,
-1947-12-31,PH,Philippines,
-1947-12-31,PL,Poland,
-1947-12-31,PT,Portugal,
-1947-12-31,RO,Romania,
-1947-12-31,RS,Serbia,
-1947-12-31,RU,Russia,
-1947-12-31,SE,Sweden,
-1947-12-31,SG,Singapore,
-1947-12-31,SI,Slovenia,
-1947-12-31,SK,Slovak Republic,
-1947-12-31,TH,Thailand,
-1947-12-31,TR,Türkiye,
-1947-12-31,US,United States,
-1947-12-31,XM,Euro area,
-1947-12-31,XW,World,
-1947-12-31,ZA,South Africa,
-1948-03-31,4T,Emerging market economies (aggregate),
-1948-03-31,5R,Advanced economies,
-1948-03-31,AE,United Arab Emirates,
-1948-03-31,AT,Austria,
-1948-03-31,AU,Australia,
-1948-03-31,BE,Belgium,
-1948-03-31,BG,Bulgaria,
-1948-03-31,BR,Brazil,
-1948-03-31,CA,Canada,
-1948-03-31,CH,Switzerland,
-1948-03-31,CL,Chile,
-1948-03-31,CN,China,
-1948-03-31,CO,Colombia,
-1948-03-31,CY,Cyprus,
-1948-03-31,CZ,Czechia,
-1948-03-31,DE,Germany,
-1948-03-31,DK,Denmark,
-1948-03-31,EE,Estonia,
-1948-03-31,ES,Spain,
-1948-03-31,FI,Finland,
-1948-03-31,FR,France,
-1948-03-31,GB,United Kingdom,
-1948-03-31,GR,Greece,
-1948-03-31,HK,Hong Kong SAR,
-1948-03-31,HR,Croatia,
-1948-03-31,HU,Hungary,
-1948-03-31,ID,Indonesia,
-1948-03-31,IE,Ireland,
-1948-03-31,IL,Israel,
-1948-03-31,IN,India,
-1948-03-31,IS,Iceland,
-1948-03-31,IT,Italy,1.0403
-1948-03-31,JP,Japan,
-1948-03-31,KR,Korea,
-1948-03-31,LT,Lithuania,
-1948-03-31,LU,Luxembourg,
-1948-03-31,LV,Latvia,
-1948-03-31,MA,Morocco,
-1948-03-31,MK,North Macedonia,
-1948-03-31,MT,Malta,
-1948-03-31,MX,Mexico,
-1948-03-31,MY,Malaysia,
-1948-03-31,NL,Netherlands,
-1948-03-31,NO,Norway,
-1948-03-31,NZ,New Zealand,
-1948-03-31,PE,Peru,
-1948-03-31,PH,Philippines,
-1948-03-31,PL,Poland,
-1948-03-31,PT,Portugal,
-1948-03-31,RO,Romania,
-1948-03-31,RS,Serbia,
-1948-03-31,RU,Russia,
-1948-03-31,SE,Sweden,
-1948-03-31,SG,Singapore,
-1948-03-31,SI,Slovenia,
-1948-03-31,SK,Slovak Republic,
-1948-03-31,TH,Thailand,
-1948-03-31,TR,Türkiye,
-1948-03-31,US,United States,
-1948-03-31,XM,Euro area,
-1948-03-31,XW,World,
-1948-03-31,ZA,South Africa,
-1948-06-30,4T,Emerging market economies (aggregate),
-1948-06-30,5R,Advanced economies,
-1948-06-30,AE,United Arab Emirates,
-1948-06-30,AT,Austria,
-1948-06-30,AU,Australia,
-1948-06-30,BE,Belgium,
-1948-06-30,BG,Bulgaria,
-1948-06-30,BR,Brazil,
-1948-06-30,CA,Canada,
-1948-06-30,CH,Switzerland,
-1948-06-30,CL,Chile,
-1948-06-30,CN,China,
-1948-06-30,CO,Colombia,
-1948-06-30,CY,Cyprus,
-1948-06-30,CZ,Czechia,
-1948-06-30,DE,Germany,
-1948-06-30,DK,Denmark,
-1948-06-30,EE,Estonia,
-1948-06-30,ES,Spain,
-1948-06-30,FI,Finland,
-1948-06-30,FR,France,
-1948-06-30,GB,United Kingdom,
-1948-06-30,GR,Greece,
-1948-06-30,HK,Hong Kong SAR,
-1948-06-30,HR,Croatia,
-1948-06-30,HU,Hungary,
-1948-06-30,ID,Indonesia,
-1948-06-30,IE,Ireland,
-1948-06-30,IL,Israel,
-1948-06-30,IN,India,
-1948-06-30,IS,Iceland,
-1948-06-30,IT,Italy,1.0707
-1948-06-30,JP,Japan,
-1948-06-30,KR,Korea,
-1948-06-30,LT,Lithuania,
-1948-06-30,LU,Luxembourg,
-1948-06-30,LV,Latvia,
-1948-06-30,MA,Morocco,
-1948-06-30,MK,North Macedonia,
-1948-06-30,MT,Malta,
-1948-06-30,MX,Mexico,
-1948-06-30,MY,Malaysia,
-1948-06-30,NL,Netherlands,
-1948-06-30,NO,Norway,
-1948-06-30,NZ,New Zealand,
-1948-06-30,PE,Peru,
-1948-06-30,PH,Philippines,
-1948-06-30,PL,Poland,
-1948-06-30,PT,Portugal,
-1948-06-30,RO,Romania,
-1948-06-30,RS,Serbia,
-1948-06-30,RU,Russia,
-1948-06-30,SE,Sweden,
-1948-06-30,SG,Singapore,
-1948-06-30,SI,Slovenia,
-1948-06-30,SK,Slovak Republic,
-1948-06-30,TH,Thailand,
-1948-06-30,TR,Türkiye,
-1948-06-30,US,United States,
-1948-06-30,XM,Euro area,
-1948-06-30,XW,World,
-1948-06-30,ZA,South Africa,
-1948-09-30,4T,Emerging market economies (aggregate),
-1948-09-30,5R,Advanced economies,
-1948-09-30,AE,United Arab Emirates,
-1948-09-30,AT,Austria,
-1948-09-30,AU,Australia,
-1948-09-30,BE,Belgium,
-1948-09-30,BG,Bulgaria,
-1948-09-30,BR,Brazil,
-1948-09-30,CA,Canada,
-1948-09-30,CH,Switzerland,
-1948-09-30,CL,Chile,
-1948-09-30,CN,China,
-1948-09-30,CO,Colombia,
-1948-09-30,CY,Cyprus,
-1948-09-30,CZ,Czechia,
-1948-09-30,DE,Germany,
-1948-09-30,DK,Denmark,
-1948-09-30,EE,Estonia,
-1948-09-30,ES,Spain,
-1948-09-30,FI,Finland,
-1948-09-30,FR,France,
-1948-09-30,GB,United Kingdom,
-1948-09-30,GR,Greece,
-1948-09-30,HK,Hong Kong SAR,
-1948-09-30,HR,Croatia,
-1948-09-30,HU,Hungary,
-1948-09-30,ID,Indonesia,
-1948-09-30,IE,Ireland,
-1948-09-30,IL,Israel,
-1948-09-30,IN,India,
-1948-09-30,IS,Iceland,
-1948-09-30,IT,Italy,0.9922
-1948-09-30,JP,Japan,
-1948-09-30,KR,Korea,
-1948-09-30,LT,Lithuania,
-1948-09-30,LU,Luxembourg,
-1948-09-30,LV,Latvia,
-1948-09-30,MA,Morocco,
-1948-09-30,MK,North Macedonia,
-1948-09-30,MT,Malta,
-1948-09-30,MX,Mexico,
-1948-09-30,MY,Malaysia,
-1948-09-30,NL,Netherlands,
-1948-09-30,NO,Norway,
-1948-09-30,NZ,New Zealand,
-1948-09-30,PE,Peru,
-1948-09-30,PH,Philippines,
-1948-09-30,PL,Poland,
-1948-09-30,PT,Portugal,
-1948-09-30,RO,Romania,
-1948-09-30,RS,Serbia,
-1948-09-30,RU,Russia,
-1948-09-30,SE,Sweden,
-1948-09-30,SG,Singapore,
-1948-09-30,SI,Slovenia,
-1948-09-30,SK,Slovak Republic,
-1948-09-30,TH,Thailand,
-1948-09-30,TR,Türkiye,
-1948-09-30,US,United States,
-1948-09-30,XM,Euro area,
-1948-09-30,XW,World,
-1948-09-30,ZA,South Africa,
-1948-12-31,4T,Emerging market economies (aggregate),
-1948-12-31,5R,Advanced economies,
-1948-12-31,AE,United Arab Emirates,
-1948-12-31,AT,Austria,
-1948-12-31,AU,Australia,
-1948-12-31,BE,Belgium,
-1948-12-31,BG,Bulgaria,
-1948-12-31,BR,Brazil,
-1948-12-31,CA,Canada,
-1948-12-31,CH,Switzerland,
-1948-12-31,CL,Chile,
-1948-12-31,CN,China,
-1948-12-31,CO,Colombia,
-1948-12-31,CY,Cyprus,
-1948-12-31,CZ,Czechia,
-1948-12-31,DE,Germany,
-1948-12-31,DK,Denmark,
-1948-12-31,EE,Estonia,
-1948-12-31,ES,Spain,
-1948-12-31,FI,Finland,
-1948-12-31,FR,France,
-1948-12-31,GB,United Kingdom,
-1948-12-31,GR,Greece,
-1948-12-31,HK,Hong Kong SAR,
-1948-12-31,HR,Croatia,
-1948-12-31,HU,Hungary,
-1948-12-31,ID,Indonesia,
-1948-12-31,IE,Ireland,
-1948-12-31,IL,Israel,
-1948-12-31,IN,India,
-1948-12-31,IS,Iceland,
-1948-12-31,IT,Italy,1.0215
-1948-12-31,JP,Japan,
-1948-12-31,KR,Korea,
-1948-12-31,LT,Lithuania,
-1948-12-31,LU,Luxembourg,
-1948-12-31,LV,Latvia,
-1948-12-31,MA,Morocco,
-1948-12-31,MK,North Macedonia,
-1948-12-31,MT,Malta,
-1948-12-31,MX,Mexico,
-1948-12-31,MY,Malaysia,
-1948-12-31,NL,Netherlands,
-1948-12-31,NO,Norway,
-1948-12-31,NZ,New Zealand,
-1948-12-31,PE,Peru,
-1948-12-31,PH,Philippines,
-1948-12-31,PL,Poland,
-1948-12-31,PT,Portugal,
-1948-12-31,RO,Romania,
-1948-12-31,RS,Serbia,
-1948-12-31,RU,Russia,
-1948-12-31,SE,Sweden,
-1948-12-31,SG,Singapore,
-1948-12-31,SI,Slovenia,
-1948-12-31,SK,Slovak Republic,
-1948-12-31,TH,Thailand,
-1948-12-31,TR,Türkiye,
-1948-12-31,US,United States,
-1948-12-31,XM,Euro area,
-1948-12-31,XW,World,
-1948-12-31,ZA,South Africa,
-1949-03-31,4T,Emerging market economies (aggregate),
-1949-03-31,5R,Advanced economies,
-1949-03-31,AE,United Arab Emirates,
-1949-03-31,AT,Austria,
-1949-03-31,AU,Australia,
-1949-03-31,BE,Belgium,
-1949-03-31,BG,Bulgaria,
-1949-03-31,BR,Brazil,
-1949-03-31,CA,Canada,
-1949-03-31,CH,Switzerland,
-1949-03-31,CL,Chile,
-1949-03-31,CN,China,
-1949-03-31,CO,Colombia,
-1949-03-31,CY,Cyprus,
-1949-03-31,CZ,Czechia,
-1949-03-31,DE,Germany,
-1949-03-31,DK,Denmark,
-1949-03-31,EE,Estonia,
-1949-03-31,ES,Spain,
-1949-03-31,FI,Finland,
-1949-03-31,FR,France,
-1949-03-31,GB,United Kingdom,
-1949-03-31,GR,Greece,
-1949-03-31,HK,Hong Kong SAR,
-1949-03-31,HR,Croatia,
-1949-03-31,HU,Hungary,
-1949-03-31,ID,Indonesia,
-1949-03-31,IE,Ireland,
-1949-03-31,IL,Israel,
-1949-03-31,IN,India,
-1949-03-31,IS,Iceland,
-1949-03-31,IT,Italy,1.0478
-1949-03-31,JP,Japan,
-1949-03-31,KR,Korea,
-1949-03-31,LT,Lithuania,
-1949-03-31,LU,Luxembourg,
-1949-03-31,LV,Latvia,
-1949-03-31,MA,Morocco,
-1949-03-31,MK,North Macedonia,
-1949-03-31,MT,Malta,
-1949-03-31,MX,Mexico,
-1949-03-31,MY,Malaysia,
-1949-03-31,NL,Netherlands,
-1949-03-31,NO,Norway,
-1949-03-31,NZ,New Zealand,
-1949-03-31,PE,Peru,
-1949-03-31,PH,Philippines,
-1949-03-31,PL,Poland,
-1949-03-31,PT,Portugal,
-1949-03-31,RO,Romania,
-1949-03-31,RS,Serbia,
-1949-03-31,RU,Russia,
-1949-03-31,SE,Sweden,
-1949-03-31,SG,Singapore,
-1949-03-31,SI,Slovenia,
-1949-03-31,SK,Slovak Republic,
-1949-03-31,TH,Thailand,
-1949-03-31,TR,Türkiye,
-1949-03-31,US,United States,
-1949-03-31,XM,Euro area,
-1949-03-31,XW,World,
-1949-03-31,ZA,South Africa,
-1949-06-30,4T,Emerging market economies (aggregate),
-1949-06-30,5R,Advanced economies,
-1949-06-30,AE,United Arab Emirates,
-1949-06-30,AT,Austria,
-1949-06-30,AU,Australia,
-1949-06-30,BE,Belgium,
-1949-06-30,BG,Bulgaria,
-1949-06-30,BR,Brazil,
-1949-06-30,CA,Canada,
-1949-06-30,CH,Switzerland,
-1949-06-30,CL,Chile,
-1949-06-30,CN,China,
-1949-06-30,CO,Colombia,
-1949-06-30,CY,Cyprus,
-1949-06-30,CZ,Czechia,
-1949-06-30,DE,Germany,
-1949-06-30,DK,Denmark,
-1949-06-30,EE,Estonia,
-1949-06-30,ES,Spain,
-1949-06-30,FI,Finland,
-1949-06-30,FR,France,
-1949-06-30,GB,United Kingdom,
-1949-06-30,GR,Greece,
-1949-06-30,HK,Hong Kong SAR,
-1949-06-30,HR,Croatia,
-1949-06-30,HU,Hungary,
-1949-06-30,ID,Indonesia,
-1949-06-30,IE,Ireland,
-1949-06-30,IL,Israel,
-1949-06-30,IN,India,
-1949-06-30,IS,Iceland,
-1949-06-30,IT,Italy,1.0504
-1949-06-30,JP,Japan,
-1949-06-30,KR,Korea,
-1949-06-30,LT,Lithuania,
-1949-06-30,LU,Luxembourg,
-1949-06-30,LV,Latvia,
-1949-06-30,MA,Morocco,
-1949-06-30,MK,North Macedonia,
-1949-06-30,MT,Malta,
-1949-06-30,MX,Mexico,
-1949-06-30,MY,Malaysia,
-1949-06-30,NL,Netherlands,
-1949-06-30,NO,Norway,
-1949-06-30,NZ,New Zealand,
-1949-06-30,PE,Peru,
-1949-06-30,PH,Philippines,
-1949-06-30,PL,Poland,
-1949-06-30,PT,Portugal,
-1949-06-30,RO,Romania,
-1949-06-30,RS,Serbia,
-1949-06-30,RU,Russia,
-1949-06-30,SE,Sweden,
-1949-06-30,SG,Singapore,
-1949-06-30,SI,Slovenia,
-1949-06-30,SK,Slovak Republic,
-1949-06-30,TH,Thailand,
-1949-06-30,TR,Türkiye,
-1949-06-30,US,United States,
-1949-06-30,XM,Euro area,
-1949-06-30,XW,World,
-1949-06-30,ZA,South Africa,
-1949-09-30,4T,Emerging market economies (aggregate),
-1949-09-30,5R,Advanced economies,
-1949-09-30,AE,United Arab Emirates,
-1949-09-30,AT,Austria,
-1949-09-30,AU,Australia,
-1949-09-30,BE,Belgium,
-1949-09-30,BG,Bulgaria,
-1949-09-30,BR,Brazil,
-1949-09-30,CA,Canada,
-1949-09-30,CH,Switzerland,
-1949-09-30,CL,Chile,
-1949-09-30,CN,China,
-1949-09-30,CO,Colombia,
-1949-09-30,CY,Cyprus,
-1949-09-30,CZ,Czechia,
-1949-09-30,DE,Germany,
-1949-09-30,DK,Denmark,
-1949-09-30,EE,Estonia,
-1949-09-30,ES,Spain,
-1949-09-30,FI,Finland,
-1949-09-30,FR,France,
-1949-09-30,GB,United Kingdom,
-1949-09-30,GR,Greece,
-1949-09-30,HK,Hong Kong SAR,
-1949-09-30,HR,Croatia,
-1949-09-30,HU,Hungary,
-1949-09-30,ID,Indonesia,
-1949-09-30,IE,Ireland,
-1949-09-30,IL,Israel,
-1949-09-30,IN,India,
-1949-09-30,IS,Iceland,
-1949-09-30,IT,Italy,0.9623
-1949-09-30,JP,Japan,
-1949-09-30,KR,Korea,
-1949-09-30,LT,Lithuania,
-1949-09-30,LU,Luxembourg,
-1949-09-30,LV,Latvia,
-1949-09-30,MA,Morocco,
-1949-09-30,MK,North Macedonia,
-1949-09-30,MT,Malta,
-1949-09-30,MX,Mexico,
-1949-09-30,MY,Malaysia,
-1949-09-30,NL,Netherlands,
-1949-09-30,NO,Norway,
-1949-09-30,NZ,New Zealand,
-1949-09-30,PE,Peru,
-1949-09-30,PH,Philippines,
-1949-09-30,PL,Poland,
-1949-09-30,PT,Portugal,
-1949-09-30,RO,Romania,
-1949-09-30,RS,Serbia,
-1949-09-30,RU,Russia,
-1949-09-30,SE,Sweden,
-1949-09-30,SG,Singapore,
-1949-09-30,SI,Slovenia,
-1949-09-30,SK,Slovak Republic,
-1949-09-30,TH,Thailand,
-1949-09-30,TR,Türkiye,
-1949-09-30,US,United States,
-1949-09-30,XM,Euro area,
-1949-09-30,XW,World,
-1949-09-30,ZA,South Africa,
-1949-12-31,4T,Emerging market economies (aggregate),
-1949-12-31,5R,Advanced economies,
-1949-12-31,AE,United Arab Emirates,
-1949-12-31,AT,Austria,
-1949-12-31,AU,Australia,
-1949-12-31,BE,Belgium,
-1949-12-31,BG,Bulgaria,
-1949-12-31,BR,Brazil,
-1949-12-31,CA,Canada,
-1949-12-31,CH,Switzerland,
-1949-12-31,CL,Chile,
-1949-12-31,CN,China,
-1949-12-31,CO,Colombia,
-1949-12-31,CY,Cyprus,
-1949-12-31,CZ,Czechia,
-1949-12-31,DE,Germany,
-1949-12-31,DK,Denmark,
-1949-12-31,EE,Estonia,
-1949-12-31,ES,Spain,
-1949-12-31,FI,Finland,
-1949-12-31,FR,France,
-1949-12-31,GB,United Kingdom,
-1949-12-31,GR,Greece,
-1949-12-31,HK,Hong Kong SAR,
-1949-12-31,HR,Croatia,
-1949-12-31,HU,Hungary,
-1949-12-31,ID,Indonesia,
-1949-12-31,IE,Ireland,
-1949-12-31,IL,Israel,
-1949-12-31,IN,India,
-1949-12-31,IS,Iceland,
-1949-12-31,IT,Italy,0.9251
-1949-12-31,JP,Japan,
-1949-12-31,KR,Korea,
-1949-12-31,LT,Lithuania,
-1949-12-31,LU,Luxembourg,
-1949-12-31,LV,Latvia,
-1949-12-31,MA,Morocco,
-1949-12-31,MK,North Macedonia,
-1949-12-31,MT,Malta,
-1949-12-31,MX,Mexico,
-1949-12-31,MY,Malaysia,
-1949-12-31,NL,Netherlands,
-1949-12-31,NO,Norway,
-1949-12-31,NZ,New Zealand,
-1949-12-31,PE,Peru,
-1949-12-31,PH,Philippines,
-1949-12-31,PL,Poland,
-1949-12-31,PT,Portugal,
-1949-12-31,RO,Romania,
-1949-12-31,RS,Serbia,
-1949-12-31,RU,Russia,
-1949-12-31,SE,Sweden,
-1949-12-31,SG,Singapore,
-1949-12-31,SI,Slovenia,
-1949-12-31,SK,Slovak Republic,
-1949-12-31,TH,Thailand,
-1949-12-31,TR,Türkiye,
-1949-12-31,US,United States,
-1949-12-31,XM,Euro area,
-1949-12-31,XW,World,
-1949-12-31,ZA,South Africa,
-1950-03-31,4T,Emerging market economies (aggregate),
-1950-03-31,5R,Advanced economies,
-1950-03-31,AE,United Arab Emirates,
-1950-03-31,AT,Austria,
-1950-03-31,AU,Australia,
-1950-03-31,BE,Belgium,
-1950-03-31,BG,Bulgaria,
-1950-03-31,BR,Brazil,
-1950-03-31,CA,Canada,
-1950-03-31,CH,Switzerland,
-1950-03-31,CL,Chile,
-1950-03-31,CN,China,
-1950-03-31,CO,Colombia,
-1950-03-31,CY,Cyprus,
-1950-03-31,CZ,Czechia,
-1950-03-31,DE,Germany,
-1950-03-31,DK,Denmark,
-1950-03-31,EE,Estonia,
-1950-03-31,ES,Spain,
-1950-03-31,FI,Finland,
-1950-03-31,FR,France,
-1950-03-31,GB,United Kingdom,
-1950-03-31,GR,Greece,
-1950-03-31,HK,Hong Kong SAR,
-1950-03-31,HR,Croatia,
-1950-03-31,HU,Hungary,
-1950-03-31,ID,Indonesia,
-1950-03-31,IE,Ireland,
-1950-03-31,IL,Israel,
-1950-03-31,IN,India,
-1950-03-31,IS,Iceland,
-1950-03-31,IT,Italy,0.9216
-1950-03-31,JP,Japan,
-1950-03-31,KR,Korea,
-1950-03-31,LT,Lithuania,
-1950-03-31,LU,Luxembourg,
-1950-03-31,LV,Latvia,
-1950-03-31,MA,Morocco,
-1950-03-31,MK,North Macedonia,
-1950-03-31,MT,Malta,
-1950-03-31,MX,Mexico,
-1950-03-31,MY,Malaysia,
-1950-03-31,NL,Netherlands,
-1950-03-31,NO,Norway,
-1950-03-31,NZ,New Zealand,
-1950-03-31,PE,Peru,
-1950-03-31,PH,Philippines,
-1950-03-31,PL,Poland,
-1950-03-31,PT,Portugal,
-1950-03-31,RO,Romania,
-1950-03-31,RS,Serbia,
-1950-03-31,RU,Russia,
-1950-03-31,SE,Sweden,
-1950-03-31,SG,Singapore,
-1950-03-31,SI,Slovenia,
-1950-03-31,SK,Slovak Republic,
-1950-03-31,TH,Thailand,
-1950-03-31,TR,Türkiye,
-1950-03-31,US,United States,
-1950-03-31,XM,Euro area,
-1950-03-31,XW,World,
-1950-03-31,ZA,South Africa,
-1950-06-30,4T,Emerging market economies (aggregate),
-1950-06-30,5R,Advanced economies,
-1950-06-30,AE,United Arab Emirates,
-1950-06-30,AT,Austria,
-1950-06-30,AU,Australia,
-1950-06-30,BE,Belgium,
-1950-06-30,BG,Bulgaria,
-1950-06-30,BR,Brazil,
-1950-06-30,CA,Canada,
-1950-06-30,CH,Switzerland,
-1950-06-30,CL,Chile,
-1950-06-30,CN,China,
-1950-06-30,CO,Colombia,
-1950-06-30,CY,Cyprus,
-1950-06-30,CZ,Czechia,
-1950-06-30,DE,Germany,
-1950-06-30,DK,Denmark,
-1950-06-30,EE,Estonia,
-1950-06-30,ES,Spain,
-1950-06-30,FI,Finland,
-1950-06-30,FR,France,
-1950-06-30,GB,United Kingdom,
-1950-06-30,GR,Greece,
-1950-06-30,HK,Hong Kong SAR,
-1950-06-30,HR,Croatia,
-1950-06-30,HU,Hungary,
-1950-06-30,ID,Indonesia,
-1950-06-30,IE,Ireland,
-1950-06-30,IL,Israel,
-1950-06-30,IN,India,
-1950-06-30,IS,Iceland,
-1950-06-30,IT,Italy,0.9826
-1950-06-30,JP,Japan,
-1950-06-30,KR,Korea,
-1950-06-30,LT,Lithuania,
-1950-06-30,LU,Luxembourg,
-1950-06-30,LV,Latvia,
-1950-06-30,MA,Morocco,
-1950-06-30,MK,North Macedonia,
-1950-06-30,MT,Malta,
-1950-06-30,MX,Mexico,
-1950-06-30,MY,Malaysia,
-1950-06-30,NL,Netherlands,
-1950-06-30,NO,Norway,
-1950-06-30,NZ,New Zealand,
-1950-06-30,PE,Peru,
-1950-06-30,PH,Philippines,
-1950-06-30,PL,Poland,
-1950-06-30,PT,Portugal,
-1950-06-30,RO,Romania,
-1950-06-30,RS,Serbia,
-1950-06-30,RU,Russia,
-1950-06-30,SE,Sweden,
-1950-06-30,SG,Singapore,
-1950-06-30,SI,Slovenia,
-1950-06-30,SK,Slovak Republic,
-1950-06-30,TH,Thailand,
-1950-06-30,TR,Türkiye,
-1950-06-30,US,United States,
-1950-06-30,XM,Euro area,
-1950-06-30,XW,World,
-1950-06-30,ZA,South Africa,
-1950-09-30,4T,Emerging market economies (aggregate),
-1950-09-30,5R,Advanced economies,
-1950-09-30,AE,United Arab Emirates,
-1950-09-30,AT,Austria,
-1950-09-30,AU,Australia,
-1950-09-30,BE,Belgium,
-1950-09-30,BG,Bulgaria,
-1950-09-30,BR,Brazil,
-1950-09-30,CA,Canada,
-1950-09-30,CH,Switzerland,
-1950-09-30,CL,Chile,
-1950-09-30,CN,China,
-1950-09-30,CO,Colombia,
-1950-09-30,CY,Cyprus,
-1950-09-30,CZ,Czechia,
-1950-09-30,DE,Germany,
-1950-09-30,DK,Denmark,
-1950-09-30,EE,Estonia,
-1950-09-30,ES,Spain,
-1950-09-30,FI,Finland,
-1950-09-30,FR,France,
-1950-09-30,GB,United Kingdom,
-1950-09-30,GR,Greece,
-1950-09-30,HK,Hong Kong SAR,
-1950-09-30,HR,Croatia,
-1950-09-30,HU,Hungary,
-1950-09-30,ID,Indonesia,
-1950-09-30,IE,Ireland,
-1950-09-30,IL,Israel,
-1950-09-30,IN,India,
-1950-09-30,IS,Iceland,
-1950-09-30,IT,Italy,1.0582
-1950-09-30,JP,Japan,
-1950-09-30,KR,Korea,
-1950-09-30,LT,Lithuania,
-1950-09-30,LU,Luxembourg,
-1950-09-30,LV,Latvia,
-1950-09-30,MA,Morocco,
-1950-09-30,MK,North Macedonia,
-1950-09-30,MT,Malta,
-1950-09-30,MX,Mexico,
-1950-09-30,MY,Malaysia,
-1950-09-30,NL,Netherlands,
-1950-09-30,NO,Norway,
-1950-09-30,NZ,New Zealand,
-1950-09-30,PE,Peru,
-1950-09-30,PH,Philippines,
-1950-09-30,PL,Poland,
-1950-09-30,PT,Portugal,
-1950-09-30,RO,Romania,
-1950-09-30,RS,Serbia,
-1950-09-30,RU,Russia,
-1950-09-30,SE,Sweden,
-1950-09-30,SG,Singapore,
-1950-09-30,SI,Slovenia,
-1950-09-30,SK,Slovak Republic,
-1950-09-30,TH,Thailand,
-1950-09-30,TR,Türkiye,
-1950-09-30,US,United States,
-1950-09-30,XM,Euro area,
-1950-09-30,XW,World,
-1950-09-30,ZA,South Africa,
-1950-12-31,4T,Emerging market economies (aggregate),
-1950-12-31,5R,Advanced economies,
-1950-12-31,AE,United Arab Emirates,
-1950-12-31,AT,Austria,
-1950-12-31,AU,Australia,
-1950-12-31,BE,Belgium,
-1950-12-31,BG,Bulgaria,
-1950-12-31,BR,Brazil,
-1950-12-31,CA,Canada,
-1950-12-31,CH,Switzerland,
-1950-12-31,CL,Chile,
-1950-12-31,CN,China,
-1950-12-31,CO,Colombia,
-1950-12-31,CY,Cyprus,
-1950-12-31,CZ,Czechia,
-1950-12-31,DE,Germany,
-1950-12-31,DK,Denmark,
-1950-12-31,EE,Estonia,
-1950-12-31,ES,Spain,
-1950-12-31,FI,Finland,
-1950-12-31,FR,France,
-1950-12-31,GB,United Kingdom,
-1950-12-31,GR,Greece,
-1950-12-31,HK,Hong Kong SAR,
-1950-12-31,HR,Croatia,
-1950-12-31,HU,Hungary,
-1950-12-31,ID,Indonesia,
-1950-12-31,IE,Ireland,
-1950-12-31,IL,Israel,
-1950-12-31,IN,India,
-1950-12-31,IS,Iceland,
-1950-12-31,IT,Italy,1.0749
-1950-12-31,JP,Japan,
-1950-12-31,KR,Korea,
-1950-12-31,LT,Lithuania,
-1950-12-31,LU,Luxembourg,
-1950-12-31,LV,Latvia,
-1950-12-31,MA,Morocco,
-1950-12-31,MK,North Macedonia,
-1950-12-31,MT,Malta,
-1950-12-31,MX,Mexico,
-1950-12-31,MY,Malaysia,
-1950-12-31,NL,Netherlands,
-1950-12-31,NO,Norway,
-1950-12-31,NZ,New Zealand,
-1950-12-31,PE,Peru,
-1950-12-31,PH,Philippines,
-1950-12-31,PL,Poland,
-1950-12-31,PT,Portugal,
-1950-12-31,RO,Romania,
-1950-12-31,RS,Serbia,
-1950-12-31,RU,Russia,
-1950-12-31,SE,Sweden,
-1950-12-31,SG,Singapore,
-1950-12-31,SI,Slovenia,
-1950-12-31,SK,Slovak Republic,
-1950-12-31,TH,Thailand,
-1950-12-31,TR,Türkiye,
-1950-12-31,US,United States,
-1950-12-31,XM,Euro area,
-1950-12-31,XW,World,
-1950-12-31,ZA,South Africa,
-1951-03-31,4T,Emerging market economies (aggregate),
-1951-03-31,5R,Advanced economies,
-1951-03-31,AE,United Arab Emirates,
-1951-03-31,AT,Austria,
-1951-03-31,AU,Australia,
-1951-03-31,BE,Belgium,
-1951-03-31,BG,Bulgaria,
-1951-03-31,BR,Brazil,
-1951-03-31,CA,Canada,
-1951-03-31,CH,Switzerland,
-1951-03-31,CL,Chile,
-1951-03-31,CN,China,
-1951-03-31,CO,Colombia,
-1951-03-31,CY,Cyprus,
-1951-03-31,CZ,Czechia,
-1951-03-31,DE,Germany,
-1951-03-31,DK,Denmark,
-1951-03-31,EE,Estonia,
-1951-03-31,ES,Spain,
-1951-03-31,FI,Finland,
-1951-03-31,FR,France,
-1951-03-31,GB,United Kingdom,
-1951-03-31,GR,Greece,
-1951-03-31,HK,Hong Kong SAR,
-1951-03-31,HR,Croatia,
-1951-03-31,HU,Hungary,
-1951-03-31,ID,Indonesia,
-1951-03-31,IE,Ireland,
-1951-03-31,IL,Israel,
-1951-03-31,IN,India,
-1951-03-31,IS,Iceland,
-1951-03-31,IT,Italy,1.143
-1951-03-31,JP,Japan,
-1951-03-31,KR,Korea,
-1951-03-31,LT,Lithuania,
-1951-03-31,LU,Luxembourg,
-1951-03-31,LV,Latvia,
-1951-03-31,MA,Morocco,
-1951-03-31,MK,North Macedonia,
-1951-03-31,MT,Malta,
-1951-03-31,MX,Mexico,
-1951-03-31,MY,Malaysia,
-1951-03-31,NL,Netherlands,
-1951-03-31,NO,Norway,
-1951-03-31,NZ,New Zealand,
-1951-03-31,PE,Peru,
-1951-03-31,PH,Philippines,
-1951-03-31,PL,Poland,
-1951-03-31,PT,Portugal,
-1951-03-31,RO,Romania,
-1951-03-31,RS,Serbia,
-1951-03-31,RU,Russia,
-1951-03-31,SE,Sweden,
-1951-03-31,SG,Singapore,
-1951-03-31,SI,Slovenia,
-1951-03-31,SK,Slovak Republic,
-1951-03-31,TH,Thailand,
-1951-03-31,TR,Türkiye,
-1951-03-31,US,United States,
-1951-03-31,XM,Euro area,
-1951-03-31,XW,World,
-1951-03-31,ZA,South Africa,
-1951-06-30,4T,Emerging market economies (aggregate),
-1951-06-30,5R,Advanced economies,
-1951-06-30,AE,United Arab Emirates,
-1951-06-30,AT,Austria,
-1951-06-30,AU,Australia,
-1951-06-30,BE,Belgium,
-1951-06-30,BG,Bulgaria,
-1951-06-30,BR,Brazil,
-1951-06-30,CA,Canada,
-1951-06-30,CH,Switzerland,
-1951-06-30,CL,Chile,
-1951-06-30,CN,China,
-1951-06-30,CO,Colombia,
-1951-06-30,CY,Cyprus,
-1951-06-30,CZ,Czechia,
-1951-06-30,DE,Germany,
-1951-06-30,DK,Denmark,
-1951-06-30,EE,Estonia,
-1951-06-30,ES,Spain,
-1951-06-30,FI,Finland,
-1951-06-30,FR,France,
-1951-06-30,GB,United Kingdom,
-1951-06-30,GR,Greece,
-1951-06-30,HK,Hong Kong SAR,
-1951-06-30,HR,Croatia,
-1951-06-30,HU,Hungary,
-1951-06-30,ID,Indonesia,
-1951-06-30,IE,Ireland,
-1951-06-30,IL,Israel,
-1951-06-30,IN,India,
-1951-06-30,IS,Iceland,
-1951-06-30,IT,Italy,1.2248
-1951-06-30,JP,Japan,
-1951-06-30,KR,Korea,
-1951-06-30,LT,Lithuania,
-1951-06-30,LU,Luxembourg,
-1951-06-30,LV,Latvia,
-1951-06-30,MA,Morocco,
-1951-06-30,MK,North Macedonia,
-1951-06-30,MT,Malta,
-1951-06-30,MX,Mexico,
-1951-06-30,MY,Malaysia,
-1951-06-30,NL,Netherlands,
-1951-06-30,NO,Norway,
-1951-06-30,NZ,New Zealand,
-1951-06-30,PE,Peru,
-1951-06-30,PH,Philippines,
-1951-06-30,PL,Poland,
-1951-06-30,PT,Portugal,
-1951-06-30,RO,Romania,
-1951-06-30,RS,Serbia,
-1951-06-30,RU,Russia,
-1951-06-30,SE,Sweden,
-1951-06-30,SG,Singapore,
-1951-06-30,SI,Slovenia,
-1951-06-30,SK,Slovak Republic,
-1951-06-30,TH,Thailand,
-1951-06-30,TR,Türkiye,
-1951-06-30,US,United States,
-1951-06-30,XM,Euro area,
-1951-06-30,XW,World,
-1951-06-30,ZA,South Africa,
-1951-09-30,4T,Emerging market economies (aggregate),
-1951-09-30,5R,Advanced economies,
-1951-09-30,AE,United Arab Emirates,
-1951-09-30,AT,Austria,
-1951-09-30,AU,Australia,
-1951-09-30,BE,Belgium,
-1951-09-30,BG,Bulgaria,
-1951-09-30,BR,Brazil,
-1951-09-30,CA,Canada,
-1951-09-30,CH,Switzerland,
-1951-09-30,CL,Chile,
-1951-09-30,CN,China,
-1951-09-30,CO,Colombia,
-1951-09-30,CY,Cyprus,
-1951-09-30,CZ,Czechia,
-1951-09-30,DE,Germany,
-1951-09-30,DK,Denmark,
-1951-09-30,EE,Estonia,
-1951-09-30,ES,Spain,
-1951-09-30,FI,Finland,
-1951-09-30,FR,France,
-1951-09-30,GB,United Kingdom,
-1951-09-30,GR,Greece,
-1951-09-30,HK,Hong Kong SAR,
-1951-09-30,HR,Croatia,
-1951-09-30,HU,Hungary,
-1951-09-30,ID,Indonesia,
-1951-09-30,IE,Ireland,
-1951-09-30,IL,Israel,
-1951-09-30,IN,India,
-1951-09-30,IS,Iceland,
-1951-09-30,IT,Italy,1.2175
-1951-09-30,JP,Japan,
-1951-09-30,KR,Korea,
-1951-09-30,LT,Lithuania,
-1951-09-30,LU,Luxembourg,
-1951-09-30,LV,Latvia,
-1951-09-30,MA,Morocco,
-1951-09-30,MK,North Macedonia,
-1951-09-30,MT,Malta,
-1951-09-30,MX,Mexico,
-1951-09-30,MY,Malaysia,
-1951-09-30,NL,Netherlands,
-1951-09-30,NO,Norway,
-1951-09-30,NZ,New Zealand,
-1951-09-30,PE,Peru,
-1951-09-30,PH,Philippines,
-1951-09-30,PL,Poland,
-1951-09-30,PT,Portugal,
-1951-09-30,RO,Romania,
-1951-09-30,RS,Serbia,
-1951-09-30,RU,Russia,
-1951-09-30,SE,Sweden,
-1951-09-30,SG,Singapore,
-1951-09-30,SI,Slovenia,
-1951-09-30,SK,Slovak Republic,
-1951-09-30,TH,Thailand,
-1951-09-30,TR,Türkiye,
-1951-09-30,US,United States,
-1951-09-30,XM,Euro area,
-1951-09-30,XW,World,
-1951-09-30,ZA,South Africa,
-1951-12-31,4T,Emerging market economies (aggregate),
-1951-12-31,5R,Advanced economies,
-1951-12-31,AE,United Arab Emirates,
-1951-12-31,AT,Austria,
-1951-12-31,AU,Australia,
-1951-12-31,BE,Belgium,
-1951-12-31,BG,Bulgaria,
-1951-12-31,BR,Brazil,
-1951-12-31,CA,Canada,
-1951-12-31,CH,Switzerland,
-1951-12-31,CL,Chile,
-1951-12-31,CN,China,
-1951-12-31,CO,Colombia,
-1951-12-31,CY,Cyprus,
-1951-12-31,CZ,Czechia,
-1951-12-31,DE,Germany,
-1951-12-31,DK,Denmark,
-1951-12-31,EE,Estonia,
-1951-12-31,ES,Spain,
-1951-12-31,FI,Finland,
-1951-12-31,FR,France,
-1951-12-31,GB,United Kingdom,
-1951-12-31,GR,Greece,
-1951-12-31,HK,Hong Kong SAR,
-1951-12-31,HR,Croatia,
-1951-12-31,HU,Hungary,
-1951-12-31,ID,Indonesia,
-1951-12-31,IE,Ireland,
-1951-12-31,IL,Israel,
-1951-12-31,IN,India,
-1951-12-31,IS,Iceland,
-1951-12-31,IT,Italy,1.2028
-1951-12-31,JP,Japan,
-1951-12-31,KR,Korea,
-1951-12-31,LT,Lithuania,
-1951-12-31,LU,Luxembourg,
-1951-12-31,LV,Latvia,
-1951-12-31,MA,Morocco,
-1951-12-31,MK,North Macedonia,
-1951-12-31,MT,Malta,
-1951-12-31,MX,Mexico,
-1951-12-31,MY,Malaysia,
-1951-12-31,NL,Netherlands,
-1951-12-31,NO,Norway,
-1951-12-31,NZ,New Zealand,
-1951-12-31,PE,Peru,
-1951-12-31,PH,Philippines,
-1951-12-31,PL,Poland,
-1951-12-31,PT,Portugal,
-1951-12-31,RO,Romania,
-1951-12-31,RS,Serbia,
-1951-12-31,RU,Russia,
-1951-12-31,SE,Sweden,
-1951-12-31,SG,Singapore,
-1951-12-31,SI,Slovenia,
-1951-12-31,SK,Slovak Republic,
-1951-12-31,TH,Thailand,
-1951-12-31,TR,Türkiye,
-1951-12-31,US,United States,
-1951-12-31,XM,Euro area,
-1951-12-31,XW,World,
-1951-12-31,ZA,South Africa,
-1952-03-31,4T,Emerging market economies (aggregate),
-1952-03-31,5R,Advanced economies,
-1952-03-31,AE,United Arab Emirates,
-1952-03-31,AT,Austria,
-1952-03-31,AU,Australia,
-1952-03-31,BE,Belgium,
-1952-03-31,BG,Bulgaria,
-1952-03-31,BR,Brazil,
-1952-03-31,CA,Canada,
-1952-03-31,CH,Switzerland,
-1952-03-31,CL,Chile,
-1952-03-31,CN,China,
-1952-03-31,CO,Colombia,
-1952-03-31,CY,Cyprus,
-1952-03-31,CZ,Czechia,
-1952-03-31,DE,Germany,
-1952-03-31,DK,Denmark,
-1952-03-31,EE,Estonia,
-1952-03-31,ES,Spain,
-1952-03-31,FI,Finland,
-1952-03-31,FR,France,
-1952-03-31,GB,United Kingdom,
-1952-03-31,GR,Greece,
-1952-03-31,HK,Hong Kong SAR,
-1952-03-31,HR,Croatia,
-1952-03-31,HU,Hungary,
-1952-03-31,ID,Indonesia,
-1952-03-31,IE,Ireland,
-1952-03-31,IL,Israel,
-1952-03-31,IN,India,
-1952-03-31,IS,Iceland,
-1952-03-31,IT,Italy,1.1984
-1952-03-31,JP,Japan,
-1952-03-31,KR,Korea,
-1952-03-31,LT,Lithuania,
-1952-03-31,LU,Luxembourg,
-1952-03-31,LV,Latvia,
-1952-03-31,MA,Morocco,
-1952-03-31,MK,North Macedonia,
-1952-03-31,MT,Malta,
-1952-03-31,MX,Mexico,
-1952-03-31,MY,Malaysia,
-1952-03-31,NL,Netherlands,
-1952-03-31,NO,Norway,
-1952-03-31,NZ,New Zealand,
-1952-03-31,PE,Peru,
-1952-03-31,PH,Philippines,
-1952-03-31,PL,Poland,
-1952-03-31,PT,Portugal,
-1952-03-31,RO,Romania,
-1952-03-31,RS,Serbia,
-1952-03-31,RU,Russia,
-1952-03-31,SE,Sweden,
-1952-03-31,SG,Singapore,
-1952-03-31,SI,Slovenia,
-1952-03-31,SK,Slovak Republic,
-1952-03-31,TH,Thailand,
-1952-03-31,TR,Türkiye,
-1952-03-31,US,United States,
-1952-03-31,XM,Euro area,
-1952-03-31,XW,World,
-1952-03-31,ZA,South Africa,
-1952-06-30,4T,Emerging market economies (aggregate),
-1952-06-30,5R,Advanced economies,
-1952-06-30,AE,United Arab Emirates,
-1952-06-30,AT,Austria,
-1952-06-30,AU,Australia,
-1952-06-30,BE,Belgium,
-1952-06-30,BG,Bulgaria,
-1952-06-30,BR,Brazil,
-1952-06-30,CA,Canada,
-1952-06-30,CH,Switzerland,
-1952-06-30,CL,Chile,
-1952-06-30,CN,China,
-1952-06-30,CO,Colombia,
-1952-06-30,CY,Cyprus,
-1952-06-30,CZ,Czechia,
-1952-06-30,DE,Germany,
-1952-06-30,DK,Denmark,
-1952-06-30,EE,Estonia,
-1952-06-30,ES,Spain,
-1952-06-30,FI,Finland,
-1952-06-30,FR,France,
-1952-06-30,GB,United Kingdom,
-1952-06-30,GR,Greece,
-1952-06-30,HK,Hong Kong SAR,
-1952-06-30,HR,Croatia,
-1952-06-30,HU,Hungary,
-1952-06-30,ID,Indonesia,
-1952-06-30,IE,Ireland,
-1952-06-30,IL,Israel,
-1952-06-30,IN,India,
-1952-06-30,IS,Iceland,
-1952-06-30,IT,Italy,1.2146
-1952-06-30,JP,Japan,
-1952-06-30,KR,Korea,
-1952-06-30,LT,Lithuania,
-1952-06-30,LU,Luxembourg,
-1952-06-30,LV,Latvia,
-1952-06-30,MA,Morocco,
-1952-06-30,MK,North Macedonia,
-1952-06-30,MT,Malta,
-1952-06-30,MX,Mexico,
-1952-06-30,MY,Malaysia,
-1952-06-30,NL,Netherlands,
-1952-06-30,NO,Norway,
-1952-06-30,NZ,New Zealand,
-1952-06-30,PE,Peru,
-1952-06-30,PH,Philippines,
-1952-06-30,PL,Poland,
-1952-06-30,PT,Portugal,
-1952-06-30,RO,Romania,
-1952-06-30,RS,Serbia,
-1952-06-30,RU,Russia,
-1952-06-30,SE,Sweden,
-1952-06-30,SG,Singapore,
-1952-06-30,SI,Slovenia,
-1952-06-30,SK,Slovak Republic,
-1952-06-30,TH,Thailand,
-1952-06-30,TR,Türkiye,
-1952-06-30,US,United States,
-1952-06-30,XM,Euro area,
-1952-06-30,XW,World,
-1952-06-30,ZA,South Africa,
-1952-09-30,4T,Emerging market economies (aggregate),
-1952-09-30,5R,Advanced economies,
-1952-09-30,AE,United Arab Emirates,
-1952-09-30,AT,Austria,
-1952-09-30,AU,Australia,
-1952-09-30,BE,Belgium,
-1952-09-30,BG,Bulgaria,
-1952-09-30,BR,Brazil,
-1952-09-30,CA,Canada,
-1952-09-30,CH,Switzerland,
-1952-09-30,CL,Chile,
-1952-09-30,CN,China,
-1952-09-30,CO,Colombia,
-1952-09-30,CY,Cyprus,
-1952-09-30,CZ,Czechia,
-1952-09-30,DE,Germany,
-1952-09-30,DK,Denmark,
-1952-09-30,EE,Estonia,
-1952-09-30,ES,Spain,
-1952-09-30,FI,Finland,
-1952-09-30,FR,France,
-1952-09-30,GB,United Kingdom,
-1952-09-30,GR,Greece,
-1952-09-30,HK,Hong Kong SAR,
-1952-09-30,HR,Croatia,
-1952-09-30,HU,Hungary,
-1952-09-30,ID,Indonesia,
-1952-09-30,IE,Ireland,
-1952-09-30,IL,Israel,
-1952-09-30,IN,India,
-1952-09-30,IS,Iceland,
-1952-09-30,IT,Italy,1.2289
-1952-09-30,JP,Japan,
-1952-09-30,KR,Korea,
-1952-09-30,LT,Lithuania,
-1952-09-30,LU,Luxembourg,
-1952-09-30,LV,Latvia,
-1952-09-30,MA,Morocco,
-1952-09-30,MK,North Macedonia,
-1952-09-30,MT,Malta,
-1952-09-30,MX,Mexico,
-1952-09-30,MY,Malaysia,
-1952-09-30,NL,Netherlands,
-1952-09-30,NO,Norway,
-1952-09-30,NZ,New Zealand,
-1952-09-30,PE,Peru,
-1952-09-30,PH,Philippines,
-1952-09-30,PL,Poland,
-1952-09-30,PT,Portugal,
-1952-09-30,RO,Romania,
-1952-09-30,RS,Serbia,
-1952-09-30,RU,Russia,
-1952-09-30,SE,Sweden,
-1952-09-30,SG,Singapore,
-1952-09-30,SI,Slovenia,
-1952-09-30,SK,Slovak Republic,
-1952-09-30,TH,Thailand,
-1952-09-30,TR,Türkiye,
-1952-09-30,US,United States,
-1952-09-30,XM,Euro area,
-1952-09-30,XW,World,
-1952-09-30,ZA,South Africa,
-1952-12-31,4T,Emerging market economies (aggregate),
-1952-12-31,5R,Advanced economies,
-1952-12-31,AE,United Arab Emirates,
-1952-12-31,AT,Austria,
-1952-12-31,AU,Australia,
-1952-12-31,BE,Belgium,
-1952-12-31,BG,Bulgaria,
-1952-12-31,BR,Brazil,
-1952-12-31,CA,Canada,
-1952-12-31,CH,Switzerland,
-1952-12-31,CL,Chile,
-1952-12-31,CN,China,
-1952-12-31,CO,Colombia,
-1952-12-31,CY,Cyprus,
-1952-12-31,CZ,Czechia,
-1952-12-31,DE,Germany,
-1952-12-31,DK,Denmark,
-1952-12-31,EE,Estonia,
-1952-12-31,ES,Spain,
-1952-12-31,FI,Finland,
-1952-12-31,FR,France,
-1952-12-31,GB,United Kingdom,
-1952-12-31,GR,Greece,
-1952-12-31,HK,Hong Kong SAR,
-1952-12-31,HR,Croatia,
-1952-12-31,HU,Hungary,
-1952-12-31,ID,Indonesia,
-1952-12-31,IE,Ireland,
-1952-12-31,IL,Israel,
-1952-12-31,IN,India,
-1952-12-31,IS,Iceland,
-1952-12-31,IT,Italy,1.2382
-1952-12-31,JP,Japan,
-1952-12-31,KR,Korea,
-1952-12-31,LT,Lithuania,
-1952-12-31,LU,Luxembourg,
-1952-12-31,LV,Latvia,
-1952-12-31,MA,Morocco,
-1952-12-31,MK,North Macedonia,
-1952-12-31,MT,Malta,
-1952-12-31,MX,Mexico,
-1952-12-31,MY,Malaysia,
-1952-12-31,NL,Netherlands,
-1952-12-31,NO,Norway,
-1952-12-31,NZ,New Zealand,
-1952-12-31,PE,Peru,
-1952-12-31,PH,Philippines,
-1952-12-31,PL,Poland,
-1952-12-31,PT,Portugal,
-1952-12-31,RO,Romania,
-1952-12-31,RS,Serbia,
-1952-12-31,RU,Russia,
-1952-12-31,SE,Sweden,
-1952-12-31,SG,Singapore,
-1952-12-31,SI,Slovenia,
-1952-12-31,SK,Slovak Republic,
-1952-12-31,TH,Thailand,
-1952-12-31,TR,Türkiye,
-1952-12-31,US,United States,
-1952-12-31,XM,Euro area,
-1952-12-31,XW,World,
-1952-12-31,ZA,South Africa,
-1953-03-31,4T,Emerging market economies (aggregate),
-1953-03-31,5R,Advanced economies,
-1953-03-31,AE,United Arab Emirates,
-1953-03-31,AT,Austria,
-1953-03-31,AU,Australia,
-1953-03-31,BE,Belgium,
-1953-03-31,BG,Bulgaria,
-1953-03-31,BR,Brazil,
-1953-03-31,CA,Canada,
-1953-03-31,CH,Switzerland,
-1953-03-31,CL,Chile,
-1953-03-31,CN,China,
-1953-03-31,CO,Colombia,
-1953-03-31,CY,Cyprus,
-1953-03-31,CZ,Czechia,
-1953-03-31,DE,Germany,
-1953-03-31,DK,Denmark,
-1953-03-31,EE,Estonia,
-1953-03-31,ES,Spain,
-1953-03-31,FI,Finland,
-1953-03-31,FR,France,
-1953-03-31,GB,United Kingdom,
-1953-03-31,GR,Greece,
-1953-03-31,HK,Hong Kong SAR,
-1953-03-31,HR,Croatia,
-1953-03-31,HU,Hungary,
-1953-03-31,ID,Indonesia,
-1953-03-31,IE,Ireland,
-1953-03-31,IL,Israel,
-1953-03-31,IN,India,
-1953-03-31,IS,Iceland,
-1953-03-31,IT,Italy,1.2204
-1953-03-31,JP,Japan,
-1953-03-31,KR,Korea,
-1953-03-31,LT,Lithuania,
-1953-03-31,LU,Luxembourg,
-1953-03-31,LV,Latvia,
-1953-03-31,MA,Morocco,
-1953-03-31,MK,North Macedonia,
-1953-03-31,MT,Malta,
-1953-03-31,MX,Mexico,
-1953-03-31,MY,Malaysia,
-1953-03-31,NL,Netherlands,
-1953-03-31,NO,Norway,
-1953-03-31,NZ,New Zealand,
-1953-03-31,PE,Peru,
-1953-03-31,PH,Philippines,
-1953-03-31,PL,Poland,
-1953-03-31,PT,Portugal,
-1953-03-31,RO,Romania,
-1953-03-31,RS,Serbia,
-1953-03-31,RU,Russia,
-1953-03-31,SE,Sweden,
-1953-03-31,SG,Singapore,
-1953-03-31,SI,Slovenia,
-1953-03-31,SK,Slovak Republic,
-1953-03-31,TH,Thailand,
-1953-03-31,TR,Türkiye,
-1953-03-31,US,United States,
-1953-03-31,XM,Euro area,
-1953-03-31,XW,World,
-1953-03-31,ZA,South Africa,
-1953-06-30,4T,Emerging market economies (aggregate),
-1953-06-30,5R,Advanced economies,
-1953-06-30,AE,United Arab Emirates,
-1953-06-30,AT,Austria,
-1953-06-30,AU,Australia,
-1953-06-30,BE,Belgium,
-1953-06-30,BG,Bulgaria,
-1953-06-30,BR,Brazil,
-1953-06-30,CA,Canada,
-1953-06-30,CH,Switzerland,
-1953-06-30,CL,Chile,
-1953-06-30,CN,China,
-1953-06-30,CO,Colombia,
-1953-06-30,CY,Cyprus,
-1953-06-30,CZ,Czechia,
-1953-06-30,DE,Germany,
-1953-06-30,DK,Denmark,
-1953-06-30,EE,Estonia,
-1953-06-30,ES,Spain,
-1953-06-30,FI,Finland,
-1953-06-30,FR,France,
-1953-06-30,GB,United Kingdom,
-1953-06-30,GR,Greece,
-1953-06-30,HK,Hong Kong SAR,
-1953-06-30,HR,Croatia,
-1953-06-30,HU,Hungary,
-1953-06-30,ID,Indonesia,
-1953-06-30,IE,Ireland,
-1953-06-30,IL,Israel,
-1953-06-30,IN,India,
-1953-06-30,IS,Iceland,
-1953-06-30,IT,Italy,1.2571
-1953-06-30,JP,Japan,
-1953-06-30,KR,Korea,
-1953-06-30,LT,Lithuania,
-1953-06-30,LU,Luxembourg,
-1953-06-30,LV,Latvia,
-1953-06-30,MA,Morocco,
-1953-06-30,MK,North Macedonia,
-1953-06-30,MT,Malta,
-1953-06-30,MX,Mexico,
-1953-06-30,MY,Malaysia,
-1953-06-30,NL,Netherlands,
-1953-06-30,NO,Norway,
-1953-06-30,NZ,New Zealand,
-1953-06-30,PE,Peru,
-1953-06-30,PH,Philippines,
-1953-06-30,PL,Poland,
-1953-06-30,PT,Portugal,
-1953-06-30,RO,Romania,
-1953-06-30,RS,Serbia,
-1953-06-30,RU,Russia,
-1953-06-30,SE,Sweden,
-1953-06-30,SG,Singapore,
-1953-06-30,SI,Slovenia,
-1953-06-30,SK,Slovak Republic,
-1953-06-30,TH,Thailand,
-1953-06-30,TR,Türkiye,
-1953-06-30,US,United States,
-1953-06-30,XM,Euro area,
-1953-06-30,XW,World,
-1953-06-30,ZA,South Africa,
-1953-09-30,4T,Emerging market economies (aggregate),
-1953-09-30,5R,Advanced economies,
-1953-09-30,AE,United Arab Emirates,
-1953-09-30,AT,Austria,
-1953-09-30,AU,Australia,
-1953-09-30,BE,Belgium,
-1953-09-30,BG,Bulgaria,
-1953-09-30,BR,Brazil,
-1953-09-30,CA,Canada,
-1953-09-30,CH,Switzerland,
-1953-09-30,CL,Chile,
-1953-09-30,CN,China,
-1953-09-30,CO,Colombia,
-1953-09-30,CY,Cyprus,
-1953-09-30,CZ,Czechia,
-1953-09-30,DE,Germany,
-1953-09-30,DK,Denmark,
-1953-09-30,EE,Estonia,
-1953-09-30,ES,Spain,
-1953-09-30,FI,Finland,
-1953-09-30,FR,France,
-1953-09-30,GB,United Kingdom,
-1953-09-30,GR,Greece,
-1953-09-30,HK,Hong Kong SAR,
-1953-09-30,HR,Croatia,
-1953-09-30,HU,Hungary,
-1953-09-30,ID,Indonesia,
-1953-09-30,IE,Ireland,
-1953-09-30,IL,Israel,
-1953-09-30,IN,India,
-1953-09-30,IS,Iceland,
-1953-09-30,IT,Italy,1.2101
-1953-09-30,JP,Japan,
-1953-09-30,KR,Korea,
-1953-09-30,LT,Lithuania,
-1953-09-30,LU,Luxembourg,
-1953-09-30,LV,Latvia,
-1953-09-30,MA,Morocco,
-1953-09-30,MK,North Macedonia,
-1953-09-30,MT,Malta,
-1953-09-30,MX,Mexico,
-1953-09-30,MY,Malaysia,
-1953-09-30,NL,Netherlands,
-1953-09-30,NO,Norway,
-1953-09-30,NZ,New Zealand,
-1953-09-30,PE,Peru,
-1953-09-30,PH,Philippines,
-1953-09-30,PL,Poland,
-1953-09-30,PT,Portugal,
-1953-09-30,RO,Romania,
-1953-09-30,RS,Serbia,
-1953-09-30,RU,Russia,
-1953-09-30,SE,Sweden,
-1953-09-30,SG,Singapore,
-1953-09-30,SI,Slovenia,
-1953-09-30,SK,Slovak Republic,
-1953-09-30,TH,Thailand,
-1953-09-30,TR,Türkiye,
-1953-09-30,US,United States,
-1953-09-30,XM,Euro area,
-1953-09-30,XW,World,
-1953-09-30,ZA,South Africa,
-1953-12-31,4T,Emerging market economies (aggregate),
-1953-12-31,5R,Advanced economies,
-1953-12-31,AE,United Arab Emirates,
-1953-12-31,AT,Austria,
-1953-12-31,AU,Australia,
-1953-12-31,BE,Belgium,
-1953-12-31,BG,Bulgaria,
-1953-12-31,BR,Brazil,
-1953-12-31,CA,Canada,
-1953-12-31,CH,Switzerland,
-1953-12-31,CL,Chile,
-1953-12-31,CN,China,
-1953-12-31,CO,Colombia,
-1953-12-31,CY,Cyprus,
-1953-12-31,CZ,Czechia,
-1953-12-31,DE,Germany,
-1953-12-31,DK,Denmark,
-1953-12-31,EE,Estonia,
-1953-12-31,ES,Spain,
-1953-12-31,FI,Finland,
-1953-12-31,FR,France,
-1953-12-31,GB,United Kingdom,
-1953-12-31,GR,Greece,
-1953-12-31,HK,Hong Kong SAR,
-1953-12-31,HR,Croatia,
-1953-12-31,HU,Hungary,
-1953-12-31,ID,Indonesia,
-1953-12-31,IE,Ireland,
-1953-12-31,IL,Israel,
-1953-12-31,IN,India,
-1953-12-31,IS,Iceland,
-1953-12-31,IT,Italy,1.2327
-1953-12-31,JP,Japan,
-1953-12-31,KR,Korea,
-1953-12-31,LT,Lithuania,
-1953-12-31,LU,Luxembourg,
-1953-12-31,LV,Latvia,
-1953-12-31,MA,Morocco,
-1953-12-31,MK,North Macedonia,
-1953-12-31,MT,Malta,
-1953-12-31,MX,Mexico,
-1953-12-31,MY,Malaysia,
-1953-12-31,NL,Netherlands,
-1953-12-31,NO,Norway,
-1953-12-31,NZ,New Zealand,
-1953-12-31,PE,Peru,
-1953-12-31,PH,Philippines,
-1953-12-31,PL,Poland,
-1953-12-31,PT,Portugal,
-1953-12-31,RO,Romania,
-1953-12-31,RS,Serbia,
-1953-12-31,RU,Russia,
-1953-12-31,SE,Sweden,
-1953-12-31,SG,Singapore,
-1953-12-31,SI,Slovenia,
-1953-12-31,SK,Slovak Republic,
-1953-12-31,TH,Thailand,
-1953-12-31,TR,Türkiye,
-1953-12-31,US,United States,
-1953-12-31,XM,Euro area,
-1953-12-31,XW,World,
-1953-12-31,ZA,South Africa,
-1954-03-31,4T,Emerging market economies (aggregate),
-1954-03-31,5R,Advanced economies,
-1954-03-31,AE,United Arab Emirates,
-1954-03-31,AT,Austria,
-1954-03-31,AU,Australia,
-1954-03-31,BE,Belgium,
-1954-03-31,BG,Bulgaria,
-1954-03-31,BR,Brazil,
-1954-03-31,CA,Canada,
-1954-03-31,CH,Switzerland,
-1954-03-31,CL,Chile,
-1954-03-31,CN,China,
-1954-03-31,CO,Colombia,
-1954-03-31,CY,Cyprus,
-1954-03-31,CZ,Czechia,
-1954-03-31,DE,Germany,
-1954-03-31,DK,Denmark,
-1954-03-31,EE,Estonia,
-1954-03-31,ES,Spain,
-1954-03-31,FI,Finland,
-1954-03-31,FR,France,
-1954-03-31,GB,United Kingdom,
-1954-03-31,GR,Greece,
-1954-03-31,HK,Hong Kong SAR,
-1954-03-31,HR,Croatia,
-1954-03-31,HU,Hungary,
-1954-03-31,ID,Indonesia,
-1954-03-31,IE,Ireland,
-1954-03-31,IL,Israel,
-1954-03-31,IN,India,
-1954-03-31,IS,Iceland,
-1954-03-31,IT,Italy,1.235
-1954-03-31,JP,Japan,
-1954-03-31,KR,Korea,
-1954-03-31,LT,Lithuania,
-1954-03-31,LU,Luxembourg,
-1954-03-31,LV,Latvia,
-1954-03-31,MA,Morocco,
-1954-03-31,MK,North Macedonia,
-1954-03-31,MT,Malta,
-1954-03-31,MX,Mexico,
-1954-03-31,MY,Malaysia,
-1954-03-31,NL,Netherlands,
-1954-03-31,NO,Norway,
-1954-03-31,NZ,New Zealand,
-1954-03-31,PE,Peru,
-1954-03-31,PH,Philippines,
-1954-03-31,PL,Poland,
-1954-03-31,PT,Portugal,
-1954-03-31,RO,Romania,
-1954-03-31,RS,Serbia,
-1954-03-31,RU,Russia,
-1954-03-31,SE,Sweden,
-1954-03-31,SG,Singapore,
-1954-03-31,SI,Slovenia,
-1954-03-31,SK,Slovak Republic,
-1954-03-31,TH,Thailand,
-1954-03-31,TR,Türkiye,
-1954-03-31,US,United States,
-1954-03-31,XM,Euro area,
-1954-03-31,XW,World,
-1954-03-31,ZA,South Africa,
-1954-06-30,4T,Emerging market economies (aggregate),
-1954-06-30,5R,Advanced economies,
-1954-06-30,AE,United Arab Emirates,
-1954-06-30,AT,Austria,
-1954-06-30,AU,Australia,
-1954-06-30,BE,Belgium,
-1954-06-30,BG,Bulgaria,
-1954-06-30,BR,Brazil,
-1954-06-30,CA,Canada,
-1954-06-30,CH,Switzerland,
-1954-06-30,CL,Chile,
-1954-06-30,CN,China,
-1954-06-30,CO,Colombia,
-1954-06-30,CY,Cyprus,
-1954-06-30,CZ,Czechia,
-1954-06-30,DE,Germany,
-1954-06-30,DK,Denmark,
-1954-06-30,EE,Estonia,
-1954-06-30,ES,Spain,
-1954-06-30,FI,Finland,
-1954-06-30,FR,France,
-1954-06-30,GB,United Kingdom,
-1954-06-30,GR,Greece,
-1954-06-30,HK,Hong Kong SAR,
-1954-06-30,HR,Croatia,
-1954-06-30,HU,Hungary,
-1954-06-30,ID,Indonesia,
-1954-06-30,IE,Ireland,
-1954-06-30,IL,Israel,
-1954-06-30,IN,India,
-1954-06-30,IS,Iceland,
-1954-06-30,IT,Italy,1.2849
-1954-06-30,JP,Japan,
-1954-06-30,KR,Korea,
-1954-06-30,LT,Lithuania,
-1954-06-30,LU,Luxembourg,
-1954-06-30,LV,Latvia,
-1954-06-30,MA,Morocco,
-1954-06-30,MK,North Macedonia,
-1954-06-30,MT,Malta,
-1954-06-30,MX,Mexico,
-1954-06-30,MY,Malaysia,
-1954-06-30,NL,Netherlands,
-1954-06-30,NO,Norway,
-1954-06-30,NZ,New Zealand,
-1954-06-30,PE,Peru,
-1954-06-30,PH,Philippines,
-1954-06-30,PL,Poland,
-1954-06-30,PT,Portugal,
-1954-06-30,RO,Romania,
-1954-06-30,RS,Serbia,
-1954-06-30,RU,Russia,
-1954-06-30,SE,Sweden,
-1954-06-30,SG,Singapore,
-1954-06-30,SI,Slovenia,
-1954-06-30,SK,Slovak Republic,
-1954-06-30,TH,Thailand,
-1954-06-30,TR,Türkiye,
-1954-06-30,US,United States,
-1954-06-30,XM,Euro area,
-1954-06-30,XW,World,
-1954-06-30,ZA,South Africa,
-1954-09-30,4T,Emerging market economies (aggregate),
-1954-09-30,5R,Advanced economies,
-1954-09-30,AE,United Arab Emirates,
-1954-09-30,AT,Austria,
-1954-09-30,AU,Australia,
-1954-09-30,BE,Belgium,
-1954-09-30,BG,Bulgaria,
-1954-09-30,BR,Brazil,
-1954-09-30,CA,Canada,
-1954-09-30,CH,Switzerland,
-1954-09-30,CL,Chile,
-1954-09-30,CN,China,
-1954-09-30,CO,Colombia,
-1954-09-30,CY,Cyprus,
-1954-09-30,CZ,Czechia,
-1954-09-30,DE,Germany,
-1954-09-30,DK,Denmark,
-1954-09-30,EE,Estonia,
-1954-09-30,ES,Spain,
-1954-09-30,FI,Finland,
-1954-09-30,FR,France,
-1954-09-30,GB,United Kingdom,
-1954-09-30,GR,Greece,
-1954-09-30,HK,Hong Kong SAR,
-1954-09-30,HR,Croatia,
-1954-09-30,HU,Hungary,
-1954-09-30,ID,Indonesia,
-1954-09-30,IE,Ireland,
-1954-09-30,IL,Israel,
-1954-09-30,IN,India,
-1954-09-30,IS,Iceland,
-1954-09-30,IT,Italy,1.3125
-1954-09-30,JP,Japan,
-1954-09-30,KR,Korea,
-1954-09-30,LT,Lithuania,
-1954-09-30,LU,Luxembourg,
-1954-09-30,LV,Latvia,
-1954-09-30,MA,Morocco,
-1954-09-30,MK,North Macedonia,
-1954-09-30,MT,Malta,
-1954-09-30,MX,Mexico,
-1954-09-30,MY,Malaysia,
-1954-09-30,NL,Netherlands,
-1954-09-30,NO,Norway,
-1954-09-30,NZ,New Zealand,
-1954-09-30,PE,Peru,
-1954-09-30,PH,Philippines,
-1954-09-30,PL,Poland,
-1954-09-30,PT,Portugal,
-1954-09-30,RO,Romania,
-1954-09-30,RS,Serbia,
-1954-09-30,RU,Russia,
-1954-09-30,SE,Sweden,
-1954-09-30,SG,Singapore,
-1954-09-30,SI,Slovenia,
-1954-09-30,SK,Slovak Republic,
-1954-09-30,TH,Thailand,
-1954-09-30,TR,Türkiye,
-1954-09-30,US,United States,
-1954-09-30,XM,Euro area,
-1954-09-30,XW,World,
-1954-09-30,ZA,South Africa,
-1954-12-31,4T,Emerging market economies (aggregate),
-1954-12-31,5R,Advanced economies,
-1954-12-31,AE,United Arab Emirates,
-1954-12-31,AT,Austria,
-1954-12-31,AU,Australia,
-1954-12-31,BE,Belgium,
-1954-12-31,BG,Bulgaria,
-1954-12-31,BR,Brazil,
-1954-12-31,CA,Canada,
-1954-12-31,CH,Switzerland,
-1954-12-31,CL,Chile,
-1954-12-31,CN,China,
-1954-12-31,CO,Colombia,
-1954-12-31,CY,Cyprus,
-1954-12-31,CZ,Czechia,
-1954-12-31,DE,Germany,
-1954-12-31,DK,Denmark,
-1954-12-31,EE,Estonia,
-1954-12-31,ES,Spain,
-1954-12-31,FI,Finland,
-1954-12-31,FR,France,
-1954-12-31,GB,United Kingdom,
-1954-12-31,GR,Greece,
-1954-12-31,HK,Hong Kong SAR,
-1954-12-31,HR,Croatia,
-1954-12-31,HU,Hungary,
-1954-12-31,ID,Indonesia,
-1954-12-31,IE,Ireland,
-1954-12-31,IL,Israel,
-1954-12-31,IN,India,
-1954-12-31,IS,Iceland,
-1954-12-31,IT,Italy,1.3006
-1954-12-31,JP,Japan,
-1954-12-31,KR,Korea,
-1954-12-31,LT,Lithuania,
-1954-12-31,LU,Luxembourg,
-1954-12-31,LV,Latvia,
-1954-12-31,MA,Morocco,
-1954-12-31,MK,North Macedonia,
-1954-12-31,MT,Malta,
-1954-12-31,MX,Mexico,
-1954-12-31,MY,Malaysia,
-1954-12-31,NL,Netherlands,
-1954-12-31,NO,Norway,
-1954-12-31,NZ,New Zealand,
-1954-12-31,PE,Peru,
-1954-12-31,PH,Philippines,
-1954-12-31,PL,Poland,
-1954-12-31,PT,Portugal,
-1954-12-31,RO,Romania,
-1954-12-31,RS,Serbia,
-1954-12-31,RU,Russia,
-1954-12-31,SE,Sweden,
-1954-12-31,SG,Singapore,
-1954-12-31,SI,Slovenia,
-1954-12-31,SK,Slovak Republic,
-1954-12-31,TH,Thailand,
-1954-12-31,TR,Türkiye,
-1954-12-31,US,United States,
-1954-12-31,XM,Euro area,
-1954-12-31,XW,World,
-1954-12-31,ZA,South Africa,
-1955-03-31,4T,Emerging market economies (aggregate),
-1955-03-31,5R,Advanced economies,
-1955-03-31,AE,United Arab Emirates,
-1955-03-31,AT,Austria,
-1955-03-31,AU,Australia,
-1955-03-31,BE,Belgium,
-1955-03-31,BG,Bulgaria,
-1955-03-31,BR,Brazil,
-1955-03-31,CA,Canada,
-1955-03-31,CH,Switzerland,
-1955-03-31,CL,Chile,
-1955-03-31,CN,China,
-1955-03-31,CO,Colombia,
-1955-03-31,CY,Cyprus,
-1955-03-31,CZ,Czechia,
-1955-03-31,DE,Germany,
-1955-03-31,DK,Denmark,
-1955-03-31,EE,Estonia,
-1955-03-31,ES,Spain,
-1955-03-31,FI,Finland,
-1955-03-31,FR,France,
-1955-03-31,GB,United Kingdom,
-1955-03-31,GR,Greece,
-1955-03-31,HK,Hong Kong SAR,
-1955-03-31,HR,Croatia,
-1955-03-31,HU,Hungary,
-1955-03-31,ID,Indonesia,
-1955-03-31,IE,Ireland,
-1955-03-31,IL,Israel,
-1955-03-31,IN,India,
-1955-03-31,IS,Iceland,
-1955-03-31,IT,Italy,1.2923
+1948-03-31,IT,Italy,1.044
+1948-06-30,IT,Italy,1.0729
+1948-09-30,IT,Italy,0.9875
+1948-12-31,IT,Italy,1.0204
+1949-03-31,IT,Italy,1.05
+1949-06-30,IT,Italy,1.0542
+1949-09-30,IT,Italy,0.9606
+1949-12-31,IT,Italy,0.9209
+1950-03-31,IT,Italy,0.9173
+1950-06-30,IT,Italy,0.9829
+1950-09-30,IT,Italy,1.0618
+1950-12-31,IT,Italy,1.0751
+1951-03-31,IT,Italy,1.1436
+1951-06-30,IT,Italy,1.2268
+1951-09-30,IT,Italy,1.2167
+1951-12-31,IT,Italy,1.2011
+1952-03-31,IT,Italy,1.1967
+1952-06-30,IT,Italy,1.2143
+1952-09-30,IT,Italy,1.2297
+1952-12-31,IT,Italy,1.2396
+1953-03-31,IT,Italy,1.2205
+1953-06-30,IT,Italy,1.2598
+1953-09-30,IT,Italy,1.2087
+1953-12-31,IT,Italy,1.2314
+1954-03-31,IT,Italy,1.2642
+1954-06-30,IT,Italy,1.2669
+1954-09-30,IT,Italy,1.29
+1954-12-31,IT,Italy,1.3125
+1955-03-31,IT,Italy,1.3224
 1955-03-31,JP,Japan,2.2115
-1955-03-31,KR,Korea,
-1955-03-31,LT,Lithuania,
-1955-03-31,LU,Luxembourg,
-1955-03-31,LV,Latvia,
-1955-03-31,MA,Morocco,
-1955-03-31,MK,North Macedonia,
-1955-03-31,MT,Malta,
-1955-03-31,MX,Mexico,
-1955-03-31,MY,Malaysia,
-1955-03-31,NL,Netherlands,
-1955-03-31,NO,Norway,
-1955-03-31,NZ,New Zealand,
-1955-03-31,PE,Peru,
-1955-03-31,PH,Philippines,
-1955-03-31,PL,Poland,
-1955-03-31,PT,Portugal,
-1955-03-31,RO,Romania,
-1955-03-31,RS,Serbia,
-1955-03-31,RU,Russia,
-1955-03-31,SE,Sweden,
-1955-03-31,SG,Singapore,
-1955-03-31,SI,Slovenia,
-1955-03-31,SK,Slovak Republic,
-1955-03-31,TH,Thailand,
-1955-03-31,TR,Türkiye,
-1955-03-31,US,United States,
-1955-03-31,XM,Euro area,
-1955-03-31,XW,World,
-1955-03-31,ZA,South Africa,
-1955-06-30,4T,Emerging market economies (aggregate),
-1955-06-30,5R,Advanced economies,
-1955-06-30,AE,United Arab Emirates,
-1955-06-30,AT,Austria,
-1955-06-30,AU,Australia,
-1955-06-30,BE,Belgium,
-1955-06-30,BG,Bulgaria,
-1955-06-30,BR,Brazil,
-1955-06-30,CA,Canada,
-1955-06-30,CH,Switzerland,
-1955-06-30,CL,Chile,
-1955-06-30,CN,China,
-1955-06-30,CO,Colombia,
-1955-06-30,CY,Cyprus,
-1955-06-30,CZ,Czechia,
-1955-06-30,DE,Germany,
-1955-06-30,DK,Denmark,
-1955-06-30,EE,Estonia,
-1955-06-30,ES,Spain,
-1955-06-30,FI,Finland,
-1955-06-30,FR,France,
-1955-06-30,GB,United Kingdom,
-1955-06-30,GR,Greece,
-1955-06-30,HK,Hong Kong SAR,
-1955-06-30,HR,Croatia,
-1955-06-30,HU,Hungary,
-1955-06-30,ID,Indonesia,
-1955-06-30,IE,Ireland,
-1955-06-30,IL,Israel,
-1955-06-30,IN,India,
-1955-06-30,IS,Iceland,
-1955-06-30,IT,Italy,1.3418
+1955-06-30,IT,Italy,1.3156
 1955-06-30,JP,Japan,2.2785
-1955-06-30,KR,Korea,
-1955-06-30,LT,Lithuania,
-1955-06-30,LU,Luxembourg,
-1955-06-30,LV,Latvia,
-1955-06-30,MA,Morocco,
-1955-06-30,MK,North Macedonia,
-1955-06-30,MT,Malta,
-1955-06-30,MX,Mexico,
-1955-06-30,MY,Malaysia,
-1955-06-30,NL,Netherlands,
-1955-06-30,NO,Norway,
-1955-06-30,NZ,New Zealand,
-1955-06-30,PE,Peru,
-1955-06-30,PH,Philippines,
-1955-06-30,PL,Poland,
-1955-06-30,PT,Portugal,
-1955-06-30,RO,Romania,
-1955-06-30,RS,Serbia,
-1955-06-30,RU,Russia,
-1955-06-30,SE,Sweden,
-1955-06-30,SG,Singapore,
-1955-06-30,SI,Slovenia,
-1955-06-30,SK,Slovak Republic,
-1955-06-30,TH,Thailand,
-1955-06-30,TR,Türkiye,
-1955-06-30,US,United States,
-1955-06-30,XM,Euro area,
-1955-06-30,XW,World,
-1955-06-30,ZA,South Africa,
-1955-09-30,4T,Emerging market economies (aggregate),
-1955-09-30,5R,Advanced economies,
-1955-09-30,AE,United Arab Emirates,
-1955-09-30,AT,Austria,
-1955-09-30,AU,Australia,
-1955-09-30,BE,Belgium,
-1955-09-30,BG,Bulgaria,
-1955-09-30,BR,Brazil,
-1955-09-30,CA,Canada,
-1955-09-30,CH,Switzerland,
-1955-09-30,CL,Chile,
-1955-09-30,CN,China,
-1955-09-30,CO,Colombia,
-1955-09-30,CY,Cyprus,
-1955-09-30,CZ,Czechia,
-1955-09-30,DE,Germany,
-1955-09-30,DK,Denmark,
-1955-09-30,EE,Estonia,
-1955-09-30,ES,Spain,
-1955-09-30,FI,Finland,
-1955-09-30,FR,France,
-1955-09-30,GB,United Kingdom,
-1955-09-30,GR,Greece,
-1955-09-30,HK,Hong Kong SAR,
-1955-09-30,HR,Croatia,
-1955-09-30,HU,Hungary,
-1955-09-30,ID,Indonesia,
-1955-09-30,IE,Ireland,
-1955-09-30,IL,Israel,
-1955-09-30,IN,India,
-1955-09-30,IS,Iceland,
-1955-09-30,IT,Italy,1.3251
+1955-09-30,IT,Italy,1.3094
 1955-09-30,JP,Japan,2.3462
-1955-09-30,KR,Korea,
-1955-09-30,LT,Lithuania,
-1955-09-30,LU,Luxembourg,
-1955-09-30,LV,Latvia,
-1955-09-30,MA,Morocco,
-1955-09-30,MK,North Macedonia,
-1955-09-30,MT,Malta,
-1955-09-30,MX,Mexico,
-1955-09-30,MY,Malaysia,
-1955-09-30,NL,Netherlands,
-1955-09-30,NO,Norway,
-1955-09-30,NZ,New Zealand,
-1955-09-30,PE,Peru,
-1955-09-30,PH,Philippines,
-1955-09-30,PL,Poland,
-1955-09-30,PT,Portugal,
-1955-09-30,RO,Romania,
-1955-09-30,RS,Serbia,
-1955-09-30,RU,Russia,
-1955-09-30,SE,Sweden,
-1955-09-30,SG,Singapore,
-1955-09-30,SI,Slovenia,
-1955-09-30,SK,Slovak Republic,
-1955-09-30,TH,Thailand,
-1955-09-30,TR,Türkiye,
-1955-09-30,US,United States,
-1955-09-30,XM,Euro area,
-1955-09-30,XW,World,
-1955-09-30,ZA,South Africa,
-1955-12-31,4T,Emerging market economies (aggregate),
-1955-12-31,5R,Advanced economies,
-1955-12-31,AE,United Arab Emirates,
-1955-12-31,AT,Austria,
-1955-12-31,AU,Australia,
-1955-12-31,BE,Belgium,
-1955-12-31,BG,Bulgaria,
-1955-12-31,BR,Brazil,
-1955-12-31,CA,Canada,
-1955-12-31,CH,Switzerland,
-1955-12-31,CL,Chile,
-1955-12-31,CN,China,
-1955-12-31,CO,Colombia,
-1955-12-31,CY,Cyprus,
-1955-12-31,CZ,Czechia,
-1955-12-31,DE,Germany,
-1955-12-31,DK,Denmark,
-1955-12-31,EE,Estonia,
-1955-12-31,ES,Spain,
-1955-12-31,FI,Finland,
-1955-12-31,FR,France,
-1955-12-31,GB,United Kingdom,
-1955-12-31,GR,Greece,
-1955-12-31,HK,Hong Kong SAR,
-1955-12-31,HR,Croatia,
-1955-12-31,HU,Hungary,
-1955-12-31,ID,Indonesia,
-1955-12-31,IE,Ireland,
-1955-12-31,IL,Israel,
-1955-12-31,IN,India,
-1955-12-31,IS,Iceland,
-1955-12-31,IT,Italy,1.2956
+1955-12-31,IT,Italy,1.3077
 1955-12-31,JP,Japan,2.4327
-1955-12-31,KR,Korea,
-1955-12-31,LT,Lithuania,
-1955-12-31,LU,Luxembourg,
-1955-12-31,LV,Latvia,
-1955-12-31,MA,Morocco,
-1955-12-31,MK,North Macedonia,
-1955-12-31,MT,Malta,
-1955-12-31,MX,Mexico,
-1955-12-31,MY,Malaysia,
-1955-12-31,NL,Netherlands,
-1955-12-31,NO,Norway,
-1955-12-31,NZ,New Zealand,
-1955-12-31,PE,Peru,
-1955-12-31,PH,Philippines,
-1955-12-31,PL,Poland,
-1955-12-31,PT,Portugal,
-1955-12-31,RO,Romania,
-1955-12-31,RS,Serbia,
-1955-12-31,RU,Russia,
-1955-12-31,SE,Sweden,
-1955-12-31,SG,Singapore,
-1955-12-31,SI,Slovenia,
-1955-12-31,SK,Slovak Republic,
-1955-12-31,TH,Thailand,
-1955-12-31,TR,Türkiye,
-1955-12-31,US,United States,
-1955-12-31,XM,Euro area,
-1955-12-31,XW,World,
-1955-12-31,ZA,South Africa,
-1956-03-31,4T,Emerging market economies (aggregate),
-1956-03-31,5R,Advanced economies,
-1956-03-31,AE,United Arab Emirates,
-1956-03-31,AT,Austria,
-1956-03-31,AU,Australia,
-1956-03-31,BE,Belgium,
-1956-03-31,BG,Bulgaria,
-1956-03-31,BR,Brazil,
-1956-03-31,CA,Canada,
-1956-03-31,CH,Switzerland,
-1956-03-31,CL,Chile,
-1956-03-31,CN,China,
-1956-03-31,CO,Colombia,
-1956-03-31,CY,Cyprus,
-1956-03-31,CZ,Czechia,
-1956-03-31,DE,Germany,
-1956-03-31,DK,Denmark,
-1956-03-31,EE,Estonia,
-1956-03-31,ES,Spain,
-1956-03-31,FI,Finland,
-1956-03-31,FR,France,
-1956-03-31,GB,United Kingdom,
-1956-03-31,GR,Greece,
-1956-03-31,HK,Hong Kong SAR,
-1956-03-31,HR,Croatia,
-1956-03-31,HU,Hungary,
-1956-03-31,ID,Indonesia,
-1956-03-31,IE,Ireland,
-1956-03-31,IL,Israel,
-1956-03-31,IN,India,
-1956-03-31,IS,Iceland,
-1956-03-31,IT,Italy,1.3412
+1956-03-31,IT,Italy,1.3441
 1956-03-31,JP,Japan,2.5192
-1956-03-31,KR,Korea,
-1956-03-31,LT,Lithuania,
-1956-03-31,LU,Luxembourg,
-1956-03-31,LV,Latvia,
-1956-03-31,MA,Morocco,
-1956-03-31,MK,North Macedonia,
-1956-03-31,MT,Malta,
-1956-03-31,MX,Mexico,
-1956-03-31,MY,Malaysia,
-1956-03-31,NL,Netherlands,
-1956-03-31,NO,Norway,
-1956-03-31,NZ,New Zealand,
-1956-03-31,PE,Peru,
-1956-03-31,PH,Philippines,
-1956-03-31,PL,Poland,
-1956-03-31,PT,Portugal,
-1956-03-31,RO,Romania,
-1956-03-31,RS,Serbia,
-1956-03-31,RU,Russia,
-1956-03-31,SE,Sweden,
-1956-03-31,SG,Singapore,
-1956-03-31,SI,Slovenia,
-1956-03-31,SK,Slovak Republic,
-1956-03-31,TH,Thailand,
-1956-03-31,TR,Türkiye,
-1956-03-31,US,United States,
-1956-03-31,XM,Euro area,
-1956-03-31,XW,World,
-1956-03-31,ZA,South Africa,
-1956-06-30,4T,Emerging market economies (aggregate),
-1956-06-30,5R,Advanced economies,
-1956-06-30,AE,United Arab Emirates,
-1956-06-30,AT,Austria,
-1956-06-30,AU,Australia,
-1956-06-30,BE,Belgium,
-1956-06-30,BG,Bulgaria,
-1956-06-30,BR,Brazil,
-1956-06-30,CA,Canada,
-1956-06-30,CH,Switzerland,
-1956-06-30,CL,Chile,
-1956-06-30,CN,China,
-1956-06-30,CO,Colombia,
-1956-06-30,CY,Cyprus,
-1956-06-30,CZ,Czechia,
-1956-06-30,DE,Germany,
-1956-06-30,DK,Denmark,
-1956-06-30,EE,Estonia,
-1956-06-30,ES,Spain,
-1956-06-30,FI,Finland,
-1956-06-30,FR,France,
-1956-06-30,GB,United Kingdom,
-1956-06-30,GR,Greece,
-1956-06-30,HK,Hong Kong SAR,
-1956-06-30,HR,Croatia,
-1956-06-30,HU,Hungary,
-1956-06-30,ID,Indonesia,
-1956-06-30,IE,Ireland,
-1956-06-30,IL,Israel,
-1956-06-30,IN,India,
-1956-06-30,IS,Iceland,
-1956-06-30,IT,Italy,1.3734
+1956-06-30,IT,Italy,1.3554
 1956-06-30,JP,Japan,2.6635
-1956-06-30,KR,Korea,
-1956-06-30,LT,Lithuania,
-1956-06-30,LU,Luxembourg,
-1956-06-30,LV,Latvia,
-1956-06-30,MA,Morocco,
-1956-06-30,MK,North Macedonia,
-1956-06-30,MT,Malta,
-1956-06-30,MX,Mexico,
-1956-06-30,MY,Malaysia,
-1956-06-30,NL,Netherlands,
-1956-06-30,NO,Norway,
-1956-06-30,NZ,New Zealand,
-1956-06-30,PE,Peru,
-1956-06-30,PH,Philippines,
-1956-06-30,PL,Poland,
-1956-06-30,PT,Portugal,
-1956-06-30,RO,Romania,
-1956-06-30,RS,Serbia,
-1956-06-30,RU,Russia,
-1956-06-30,SE,Sweden,
-1956-06-30,SG,Singapore,
-1956-06-30,SI,Slovenia,
-1956-06-30,SK,Slovak Republic,
-1956-06-30,TH,Thailand,
-1956-06-30,TR,Türkiye,
-1956-06-30,US,United States,
-1956-06-30,XM,Euro area,
-1956-06-30,XW,World,
-1956-06-30,ZA,South Africa,
-1956-09-30,4T,Emerging market economies (aggregate),
-1956-09-30,5R,Advanced economies,
-1956-09-30,AE,United Arab Emirates,
-1956-09-30,AT,Austria,
-1956-09-30,AU,Australia,
-1956-09-30,BE,Belgium,
-1956-09-30,BG,Bulgaria,
-1956-09-30,BR,Brazil,
-1956-09-30,CA,Canada,
-1956-09-30,CH,Switzerland,
-1956-09-30,CL,Chile,
-1956-09-30,CN,China,
-1956-09-30,CO,Colombia,
-1956-09-30,CY,Cyprus,
-1956-09-30,CZ,Czechia,
-1956-09-30,DE,Germany,
-1956-09-30,DK,Denmark,
-1956-09-30,EE,Estonia,
-1956-09-30,ES,Spain,
-1956-09-30,FI,Finland,
-1956-09-30,FR,France,
-1956-09-30,GB,United Kingdom,
-1956-09-30,GR,Greece,
-1956-09-30,HK,Hong Kong SAR,
-1956-09-30,HR,Croatia,
-1956-09-30,HU,Hungary,
-1956-09-30,ID,Indonesia,
-1956-09-30,IE,Ireland,
-1956-09-30,IL,Israel,
-1956-09-30,IN,India,
-1956-09-30,IS,Iceland,
-1956-09-30,IT,Italy,1.3473
+1956-09-30,IT,Italy,1.3446
 1956-09-30,JP,Japan,2.8077
-1956-09-30,KR,Korea,
-1956-09-30,LT,Lithuania,
-1956-09-30,LU,Luxembourg,
-1956-09-30,LV,Latvia,
-1956-09-30,MA,Morocco,
-1956-09-30,MK,North Macedonia,
-1956-09-30,MT,Malta,
-1956-09-30,MX,Mexico,
-1956-09-30,MY,Malaysia,
-1956-09-30,NL,Netherlands,
-1956-09-30,NO,Norway,
-1956-09-30,NZ,New Zealand,
-1956-09-30,PE,Peru,
-1956-09-30,PH,Philippines,
-1956-09-30,PL,Poland,
-1956-09-30,PT,Portugal,
-1956-09-30,RO,Romania,
-1956-09-30,RS,Serbia,
-1956-09-30,RU,Russia,
-1956-09-30,SE,Sweden,
-1956-09-30,SG,Singapore,
-1956-09-30,SI,Slovenia,
-1956-09-30,SK,Slovak Republic,
-1956-09-30,TH,Thailand,
-1956-09-30,TR,Türkiye,
-1956-09-30,US,United States,
-1956-09-30,XM,Euro area,
-1956-09-30,XW,World,
-1956-09-30,ZA,South Africa,
-1956-12-31,4T,Emerging market economies (aggregate),
-1956-12-31,5R,Advanced economies,
-1956-12-31,AE,United Arab Emirates,
-1956-12-31,AT,Austria,
-1956-12-31,AU,Australia,
-1956-12-31,BE,Belgium,
-1956-12-31,BG,Bulgaria,
-1956-12-31,BR,Brazil,
-1956-12-31,CA,Canada,
-1956-12-31,CH,Switzerland,
-1956-12-31,CL,Chile,
-1956-12-31,CN,China,
-1956-12-31,CO,Colombia,
-1956-12-31,CY,Cyprus,
-1956-12-31,CZ,Czechia,
-1956-12-31,DE,Germany,
-1956-12-31,DK,Denmark,
-1956-12-31,EE,Estonia,
-1956-12-31,ES,Spain,
-1956-12-31,FI,Finland,
-1956-12-31,FR,France,
-1956-12-31,GB,United Kingdom,
-1956-12-31,GR,Greece,
-1956-12-31,HK,Hong Kong SAR,
-1956-12-31,HR,Croatia,
-1956-12-31,HU,Hungary,
-1956-12-31,ID,Indonesia,
-1956-12-31,IE,Ireland,
-1956-12-31,IL,Israel,
-1956-12-31,IN,India,
-1956-12-31,IS,Iceland,
-1956-12-31,IT,Italy,1.3454
+1956-12-31,IT,Italy,1.363
 1956-12-31,JP,Japan,2.9952
-1956-12-31,KR,Korea,
-1956-12-31,LT,Lithuania,
-1956-12-31,LU,Luxembourg,
-1956-12-31,LV,Latvia,
-1956-12-31,MA,Morocco,
-1956-12-31,MK,North Macedonia,
-1956-12-31,MT,Malta,
-1956-12-31,MX,Mexico,
-1956-12-31,MY,Malaysia,
-1956-12-31,NL,Netherlands,
-1956-12-31,NO,Norway,
-1956-12-31,NZ,New Zealand,
-1956-12-31,PE,Peru,
-1956-12-31,PH,Philippines,
-1956-12-31,PL,Poland,
-1956-12-31,PT,Portugal,
-1956-12-31,RO,Romania,
-1956-12-31,RS,Serbia,
-1956-12-31,RU,Russia,
-1956-12-31,SE,Sweden,
-1956-12-31,SG,Singapore,
-1956-12-31,SI,Slovenia,
-1956-12-31,SK,Slovak Republic,
-1956-12-31,TH,Thailand,
-1956-12-31,TR,Türkiye,
-1956-12-31,US,United States,
-1956-12-31,XM,Euro area,
-1956-12-31,XW,World,
-1956-12-31,ZA,South Africa,
-1957-03-31,4T,Emerging market economies (aggregate),
-1957-03-31,5R,Advanced economies,
-1957-03-31,AE,United Arab Emirates,
-1957-03-31,AT,Austria,
-1957-03-31,AU,Australia,
-1957-03-31,BE,Belgium,
-1957-03-31,BG,Bulgaria,
-1957-03-31,BR,Brazil,
-1957-03-31,CA,Canada,
-1957-03-31,CH,Switzerland,
-1957-03-31,CL,Chile,
-1957-03-31,CN,China,
-1957-03-31,CO,Colombia,
-1957-03-31,CY,Cyprus,
-1957-03-31,CZ,Czechia,
-1957-03-31,DE,Germany,
-1957-03-31,DK,Denmark,
-1957-03-31,EE,Estonia,
-1957-03-31,ES,Spain,
-1957-03-31,FI,Finland,
-1957-03-31,FR,France,
-1957-03-31,GB,United Kingdom,
-1957-03-31,GR,Greece,
-1957-03-31,HK,Hong Kong SAR,
-1957-03-31,HR,Croatia,
-1957-03-31,HU,Hungary,
-1957-03-31,ID,Indonesia,
-1957-03-31,IE,Ireland,
-1957-03-31,IL,Israel,
-1957-03-31,IN,India,
-1957-03-31,IS,Iceland,
-1957-03-31,IT,Italy,1.3844
+1957-03-31,IT,Italy,1.3855
 1957-03-31,JP,Japan,3.1827
-1957-03-31,KR,Korea,
-1957-03-31,LT,Lithuania,
-1957-03-31,LU,Luxembourg,
-1957-03-31,LV,Latvia,
-1957-03-31,MA,Morocco,
-1957-03-31,MK,North Macedonia,
-1957-03-31,MT,Malta,
-1957-03-31,MX,Mexico,
-1957-03-31,MY,Malaysia,
-1957-03-31,NL,Netherlands,
-1957-03-31,NO,Norway,
-1957-03-31,NZ,New Zealand,
-1957-03-31,PE,Peru,
-1957-03-31,PH,Philippines,
-1957-03-31,PL,Poland,
-1957-03-31,PT,Portugal,
-1957-03-31,RO,Romania,
-1957-03-31,RS,Serbia,
-1957-03-31,RU,Russia,
-1957-03-31,SE,Sweden,
-1957-03-31,SG,Singapore,
-1957-03-31,SI,Slovenia,
-1957-03-31,SK,Slovak Republic,
-1957-03-31,TH,Thailand,
-1957-03-31,TR,Türkiye,
-1957-03-31,US,United States,
-1957-03-31,XM,Euro area,
-1957-03-31,XW,World,
-1957-03-31,ZA,South Africa,
-1957-06-30,4T,Emerging market economies (aggregate),
-1957-06-30,5R,Advanced economies,
-1957-06-30,AE,United Arab Emirates,
-1957-06-30,AT,Austria,
-1957-06-30,AU,Australia,
-1957-06-30,BE,Belgium,
-1957-06-30,BG,Bulgaria,
-1957-06-30,BR,Brazil,
-1957-06-30,CA,Canada,
-1957-06-30,CH,Switzerland,
-1957-06-30,CL,Chile,
-1957-06-30,CN,China,
-1957-06-30,CO,Colombia,
-1957-06-30,CY,Cyprus,
-1957-06-30,CZ,Czechia,
-1957-06-30,DE,Germany,
-1957-06-30,DK,Denmark,
-1957-06-30,EE,Estonia,
-1957-06-30,ES,Spain,
-1957-06-30,FI,Finland,
-1957-06-30,FR,France,
-1957-06-30,GB,United Kingdom,
-1957-06-30,GR,Greece,
-1957-06-30,HK,Hong Kong SAR,
-1957-06-30,HR,Croatia,
-1957-06-30,HU,Hungary,
-1957-06-30,ID,Indonesia,
-1957-06-30,IE,Ireland,
-1957-06-30,IL,Israel,
-1957-06-30,IN,India,
-1957-06-30,IS,Iceland,
-1957-06-30,IT,Italy,1.3791
+1957-06-30,IT,Italy,1.3785
 1957-06-30,JP,Japan,3.35
-1957-06-30,KR,Korea,
-1957-06-30,LT,Lithuania,
-1957-06-30,LU,Luxembourg,
-1957-06-30,LV,Latvia,
-1957-06-30,MA,Morocco,
-1957-06-30,MK,North Macedonia,
-1957-06-30,MT,Malta,
-1957-06-30,MX,Mexico,
-1957-06-30,MY,Malaysia,
-1957-06-30,NL,Netherlands,
-1957-06-30,NO,Norway,
-1957-06-30,NZ,New Zealand,
-1957-06-30,PE,Peru,
-1957-06-30,PH,Philippines,
-1957-06-30,PL,Poland,
-1957-06-30,PT,Portugal,
-1957-06-30,RO,Romania,
-1957-06-30,RS,Serbia,
-1957-06-30,RU,Russia,
-1957-06-30,SE,Sweden,
-1957-06-30,SG,Singapore,
-1957-06-30,SI,Slovenia,
-1957-06-30,SK,Slovak Republic,
-1957-06-30,TH,Thailand,
-1957-06-30,TR,Türkiye,
-1957-06-30,US,United States,
-1957-06-30,XM,Euro area,
-1957-06-30,XW,World,
-1957-06-30,ZA,South Africa,
-1957-09-30,4T,Emerging market economies (aggregate),
-1957-09-30,5R,Advanced economies,
-1957-09-30,AE,United Arab Emirates,
-1957-09-30,AT,Austria,
-1957-09-30,AU,Australia,
-1957-09-30,BE,Belgium,
-1957-09-30,BG,Bulgaria,
-1957-09-30,BR,Brazil,
-1957-09-30,CA,Canada,
-1957-09-30,CH,Switzerland,
-1957-09-30,CL,Chile,
-1957-09-30,CN,China,
-1957-09-30,CO,Colombia,
-1957-09-30,CY,Cyprus,
-1957-09-30,CZ,Czechia,
-1957-09-30,DE,Germany,
-1957-09-30,DK,Denmark,
-1957-09-30,EE,Estonia,
-1957-09-30,ES,Spain,
-1957-09-30,FI,Finland,
-1957-09-30,FR,France,
-1957-09-30,GB,United Kingdom,
-1957-09-30,GR,Greece,
-1957-09-30,HK,Hong Kong SAR,
-1957-09-30,HR,Croatia,
-1957-09-30,HU,Hungary,
-1957-09-30,ID,Indonesia,
-1957-09-30,IE,Ireland,
-1957-09-30,IL,Israel,
-1957-09-30,IN,India,
-1957-09-30,IS,Iceland,
-1957-09-30,IT,Italy,1.3906
+1957-09-30,IT,Italy,1.3844
 1957-09-30,JP,Japan,3.5192
-1957-09-30,KR,Korea,
-1957-09-30,LT,Lithuania,
-1957-09-30,LU,Luxembourg,
-1957-09-30,LV,Latvia,
-1957-09-30,MA,Morocco,
-1957-09-30,MK,North Macedonia,
-1957-09-30,MT,Malta,
-1957-09-30,MX,Mexico,
-1957-09-30,MY,Malaysia,
-1957-09-30,NL,Netherlands,
-1957-09-30,NO,Norway,
-1957-09-30,NZ,New Zealand,
-1957-09-30,PE,Peru,
-1957-09-30,PH,Philippines,
-1957-09-30,PL,Poland,
-1957-09-30,PT,Portugal,
-1957-09-30,RO,Romania,
-1957-09-30,RS,Serbia,
-1957-09-30,RU,Russia,
-1957-09-30,SE,Sweden,
-1957-09-30,SG,Singapore,
-1957-09-30,SI,Slovenia,
-1957-09-30,SK,Slovak Republic,
-1957-09-30,TH,Thailand,
-1957-09-30,TR,Türkiye,
-1957-09-30,US,United States,
-1957-09-30,XM,Euro area,
-1957-09-30,XW,World,
-1957-09-30,ZA,South Africa,
-1957-12-31,4T,Emerging market economies (aggregate),
-1957-12-31,5R,Advanced economies,
-1957-12-31,AE,United Arab Emirates,
-1957-12-31,AT,Austria,
-1957-12-31,AU,Australia,
-1957-12-31,BE,Belgium,
-1957-12-31,BG,Bulgaria,
-1957-12-31,BR,Brazil,
-1957-12-31,CA,Canada,
-1957-12-31,CH,Switzerland,
-1957-12-31,CL,Chile,
-1957-12-31,CN,China,
-1957-12-31,CO,Colombia,
-1957-12-31,CY,Cyprus,
-1957-12-31,CZ,Czechia,
-1957-12-31,DE,Germany,
-1957-12-31,DK,Denmark,
-1957-12-31,EE,Estonia,
-1957-12-31,ES,Spain,
-1957-12-31,FI,Finland,
-1957-12-31,FR,France,
-1957-12-31,GB,United Kingdom,
-1957-12-31,GR,Greece,
-1957-12-31,HK,Hong Kong SAR,
-1957-12-31,HR,Croatia,
-1957-12-31,HU,Hungary,
-1957-12-31,ID,Indonesia,
-1957-12-31,IE,Ireland,
-1957-12-31,IL,Israel,
-1957-12-31,IN,India,
-1957-12-31,IS,Iceland,
-1957-12-31,IT,Italy,1.3963
+1957-12-31,IT,Italy,1.4018
 1957-12-31,JP,Japan,3.7163
-1957-12-31,KR,Korea,
-1957-12-31,LT,Lithuania,
-1957-12-31,LU,Luxembourg,
-1957-12-31,LV,Latvia,
-1957-12-31,MA,Morocco,
-1957-12-31,MK,North Macedonia,
-1957-12-31,MT,Malta,
-1957-12-31,MX,Mexico,
-1957-12-31,MY,Malaysia,
-1957-12-31,NL,Netherlands,
-1957-12-31,NO,Norway,
-1957-12-31,NZ,New Zealand,
-1957-12-31,PE,Peru,
-1957-12-31,PH,Philippines,
-1957-12-31,PL,Poland,
-1957-12-31,PT,Portugal,
-1957-12-31,RO,Romania,
-1957-12-31,RS,Serbia,
-1957-12-31,RU,Russia,
-1957-12-31,SE,Sweden,
-1957-12-31,SG,Singapore,
-1957-12-31,SI,Slovenia,
-1957-12-31,SK,Slovak Republic,
-1957-12-31,TH,Thailand,
-1957-12-31,TR,Türkiye,
-1957-12-31,US,United States,
-1957-12-31,XM,Euro area,
-1957-12-31,XW,World,
-1957-12-31,ZA,South Africa,
-1958-03-31,4T,Emerging market economies (aggregate),
-1958-03-31,5R,Advanced economies,
-1958-03-31,AE,United Arab Emirates,
-1958-03-31,AT,Austria,
-1958-03-31,AU,Australia,
-1958-03-31,BE,Belgium,
-1958-03-31,BG,Bulgaria,
-1958-03-31,BR,Brazil,
-1958-03-31,CA,Canada,
-1958-03-31,CH,Switzerland,
-1958-03-31,CL,Chile,
-1958-03-31,CN,China,
-1958-03-31,CO,Colombia,
-1958-03-31,CY,Cyprus,
-1958-03-31,CZ,Czechia,
-1958-03-31,DE,Germany,
-1958-03-31,DK,Denmark,
-1958-03-31,EE,Estonia,
-1958-03-31,ES,Spain,
-1958-03-31,FI,Finland,
-1958-03-31,FR,France,
-1958-03-31,GB,United Kingdom,
-1958-03-31,GR,Greece,
-1958-03-31,HK,Hong Kong SAR,
-1958-03-31,HR,Croatia,
-1958-03-31,HU,Hungary,
-1958-03-31,ID,Indonesia,
-1958-03-31,IE,Ireland,
-1958-03-31,IL,Israel,
-1958-03-31,IN,India,
-1958-03-31,IS,Iceland,
-1958-03-31,IT,Italy,1.3891
+1958-03-31,IT,Italy,1.39
 1958-03-31,JP,Japan,3.9135
-1958-03-31,KR,Korea,
-1958-03-31,LT,Lithuania,
-1958-03-31,LU,Luxembourg,
-1958-03-31,LV,Latvia,
-1958-03-31,MA,Morocco,
-1958-03-31,MK,North Macedonia,
-1958-03-31,MT,Malta,
-1958-03-31,MX,Mexico,
-1958-03-31,MY,Malaysia,
-1958-03-31,NL,Netherlands,
-1958-03-31,NO,Norway,
-1958-03-31,NZ,New Zealand,
-1958-03-31,PE,Peru,
-1958-03-31,PH,Philippines,
-1958-03-31,PL,Poland,
-1958-03-31,PT,Portugal,
-1958-03-31,RO,Romania,
-1958-03-31,RS,Serbia,
-1958-03-31,RU,Russia,
-1958-03-31,SE,Sweden,
-1958-03-31,SG,Singapore,
-1958-03-31,SI,Slovenia,
-1958-03-31,SK,Slovak Republic,
-1958-03-31,TH,Thailand,
-1958-03-31,TR,Türkiye,
-1958-03-31,US,United States,
-1958-03-31,XM,Euro area,
-1958-03-31,XW,World,
-1958-03-31,ZA,South Africa,
-1958-06-30,4T,Emerging market economies (aggregate),
-1958-06-30,5R,Advanced economies,
-1958-06-30,AE,United Arab Emirates,
-1958-06-30,AT,Austria,
-1958-06-30,AU,Australia,
-1958-06-30,BE,Belgium,
-1958-06-30,BG,Bulgaria,
-1958-06-30,BR,Brazil,
-1958-06-30,CA,Canada,
-1958-06-30,CH,Switzerland,
-1958-06-30,CL,Chile,
-1958-06-30,CN,China,
-1958-06-30,CO,Colombia,
-1958-06-30,CY,Cyprus,
-1958-06-30,CZ,Czechia,
-1958-06-30,DE,Germany,
-1958-06-30,DK,Denmark,
-1958-06-30,EE,Estonia,
-1958-06-30,ES,Spain,
-1958-06-30,FI,Finland,
-1958-06-30,FR,France,
-1958-06-30,GB,United Kingdom,
-1958-06-30,GR,Greece,
-1958-06-30,HK,Hong Kong SAR,
-1958-06-30,HR,Croatia,
-1958-06-30,HU,Hungary,
-1958-06-30,ID,Indonesia,
-1958-06-30,IE,Ireland,
-1958-06-30,IL,Israel,
-1958-06-30,IN,India,
-1958-06-30,IS,Iceland,
-1958-06-30,IT,Italy,1.4264
+1958-06-30,IT,Italy,1.4122
 1958-06-30,JP,Japan,4.1477
-1958-06-30,KR,Korea,
-1958-06-30,LT,Lithuania,
-1958-06-30,LU,Luxembourg,
-1958-06-30,LV,Latvia,
-1958-06-30,MA,Morocco,
-1958-06-30,MK,North Macedonia,
-1958-06-30,MT,Malta,
-1958-06-30,MX,Mexico,
-1958-06-30,MY,Malaysia,
-1958-06-30,NL,Netherlands,
-1958-06-30,NO,Norway,
-1958-06-30,NZ,New Zealand,
-1958-06-30,PE,Peru,
-1958-06-30,PH,Philippines,
-1958-06-30,PL,Poland,
-1958-06-30,PT,Portugal,
-1958-06-30,RO,Romania,
-1958-06-30,RS,Serbia,
-1958-06-30,RU,Russia,
-1958-06-30,SE,Sweden,
-1958-06-30,SG,Singapore,
-1958-06-30,SI,Slovenia,
-1958-06-30,SK,Slovak Republic,
-1958-06-30,TH,Thailand,
-1958-06-30,TR,Türkiye,
-1958-06-30,US,United States,
-1958-06-30,XM,Euro area,
-1958-06-30,XW,World,
-1958-06-30,ZA,South Africa,
-1958-09-30,4T,Emerging market economies (aggregate),
-1958-09-30,5R,Advanced economies,
-1958-09-30,AE,United Arab Emirates,
-1958-09-30,AT,Austria,
-1958-09-30,AU,Australia,
-1958-09-30,BE,Belgium,
-1958-09-30,BG,Bulgaria,
-1958-09-30,BR,Brazil,
-1958-09-30,CA,Canada,
-1958-09-30,CH,Switzerland,
-1958-09-30,CL,Chile,
-1958-09-30,CN,China,
-1958-09-30,CO,Colombia,
-1958-09-30,CY,Cyprus,
-1958-09-30,CZ,Czechia,
-1958-09-30,DE,Germany,
-1958-09-30,DK,Denmark,
-1958-09-30,EE,Estonia,
-1958-09-30,ES,Spain,
-1958-09-30,FI,Finland,
-1958-09-30,FR,France,
-1958-09-30,GB,United Kingdom,
-1958-09-30,GR,Greece,
-1958-09-30,HK,Hong Kong SAR,
-1958-09-30,HR,Croatia,
-1958-09-30,HU,Hungary,
-1958-09-30,ID,Indonesia,
-1958-09-30,IE,Ireland,
-1958-09-30,IL,Israel,
-1958-09-30,IN,India,
-1958-09-30,IS,Iceland,
-1958-09-30,IT,Italy,1.4079
+1958-09-30,IT,Italy,1.4003
 1958-09-30,JP,Japan,4.3846
-1958-09-30,KR,Korea,
-1958-09-30,LT,Lithuania,
-1958-09-30,LU,Luxembourg,
-1958-09-30,LV,Latvia,
-1958-09-30,MA,Morocco,
-1958-09-30,MK,North Macedonia,
-1958-09-30,MT,Malta,
-1958-09-30,MX,Mexico,
-1958-09-30,MY,Malaysia,
-1958-09-30,NL,Netherlands,
-1958-09-30,NO,Norway,
-1958-09-30,NZ,New Zealand,
-1958-09-30,PE,Peru,
-1958-09-30,PH,Philippines,
-1958-09-30,PL,Poland,
-1958-09-30,PT,Portugal,
-1958-09-30,RO,Romania,
-1958-09-30,RS,Serbia,
-1958-09-30,RU,Russia,
-1958-09-30,SE,Sweden,
-1958-09-30,SG,Singapore,
-1958-09-30,SI,Slovenia,
-1958-09-30,SK,Slovak Republic,
-1958-09-30,TH,Thailand,
-1958-09-30,TR,Türkiye,
-1958-09-30,US,United States,
-1958-09-30,XM,Euro area,
-1958-09-30,XW,World,
-1958-09-30,ZA,South Africa,
-1958-12-31,4T,Emerging market economies (aggregate),
-1958-12-31,5R,Advanced economies,
-1958-12-31,AE,United Arab Emirates,
-1958-12-31,AT,Austria,
-1958-12-31,AU,Australia,
-1958-12-31,BE,Belgium,
-1958-12-31,BG,Bulgaria,
-1958-12-31,BR,Brazil,
-1958-12-31,CA,Canada,
-1958-12-31,CH,Switzerland,
-1958-12-31,CL,Chile,
-1958-12-31,CN,China,
-1958-12-31,CO,Colombia,
-1958-12-31,CY,Cyprus,
-1958-12-31,CZ,Czechia,
-1958-12-31,DE,Germany,
-1958-12-31,DK,Denmark,
-1958-12-31,EE,Estonia,
-1958-12-31,ES,Spain,
-1958-12-31,FI,Finland,
-1958-12-31,FR,France,
-1958-12-31,GB,United Kingdom,
-1958-12-31,GR,Greece,
-1958-12-31,HK,Hong Kong SAR,
-1958-12-31,HR,Croatia,
-1958-12-31,HU,Hungary,
-1958-12-31,ID,Indonesia,
-1958-12-31,IE,Ireland,
-1958-12-31,IL,Israel,
-1958-12-31,IN,India,
-1958-12-31,IS,Iceland,
-1958-12-31,IT,Italy,1.3566
+1958-12-31,IT,Italy,1.3773
 1958-12-31,JP,Japan,4.6154
-1958-12-31,KR,Korea,
-1958-12-31,LT,Lithuania,
-1958-12-31,LU,Luxembourg,
-1958-12-31,LV,Latvia,
-1958-12-31,MA,Morocco,
-1958-12-31,MK,North Macedonia,
-1958-12-31,MT,Malta,
-1958-12-31,MX,Mexico,
-1958-12-31,MY,Malaysia,
-1958-12-31,NL,Netherlands,
-1958-12-31,NO,Norway,
-1958-12-31,NZ,New Zealand,
-1958-12-31,PE,Peru,
-1958-12-31,PH,Philippines,
-1958-12-31,PL,Poland,
-1958-12-31,PT,Portugal,
-1958-12-31,RO,Romania,
-1958-12-31,RS,Serbia,
-1958-12-31,RU,Russia,
-1958-12-31,SE,Sweden,
-1958-12-31,SG,Singapore,
-1958-12-31,SI,Slovenia,
-1958-12-31,SK,Slovak Republic,
-1958-12-31,TH,Thailand,
-1958-12-31,TR,Türkiye,
-1958-12-31,US,United States,
-1958-12-31,XM,Euro area,
-1958-12-31,XW,World,
-1958-12-31,ZA,South Africa,
-1959-03-31,4T,Emerging market economies (aggregate),
-1959-03-31,5R,Advanced economies,
-1959-03-31,AE,United Arab Emirates,
-1959-03-31,AT,Austria,
-1959-03-31,AU,Australia,
-1959-03-31,BE,Belgium,
-1959-03-31,BG,Bulgaria,
-1959-03-31,BR,Brazil,
-1959-03-31,CA,Canada,
-1959-03-31,CH,Switzerland,
-1959-03-31,CL,Chile,
-1959-03-31,CN,China,
-1959-03-31,CO,Colombia,
-1959-03-31,CY,Cyprus,
-1959-03-31,CZ,Czechia,
-1959-03-31,DE,Germany,
-1959-03-31,DK,Denmark,
-1959-03-31,EE,Estonia,
-1959-03-31,ES,Spain,
-1959-03-31,FI,Finland,
-1959-03-31,FR,France,
-1959-03-31,GB,United Kingdom,
-1959-03-31,GR,Greece,
-1959-03-31,HK,Hong Kong SAR,
-1959-03-31,HR,Croatia,
-1959-03-31,HU,Hungary,
-1959-03-31,ID,Indonesia,
-1959-03-31,IE,Ireland,
-1959-03-31,IL,Israel,
-1959-03-31,IN,India,
-1959-03-31,IS,Iceland,
-1959-03-31,IT,Italy,1.363
+1959-03-31,IT,Italy,1.3668
 1959-03-31,JP,Japan,4.8462
-1959-03-31,KR,Korea,
-1959-03-31,LT,Lithuania,
-1959-03-31,LU,Luxembourg,
-1959-03-31,LV,Latvia,
-1959-03-31,MA,Morocco,
-1959-03-31,MK,North Macedonia,
-1959-03-31,MT,Malta,
-1959-03-31,MX,Mexico,
-1959-03-31,MY,Malaysia,
-1959-03-31,NL,Netherlands,
-1959-03-31,NO,Norway,
-1959-03-31,NZ,New Zealand,
-1959-03-31,PE,Peru,
-1959-03-31,PH,Philippines,
-1959-03-31,PL,Poland,
-1959-03-31,PT,Portugal,
-1959-03-31,RO,Romania,
-1959-03-31,RS,Serbia,
-1959-03-31,RU,Russia,
-1959-03-31,SE,Sweden,
-1959-03-31,SG,Singapore,
-1959-03-31,SI,Slovenia,
-1959-03-31,SK,Slovak Republic,
-1959-03-31,TH,Thailand,
-1959-03-31,TR,Türkiye,
-1959-03-31,US,United States,
-1959-03-31,XM,Euro area,
-1959-03-31,XW,World,
-1959-03-31,ZA,South Africa,
-1959-06-30,4T,Emerging market economies (aggregate),
-1959-06-30,5R,Advanced economies,
-1959-06-30,AE,United Arab Emirates,
-1959-06-30,AT,Austria,
-1959-06-30,AU,Australia,
-1959-06-30,BE,Belgium,
-1959-06-30,BG,Bulgaria,
-1959-06-30,BR,Brazil,
-1959-06-30,CA,Canada,
-1959-06-30,CH,Switzerland,
-1959-06-30,CL,Chile,
-1959-06-30,CN,China,
-1959-06-30,CO,Colombia,
-1959-06-30,CY,Cyprus,
-1959-06-30,CZ,Czechia,
-1959-06-30,DE,Germany,
-1959-06-30,DK,Denmark,
-1959-06-30,EE,Estonia,
-1959-06-30,ES,Spain,
-1959-06-30,FI,Finland,
-1959-06-30,FR,France,
-1959-06-30,GB,United Kingdom,
-1959-06-30,GR,Greece,
-1959-06-30,HK,Hong Kong SAR,
-1959-06-30,HR,Croatia,
-1959-06-30,HU,Hungary,
-1959-06-30,ID,Indonesia,
-1959-06-30,IE,Ireland,
-1959-06-30,IL,Israel,
-1959-06-30,IN,India,
-1959-06-30,IS,Iceland,
-1959-06-30,IT,Italy,1.383
+1959-06-30,IT,Italy,1.3815
 1959-06-30,JP,Japan,5.133
-1959-06-30,KR,Korea,
-1959-06-30,LT,Lithuania,
-1959-06-30,LU,Luxembourg,
-1959-06-30,LV,Latvia,
-1959-06-30,MA,Morocco,
-1959-06-30,MK,North Macedonia,
-1959-06-30,MT,Malta,
-1959-06-30,MX,Mexico,
-1959-06-30,MY,Malaysia,
-1959-06-30,NL,Netherlands,
-1959-06-30,NO,Norway,
-1959-06-30,NZ,New Zealand,
-1959-06-30,PE,Peru,
-1959-06-30,PH,Philippines,
-1959-06-30,PL,Poland,
-1959-06-30,PT,Portugal,
-1959-06-30,RO,Romania,
-1959-06-30,RS,Serbia,
-1959-06-30,RU,Russia,
-1959-06-30,SE,Sweden,
-1959-06-30,SG,Singapore,
-1959-06-30,SI,Slovenia,
-1959-06-30,SK,Slovak Republic,
-1959-06-30,TH,Thailand,
-1959-06-30,TR,Türkiye,
-1959-06-30,US,United States,
-1959-06-30,XM,Euro area,
-1959-06-30,XW,World,
-1959-06-30,ZA,South Africa,
-1959-09-30,4T,Emerging market economies (aggregate),
-1959-09-30,5R,Advanced economies,
-1959-09-30,AE,United Arab Emirates,
-1959-09-30,AT,Austria,
-1959-09-30,AU,Australia,
-1959-09-30,BE,Belgium,
-1959-09-30,BG,Bulgaria,
-1959-09-30,BR,Brazil,
-1959-09-30,CA,Canada,
-1959-09-30,CH,Switzerland,
-1959-09-30,CL,Chile,
-1959-09-30,CN,China,
-1959-09-30,CO,Colombia,
-1959-09-30,CY,Cyprus,
-1959-09-30,CZ,Czechia,
-1959-09-30,DE,Germany,
-1959-09-30,DK,Denmark,
-1959-09-30,EE,Estonia,
-1959-09-30,ES,Spain,
-1959-09-30,FI,Finland,
-1959-09-30,FR,France,
-1959-09-30,GB,United Kingdom,
-1959-09-30,GR,Greece,
-1959-09-30,HK,Hong Kong SAR,
-1959-09-30,HR,Croatia,
-1959-09-30,HU,Hungary,
-1959-09-30,ID,Indonesia,
-1959-09-30,IE,Ireland,
-1959-09-30,IL,Israel,
-1959-09-30,IN,India,
-1959-09-30,IS,Iceland,
-1959-09-30,IT,Italy,1.3879
+1959-09-30,IT,Italy,1.3835
 1959-09-30,JP,Japan,5.4231
-1959-09-30,KR,Korea,
-1959-09-30,LT,Lithuania,
-1959-09-30,LU,Luxembourg,
-1959-09-30,LV,Latvia,
-1959-09-30,MA,Morocco,
-1959-09-30,MK,North Macedonia,
-1959-09-30,MT,Malta,
-1959-09-30,MX,Mexico,
-1959-09-30,MY,Malaysia,
-1959-09-30,NL,Netherlands,
-1959-09-30,NO,Norway,
-1959-09-30,NZ,New Zealand,
-1959-09-30,PE,Peru,
-1959-09-30,PH,Philippines,
-1959-09-30,PL,Poland,
-1959-09-30,PT,Portugal,
-1959-09-30,RO,Romania,
-1959-09-30,RS,Serbia,
-1959-09-30,RU,Russia,
-1959-09-30,SE,Sweden,
-1959-09-30,SG,Singapore,
-1959-09-30,SI,Slovenia,
-1959-09-30,SK,Slovak Republic,
-1959-09-30,TH,Thailand,
-1959-09-30,TR,Türkiye,
-1959-09-30,US,United States,
-1959-09-30,XM,Euro area,
-1959-09-30,XW,World,
-1959-09-30,ZA,South Africa,
-1959-12-31,4T,Emerging market economies (aggregate),
-1959-12-31,5R,Advanced economies,
-1959-12-31,AE,United Arab Emirates,
-1959-12-31,AT,Austria,
-1959-12-31,AU,Australia,
-1959-12-31,BE,Belgium,
-1959-12-31,BG,Bulgaria,
-1959-12-31,BR,Brazil,
-1959-12-31,CA,Canada,
-1959-12-31,CH,Switzerland,
-1959-12-31,CL,Chile,
-1959-12-31,CN,China,
-1959-12-31,CO,Colombia,
-1959-12-31,CY,Cyprus,
-1959-12-31,CZ,Czechia,
-1959-12-31,DE,Germany,
-1959-12-31,DK,Denmark,
-1959-12-31,EE,Estonia,
-1959-12-31,ES,Spain,
-1959-12-31,FI,Finland,
-1959-12-31,FR,France,
-1959-12-31,GB,United Kingdom,
-1959-12-31,GR,Greece,
-1959-12-31,HK,Hong Kong SAR,
-1959-12-31,HR,Croatia,
-1959-12-31,HU,Hungary,
-1959-12-31,ID,Indonesia,
-1959-12-31,IE,Ireland,
-1959-12-31,IL,Israel,
-1959-12-31,IN,India,
-1959-12-31,IS,Iceland,
-1959-12-31,IT,Italy,1.4242
+1959-12-31,IT,Italy,1.4263
 1959-12-31,JP,Japan,5.6923
-1959-12-31,KR,Korea,
-1959-12-31,LT,Lithuania,
-1959-12-31,LU,Luxembourg,
-1959-12-31,LV,Latvia,
-1959-12-31,MA,Morocco,
-1959-12-31,MK,North Macedonia,
-1959-12-31,MT,Malta,
-1959-12-31,MX,Mexico,
-1959-12-31,MY,Malaysia,
-1959-12-31,NL,Netherlands,
-1959-12-31,NO,Norway,
-1959-12-31,NZ,New Zealand,
-1959-12-31,PE,Peru,
-1959-12-31,PH,Philippines,
-1959-12-31,PL,Poland,
-1959-12-31,PT,Portugal,
-1959-12-31,RO,Romania,
-1959-12-31,RS,Serbia,
-1959-12-31,RU,Russia,
-1959-12-31,SE,Sweden,
-1959-12-31,SG,Singapore,
-1959-12-31,SI,Slovenia,
-1959-12-31,SK,Slovak Republic,
-1959-12-31,TH,Thailand,
-1959-12-31,TR,Türkiye,
-1959-12-31,US,United States,
-1959-12-31,XM,Euro area,
-1959-12-31,XW,World,
-1959-12-31,ZA,South Africa,
-1960-03-31,4T,Emerging market economies (aggregate),
-1960-03-31,5R,Advanced economies,
-1960-03-31,AE,United Arab Emirates,
-1960-03-31,AT,Austria,
-1960-03-31,AU,Australia,
-1960-03-31,BE,Belgium,
-1960-03-31,BG,Bulgaria,
-1960-03-31,BR,Brazil,
-1960-03-31,CA,Canada,
-1960-03-31,CH,Switzerland,
-1960-03-31,CL,Chile,
-1960-03-31,CN,China,
-1960-03-31,CO,Colombia,
-1960-03-31,CY,Cyprus,
-1960-03-31,CZ,Czechia,
-1960-03-31,DE,Germany,
-1960-03-31,DK,Denmark,
-1960-03-31,EE,Estonia,
-1960-03-31,ES,Spain,
-1960-03-31,FI,Finland,
-1960-03-31,FR,France,
-1960-03-31,GB,United Kingdom,
-1960-03-31,GR,Greece,
-1960-03-31,HK,Hong Kong SAR,
-1960-03-31,HR,Croatia,
-1960-03-31,HU,Hungary,
-1960-03-31,ID,Indonesia,
-1960-03-31,IE,Ireland,
-1960-03-31,IL,Israel,
-1960-03-31,IN,India,
-1960-03-31,IS,Iceland,
-1960-03-31,IT,Italy,1.4367
+1960-03-31,IT,Italy,1.4355
 1960-03-31,JP,Japan,5.9615
-1960-03-31,KR,Korea,
-1960-03-31,LT,Lithuania,
-1960-03-31,LU,Luxembourg,
-1960-03-31,LV,Latvia,
-1960-03-31,MA,Morocco,
-1960-03-31,MK,North Macedonia,
-1960-03-31,MT,Malta,
-1960-03-31,MX,Mexico,
-1960-03-31,MY,Malaysia,
-1960-03-31,NL,Netherlands,
-1960-03-31,NO,Norway,
-1960-03-31,NZ,New Zealand,
-1960-03-31,PE,Peru,
-1960-03-31,PH,Philippines,
-1960-03-31,PL,Poland,
-1960-03-31,PT,Portugal,
-1960-03-31,RO,Romania,
-1960-03-31,RS,Serbia,
-1960-03-31,RU,Russia,
-1960-03-31,SE,Sweden,
-1960-03-31,SG,Singapore,
-1960-03-31,SI,Slovenia,
-1960-03-31,SK,Slovak Republic,
-1960-03-31,TH,Thailand,
-1960-03-31,TR,Türkiye,
-1960-03-31,US,United States,
-1960-03-31,XM,Euro area,
-1960-03-31,XW,World,
-1960-03-31,ZA,South Africa,
-1960-06-30,4T,Emerging market economies (aggregate),
-1960-06-30,5R,Advanced economies,
-1960-06-30,AE,United Arab Emirates,
-1960-06-30,AT,Austria,
-1960-06-30,AU,Australia,
-1960-06-30,BE,Belgium,
-1960-06-30,BG,Bulgaria,
-1960-06-30,BR,Brazil,
-1960-06-30,CA,Canada,
-1960-06-30,CH,Switzerland,
-1960-06-30,CL,Chile,
-1960-06-30,CN,China,
-1960-06-30,CO,Colombia,
-1960-06-30,CY,Cyprus,
-1960-06-30,CZ,Czechia,
-1960-06-30,DE,Germany,
-1960-06-30,DK,Denmark,
-1960-06-30,EE,Estonia,
-1960-06-30,ES,Spain,
-1960-06-30,FI,Finland,
-1960-06-30,FR,France,
-1960-06-30,GB,United Kingdom,
-1960-06-30,GR,Greece,
-1960-06-30,HK,Hong Kong SAR,
-1960-06-30,HR,Croatia,
-1960-06-30,HU,Hungary,
-1960-06-30,ID,Indonesia,
-1960-06-30,IE,Ireland,
-1960-06-30,IL,Israel,
-1960-06-30,IN,India,
-1960-06-30,IS,Iceland,
-1960-06-30,IT,Italy,1.4221
+1960-06-30,IT,Italy,1.411
 1960-06-30,JP,Japan,6.4087
-1960-06-30,KR,Korea,
-1960-06-30,LT,Lithuania,
-1960-06-30,LU,Luxembourg,
-1960-06-30,LV,Latvia,
-1960-06-30,MA,Morocco,
-1960-06-30,MK,North Macedonia,
-1960-06-30,MT,Malta,
-1960-06-30,MX,Mexico,
-1960-06-30,MY,Malaysia,
-1960-06-30,NL,Netherlands,
-1960-06-30,NO,Norway,
-1960-06-30,NZ,New Zealand,
-1960-06-30,PE,Peru,
-1960-06-30,PH,Philippines,
-1960-06-30,PL,Poland,
-1960-06-30,PT,Portugal,
-1960-06-30,RO,Romania,
-1960-06-30,RS,Serbia,
-1960-06-30,RU,Russia,
-1960-06-30,SE,Sweden,
-1960-06-30,SG,Singapore,
-1960-06-30,SI,Slovenia,
-1960-06-30,SK,Slovak Republic,
-1960-06-30,TH,Thailand,
-1960-06-30,TR,Türkiye,
-1960-06-30,US,United States,
-1960-06-30,XM,Euro area,
-1960-06-30,XW,World,
-1960-06-30,ZA,South Africa,
-1960-09-30,4T,Emerging market economies (aggregate),
-1960-09-30,5R,Advanced economies,
-1960-09-30,AE,United Arab Emirates,
-1960-09-30,AT,Austria,
-1960-09-30,AU,Australia,
-1960-09-30,BE,Belgium,
-1960-09-30,BG,Bulgaria,
-1960-09-30,BR,Brazil,
-1960-09-30,CA,Canada,
-1960-09-30,CH,Switzerland,
-1960-09-30,CL,Chile,
-1960-09-30,CN,China,
-1960-09-30,CO,Colombia,
-1960-09-30,CY,Cyprus,
-1960-09-30,CZ,Czechia,
-1960-09-30,DE,Germany,
-1960-09-30,DK,Denmark,
-1960-09-30,EE,Estonia,
-1960-09-30,ES,Spain,
-1960-09-30,FI,Finland,
-1960-09-30,FR,France,
-1960-09-30,GB,United Kingdom,
-1960-09-30,GR,Greece,
-1960-09-30,HK,Hong Kong SAR,
-1960-09-30,HR,Croatia,
-1960-09-30,HU,Hungary,
-1960-09-30,ID,Indonesia,
-1960-09-30,IE,Ireland,
-1960-09-30,IL,Israel,
-1960-09-30,IN,India,
-1960-09-30,IS,Iceland,
-1960-09-30,IT,Italy,1.4269
+1960-09-30,IT,Italy,1.4265
 1960-09-30,JP,Japan,6.8558
-1960-09-30,KR,Korea,
-1960-09-30,LT,Lithuania,
-1960-09-30,LU,Luxembourg,
-1960-09-30,LV,Latvia,
-1960-09-30,MA,Morocco,
-1960-09-30,MK,North Macedonia,
-1960-09-30,MT,Malta,
-1960-09-30,MX,Mexico,
-1960-09-30,MY,Malaysia,
-1960-09-30,NL,Netherlands,
-1960-09-30,NO,Norway,
-1960-09-30,NZ,New Zealand,
-1960-09-30,PE,Peru,
-1960-09-30,PH,Philippines,
-1960-09-30,PL,Poland,
-1960-09-30,PT,Portugal,
-1960-09-30,RO,Romania,
-1960-09-30,RS,Serbia,
-1960-09-30,RU,Russia,
-1960-09-30,SE,Sweden,
-1960-09-30,SG,Singapore,
-1960-09-30,SI,Slovenia,
-1960-09-30,SK,Slovak Republic,
-1960-09-30,TH,Thailand,
-1960-09-30,TR,Türkiye,
-1960-09-30,US,United States,
-1960-09-30,XM,Euro area,
-1960-09-30,XW,World,
-1960-09-30,ZA,South Africa,
-1960-12-31,4T,Emerging market economies (aggregate),
-1960-12-31,5R,Advanced economies,
-1960-12-31,AE,United Arab Emirates,
-1960-12-31,AT,Austria,
-1960-12-31,AU,Australia,
-1960-12-31,BE,Belgium,
-1960-12-31,BG,Bulgaria,
-1960-12-31,BR,Brazil,
-1960-12-31,CA,Canada,
-1960-12-31,CH,Switzerland,
-1960-12-31,CL,Chile,
-1960-12-31,CN,China,
-1960-12-31,CO,Colombia,
-1960-12-31,CY,Cyprus,
-1960-12-31,CZ,Czechia,
-1960-12-31,DE,Germany,
-1960-12-31,DK,Denmark,
-1960-12-31,EE,Estonia,
-1960-12-31,ES,Spain,
-1960-12-31,FI,Finland,
-1960-12-31,FR,France,
-1960-12-31,GB,United Kingdom,
-1960-12-31,GR,Greece,
-1960-12-31,HK,Hong Kong SAR,
-1960-12-31,HR,Croatia,
-1960-12-31,HU,Hungary,
-1960-12-31,ID,Indonesia,
-1960-12-31,IE,Ireland,
-1960-12-31,IL,Israel,
-1960-12-31,IN,India,
-1960-12-31,IS,Iceland,
-1960-12-31,IT,Italy,1.4276
+1960-12-31,IT,Italy,1.4402
 1960-12-31,JP,Japan,7.5337
-1960-12-31,KR,Korea,
-1960-12-31,LT,Lithuania,
-1960-12-31,LU,Luxembourg,
-1960-12-31,LV,Latvia,
-1960-12-31,MA,Morocco,
-1960-12-31,MK,North Macedonia,
-1960-12-31,MT,Malta,
-1960-12-31,MX,Mexico,
-1960-12-31,MY,Malaysia,
-1960-12-31,NL,Netherlands,
-1960-12-31,NO,Norway,
-1960-12-31,NZ,New Zealand,
-1960-12-31,PE,Peru,
-1960-12-31,PH,Philippines,
-1960-12-31,PL,Poland,
-1960-12-31,PT,Portugal,
-1960-12-31,RO,Romania,
-1960-12-31,RS,Serbia,
-1960-12-31,RU,Russia,
-1960-12-31,SE,Sweden,
-1960-12-31,SG,Singapore,
-1960-12-31,SI,Slovenia,
-1960-12-31,SK,Slovak Republic,
-1960-12-31,TH,Thailand,
-1960-12-31,TR,Türkiye,
-1960-12-31,US,United States,
-1960-12-31,XM,Euro area,
-1960-12-31,XW,World,
-1960-12-31,ZA,South Africa,
-1961-03-31,4T,Emerging market economies (aggregate),
-1961-03-31,5R,Advanced economies,
-1961-03-31,AE,United Arab Emirates,
-1961-03-31,AT,Austria,
-1961-03-31,AU,Australia,
-1961-03-31,BE,Belgium,
-1961-03-31,BG,Bulgaria,
-1961-03-31,BR,Brazil,
-1961-03-31,CA,Canada,
-1961-03-31,CH,Switzerland,
-1961-03-31,CL,Chile,
-1961-03-31,CN,China,
-1961-03-31,CO,Colombia,
-1961-03-31,CY,Cyprus,
-1961-03-31,CZ,Czechia,
-1961-03-31,DE,Germany,
-1961-03-31,DK,Denmark,
-1961-03-31,EE,Estonia,
-1961-03-31,ES,Spain,
-1961-03-31,FI,Finland,
-1961-03-31,FR,France,
-1961-03-31,GB,United Kingdom,
-1961-03-31,GR,Greece,
-1961-03-31,HK,Hong Kong SAR,
-1961-03-31,HR,Croatia,
-1961-03-31,HU,Hungary,
-1961-03-31,ID,Indonesia,
-1961-03-31,IE,Ireland,
-1961-03-31,IL,Israel,
-1961-03-31,IN,India,
-1961-03-31,IS,Iceland,
-1961-03-31,IT,Italy,1.4692
+1961-03-31,IT,Italy,1.4666
 1961-03-31,JP,Japan,8.2115
-1961-03-31,KR,Korea,
-1961-03-31,LT,Lithuania,
-1961-03-31,LU,Luxembourg,
-1961-03-31,LV,Latvia,
-1961-03-31,MA,Morocco,
-1961-03-31,MK,North Macedonia,
-1961-03-31,MT,Malta,
-1961-03-31,MX,Mexico,
-1961-03-31,MY,Malaysia,
-1961-03-31,NL,Netherlands,
-1961-03-31,NO,Norway,
-1961-03-31,NZ,New Zealand,
-1961-03-31,PE,Peru,
-1961-03-31,PH,Philippines,
-1961-03-31,PL,Poland,
-1961-03-31,PT,Portugal,
-1961-03-31,RO,Romania,
-1961-03-31,RS,Serbia,
-1961-03-31,RU,Russia,
-1961-03-31,SE,Sweden,
-1961-03-31,SG,Singapore,
-1961-03-31,SI,Slovenia,
-1961-03-31,SK,Slovak Republic,
-1961-03-31,TH,Thailand,
-1961-03-31,TR,Türkiye,
-1961-03-31,US,United States,
-1961-03-31,XM,Euro area,
-1961-03-31,XW,World,
-1961-03-31,ZA,South Africa,
-1961-06-30,4T,Emerging market economies (aggregate),
-1961-06-30,5R,Advanced economies,
-1961-06-30,AE,United Arab Emirates,
-1961-06-30,AT,Austria,
-1961-06-30,AU,Australia,
-1961-06-30,BE,Belgium,
-1961-06-30,BG,Bulgaria,
-1961-06-30,BR,Brazil,
-1961-06-30,CA,Canada,
-1961-06-30,CH,Switzerland,
-1961-06-30,CL,Chile,
-1961-06-30,CN,China,
-1961-06-30,CO,Colombia,
-1961-06-30,CY,Cyprus,
-1961-06-30,CZ,Czechia,
-1961-06-30,DE,Germany,
-1961-06-30,DK,Denmark,
-1961-06-30,EE,Estonia,
-1961-06-30,ES,Spain,
-1961-06-30,FI,Finland,
-1961-06-30,FR,France,
-1961-06-30,GB,United Kingdom,
-1961-06-30,GR,Greece,
-1961-06-30,HK,Hong Kong SAR,
-1961-06-30,HR,Croatia,
-1961-06-30,HU,Hungary,
-1961-06-30,ID,Indonesia,
-1961-06-30,IE,Ireland,
-1961-06-30,IL,Israel,
-1961-06-30,IN,India,
-1961-06-30,IS,Iceland,
-1961-06-30,IT,Italy,1.4972
+1961-06-30,IT,Italy,1.4887
 1961-06-30,JP,Japan,8.857
-1961-06-30,KR,Korea,
-1961-06-30,LT,Lithuania,
-1961-06-30,LU,Luxembourg,
-1961-06-30,LV,Latvia,
-1961-06-30,MA,Morocco,
-1961-06-30,MK,North Macedonia,
-1961-06-30,MT,Malta,
-1961-06-30,MX,Mexico,
-1961-06-30,MY,Malaysia,
-1961-06-30,NL,Netherlands,
-1961-06-30,NO,Norway,
-1961-06-30,NZ,New Zealand,
-1961-06-30,PE,Peru,
-1961-06-30,PH,Philippines,
-1961-06-30,PL,Poland,
-1961-06-30,PT,Portugal,
-1961-06-30,RO,Romania,
-1961-06-30,RS,Serbia,
-1961-06-30,RU,Russia,
-1961-06-30,SE,Sweden,
-1961-06-30,SG,Singapore,
-1961-06-30,SI,Slovenia,
-1961-06-30,SK,Slovak Republic,
-1961-06-30,TH,Thailand,
-1961-06-30,TR,Türkiye,
-1961-06-30,US,United States,
-1961-06-30,XM,Euro area,
-1961-06-30,XW,World,
-1961-06-30,ZA,South Africa,
-1961-09-30,4T,Emerging market economies (aggregate),
-1961-09-30,5R,Advanced economies,
-1961-09-30,AE,United Arab Emirates,
-1961-09-30,AT,Austria,
-1961-09-30,AU,Australia,
-1961-09-30,BE,Belgium,
-1961-09-30,BG,Bulgaria,
-1961-09-30,BR,Brazil,
-1961-09-30,CA,Canada,
-1961-09-30,CH,Switzerland,
-1961-09-30,CL,Chile,
-1961-09-30,CN,China,
-1961-09-30,CO,Colombia,
-1961-09-30,CY,Cyprus,
-1961-09-30,CZ,Czechia,
-1961-09-30,DE,Germany,
-1961-09-30,DK,Denmark,
-1961-09-30,EE,Estonia,
-1961-09-30,ES,Spain,
-1961-09-30,FI,Finland,
-1961-09-30,FR,France,
-1961-09-30,GB,United Kingdom,
-1961-09-30,GR,Greece,
-1961-09-30,HK,Hong Kong SAR,
-1961-09-30,HR,Croatia,
-1961-09-30,HU,Hungary,
-1961-09-30,ID,Indonesia,
-1961-09-30,IE,Ireland,
-1961-09-30,IL,Israel,
-1961-09-30,IN,India,
-1961-09-30,IS,Iceland,
-1961-09-30,IT,Italy,1.4967
+1961-09-30,IT,Italy,1.5023
 1961-09-30,JP,Japan,9.5096
-1961-09-30,KR,Korea,
-1961-09-30,LT,Lithuania,
-1961-09-30,LU,Luxembourg,
-1961-09-30,LV,Latvia,
-1961-09-30,MA,Morocco,
-1961-09-30,MK,North Macedonia,
-1961-09-30,MT,Malta,
-1961-09-30,MX,Mexico,
-1961-09-30,MY,Malaysia,
-1961-09-30,NL,Netherlands,
-1961-09-30,NO,Norway,
-1961-09-30,NZ,New Zealand,
-1961-09-30,PE,Peru,
-1961-09-30,PH,Philippines,
-1961-09-30,PL,Poland,
-1961-09-30,PT,Portugal,
-1961-09-30,RO,Romania,
-1961-09-30,RS,Serbia,
-1961-09-30,RU,Russia,
-1961-09-30,SE,Sweden,
-1961-09-30,SG,Singapore,
-1961-09-30,SI,Slovenia,
-1961-09-30,SK,Slovak Republic,
-1961-09-30,TH,Thailand,
-1961-09-30,TR,Türkiye,
-1961-09-30,US,United States,
-1961-09-30,XM,Euro area,
-1961-09-30,XW,World,
-1961-09-30,ZA,South Africa,
-1961-12-31,4T,Emerging market economies (aggregate),
-1961-12-31,5R,Advanced economies,
-1961-12-31,AE,United Arab Emirates,
-1961-12-31,AT,Austria,
-1961-12-31,AU,Australia,
-1961-12-31,BE,Belgium,
-1961-12-31,BG,Bulgaria,
-1961-12-31,BR,Brazil,
-1961-12-31,CA,Canada,
-1961-12-31,CH,Switzerland,
-1961-12-31,CL,Chile,
-1961-12-31,CN,China,
-1961-12-31,CO,Colombia,
-1961-12-31,CY,Cyprus,
-1961-12-31,CZ,Czechia,
-1961-12-31,DE,Germany,
-1961-12-31,DK,Denmark,
-1961-12-31,EE,Estonia,
-1961-12-31,ES,Spain,
-1961-12-31,FI,Finland,
-1961-12-31,FR,France,
-1961-12-31,GB,United Kingdom,
-1961-12-31,GR,Greece,
-1961-12-31,HK,Hong Kong SAR,
-1961-12-31,HR,Croatia,
-1961-12-31,HU,Hungary,
-1961-12-31,ID,Indonesia,
-1961-12-31,IE,Ireland,
-1961-12-31,IL,Israel,
-1961-12-31,IN,India,
-1961-12-31,IS,Iceland,
-1961-12-31,IT,Italy,1.5182
+1961-12-31,IT,Italy,1.5236
 1961-12-31,JP,Japan,9.9471
-1961-12-31,KR,Korea,
-1961-12-31,LT,Lithuania,
-1961-12-31,LU,Luxembourg,
-1961-12-31,LV,Latvia,
-1961-12-31,MA,Morocco,
-1961-12-31,MK,North Macedonia,
-1961-12-31,MT,Malta,
-1961-12-31,MX,Mexico,
-1961-12-31,MY,Malaysia,
-1961-12-31,NL,Netherlands,
-1961-12-31,NO,Norway,
-1961-12-31,NZ,New Zealand,
-1961-12-31,PE,Peru,
-1961-12-31,PH,Philippines,
-1961-12-31,PL,Poland,
-1961-12-31,PT,Portugal,
-1961-12-31,RO,Romania,
-1961-12-31,RS,Serbia,
-1961-12-31,RU,Russia,
-1961-12-31,SE,Sweden,
-1961-12-31,SG,Singapore,
-1961-12-31,SI,Slovenia,
-1961-12-31,SK,Slovak Republic,
-1961-12-31,TH,Thailand,
-1961-12-31,TR,Türkiye,
-1961-12-31,US,United States,
-1961-12-31,XM,Euro area,
-1961-12-31,XW,World,
-1961-12-31,ZA,South Africa,
-1962-03-31,4T,Emerging market economies (aggregate),
-1962-03-31,5R,Advanced economies,
-1962-03-31,AE,United Arab Emirates,
-1962-03-31,AT,Austria,
-1962-03-31,AU,Australia,
-1962-03-31,BE,Belgium,
-1962-03-31,BG,Bulgaria,
-1962-03-31,BR,Brazil,
-1962-03-31,CA,Canada,
-1962-03-31,CH,Switzerland,
-1962-03-31,CL,Chile,
-1962-03-31,CN,China,
-1962-03-31,CO,Colombia,
-1962-03-31,CY,Cyprus,
-1962-03-31,CZ,Czechia,
-1962-03-31,DE,Germany,
-1962-03-31,DK,Denmark,
-1962-03-31,EE,Estonia,
-1962-03-31,ES,Spain,
-1962-03-31,FI,Finland,
-1962-03-31,FR,France,
-1962-03-31,GB,United Kingdom,
-1962-03-31,GR,Greece,
-1962-03-31,HK,Hong Kong SAR,
-1962-03-31,HR,Croatia,
-1962-03-31,HU,Hungary,
-1962-03-31,ID,Indonesia,
-1962-03-31,IE,Ireland,
-1962-03-31,IL,Israel,
-1962-03-31,IN,India,
-1962-03-31,IS,Iceland,
-1962-03-31,IT,Italy,1.5707
+1962-03-31,IT,Italy,1.5662
 1962-03-31,JP,Japan,10.3846
-1962-03-31,KR,Korea,
-1962-03-31,LT,Lithuania,
-1962-03-31,LU,Luxembourg,
-1962-03-31,LV,Latvia,
-1962-03-31,MA,Morocco,
-1962-03-31,MK,North Macedonia,
-1962-03-31,MT,Malta,
-1962-03-31,MX,Mexico,
-1962-03-31,MY,Malaysia,
-1962-03-31,NL,Netherlands,
-1962-03-31,NO,Norway,
-1962-03-31,NZ,New Zealand,
-1962-03-31,PE,Peru,
-1962-03-31,PH,Philippines,
-1962-03-31,PL,Poland,
-1962-03-31,PT,Portugal,
-1962-03-31,RO,Romania,
-1962-03-31,RS,Serbia,
-1962-03-31,RU,Russia,
-1962-03-31,SE,Sweden,
-1962-03-31,SG,Singapore,
-1962-03-31,SI,Slovenia,
-1962-03-31,SK,Slovak Republic,
-1962-03-31,TH,Thailand,
-1962-03-31,TR,Türkiye,
-1962-03-31,US,United States,
-1962-03-31,XM,Euro area,
-1962-03-31,XW,World,
-1962-03-31,ZA,South Africa,
-1962-06-30,4T,Emerging market economies (aggregate),
-1962-06-30,5R,Advanced economies,
-1962-06-30,AE,United Arab Emirates,
-1962-06-30,AT,Austria,
-1962-06-30,AU,Australia,
-1962-06-30,BE,Belgium,
-1962-06-30,BG,Bulgaria,
-1962-06-30,BR,Brazil,
-1962-06-30,CA,Canada,
-1962-06-30,CH,Switzerland,
-1962-06-30,CL,Chile,
-1962-06-30,CN,China,
-1962-06-30,CO,Colombia,
-1962-06-30,CY,Cyprus,
-1962-06-30,CZ,Czechia,
-1962-06-30,DE,Germany,
-1962-06-30,DK,Denmark,
-1962-06-30,EE,Estonia,
-1962-06-30,ES,Spain,
-1962-06-30,FI,Finland,
-1962-06-30,FR,France,
-1962-06-30,GB,United Kingdom,
-1962-06-30,GR,Greece,
-1962-06-30,HK,Hong Kong SAR,
-1962-06-30,HR,Croatia,
-1962-06-30,HU,Hungary,
-1962-06-30,ID,Indonesia,
-1962-06-30,IE,Ireland,
-1962-06-30,IL,Israel,
-1962-06-30,IN,India,
-1962-06-30,IS,Iceland,
-1962-06-30,IT,Italy,1.63
+1962-06-30,IT,Italy,1.6174
 1962-06-30,JP,Japan,10.8149
-1962-06-30,KR,Korea,
-1962-06-30,LT,Lithuania,
-1962-06-30,LU,Luxembourg,
-1962-06-30,LV,Latvia,
-1962-06-30,MA,Morocco,
-1962-06-30,MK,North Macedonia,
-1962-06-30,MT,Malta,
-1962-06-30,MX,Mexico,
-1962-06-30,MY,Malaysia,
-1962-06-30,NL,Netherlands,
-1962-06-30,NO,Norway,
-1962-06-30,NZ,New Zealand,
-1962-06-30,PE,Peru,
-1962-06-30,PH,Philippines,
-1962-06-30,PL,Poland,
-1962-06-30,PT,Portugal,
-1962-06-30,RO,Romania,
-1962-06-30,RS,Serbia,
-1962-06-30,RU,Russia,
-1962-06-30,SE,Sweden,
-1962-06-30,SG,Singapore,
-1962-06-30,SI,Slovenia,
-1962-06-30,SK,Slovak Republic,
-1962-06-30,TH,Thailand,
-1962-06-30,TR,Türkiye,
-1962-06-30,US,United States,
-1962-06-30,XM,Euro area,
-1962-06-30,XW,World,
-1962-06-30,ZA,South Africa,
-1962-09-30,4T,Emerging market economies (aggregate),
-1962-09-30,5R,Advanced economies,
-1962-09-30,AE,United Arab Emirates,
-1962-09-30,AT,Austria,
-1962-09-30,AU,Australia,
-1962-09-30,BE,Belgium,
-1962-09-30,BG,Bulgaria,
-1962-09-30,BR,Brazil,
-1962-09-30,CA,Canada,
-1962-09-30,CH,Switzerland,
-1962-09-30,CL,Chile,
-1962-09-30,CN,China,
-1962-09-30,CO,Colombia,
-1962-09-30,CY,Cyprus,
-1962-09-30,CZ,Czechia,
-1962-09-30,DE,Germany,
-1962-09-30,DK,Denmark,
-1962-09-30,EE,Estonia,
-1962-09-30,ES,Spain,
-1962-09-30,FI,Finland,
-1962-09-30,FR,France,
-1962-09-30,GB,United Kingdom,
-1962-09-30,GR,Greece,
-1962-09-30,HK,Hong Kong SAR,
-1962-09-30,HR,Croatia,
-1962-09-30,HU,Hungary,
-1962-09-30,ID,Indonesia,
-1962-09-30,IE,Ireland,
-1962-09-30,IL,Israel,
-1962-09-30,IN,India,
-1962-09-30,IS,Iceland,
-1962-09-30,IT,Italy,1.6212
+1962-06-30,NZ,New Zealand,1.8046
+1962-09-30,IT,Italy,1.6208
 1962-09-30,JP,Japan,11.25
-1962-09-30,KR,Korea,
-1962-09-30,LT,Lithuania,
-1962-09-30,LU,Luxembourg,
-1962-09-30,LV,Latvia,
-1962-09-30,MA,Morocco,
-1962-09-30,MK,North Macedonia,
-1962-09-30,MT,Malta,
-1962-09-30,MX,Mexico,
-1962-09-30,MY,Malaysia,
-1962-09-30,NL,Netherlands,
-1962-09-30,NO,Norway,
-1962-09-30,NZ,New Zealand,
-1962-09-30,PE,Peru,
-1962-09-30,PH,Philippines,
-1962-09-30,PL,Poland,
-1962-09-30,PT,Portugal,
-1962-09-30,RO,Romania,
-1962-09-30,RS,Serbia,
-1962-09-30,RU,Russia,
-1962-09-30,SE,Sweden,
-1962-09-30,SG,Singapore,
-1962-09-30,SI,Slovenia,
-1962-09-30,SK,Slovak Republic,
-1962-09-30,TH,Thailand,
-1962-09-30,TR,Türkiye,
-1962-09-30,US,United States,
-1962-09-30,XM,Euro area,
-1962-09-30,XW,World,
-1962-09-30,ZA,South Africa,
-1962-12-31,4T,Emerging market economies (aggregate),
-1962-12-31,5R,Advanced economies,
-1962-12-31,AE,United Arab Emirates,
-1962-12-31,AT,Austria,
-1962-12-31,AU,Australia,
-1962-12-31,BE,Belgium,
-1962-12-31,BG,Bulgaria,
-1962-12-31,BR,Brazil,
-1962-12-31,CA,Canada,
-1962-12-31,CH,Switzerland,
-1962-12-31,CL,Chile,
-1962-12-31,CN,China,
-1962-12-31,CO,Colombia,
-1962-12-31,CY,Cyprus,
-1962-12-31,CZ,Czechia,
-1962-12-31,DE,Germany,
-1962-12-31,DK,Denmark,
-1962-12-31,EE,Estonia,
-1962-12-31,ES,Spain,
-1962-12-31,FI,Finland,
-1962-12-31,FR,France,
-1962-12-31,GB,United Kingdom,
-1962-12-31,GR,Greece,
-1962-12-31,HK,Hong Kong SAR,
-1962-12-31,HR,Croatia,
-1962-12-31,HU,Hungary,
-1962-12-31,ID,Indonesia,
-1962-12-31,IE,Ireland,
-1962-12-31,IL,Israel,
-1962-12-31,IN,India,
-1962-12-31,IS,Iceland,
-1962-12-31,IT,Italy,1.6215
+1962-09-30,NZ,New Zealand,1.8188
+1962-12-31,IT,Italy,1.6387
 1962-12-31,JP,Japan,11.6346
-1962-12-31,KR,Korea,
-1962-12-31,LT,Lithuania,
-1962-12-31,LU,Luxembourg,
-1962-12-31,LV,Latvia,
-1962-12-31,MA,Morocco,
-1962-12-31,MK,North Macedonia,
-1962-12-31,MT,Malta,
-1962-12-31,MX,Mexico,
-1962-12-31,MY,Malaysia,
-1962-12-31,NL,Netherlands,
-1962-12-31,NO,Norway,
-1962-12-31,NZ,New Zealand,
-1962-12-31,PE,Peru,
-1962-12-31,PH,Philippines,
-1962-12-31,PL,Poland,
-1962-12-31,PT,Portugal,
-1962-12-31,RO,Romania,
-1962-12-31,RS,Serbia,
-1962-12-31,RU,Russia,
-1962-12-31,SE,Sweden,
-1962-12-31,SG,Singapore,
-1962-12-31,SI,Slovenia,
-1962-12-31,SK,Slovak Republic,
-1962-12-31,TH,Thailand,
-1962-12-31,TR,Türkiye,
-1962-12-31,US,United States,
-1962-12-31,XM,Euro area,
-1962-12-31,XW,World,
-1962-12-31,ZA,South Africa,
-1963-03-31,4T,Emerging market economies (aggregate),
-1963-03-31,5R,Advanced economies,
-1963-03-31,AE,United Arab Emirates,
-1963-03-31,AT,Austria,
-1963-03-31,AU,Australia,
-1963-03-31,BE,Belgium,
-1963-03-31,BG,Bulgaria,
-1963-03-31,BR,Brazil,
-1963-03-31,CA,Canada,
-1963-03-31,CH,Switzerland,
-1963-03-31,CL,Chile,
-1963-03-31,CN,China,
-1963-03-31,CO,Colombia,
-1963-03-31,CY,Cyprus,
-1963-03-31,CZ,Czechia,
-1963-03-31,DE,Germany,
-1963-03-31,DK,Denmark,
-1963-03-31,EE,Estonia,
-1963-03-31,ES,Spain,
-1963-03-31,FI,Finland,
-1963-03-31,FR,France,
-1963-03-31,GB,United Kingdom,
-1963-03-31,GR,Greece,
-1963-03-31,HK,Hong Kong SAR,
-1963-03-31,HR,Croatia,
-1963-03-31,HU,Hungary,
-1963-03-31,ID,Indonesia,
-1963-03-31,IE,Ireland,
-1963-03-31,IL,Israel,
-1963-03-31,IN,India,
-1963-03-31,IS,Iceland,
-1963-03-31,IT,Italy,1.7381
+1962-12-31,NZ,New Zealand,1.833
+1963-03-31,IT,Italy,1.7331
 1963-03-31,JP,Japan,12.0192
-1963-03-31,KR,Korea,
-1963-03-31,LT,Lithuania,
-1963-03-31,LU,Luxembourg,
-1963-03-31,LV,Latvia,
-1963-03-31,MA,Morocco,
-1963-03-31,MK,North Macedonia,
-1963-03-31,MT,Malta,
-1963-03-31,MX,Mexico,
-1963-03-31,MY,Malaysia,
-1963-03-31,NL,Netherlands,
-1963-03-31,NO,Norway,
-1963-03-31,NZ,New Zealand,
-1963-03-31,PE,Peru,
-1963-03-31,PH,Philippines,
-1963-03-31,PL,Poland,
-1963-03-31,PT,Portugal,
-1963-03-31,RO,Romania,
-1963-03-31,RS,Serbia,
-1963-03-31,RU,Russia,
-1963-03-31,SE,Sweden,
-1963-03-31,SG,Singapore,
-1963-03-31,SI,Slovenia,
-1963-03-31,SK,Slovak Republic,
-1963-03-31,TH,Thailand,
-1963-03-31,TR,Türkiye,
-1963-03-31,US,United States,
-1963-03-31,XM,Euro area,
-1963-03-31,XW,World,
-1963-03-31,ZA,South Africa,
-1963-06-30,4T,Emerging market economies (aggregate),
-1963-06-30,5R,Advanced economies,
-1963-06-30,AE,United Arab Emirates,
-1963-06-30,AT,Austria,
-1963-06-30,AU,Australia,
-1963-06-30,BE,Belgium,
-1963-06-30,BG,Bulgaria,
-1963-06-30,BR,Brazil,
-1963-06-30,CA,Canada,
-1963-06-30,CH,Switzerland,
-1963-06-30,CL,Chile,
-1963-06-30,CN,China,
-1963-06-30,CO,Colombia,
-1963-06-30,CY,Cyprus,
-1963-06-30,CZ,Czechia,
-1963-06-30,DE,Germany,
-1963-06-30,DK,Denmark,
-1963-06-30,EE,Estonia,
-1963-06-30,ES,Spain,
-1963-06-30,FI,Finland,
-1963-06-30,FR,France,
-1963-06-30,GB,United Kingdom,
-1963-06-30,GR,Greece,
-1963-06-30,HK,Hong Kong SAR,
-1963-06-30,HR,Croatia,
-1963-06-30,HU,Hungary,
-1963-06-30,ID,Indonesia,
-1963-06-30,IE,Ireland,
-1963-06-30,IL,Israel,
-1963-06-30,IN,India,
-1963-06-30,IS,Iceland,
-1963-06-30,IT,Italy,1.7461
+1963-03-31,NZ,New Zealand,1.833
+1963-06-30,IT,Italy,1.7392
 1963-06-30,JP,Japan,12.4017
-1963-06-30,KR,Korea,
-1963-06-30,LT,Lithuania,
-1963-06-30,LU,Luxembourg,
-1963-06-30,LV,Latvia,
-1963-06-30,MA,Morocco,
-1963-06-30,MK,North Macedonia,
-1963-06-30,MT,Malta,
-1963-06-30,MX,Mexico,
-1963-06-30,MY,Malaysia,
-1963-06-30,NL,Netherlands,
-1963-06-30,NO,Norway,
-1963-06-30,NZ,New Zealand,
-1963-06-30,PE,Peru,
-1963-06-30,PH,Philippines,
-1963-06-30,PL,Poland,
-1963-06-30,PT,Portugal,
-1963-06-30,RO,Romania,
-1963-06-30,RS,Serbia,
-1963-06-30,RU,Russia,
-1963-06-30,SE,Sweden,
-1963-06-30,SG,Singapore,
-1963-06-30,SI,Slovenia,
-1963-06-30,SK,Slovak Republic,
-1963-06-30,TH,Thailand,
-1963-06-30,TR,Türkiye,
-1963-06-30,US,United States,
-1963-06-30,XM,Euro area,
-1963-06-30,XW,World,
-1963-06-30,ZA,South Africa,
-1963-09-30,4T,Emerging market economies (aggregate),
-1963-09-30,5R,Advanced economies,
-1963-09-30,AE,United Arab Emirates,
-1963-09-30,AT,Austria,
-1963-09-30,AU,Australia,
-1963-09-30,BE,Belgium,
-1963-09-30,BG,Bulgaria,
-1963-09-30,BR,Brazil,
-1963-09-30,CA,Canada,
-1963-09-30,CH,Switzerland,
-1963-09-30,CL,Chile,
-1963-09-30,CN,China,
-1963-09-30,CO,Colombia,
-1963-09-30,CY,Cyprus,
-1963-09-30,CZ,Czechia,
-1963-09-30,DE,Germany,
-1963-09-30,DK,Denmark,
-1963-09-30,EE,Estonia,
-1963-09-30,ES,Spain,
-1963-09-30,FI,Finland,
-1963-09-30,FR,France,
-1963-09-30,GB,United Kingdom,
-1963-09-30,GR,Greece,
-1963-09-30,HK,Hong Kong SAR,
-1963-09-30,HR,Croatia,
-1963-09-30,HU,Hungary,
-1963-09-30,ID,Indonesia,
-1963-09-30,IE,Ireland,
-1963-09-30,IL,Israel,
-1963-09-30,IN,India,
-1963-09-30,IS,Iceland,
-1963-09-30,IT,Italy,1.7343
+1963-06-30,NZ,New Zealand,1.8472
+1963-09-30,IT,Italy,1.7318
 1963-09-30,JP,Japan,12.7885
-1963-09-30,KR,Korea,
-1963-09-30,LT,Lithuania,
-1963-09-30,LU,Luxembourg,
-1963-09-30,LV,Latvia,
-1963-09-30,MA,Morocco,
-1963-09-30,MK,North Macedonia,
-1963-09-30,MT,Malta,
-1963-09-30,MX,Mexico,
-1963-09-30,MY,Malaysia,
-1963-09-30,NL,Netherlands,
-1963-09-30,NO,Norway,
-1963-09-30,NZ,New Zealand,
-1963-09-30,PE,Peru,
-1963-09-30,PH,Philippines,
-1963-09-30,PL,Poland,
-1963-09-30,PT,Portugal,
-1963-09-30,RO,Romania,
-1963-09-30,RS,Serbia,
-1963-09-30,RU,Russia,
-1963-09-30,SE,Sweden,
-1963-09-30,SG,Singapore,
-1963-09-30,SI,Slovenia,
-1963-09-30,SK,Slovak Republic,
-1963-09-30,TH,Thailand,
-1963-09-30,TR,Türkiye,
-1963-09-30,US,United States,
-1963-09-30,XM,Euro area,
-1963-09-30,XW,World,
-1963-09-30,ZA,South Africa,
-1963-12-31,4T,Emerging market economies (aggregate),
-1963-12-31,5R,Advanced economies,
-1963-12-31,AE,United Arab Emirates,
-1963-12-31,AT,Austria,
-1963-12-31,AU,Australia,
-1963-12-31,BE,Belgium,
-1963-12-31,BG,Bulgaria,
-1963-12-31,BR,Brazil,
-1963-12-31,CA,Canada,
-1963-12-31,CH,Switzerland,
-1963-12-31,CL,Chile,
-1963-12-31,CN,China,
-1963-12-31,CO,Colombia,
-1963-12-31,CY,Cyprus,
-1963-12-31,CZ,Czechia,
-1963-12-31,DE,Germany,
-1963-12-31,DK,Denmark,
-1963-12-31,EE,Estonia,
-1963-12-31,ES,Spain,
-1963-12-31,FI,Finland,
-1963-12-31,FR,France,
-1963-12-31,GB,United Kingdom,
-1963-12-31,GR,Greece,
-1963-12-31,HK,Hong Kong SAR,
-1963-12-31,HR,Croatia,
-1963-12-31,HU,Hungary,
-1963-12-31,ID,Indonesia,
-1963-12-31,IE,Ireland,
-1963-12-31,IL,Israel,
-1963-12-31,IN,India,
-1963-12-31,IS,Iceland,
-1963-12-31,IT,Italy,1.817
+1963-09-30,NZ,New Zealand,1.8757
+1963-12-31,IT,Italy,1.8311
 1963-12-31,JP,Japan,13.2212
-1963-12-31,KR,Korea,
-1963-12-31,LT,Lithuania,
-1963-12-31,LU,Luxembourg,
-1963-12-31,LV,Latvia,
-1963-12-31,MA,Morocco,
-1963-12-31,MK,North Macedonia,
-1963-12-31,MT,Malta,
-1963-12-31,MX,Mexico,
-1963-12-31,MY,Malaysia,
-1963-12-31,NL,Netherlands,
-1963-12-31,NO,Norway,
-1963-12-31,NZ,New Zealand,
-1963-12-31,PE,Peru,
-1963-12-31,PH,Philippines,
-1963-12-31,PL,Poland,
-1963-12-31,PT,Portugal,
-1963-12-31,RO,Romania,
-1963-12-31,RS,Serbia,
-1963-12-31,RU,Russia,
-1963-12-31,SE,Sweden,
-1963-12-31,SG,Singapore,
-1963-12-31,SI,Slovenia,
-1963-12-31,SK,Slovak Republic,
-1963-12-31,TH,Thailand,
-1963-12-31,TR,Türkiye,
-1963-12-31,US,United States,
-1963-12-31,XM,Euro area,
-1963-12-31,XW,World,
-1963-12-31,ZA,South Africa,
-1964-03-31,4T,Emerging market economies (aggregate),
-1964-03-31,5R,Advanced economies,
-1964-03-31,AE,United Arab Emirates,
-1964-03-31,AT,Austria,
-1964-03-31,AU,Australia,
-1964-03-31,BE,Belgium,
-1964-03-31,BG,Bulgaria,
-1964-03-31,BR,Brazil,
-1964-03-31,CA,Canada,
-1964-03-31,CH,Switzerland,
-1964-03-31,CL,Chile,
-1964-03-31,CN,China,
-1964-03-31,CO,Colombia,
-1964-03-31,CY,Cyprus,
-1964-03-31,CZ,Czechia,
-1964-03-31,DE,Germany,
-1964-03-31,DK,Denmark,
-1964-03-31,EE,Estonia,
-1964-03-31,ES,Spain,
-1964-03-31,FI,Finland,
-1964-03-31,FR,France,
-1964-03-31,GB,United Kingdom,
-1964-03-31,GR,Greece,
-1964-03-31,HK,Hong Kong SAR,
-1964-03-31,HR,Croatia,
-1964-03-31,HU,Hungary,
-1964-03-31,ID,Indonesia,
-1964-03-31,IE,Ireland,
-1964-03-31,IL,Israel,
-1964-03-31,IN,India,
-1964-03-31,IS,Iceland,
-1964-03-31,IT,Italy,1.8895
+1963-12-31,NZ,New Zealand,1.9041
+1964-03-31,IT,Italy,1.8966
 1964-03-31,JP,Japan,13.6539
-1964-03-31,KR,Korea,
-1964-03-31,LT,Lithuania,
-1964-03-31,LU,Luxembourg,
-1964-03-31,LV,Latvia,
-1964-03-31,MA,Morocco,
-1964-03-31,MK,North Macedonia,
-1964-03-31,MT,Malta,
-1964-03-31,MX,Mexico,
-1964-03-31,MY,Malaysia,
-1964-03-31,NL,Netherlands,
-1964-03-31,NO,Norway,
-1964-03-31,NZ,New Zealand,
-1964-03-31,PE,Peru,
-1964-03-31,PH,Philippines,
-1964-03-31,PL,Poland,
-1964-03-31,PT,Portugal,
-1964-03-31,RO,Romania,
-1964-03-31,RS,Serbia,
-1964-03-31,RU,Russia,
-1964-03-31,SE,Sweden,
-1964-03-31,SG,Singapore,
-1964-03-31,SI,Slovenia,
-1964-03-31,SK,Slovak Republic,
-1964-03-31,TH,Thailand,
-1964-03-31,TR,Türkiye,
-1964-03-31,US,United States,
-1964-03-31,XM,Euro area,
-1964-03-31,XW,World,
-1964-03-31,ZA,South Africa,
-1964-06-30,4T,Emerging market economies (aggregate),
-1964-06-30,5R,Advanced economies,
-1964-06-30,AE,United Arab Emirates,
-1964-06-30,AT,Austria,
-1964-06-30,AU,Australia,
-1964-06-30,BE,Belgium,
-1964-06-30,BG,Bulgaria,
-1964-06-30,BR,Brazil,
-1964-06-30,CA,Canada,
-1964-06-30,CH,Switzerland,
-1964-06-30,CL,Chile,
-1964-06-30,CN,China,
-1964-06-30,CO,Colombia,
-1964-06-30,CY,Cyprus,
-1964-06-30,CZ,Czechia,
-1964-06-30,DE,Germany,
-1964-06-30,DK,Denmark,
-1964-06-30,EE,Estonia,
-1964-06-30,ES,Spain,
-1964-06-30,FI,Finland,
-1964-06-30,FR,France,
-1964-06-30,GB,United Kingdom,
-1964-06-30,GR,Greece,
-1964-06-30,HK,Hong Kong SAR,
-1964-06-30,HR,Croatia,
-1964-06-30,HU,Hungary,
-1964-06-30,ID,Indonesia,
-1964-06-30,IE,Ireland,
-1964-06-30,IL,Israel,
-1964-06-30,IN,India,
-1964-06-30,IS,Iceland,
-1964-06-30,IT,Italy,1.9518
+1964-03-31,NZ,New Zealand,1.9183
+1964-06-30,IT,Italy,1.9537
 1964-06-30,JP,Japan,14.1346
-1964-06-30,KR,Korea,
-1964-06-30,LT,Lithuania,
-1964-06-30,LU,Luxembourg,
-1964-06-30,LV,Latvia,
-1964-06-30,MA,Morocco,
-1964-06-30,MK,North Macedonia,
-1964-06-30,MT,Malta,
-1964-06-30,MX,Mexico,
-1964-06-30,MY,Malaysia,
-1964-06-30,NL,Netherlands,
-1964-06-30,NO,Norway,
-1964-06-30,NZ,New Zealand,
-1964-06-30,PE,Peru,
-1964-06-30,PH,Philippines,
-1964-06-30,PL,Poland,
-1964-06-30,PT,Portugal,
-1964-06-30,RO,Romania,
-1964-06-30,RS,Serbia,
-1964-06-30,RU,Russia,
-1964-06-30,SE,Sweden,
-1964-06-30,SG,Singapore,
-1964-06-30,SI,Slovenia,
-1964-06-30,SK,Slovak Republic,
-1964-06-30,TH,Thailand,
-1964-06-30,TR,Türkiye,
-1964-06-30,US,United States,
-1964-06-30,XM,Euro area,
-1964-06-30,XW,World,
-1964-06-30,ZA,South Africa,
-1964-09-30,4T,Emerging market economies (aggregate),
-1964-09-30,5R,Advanced economies,
-1964-09-30,AE,United Arab Emirates,
-1964-09-30,AT,Austria,
-1964-09-30,AU,Australia,
-1964-09-30,BE,Belgium,
-1964-09-30,BG,Bulgaria,
-1964-09-30,BR,Brazil,
-1964-09-30,CA,Canada,
-1964-09-30,CH,Switzerland,
-1964-09-30,CL,Chile,
-1964-09-30,CN,China,
-1964-09-30,CO,Colombia,
-1964-09-30,CY,Cyprus,
-1964-09-30,CZ,Czechia,
-1964-09-30,DE,Germany,
-1964-09-30,DK,Denmark,
-1964-09-30,EE,Estonia,
-1964-09-30,ES,Spain,
-1964-09-30,FI,Finland,
-1964-09-30,FR,France,
-1964-09-30,GB,United Kingdom,
-1964-09-30,GR,Greece,
-1964-09-30,HK,Hong Kong SAR,
-1964-09-30,HR,Croatia,
-1964-09-30,HU,Hungary,
-1964-09-30,ID,Indonesia,
-1964-09-30,IE,Ireland,
-1964-09-30,IL,Israel,
-1964-09-30,IN,India,
-1964-09-30,IS,Iceland,
-1964-09-30,IT,Italy,1.9955
+1964-06-30,NZ,New Zealand,1.9325
+1964-09-30,IT,Italy,1.9933
 1964-09-30,JP,Japan,14.6154
-1964-09-30,KR,Korea,
-1964-09-30,LT,Lithuania,
-1964-09-30,LU,Luxembourg,
-1964-09-30,LV,Latvia,
-1964-09-30,MA,Morocco,
-1964-09-30,MK,North Macedonia,
-1964-09-30,MT,Malta,
-1964-09-30,MX,Mexico,
-1964-09-30,MY,Malaysia,
-1964-09-30,NL,Netherlands,
-1964-09-30,NO,Norway,
-1964-09-30,NZ,New Zealand,
-1964-09-30,PE,Peru,
-1964-09-30,PH,Philippines,
-1964-09-30,PL,Poland,
-1964-09-30,PT,Portugal,
-1964-09-30,RO,Romania,
-1964-09-30,RS,Serbia,
-1964-09-30,RU,Russia,
-1964-09-30,SE,Sweden,
-1964-09-30,SG,Singapore,
-1964-09-30,SI,Slovenia,
-1964-09-30,SK,Slovak Republic,
-1964-09-30,TH,Thailand,
-1964-09-30,TR,Türkiye,
-1964-09-30,US,United States,
-1964-09-30,XM,Euro area,
-1964-09-30,XW,World,
-1964-09-30,ZA,South Africa,
-1964-12-31,4T,Emerging market economies (aggregate),
-1964-12-31,5R,Advanced economies,
-1964-12-31,AE,United Arab Emirates,
-1964-12-31,AT,Austria,
-1964-12-31,AU,Australia,
-1964-12-31,BE,Belgium,
-1964-12-31,BG,Bulgaria,
-1964-12-31,BR,Brazil,
-1964-12-31,CA,Canada,
-1964-12-31,CH,Switzerland,
-1964-12-31,CL,Chile,
-1964-12-31,CN,China,
-1964-12-31,CO,Colombia,
-1964-12-31,CY,Cyprus,
-1964-12-31,CZ,Czechia,
-1964-12-31,DE,Germany,
-1964-12-31,DK,Denmark,
-1964-12-31,EE,Estonia,
-1964-12-31,ES,Spain,
-1964-12-31,FI,Finland,
-1964-12-31,FR,France,
-1964-12-31,GB,United Kingdom,
-1964-12-31,GR,Greece,
-1964-12-31,HK,Hong Kong SAR,
-1964-12-31,HR,Croatia,
-1964-12-31,HU,Hungary,
-1964-12-31,ID,Indonesia,
-1964-12-31,IE,Ireland,
-1964-12-31,IL,Israel,
-1964-12-31,IN,India,
-1964-12-31,IS,Iceland,
-1964-12-31,IT,Italy,1.9952
+1964-09-30,NZ,New Zealand,1.9609
+1964-12-31,IT,Italy,1.9884
 1964-12-31,JP,Japan,15.1442
-1964-12-31,KR,Korea,
-1964-12-31,LT,Lithuania,
-1964-12-31,LU,Luxembourg,
-1964-12-31,LV,Latvia,
-1964-12-31,MA,Morocco,
-1964-12-31,MK,North Macedonia,
-1964-12-31,MT,Malta,
-1964-12-31,MX,Mexico,
-1964-12-31,MY,Malaysia,
-1964-12-31,NL,Netherlands,
-1964-12-31,NO,Norway,
-1964-12-31,NZ,New Zealand,
-1964-12-31,PE,Peru,
-1964-12-31,PH,Philippines,
-1964-12-31,PL,Poland,
-1964-12-31,PT,Portugal,
-1964-12-31,RO,Romania,
-1964-12-31,RS,Serbia,
-1964-12-31,RU,Russia,
-1964-12-31,SE,Sweden,
-1964-12-31,SG,Singapore,
-1964-12-31,SI,Slovenia,
-1964-12-31,SK,Slovak Republic,
-1964-12-31,TH,Thailand,
-1964-12-31,TR,Türkiye,
-1964-12-31,US,United States,
-1964-12-31,XM,Euro area,
-1964-12-31,XW,World,
-1964-12-31,ZA,South Africa,
-1965-03-31,4T,Emerging market economies (aggregate),
-1965-03-31,5R,Advanced economies,
-1965-03-31,AE,United Arab Emirates,
-1965-03-31,AT,Austria,
-1965-03-31,AU,Australia,
-1965-03-31,BE,Belgium,
-1965-03-31,BG,Bulgaria,
-1965-03-31,BR,Brazil,
-1965-03-31,CA,Canada,
-1965-03-31,CH,Switzerland,
-1965-03-31,CL,Chile,
-1965-03-31,CN,China,
-1965-03-31,CO,Colombia,
-1965-03-31,CY,Cyprus,
-1965-03-31,CZ,Czechia,
-1965-03-31,DE,Germany,
-1965-03-31,DK,Denmark,
-1965-03-31,EE,Estonia,
-1965-03-31,ES,Spain,
-1965-03-31,FI,Finland,
-1965-03-31,FR,France,
-1965-03-31,GB,United Kingdom,
-1965-03-31,GR,Greece,
-1965-03-31,HK,Hong Kong SAR,
-1965-03-31,HR,Croatia,
-1965-03-31,HU,Hungary,
-1965-03-31,ID,Indonesia,
-1965-03-31,IE,Ireland,
-1965-03-31,IL,Israel,
-1965-03-31,IN,India,
-1965-03-31,IS,Iceland,
-1965-03-31,IT,Italy,1.9786
+1964-12-31,NZ,New Zealand,2.0035
+1965-03-31,IT,Italy,1.976
 1965-03-31,JP,Japan,15.6731
-1965-03-31,KR,Korea,
-1965-03-31,LT,Lithuania,
-1965-03-31,LU,Luxembourg,
-1965-03-31,LV,Latvia,
-1965-03-31,MA,Morocco,
-1965-03-31,MK,North Macedonia,
-1965-03-31,MT,Malta,
-1965-03-31,MX,Mexico,
-1965-03-31,MY,Malaysia,
-1965-03-31,NL,Netherlands,
-1965-03-31,NO,Norway,
-1965-03-31,NZ,New Zealand,
-1965-03-31,PE,Peru,
-1965-03-31,PH,Philippines,
-1965-03-31,PL,Poland,
-1965-03-31,PT,Portugal,
-1965-03-31,RO,Romania,
-1965-03-31,RS,Serbia,
-1965-03-31,RU,Russia,
-1965-03-31,SE,Sweden,
-1965-03-31,SG,Singapore,
-1965-03-31,SI,Slovenia,
-1965-03-31,SK,Slovak Republic,
-1965-03-31,TH,Thailand,
-1965-03-31,TR,Türkiye,
-1965-03-31,US,United States,
-1965-03-31,XM,Euro area,
-1965-03-31,XW,World,
-1965-03-31,ZA,South Africa,
-1965-06-30,4T,Emerging market economies (aggregate),
-1965-06-30,5R,Advanced economies,
-1965-06-30,AE,United Arab Emirates,
-1965-06-30,AT,Austria,
-1965-06-30,AU,Australia,
-1965-06-30,BE,Belgium,
-1965-06-30,BG,Bulgaria,
-1965-06-30,BR,Brazil,
-1965-06-30,CA,Canada,
-1965-06-30,CH,Switzerland,
-1965-06-30,CL,Chile,
-1965-06-30,CN,China,
-1965-06-30,CO,Colombia,
-1965-06-30,CY,Cyprus,
-1965-06-30,CZ,Czechia,
-1965-06-30,DE,Germany,
-1965-06-30,DK,Denmark,
-1965-06-30,EE,Estonia,
-1965-06-30,ES,Spain,
-1965-06-30,FI,Finland,
-1965-06-30,FR,France,
-1965-06-30,GB,United Kingdom,
-1965-06-30,GR,Greece,
-1965-06-30,HK,Hong Kong SAR,
-1965-06-30,HR,Croatia,
-1965-06-30,HU,Hungary,
-1965-06-30,ID,Indonesia,
-1965-06-30,IE,Ireland,
-1965-06-30,IL,Israel,
-1965-06-30,IN,India,
-1965-06-30,IS,Iceland,
-1965-06-30,IT,Italy,1.9488
+1965-03-31,NZ,New Zealand,2.0462
+1965-06-30,IT,Italy,1.9343
 1965-06-30,JP,Japan,15.8643
-1965-06-30,KR,Korea,
-1965-06-30,LT,Lithuania,
-1965-06-30,LU,Luxembourg,
-1965-06-30,LV,Latvia,
-1965-06-30,MA,Morocco,
-1965-06-30,MK,North Macedonia,
-1965-06-30,MT,Malta,
-1965-06-30,MX,Mexico,
-1965-06-30,MY,Malaysia,
-1965-06-30,NL,Netherlands,
-1965-06-30,NO,Norway,
-1965-06-30,NZ,New Zealand,
-1965-06-30,PE,Peru,
-1965-06-30,PH,Philippines,
-1965-06-30,PL,Poland,
-1965-06-30,PT,Portugal,
-1965-06-30,RO,Romania,
-1965-06-30,RS,Serbia,
-1965-06-30,RU,Russia,
-1965-06-30,SE,Sweden,
-1965-06-30,SG,Singapore,
-1965-06-30,SI,Slovenia,
-1965-06-30,SK,Slovak Republic,
-1965-06-30,TH,Thailand,
-1965-06-30,TR,Türkiye,
-1965-06-30,US,United States,
-1965-06-30,XM,Euro area,
-1965-06-30,XW,World,
-1965-06-30,ZA,South Africa,
-1965-09-30,4T,Emerging market economies (aggregate),
-1965-09-30,5R,Advanced economies,
-1965-09-30,AE,United Arab Emirates,
-1965-09-30,AT,Austria,
-1965-09-30,AU,Australia,
-1965-09-30,BE,Belgium,
-1965-09-30,BG,Bulgaria,
-1965-09-30,BR,Brazil,
-1965-09-30,CA,Canada,
-1965-09-30,CH,Switzerland,
-1965-09-30,CL,Chile,
-1965-09-30,CN,China,
-1965-09-30,CO,Colombia,
-1965-09-30,CY,Cyprus,
-1965-09-30,CZ,Czechia,
-1965-09-30,DE,Germany,
-1965-09-30,DK,Denmark,
-1965-09-30,EE,Estonia,
-1965-09-30,ES,Spain,
-1965-09-30,FI,Finland,
-1965-09-30,FR,France,
-1965-09-30,GB,United Kingdom,
-1965-09-30,GR,Greece,
-1965-09-30,HK,Hong Kong SAR,
-1965-09-30,HR,Croatia,
-1965-09-30,HU,Hungary,
-1965-09-30,ID,Indonesia,
-1965-09-30,IE,Ireland,
-1965-09-30,IL,Israel,
-1965-09-30,IN,India,
-1965-09-30,IS,Iceland,
+1965-06-30,NZ,New Zealand,2.0888
 1965-09-30,IT,Italy,1.942
 1965-09-30,JP,Japan,16.0577
-1965-09-30,KR,Korea,
-1965-09-30,LT,Lithuania,
-1965-09-30,LU,Luxembourg,
-1965-09-30,LV,Latvia,
-1965-09-30,MA,Morocco,
-1965-09-30,MK,North Macedonia,
-1965-09-30,MT,Malta,
-1965-09-30,MX,Mexico,
-1965-09-30,MY,Malaysia,
-1965-09-30,NL,Netherlands,
-1965-09-30,NO,Norway,
-1965-09-30,NZ,New Zealand,
-1965-09-30,PE,Peru,
-1965-09-30,PH,Philippines,
-1965-09-30,PL,Poland,
-1965-09-30,PT,Portugal,
-1965-09-30,RO,Romania,
-1965-09-30,RS,Serbia,
-1965-09-30,RU,Russia,
-1965-09-30,SE,Sweden,
-1965-09-30,SG,Singapore,
-1965-09-30,SI,Slovenia,
-1965-09-30,SK,Slovak Republic,
-1965-09-30,TH,Thailand,
-1965-09-30,TR,Türkiye,
-1965-09-30,US,United States,
-1965-09-30,XM,Euro area,
-1965-09-30,XW,World,
-1965-09-30,ZA,South Africa,
-1965-12-31,4T,Emerging market economies (aggregate),
-1965-12-31,5R,Advanced economies,
-1965-12-31,AE,United Arab Emirates,
-1965-12-31,AT,Austria,
-1965-12-31,AU,Australia,
-1965-12-31,BE,Belgium,
-1965-12-31,BG,Bulgaria,
-1965-12-31,BR,Brazil,
-1965-12-31,CA,Canada,
-1965-12-31,CH,Switzerland,
-1965-12-31,CL,Chile,
-1965-12-31,CN,China,
-1965-12-31,CO,Colombia,
-1965-12-31,CY,Cyprus,
-1965-12-31,CZ,Czechia,
-1965-12-31,DE,Germany,
-1965-12-31,DK,Denmark,
-1965-12-31,EE,Estonia,
-1965-12-31,ES,Spain,
-1965-12-31,FI,Finland,
-1965-12-31,FR,France,
-1965-12-31,GB,United Kingdom,
-1965-12-31,GR,Greece,
-1965-12-31,HK,Hong Kong SAR,
-1965-12-31,HR,Croatia,
-1965-12-31,HU,Hungary,
-1965-12-31,ID,Indonesia,
-1965-12-31,IE,Ireland,
-1965-12-31,IL,Israel,
-1965-12-31,IN,India,
-1965-12-31,IS,Iceland,
-1965-12-31,IT,Italy,1.9466
+1965-09-30,NZ,New Zealand,2.103
+1965-12-31,IT,Italy,1.9635
 1965-12-31,JP,Japan,16.3462
-1965-12-31,KR,Korea,
-1965-12-31,LT,Lithuania,
-1965-12-31,LU,Luxembourg,
-1965-12-31,LV,Latvia,
-1965-12-31,MA,Morocco,
-1965-12-31,MK,North Macedonia,
-1965-12-31,MT,Malta,
-1965-12-31,MX,Mexico,
-1965-12-31,MY,Malaysia,
-1965-12-31,NL,Netherlands,
-1965-12-31,NO,Norway,
-1965-12-31,NZ,New Zealand,
-1965-12-31,PE,Peru,
-1965-12-31,PH,Philippines,
-1965-12-31,PL,Poland,
-1965-12-31,PT,Portugal,
-1965-12-31,RO,Romania,
-1965-12-31,RS,Serbia,
-1965-12-31,RU,Russia,
-1965-12-31,SE,Sweden,
-1965-12-31,SG,Singapore,
-1965-12-31,SI,Slovenia,
-1965-12-31,SK,Slovak Republic,
-1965-12-31,TH,Thailand,
-1965-12-31,TR,Türkiye,
-1965-12-31,US,United States,
-1965-12-31,XM,Euro area,
-1965-12-31,XW,World,
-1965-12-31,ZA,South Africa,
-1966-03-31,4T,Emerging market economies (aggregate),
-1966-03-31,5R,Advanced economies,
-1966-03-31,AE,United Arab Emirates,
-1966-03-31,AT,Austria,
-1966-03-31,AU,Australia,
-1966-03-31,BE,Belgium,
-1966-03-31,BG,Bulgaria,
-1966-03-31,BR,Brazil,
-1966-03-31,CA,Canada,
-1966-03-31,CH,Switzerland,
-1966-03-31,CL,Chile,
-1966-03-31,CN,China,
-1966-03-31,CO,Colombia,
-1966-03-31,CY,Cyprus,
-1966-03-31,CZ,Czechia,
-1966-03-31,DE,Germany,
-1966-03-31,DK,Denmark,
-1966-03-31,EE,Estonia,
-1966-03-31,ES,Spain,
-1966-03-31,FI,Finland,
-1966-03-31,FR,France,
-1966-03-31,GB,United Kingdom,
-1966-03-31,GR,Greece,
-1966-03-31,HK,Hong Kong SAR,
-1966-03-31,HR,Croatia,
-1966-03-31,HU,Hungary,
-1966-03-31,ID,Indonesia,
-1966-03-31,IE,Ireland,
-1966-03-31,IL,Israel,
-1966-03-31,IN,India,
-1966-03-31,IS,Iceland,
-1966-03-31,IT,Italy,1.9684
+1965-12-31,NZ,New Zealand,2.1314
+1966-03-31,IT,Italy,1.985
 1966-03-31,JP,Japan,16.6346
-1966-03-31,KR,Korea,
-1966-03-31,LT,Lithuania,
-1966-03-31,LU,Luxembourg,
-1966-03-31,LV,Latvia,
-1966-03-31,MA,Morocco,
-1966-03-31,MK,North Macedonia,
-1966-03-31,MT,Malta,
-1966-03-31,MX,Mexico,
-1966-03-31,MY,Malaysia,
-1966-03-31,NL,Netherlands,
-1966-03-31,NO,Norway,
-1966-03-31,NZ,New Zealand,
-1966-03-31,PE,Peru,
-1966-03-31,PH,Philippines,
-1966-03-31,PL,Poland,
-1966-03-31,PT,Portugal,
-1966-03-31,RO,Romania,
-1966-03-31,RS,Serbia,
-1966-03-31,RU,Russia,
-1966-03-31,SE,Sweden,
-1966-03-31,SG,Singapore,
-1966-03-31,SI,Slovenia,
-1966-03-31,SK,Slovak Republic,
-1966-03-31,TH,Thailand,
-1966-03-31,TR,Türkiye,
-1966-03-31,US,United States,
-1966-03-31,XM,Euro area,
-1966-03-31,XW,World,
-1966-03-31,ZA,South Africa,1.048
-1966-06-30,4T,Emerging market economies (aggregate),
-1966-06-30,5R,Advanced economies,
-1966-06-30,AE,United Arab Emirates,
-1966-06-30,AT,Austria,
-1966-06-30,AU,Australia,
-1966-06-30,BE,Belgium,
-1966-06-30,BG,Bulgaria,
-1966-06-30,BR,Brazil,
-1966-06-30,CA,Canada,
-1966-06-30,CH,Switzerland,
-1966-06-30,CL,Chile,
-1966-06-30,CN,China,
-1966-06-30,CO,Colombia,
-1966-06-30,CY,Cyprus,
-1966-06-30,CZ,Czechia,
-1966-06-30,DE,Germany,
-1966-06-30,DK,Denmark,
-1966-06-30,EE,Estonia,
-1966-06-30,ES,Spain,
-1966-06-30,FI,Finland,
-1966-06-30,FR,France,
-1966-06-30,GB,United Kingdom,
-1966-06-30,GR,Greece,
-1966-06-30,HK,Hong Kong SAR,
-1966-06-30,HR,Croatia,
-1966-06-30,HU,Hungary,
-1966-06-30,ID,Indonesia,
-1966-06-30,IE,Ireland,
-1966-06-30,IL,Israel,
-1966-06-30,IN,India,
-1966-06-30,IS,Iceland,
-1966-06-30,IT,Italy,1.9835
+1966-03-31,NZ,New Zealand,2.1456
+1966-03-31,ZA,South Africa,1.0467
+1966-06-30,IT,Italy,1.9855
 1966-06-30,JP,Japan,16.9693
-1966-06-30,KR,Korea,
-1966-06-30,LT,Lithuania,
-1966-06-30,LU,Luxembourg,
-1966-06-30,LV,Latvia,
-1966-06-30,MA,Morocco,
-1966-06-30,MK,North Macedonia,
-1966-06-30,MT,Malta,
-1966-06-30,MX,Mexico,
-1966-06-30,MY,Malaysia,
-1966-06-30,NL,Netherlands,
-1966-06-30,NO,Norway,
-1966-06-30,NZ,New Zealand,
-1966-06-30,PE,Peru,
-1966-06-30,PH,Philippines,
-1966-06-30,PL,Poland,
-1966-06-30,PT,Portugal,
-1966-06-30,RO,Romania,
-1966-06-30,RS,Serbia,
-1966-06-30,RU,Russia,
-1966-06-30,SE,Sweden,
-1966-06-30,SG,Singapore,
-1966-06-30,SI,Slovenia,
-1966-06-30,SK,Slovak Republic,
-1966-06-30,TH,Thailand,
-1966-06-30,TR,Türkiye,
-1966-06-30,US,United States,
-1966-06-30,XM,Euro area,
-1966-06-30,XW,World,
-1966-06-30,ZA,South Africa,1.0684
-1966-09-30,4T,Emerging market economies (aggregate),
-1966-09-30,5R,Advanced economies,
-1966-09-30,AE,United Arab Emirates,
-1966-09-30,AT,Austria,
-1966-09-30,AU,Australia,
-1966-09-30,BE,Belgium,
-1966-09-30,BG,Bulgaria,
-1966-09-30,BR,Brazil,
-1966-09-30,CA,Canada,
-1966-09-30,CH,Switzerland,
-1966-09-30,CL,Chile,
-1966-09-30,CN,China,
-1966-09-30,CO,Colombia,
-1966-09-30,CY,Cyprus,
-1966-09-30,CZ,Czechia,
-1966-09-30,DE,Germany,
-1966-09-30,DK,Denmark,
-1966-09-30,EE,Estonia,
-1966-09-30,ES,Spain,
-1966-09-30,FI,Finland,
-1966-09-30,FR,France,
-1966-09-30,GB,United Kingdom,
-1966-09-30,GR,Greece,
-1966-09-30,HK,Hong Kong SAR,
-1966-09-30,HR,Croatia,
-1966-09-30,HU,Hungary,
-1966-09-30,ID,Indonesia,
-1966-09-30,IE,Ireland,
-1966-09-30,IL,Israel,
-1966-09-30,IN,India,
-1966-09-30,IS,Iceland,
-1966-09-30,IT,Italy,1.9667
+1966-06-30,NZ,New Zealand,2.174
+1966-06-30,ZA,South Africa,1.0671
+1966-09-30,IT,Italy,1.9632
 1966-09-30,JP,Japan,17.3077
-1966-09-30,KR,Korea,
-1966-09-30,LT,Lithuania,
-1966-09-30,LU,Luxembourg,
-1966-09-30,LV,Latvia,
-1966-09-30,MA,Morocco,
-1966-09-30,MK,North Macedonia,
-1966-09-30,MT,Malta,
-1966-09-30,MX,Mexico,
-1966-09-30,MY,Malaysia,
-1966-09-30,NL,Netherlands,
-1966-09-30,NO,Norway,
-1966-09-30,NZ,New Zealand,
-1966-09-30,PE,Peru,
-1966-09-30,PH,Philippines,
-1966-09-30,PL,Poland,
-1966-09-30,PT,Portugal,
-1966-09-30,RO,Romania,
-1966-09-30,RS,Serbia,
-1966-09-30,RU,Russia,
-1966-09-30,SE,Sweden,
-1966-09-30,SG,Singapore,
-1966-09-30,SI,Slovenia,
-1966-09-30,SK,Slovak Republic,
-1966-09-30,TH,Thailand,
-1966-09-30,TR,Türkiye,
-1966-09-30,US,United States,
-1966-09-30,XM,Euro area,
-1966-09-30,XW,World,
-1966-09-30,ZA,South Africa,1.0582
-1966-12-31,4T,Emerging market economies (aggregate),
-1966-12-31,5R,Advanced economies,
-1966-12-31,AE,United Arab Emirates,
-1966-12-31,AT,Austria,
-1966-12-31,AU,Australia,
-1966-12-31,BE,Belgium,
-1966-12-31,BG,Bulgaria,
-1966-12-31,BR,Brazil,
-1966-12-31,CA,Canada,
-1966-12-31,CH,Switzerland,
-1966-12-31,CL,Chile,
-1966-12-31,CN,China,
-1966-12-31,CO,Colombia,
-1966-12-31,CY,Cyprus,
-1966-12-31,CZ,Czechia,
-1966-12-31,DE,Germany,
-1966-12-31,DK,Denmark,
-1966-12-31,EE,Estonia,
-1966-12-31,ES,Spain,
-1966-12-31,FI,Finland,
-1966-12-31,FR,France,
-1966-12-31,GB,United Kingdom,
-1966-12-31,GR,Greece,
-1966-12-31,HK,Hong Kong SAR,
-1966-12-31,HR,Croatia,
-1966-12-31,HU,Hungary,
-1966-12-31,ID,Indonesia,
-1966-12-31,IE,Ireland,
-1966-12-31,IL,Israel,
-1966-12-31,IN,India,
-1966-12-31,IS,Iceland,
-1966-12-31,IT,Italy,1.9653
+1966-09-30,NZ,New Zealand,2.2167
+1966-09-30,ZA,South Africa,1.0569
+1966-12-31,IT,Italy,1.9505
 1966-12-31,JP,Japan,17.7885
-1966-12-31,KR,Korea,
-1966-12-31,LT,Lithuania,
-1966-12-31,LU,Luxembourg,
-1966-12-31,LV,Latvia,
-1966-12-31,MA,Morocco,
-1966-12-31,MK,North Macedonia,
-1966-12-31,MT,Malta,
-1966-12-31,MX,Mexico,
-1966-12-31,MY,Malaysia,
-1966-12-31,NL,Netherlands,
-1966-12-31,NO,Norway,
-1966-12-31,NZ,New Zealand,
-1966-12-31,PE,Peru,
-1966-12-31,PH,Philippines,
-1966-12-31,PL,Poland,
-1966-12-31,PT,Portugal,
-1966-12-31,RO,Romania,
-1966-12-31,RS,Serbia,
-1966-12-31,RU,Russia,
-1966-12-31,SE,Sweden,
-1966-12-31,SG,Singapore,
-1966-12-31,SI,Slovenia,
-1966-12-31,SK,Slovak Republic,
-1966-12-31,TH,Thailand,
-1966-12-31,TR,Türkiye,
-1966-12-31,US,United States,
-1966-12-31,XM,Euro area,
-1966-12-31,XW,World,
-1966-12-31,ZA,South Africa,1.0989
-1967-03-31,4T,Emerging market economies (aggregate),
-1967-03-31,5R,Advanced economies,
-1967-03-31,AE,United Arab Emirates,
-1967-03-31,AT,Austria,
-1967-03-31,AU,Australia,
-1967-03-31,BE,Belgium,
-1967-03-31,BG,Bulgaria,
-1967-03-31,BR,Brazil,
-1967-03-31,CA,Canada,
-1967-03-31,CH,Switzerland,
-1967-03-31,CL,Chile,
-1967-03-31,CN,China,
-1967-03-31,CO,Colombia,
-1967-03-31,CY,Cyprus,
-1967-03-31,CZ,Czechia,
-1967-03-31,DE,Germany,
-1967-03-31,DK,Denmark,
-1967-03-31,EE,Estonia,
-1967-03-31,ES,Spain,
-1967-03-31,FI,Finland,
-1967-03-31,FR,France,
-1967-03-31,GB,United Kingdom,
-1967-03-31,GR,Greece,
-1967-03-31,HK,Hong Kong SAR,
-1967-03-31,HR,Croatia,
-1967-03-31,HU,Hungary,
-1967-03-31,ID,Indonesia,
-1967-03-31,IE,Ireland,
-1967-03-31,IL,Israel,
-1967-03-31,IN,India,
-1967-03-31,IS,Iceland,
-1967-03-31,IT,Italy,1.9656
+1966-12-31,NZ,New Zealand,2.2593
+1966-12-31,ZA,South Africa,1.0975
+1967-03-31,IT,Italy,1.989
 1967-03-31,JP,Japan,18.2692
-1967-03-31,KR,Korea,
-1967-03-31,LT,Lithuania,
-1967-03-31,LU,Luxembourg,
-1967-03-31,LV,Latvia,
-1967-03-31,MA,Morocco,
-1967-03-31,MK,North Macedonia,
-1967-03-31,MT,Malta,
-1967-03-31,MX,Mexico,
-1967-03-31,MY,Malaysia,
-1967-03-31,NL,Netherlands,
-1967-03-31,NO,Norway,
-1967-03-31,NZ,New Zealand,
-1967-03-31,PE,Peru,
-1967-03-31,PH,Philippines,
-1967-03-31,PL,Poland,
-1967-03-31,PT,Portugal,
-1967-03-31,RO,Romania,
-1967-03-31,RS,Serbia,
-1967-03-31,RU,Russia,
-1967-03-31,SE,Sweden,
-1967-03-31,SG,Singapore,
-1967-03-31,SI,Slovenia,
-1967-03-31,SK,Slovak Republic,
-1967-03-31,TH,Thailand,
-1967-03-31,TR,Türkiye,
-1967-03-31,US,United States,
-1967-03-31,XM,Euro area,
-1967-03-31,XW,World,
-1967-03-31,ZA,South Africa,1.221
-1967-06-30,4T,Emerging market economies (aggregate),
-1967-06-30,5R,Advanced economies,
-1967-06-30,AE,United Arab Emirates,
-1967-06-30,AT,Austria,
-1967-06-30,AU,Australia,
-1967-06-30,BE,Belgium,
-1967-06-30,BG,Bulgaria,
-1967-06-30,BR,Brazil,
-1967-06-30,CA,Canada,
-1967-06-30,CH,Switzerland,
-1967-06-30,CL,Chile,
-1967-06-30,CN,China,
-1967-06-30,CO,Colombia,
-1967-06-30,CY,Cyprus,
-1967-06-30,CZ,Czechia,
-1967-06-30,DE,Germany,
-1967-06-30,DK,Denmark,
-1967-06-30,EE,Estonia,
-1967-06-30,ES,Spain,
-1967-06-30,FI,Finland,
-1967-06-30,FR,France,
-1967-06-30,GB,United Kingdom,
-1967-06-30,GR,Greece,
-1967-06-30,HK,Hong Kong SAR,
-1967-06-30,HR,Croatia,
-1967-06-30,HU,Hungary,
-1967-06-30,ID,Indonesia,
-1967-06-30,IE,Ireland,
-1967-06-30,IL,Israel,
-1967-06-30,IN,India,
-1967-06-30,IS,Iceland,
-1967-06-30,IT,Italy,1.9717
+1967-03-31,NZ,New Zealand,2.2735
+1967-03-31,ZA,South Africa,1.2195
+1967-06-30,IT,Italy,1.9646
 1967-06-30,JP,Japan,18.9864
-1967-06-30,KR,Korea,
-1967-06-30,LT,Lithuania,
-1967-06-30,LU,Luxembourg,
-1967-06-30,LV,Latvia,
-1967-06-30,MA,Morocco,
-1967-06-30,MK,North Macedonia,
-1967-06-30,MT,Malta,
-1967-06-30,MX,Mexico,
-1967-06-30,MY,Malaysia,
-1967-06-30,NL,Netherlands,
-1967-06-30,NO,Norway,
-1967-06-30,NZ,New Zealand,
-1967-06-30,PE,Peru,
-1967-06-30,PH,Philippines,
-1967-06-30,PL,Poland,
-1967-06-30,PT,Portugal,
-1967-06-30,RO,Romania,
-1967-06-30,RS,Serbia,
-1967-06-30,RU,Russia,
-1967-06-30,SE,Sweden,
-1967-06-30,SG,Singapore,
-1967-06-30,SI,Slovenia,
-1967-06-30,SK,Slovak Republic,
-1967-06-30,TH,Thailand,
-1967-06-30,TR,Türkiye,
-1967-06-30,US,United States,
-1967-06-30,XM,Euro area,
-1967-06-30,XW,World,
-1967-06-30,ZA,South Africa,1.2617
-1967-09-30,4T,Emerging market economies (aggregate),
-1967-09-30,5R,Advanced economies,
-1967-09-30,AE,United Arab Emirates,
-1967-09-30,AT,Austria,
-1967-09-30,AU,Australia,
-1967-09-30,BE,Belgium,
-1967-09-30,BG,Bulgaria,
-1967-09-30,BR,Brazil,
-1967-09-30,CA,Canada,
-1967-09-30,CH,Switzerland,
-1967-09-30,CL,Chile,
-1967-09-30,CN,China,
-1967-09-30,CO,Colombia,
-1967-09-30,CY,Cyprus,
-1967-09-30,CZ,Czechia,
-1967-09-30,DE,Germany,
-1967-09-30,DK,Denmark,
-1967-09-30,EE,Estonia,
-1967-09-30,ES,Spain,
-1967-09-30,FI,Finland,
-1967-09-30,FR,France,
-1967-09-30,GB,United Kingdom,
-1967-09-30,GR,Greece,
-1967-09-30,HK,Hong Kong SAR,
-1967-09-30,HR,Croatia,
-1967-09-30,HU,Hungary,
-1967-09-30,ID,Indonesia,
-1967-09-30,IE,Ireland,
-1967-09-30,IL,Israel,
-1967-09-30,IN,India,
-1967-09-30,IS,Iceland,
-1967-09-30,IT,Italy,2.0149
+1967-06-30,NZ,New Zealand,2.2877
+1967-06-30,ZA,South Africa,1.2601
+1967-09-30,IT,Italy,2.0065
 1967-09-30,JP,Japan,19.7115
-1967-09-30,KR,Korea,
-1967-09-30,LT,Lithuania,
-1967-09-30,LU,Luxembourg,
-1967-09-30,LV,Latvia,
-1967-09-30,MA,Morocco,
-1967-09-30,MK,North Macedonia,
-1967-09-30,MT,Malta,
-1967-09-30,MX,Mexico,
-1967-09-30,MY,Malaysia,
-1967-09-30,NL,Netherlands,
-1967-09-30,NO,Norway,
-1967-09-30,NZ,New Zealand,
-1967-09-30,PE,Peru,
-1967-09-30,PH,Philippines,
-1967-09-30,PL,Poland,
-1967-09-30,PT,Portugal,
-1967-09-30,RO,Romania,
-1967-09-30,RS,Serbia,
-1967-09-30,RU,Russia,
-1967-09-30,SE,Sweden,
-1967-09-30,SG,Singapore,
-1967-09-30,SI,Slovenia,
-1967-09-30,SK,Slovak Republic,
-1967-09-30,TH,Thailand,
-1967-09-30,TR,Türkiye,
-1967-09-30,US,United States,
-1967-09-30,XM,Euro area,
-1967-09-30,XW,World,
-1967-09-30,ZA,South Africa,1.3024
-1967-12-31,4T,Emerging market economies (aggregate),
-1967-12-31,5R,Advanced economies,
-1967-12-31,AE,United Arab Emirates,
-1967-12-31,AT,Austria,
-1967-12-31,AU,Australia,
-1967-12-31,BE,Belgium,
-1967-12-31,BG,Bulgaria,
-1967-12-31,BR,Brazil,
-1967-12-31,CA,Canada,
-1967-12-31,CH,Switzerland,
-1967-12-31,CL,Chile,
-1967-12-31,CN,China,
-1967-12-31,CO,Colombia,
-1967-12-31,CY,Cyprus,
-1967-12-31,CZ,Czechia,
-1967-12-31,DE,Germany,
-1967-12-31,DK,Denmark,
-1967-12-31,EE,Estonia,
-1967-12-31,ES,Spain,
-1967-12-31,FI,Finland,
-1967-12-31,FR,France,
-1967-12-31,GB,United Kingdom,
-1967-12-31,GR,Greece,
-1967-12-31,HK,Hong Kong SAR,
-1967-12-31,HR,Croatia,
-1967-12-31,HU,Hungary,
-1967-12-31,ID,Indonesia,
-1967-12-31,IE,Ireland,
-1967-12-31,IL,Israel,
-1967-12-31,IN,India,
-1967-12-31,IS,Iceland,
-1967-12-31,IT,Italy,2.084
+1967-09-30,NZ,New Zealand,2.2877
+1967-09-30,ZA,South Africa,1.3008
+1967-12-31,IT,Italy,2.0765
 1967-12-31,JP,Japan,20.5289
-1967-12-31,KR,Korea,
-1967-12-31,LT,Lithuania,
-1967-12-31,LU,Luxembourg,
-1967-12-31,LV,Latvia,
-1967-12-31,MA,Morocco,
-1967-12-31,MK,North Macedonia,
-1967-12-31,MT,Malta,
-1967-12-31,MX,Mexico,
-1967-12-31,MY,Malaysia,
-1967-12-31,NL,Netherlands,
-1967-12-31,NO,Norway,
-1967-12-31,NZ,New Zealand,
-1967-12-31,PE,Peru,
-1967-12-31,PH,Philippines,
-1967-12-31,PL,Poland,
-1967-12-31,PT,Portugal,
-1967-12-31,RO,Romania,
-1967-12-31,RS,Serbia,
-1967-12-31,RU,Russia,
-1967-12-31,SE,Sweden,
-1967-12-31,SG,Singapore,
-1967-12-31,SI,Slovenia,
-1967-12-31,SK,Slovak Republic,
-1967-12-31,TH,Thailand,
-1967-12-31,TR,Türkiye,
-1967-12-31,US,United States,
-1967-12-31,XM,Euro area,
-1967-12-31,XW,World,
-1967-12-31,ZA,South Africa,1.3024
-1968-03-31,4T,Emerging market economies (aggregate),
-1968-03-31,5R,Advanced economies,
-1968-03-31,AE,United Arab Emirates,
-1968-03-31,AT,Austria,
-1968-03-31,AU,Australia,
-1968-03-31,BE,Belgium,
-1968-03-31,BG,Bulgaria,
-1968-03-31,BR,Brazil,
-1968-03-31,CA,Canada,
-1968-03-31,CH,Switzerland,
-1968-03-31,CL,Chile,
-1968-03-31,CN,China,
-1968-03-31,CO,Colombia,
-1968-03-31,CY,Cyprus,
-1968-03-31,CZ,Czechia,
-1968-03-31,DE,Germany,
-1968-03-31,DK,Denmark,
-1968-03-31,EE,Estonia,
-1968-03-31,ES,Spain,
-1968-03-31,FI,Finland,
-1968-03-31,FR,France,
-1968-03-31,GB,United Kingdom,
-1968-03-31,GR,Greece,
-1968-03-31,HK,Hong Kong SAR,
-1968-03-31,HR,Croatia,
-1968-03-31,HU,Hungary,
-1968-03-31,ID,Indonesia,
-1968-03-31,IE,Ireland,
-1968-03-31,IL,Israel,
-1968-03-31,IN,India,
-1968-03-31,IS,Iceland,
-1968-03-31,IT,Italy,2.146
+1967-12-31,NZ,New Zealand,2.2877
+1967-12-31,ZA,South Africa,1.3008
+1968-03-31,IT,Italy,2.1378
 1968-03-31,JP,Japan,21.3462
-1968-03-31,KR,Korea,
-1968-03-31,LT,Lithuania,
-1968-03-31,LU,Luxembourg,
-1968-03-31,LV,Latvia,
-1968-03-31,MA,Morocco,
-1968-03-31,MK,North Macedonia,
-1968-03-31,MT,Malta,
-1968-03-31,MX,Mexico,
-1968-03-31,MY,Malaysia,
-1968-03-31,NL,Netherlands,
-1968-03-31,NO,Norway,
-1968-03-31,NZ,New Zealand,
-1968-03-31,PE,Peru,
-1968-03-31,PH,Philippines,
-1968-03-31,PL,Poland,
-1968-03-31,PT,Portugal,
-1968-03-31,RO,Romania,
-1968-03-31,RS,Serbia,
-1968-03-31,RU,Russia,
-1968-03-31,SE,Sweden,
-1968-03-31,SG,Singapore,
-1968-03-31,SI,Slovenia,
-1968-03-31,SK,Slovak Republic,
-1968-03-31,TH,Thailand,
-1968-03-31,TR,Türkiye,
-1968-03-31,US,United States,
-1968-03-31,XM,Euro area,
-1968-03-31,XW,World,
-1968-03-31,ZA,South Africa,1.282
-1968-06-30,4T,Emerging market economies (aggregate),
-1968-06-30,5R,Advanced economies,
-1968-06-30,AE,United Arab Emirates,
-1968-06-30,AT,Austria,
-1968-06-30,AU,Australia,
-1968-06-30,BE,Belgium,
-1968-06-30,BG,Bulgaria,
-1968-06-30,BR,Brazil,
-1968-06-30,CA,Canada,
-1968-06-30,CH,Switzerland,
-1968-06-30,CL,Chile,
-1968-06-30,CN,China,
-1968-06-30,CO,Colombia,
-1968-06-30,CY,Cyprus,
-1968-06-30,CZ,Czechia,
-1968-06-30,DE,Germany,
-1968-06-30,DK,Denmark,
-1968-06-30,EE,Estonia,
-1968-06-30,ES,Spain,
-1968-06-30,FI,Finland,
-1968-06-30,FR,France,
-1968-06-30,GB,United Kingdom,2.175
-1968-06-30,GR,Greece,
-1968-06-30,HK,Hong Kong SAR,
-1968-06-30,HR,Croatia,
-1968-06-30,HU,Hungary,
-1968-06-30,ID,Indonesia,
-1968-06-30,IE,Ireland,
-1968-06-30,IL,Israel,
-1968-06-30,IN,India,
-1968-06-30,IS,Iceland,
-1968-06-30,IT,Italy,2.2077
+1968-03-31,NZ,New Zealand,2.302
+1968-03-31,ZA,South Africa,1.2805
+1968-06-30,GB,United Kingdom,2.1742
+1968-06-30,IT,Italy,2.2114
 1968-06-30,JP,Japan,22.2596
-1968-06-30,KR,Korea,
-1968-06-30,LT,Lithuania,
-1968-06-30,LU,Luxembourg,
-1968-06-30,LV,Latvia,
-1968-06-30,MA,Morocco,
-1968-06-30,MK,North Macedonia,
-1968-06-30,MT,Malta,
-1968-06-30,MX,Mexico,
-1968-06-30,MY,Malaysia,
-1968-06-30,NL,Netherlands,
-1968-06-30,NO,Norway,
-1968-06-30,NZ,New Zealand,
-1968-06-30,PE,Peru,
-1968-06-30,PH,Philippines,
-1968-06-30,PL,Poland,
-1968-06-30,PT,Portugal,
-1968-06-30,RO,Romania,
-1968-06-30,RS,Serbia,
-1968-06-30,RU,Russia,
-1968-06-30,SE,Sweden,
-1968-06-30,SG,Singapore,
-1968-06-30,SI,Slovenia,
-1968-06-30,SK,Slovak Republic,
-1968-06-30,TH,Thailand,
-1968-06-30,TR,Türkiye,
-1968-06-30,US,United States,
-1968-06-30,XM,Euro area,
-1968-06-30,XW,World,
-1968-06-30,ZA,South Africa,1.2922
-1968-09-30,4T,Emerging market economies (aggregate),
-1968-09-30,5R,Advanced economies,
-1968-09-30,AE,United Arab Emirates,
-1968-09-30,AT,Austria,
-1968-09-30,AU,Australia,
-1968-09-30,BE,Belgium,
-1968-09-30,BG,Bulgaria,
-1968-09-30,BR,Brazil,
-1968-09-30,CA,Canada,
-1968-09-30,CH,Switzerland,
-1968-09-30,CL,Chile,
-1968-09-30,CN,China,
-1968-09-30,CO,Colombia,
-1968-09-30,CY,Cyprus,
-1968-09-30,CZ,Czechia,
-1968-09-30,DE,Germany,
-1968-09-30,DK,Denmark,
-1968-09-30,EE,Estonia,
-1968-09-30,ES,Spain,
-1968-09-30,FI,Finland,
-1968-09-30,FR,France,
-1968-09-30,GB,United Kingdom,2.2354
-1968-09-30,GR,Greece,
-1968-09-30,HK,Hong Kong SAR,
-1968-09-30,HR,Croatia,
-1968-09-30,HU,Hungary,
-1968-09-30,ID,Indonesia,
-1968-09-30,IE,Ireland,
-1968-09-30,IL,Israel,
-1968-09-30,IN,India,
-1968-09-30,IS,Iceland,
-1968-09-30,IT,Italy,2.211
+1968-06-30,NZ,New Zealand,2.3162
+1968-06-30,ZA,South Africa,1.2906
+1968-09-30,GB,United Kingdom,2.2346
+1968-09-30,IT,Italy,2.2138
 1968-09-30,JP,Japan,23.1731
-1968-09-30,KR,Korea,
-1968-09-30,LT,Lithuania,
-1968-09-30,LU,Luxembourg,
-1968-09-30,LV,Latvia,
-1968-09-30,MA,Morocco,
-1968-09-30,MK,North Macedonia,
-1968-09-30,MT,Malta,
-1968-09-30,MX,Mexico,
-1968-09-30,MY,Malaysia,
-1968-09-30,NL,Netherlands,
-1968-09-30,NO,Norway,
-1968-09-30,NZ,New Zealand,
-1968-09-30,PE,Peru,
-1968-09-30,PH,Philippines,
-1968-09-30,PL,Poland,
-1968-09-30,PT,Portugal,
-1968-09-30,RO,Romania,
-1968-09-30,RS,Serbia,
-1968-09-30,RU,Russia,
-1968-09-30,SE,Sweden,
-1968-09-30,SG,Singapore,
-1968-09-30,SI,Slovenia,
-1968-09-30,SK,Slovak Republic,
-1968-09-30,TH,Thailand,
-1968-09-30,TR,Türkiye,
-1968-09-30,US,United States,
-1968-09-30,XM,Euro area,
-1968-09-30,XW,World,
-1968-09-30,ZA,South Africa,1.3431
-1968-12-31,4T,Emerging market economies (aggregate),
-1968-12-31,5R,Advanced economies,
-1968-12-31,AE,United Arab Emirates,
-1968-12-31,AT,Austria,
-1968-12-31,AU,Australia,
-1968-12-31,BE,Belgium,
-1968-12-31,BG,Bulgaria,
-1968-12-31,BR,Brazil,
-1968-12-31,CA,Canada,
-1968-12-31,CH,Switzerland,
-1968-12-31,CL,Chile,
-1968-12-31,CN,China,
-1968-12-31,CO,Colombia,
-1968-12-31,CY,Cyprus,
-1968-12-31,CZ,Czechia,
-1968-12-31,DE,Germany,
-1968-12-31,DK,Denmark,
-1968-12-31,EE,Estonia,
-1968-12-31,ES,Spain,
-1968-12-31,FI,Finland,
-1968-12-31,FR,France,
-1968-12-31,GB,United Kingdom,2.2354
-1968-12-31,GR,Greece,
-1968-12-31,HK,Hong Kong SAR,
-1968-12-31,HR,Croatia,
-1968-12-31,HU,Hungary,
-1968-12-31,ID,Indonesia,
-1968-12-31,IE,Ireland,
-1968-12-31,IL,Israel,
-1968-12-31,IN,India,
-1968-12-31,IS,Iceland,
-1968-12-31,IT,Italy,2.2093
+1968-09-30,NZ,New Zealand,2.3304
+1968-09-30,ZA,South Africa,1.3414
+1968-12-31,GB,United Kingdom,2.2346
+1968-12-31,IT,Italy,2.2109
 1968-12-31,JP,Japan,24.3269
-1968-12-31,KR,Korea,
-1968-12-31,LT,Lithuania,
-1968-12-31,LU,Luxembourg,
-1968-12-31,LV,Latvia,
-1968-12-31,MA,Morocco,
-1968-12-31,MK,North Macedonia,
-1968-12-31,MT,Malta,
-1968-12-31,MX,Mexico,
-1968-12-31,MY,Malaysia,
-1968-12-31,NL,Netherlands,
-1968-12-31,NO,Norway,
-1968-12-31,NZ,New Zealand,
-1968-12-31,PE,Peru,
-1968-12-31,PH,Philippines,
-1968-12-31,PL,Poland,
-1968-12-31,PT,Portugal,
-1968-12-31,RO,Romania,
-1968-12-31,RS,Serbia,
-1968-12-31,RU,Russia,
-1968-12-31,SE,Sweden,
-1968-12-31,SG,Singapore,
-1968-12-31,SI,Slovenia,
-1968-12-31,SK,Slovak Republic,
-1968-12-31,TH,Thailand,
-1968-12-31,TR,Türkiye,
-1968-12-31,US,United States,
-1968-12-31,XM,Euro area,
-1968-12-31,XW,World,
-1968-12-31,ZA,South Africa,1.394
-1969-03-31,4T,Emerging market economies (aggregate),
-1969-03-31,5R,Advanced economies,
-1969-03-31,AE,United Arab Emirates,
-1969-03-31,AT,Austria,
-1969-03-31,AU,Australia,
-1969-03-31,BE,Belgium,
-1969-03-31,BG,Bulgaria,
-1969-03-31,BR,Brazil,
-1969-03-31,CA,Canada,
-1969-03-31,CH,Switzerland,
-1969-03-31,CL,Chile,
-1969-03-31,CN,China,
-1969-03-31,CO,Colombia,
-1969-03-31,CY,Cyprus,
-1969-03-31,CZ,Czechia,
-1969-03-31,DE,Germany,
-1969-03-31,DK,Denmark,
-1969-03-31,EE,Estonia,
-1969-03-31,ES,Spain,
-1969-03-31,FI,Finland,
-1969-03-31,FR,France,
-1969-03-31,GB,United Kingdom,2.2354
-1969-03-31,GR,Greece,
-1969-03-31,HK,Hong Kong SAR,
-1969-03-31,HR,Croatia,
-1969-03-31,HU,Hungary,
-1969-03-31,ID,Indonesia,
-1969-03-31,IE,Ireland,
-1969-03-31,IL,Israel,
-1969-03-31,IN,India,
-1969-03-31,IS,Iceland,
-1969-03-31,IT,Italy,2.2284
+1968-12-31,NZ,New Zealand,2.3446
+1968-12-31,ZA,South Africa,1.3923
+1969-03-31,GB,United Kingdom,2.2346
+1969-03-31,IT,Italy,2.2293
 1969-03-31,JP,Japan,25.4808
-1969-03-31,KR,Korea,
-1969-03-31,LT,Lithuania,
-1969-03-31,LU,Luxembourg,
-1969-03-31,LV,Latvia,
-1969-03-31,MA,Morocco,
-1969-03-31,MK,North Macedonia,
-1969-03-31,MT,Malta,
-1969-03-31,MX,Mexico,
-1969-03-31,MY,Malaysia,
-1969-03-31,NL,Netherlands,
-1969-03-31,NO,Norway,
-1969-03-31,NZ,New Zealand,
-1969-03-31,PE,Peru,
-1969-03-31,PH,Philippines,
-1969-03-31,PL,Poland,
-1969-03-31,PT,Portugal,
-1969-03-31,RO,Romania,
-1969-03-31,RS,Serbia,
-1969-03-31,RU,Russia,
-1969-03-31,SE,Sweden,
-1969-03-31,SG,Singapore,
-1969-03-31,SI,Slovenia,
-1969-03-31,SK,Slovak Republic,
-1969-03-31,TH,Thailand,
-1969-03-31,TR,Türkiye,
-1969-03-31,US,United States,
-1969-03-31,XM,Euro area,
-1969-03-31,XW,World,
-1969-03-31,ZA,South Africa,1.4143
-1969-06-30,4T,Emerging market economies (aggregate),
-1969-06-30,5R,Advanced economies,
-1969-06-30,AE,United Arab Emirates,
-1969-06-30,AT,Austria,
-1969-06-30,AU,Australia,
-1969-06-30,BE,Belgium,
-1969-06-30,BG,Bulgaria,
-1969-06-30,BR,Brazil,
-1969-06-30,CA,Canada,
-1969-06-30,CH,Switzerland,
-1969-06-30,CL,Chile,
-1969-06-30,CN,China,
-1969-06-30,CO,Colombia,
-1969-06-30,CY,Cyprus,
-1969-06-30,CZ,Czechia,
-1969-06-30,DE,Germany,
-1969-06-30,DK,Denmark,
-1969-06-30,EE,Estonia,
-1969-06-30,ES,Spain,
-1969-06-30,FI,Finland,
-1969-06-30,FR,France,
-1969-06-30,GB,United Kingdom,2.2958
-1969-06-30,GR,Greece,
-1969-06-30,HK,Hong Kong SAR,
-1969-06-30,HR,Croatia,
-1969-06-30,HU,Hungary,
-1969-06-30,ID,Indonesia,
-1969-06-30,IE,Ireland,
-1969-06-30,IL,Israel,
-1969-06-30,IN,India,
-1969-06-30,IS,Iceland,
-1969-06-30,IT,Italy,2.2648
+1969-03-31,NZ,New Zealand,2.3872
+1969-03-31,ZA,South Africa,1.4126
+1969-06-30,GB,United Kingdom,2.295
+1969-06-30,IT,Italy,2.2605
 1969-06-30,JP,Japan,26.9151
-1969-06-30,KR,Korea,
-1969-06-30,LT,Lithuania,
-1969-06-30,LU,Luxembourg,
-1969-06-30,LV,Latvia,
-1969-06-30,MA,Morocco,
-1969-06-30,MK,North Macedonia,
-1969-06-30,MT,Malta,
-1969-06-30,MX,Mexico,
-1969-06-30,MY,Malaysia,
-1969-06-30,NL,Netherlands,
-1969-06-30,NO,Norway,
-1969-06-30,NZ,New Zealand,
-1969-06-30,PE,Peru,
-1969-06-30,PH,Philippines,
-1969-06-30,PL,Poland,
-1969-06-30,PT,Portugal,
-1969-06-30,RO,Romania,
-1969-06-30,RS,Serbia,
-1969-06-30,RU,Russia,
-1969-06-30,SE,Sweden,
-1969-06-30,SG,Singapore,
-1969-06-30,SI,Slovenia,
-1969-06-30,SK,Slovak Republic,
-1969-06-30,TH,Thailand,
-1969-06-30,TR,Türkiye,
-1969-06-30,US,United States,
-1969-06-30,XM,Euro area,
-1969-06-30,XW,World,
-1969-06-30,ZA,South Africa,1.455
-1969-09-30,4T,Emerging market economies (aggregate),
-1969-09-30,5R,Advanced economies,
-1969-09-30,AE,United Arab Emirates,
-1969-09-30,AT,Austria,
-1969-09-30,AU,Australia,
-1969-09-30,BE,Belgium,
-1969-09-30,BG,Bulgaria,
-1969-09-30,BR,Brazil,
-1969-09-30,CA,Canada,
-1969-09-30,CH,Switzerland,
-1969-09-30,CL,Chile,
-1969-09-30,CN,China,
-1969-09-30,CO,Colombia,
-1969-09-30,CY,Cyprus,
-1969-09-30,CZ,Czechia,
-1969-09-30,DE,Germany,
-1969-09-30,DK,Denmark,
-1969-09-30,EE,Estonia,
-1969-09-30,ES,Spain,
-1969-09-30,FI,Finland,
-1969-09-30,FR,France,
-1969-09-30,GB,United Kingdom,2.2958
-1969-09-30,GR,Greece,
-1969-09-30,HK,Hong Kong SAR,
-1969-09-30,HR,Croatia,
-1969-09-30,HU,Hungary,
-1969-09-30,ID,Indonesia,
-1969-09-30,IE,Ireland,
-1969-09-30,IL,Israel,
-1969-09-30,IN,India,
-1969-09-30,IS,Iceland,
-1969-09-30,IT,Italy,2.2982
+1969-06-30,NZ,New Zealand,2.4156
+1969-06-30,ZA,South Africa,1.4532
+1969-09-30,GB,United Kingdom,2.295
+1969-09-30,IT,Italy,2.297
 1969-09-30,JP,Japan,28.3654
-1969-09-30,KR,Korea,
-1969-09-30,LT,Lithuania,
-1969-09-30,LU,Luxembourg,
-1969-09-30,LV,Latvia,
-1969-09-30,MA,Morocco,
-1969-09-30,MK,North Macedonia,
-1969-09-30,MT,Malta,
-1969-09-30,MX,Mexico,
-1969-09-30,MY,Malaysia,
-1969-09-30,NL,Netherlands,
-1969-09-30,NO,Norway,
-1969-09-30,NZ,New Zealand,
-1969-09-30,PE,Peru,
-1969-09-30,PH,Philippines,
-1969-09-30,PL,Poland,
-1969-09-30,PT,Portugal,
-1969-09-30,RO,Romania,
-1969-09-30,RS,Serbia,
-1969-09-30,RU,Russia,
-1969-09-30,SE,Sweden,
-1969-09-30,SG,Singapore,
-1969-09-30,SI,Slovenia,
-1969-09-30,SK,Slovak Republic,
-1969-09-30,TH,Thailand,
-1969-09-30,TR,Türkiye,
-1969-09-30,US,United States,
-1969-09-30,XM,Euro area,
-1969-09-30,XW,World,
-1969-09-30,ZA,South Africa,1.4957
-1969-12-31,4T,Emerging market economies (aggregate),
-1969-12-31,5R,Advanced economies,
-1969-12-31,AE,United Arab Emirates,
-1969-12-31,AT,Austria,
-1969-12-31,AU,Australia,
-1969-12-31,BE,Belgium,
-1969-12-31,BG,Bulgaria,
-1969-12-31,BR,Brazil,
-1969-12-31,CA,Canada,
-1969-12-31,CH,Switzerland,
-1969-12-31,CL,Chile,
-1969-12-31,CN,China,
-1969-12-31,CO,Colombia,
-1969-12-31,CY,Cyprus,
-1969-12-31,CZ,Czechia,
-1969-12-31,DE,Germany,
-1969-12-31,DK,Denmark,
-1969-12-31,EE,Estonia,
-1969-12-31,ES,Spain,
-1969-12-31,FI,Finland,
-1969-12-31,FR,France,
-1969-12-31,GB,United Kingdom,2.3562
-1969-12-31,GR,Greece,
-1969-12-31,HK,Hong Kong SAR,
-1969-12-31,HR,Croatia,
-1969-12-31,HU,Hungary,
-1969-12-31,ID,Indonesia,
-1969-12-31,IE,Ireland,
-1969-12-31,IL,Israel,
-1969-12-31,IN,India,
-1969-12-31,IS,Iceland,
-1969-12-31,IT,Italy,2.3216
+1969-09-30,NZ,New Zealand,2.444
+1969-09-30,ZA,South Africa,1.4939
+1969-12-31,GB,United Kingdom,2.3554
+1969-12-31,IT,Italy,2.3262
 1969-12-31,JP,Japan,29.8077
-1969-12-31,KR,Korea,
-1969-12-31,LT,Lithuania,
-1969-12-31,LU,Luxembourg,
-1969-12-31,LV,Latvia,
-1969-12-31,MA,Morocco,
-1969-12-31,MK,North Macedonia,
-1969-12-31,MT,Malta,
-1969-12-31,MX,Mexico,
-1969-12-31,MY,Malaysia,
-1969-12-31,NL,Netherlands,
-1969-12-31,NO,Norway,
-1969-12-31,NZ,New Zealand,
-1969-12-31,PE,Peru,
-1969-12-31,PH,Philippines,
-1969-12-31,PL,Poland,
-1969-12-31,PT,Portugal,
-1969-12-31,RO,Romania,
-1969-12-31,RS,Serbia,
-1969-12-31,RU,Russia,
-1969-12-31,SE,Sweden,
-1969-12-31,SG,Singapore,
-1969-12-31,SI,Slovenia,
-1969-12-31,SK,Slovak Republic,
-1969-12-31,TH,Thailand,
-1969-12-31,TR,Türkiye,
-1969-12-31,US,United States,
-1969-12-31,XM,Euro area,
-1969-12-31,XW,World,
-1969-12-31,ZA,South Africa,1.5364
-1970-03-31,4T,Emerging market economies (aggregate),
-1970-03-31,5R,Advanced economies,
-1970-03-31,AE,United Arab Emirates,
-1970-03-31,AT,Austria,
+1969-12-31,NZ,New Zealand,2.4725
+1969-12-31,ZA,South Africa,1.5345
 1970-03-31,AU,Australia,3.1274
-1970-03-31,BE,Belgium,8.5112
-1970-03-31,BG,Bulgaria,
-1970-03-31,BR,Brazil,
-1970-03-31,CA,Canada,6.5661
-1970-03-31,CH,Switzerland,24.7531
-1970-03-31,CL,Chile,
-1970-03-31,CN,China,
-1970-03-31,CO,Colombia,
-1970-03-31,CY,Cyprus,
-1970-03-31,CZ,Czechia,
+1970-03-31,BE,Belgium,8.5837
+1970-03-31,CA,Canada,6.617
+1970-03-31,CH,Switzerland,24.7522
 1970-03-31,DE,Germany,37.6187
 1970-03-31,DK,Denmark,7.7176
-1970-03-31,EE,Estonia,
-1970-03-31,ES,Spain,
 1970-03-31,FI,Finland,6.7446
 1970-03-31,FR,France,6.1123
-1970-03-31,GB,United Kingdom,2.3562
-1970-03-31,GR,Greece,
-1970-03-31,HK,Hong Kong SAR,
-1970-03-31,HR,Croatia,
-1970-03-31,HU,Hungary,
-1970-03-31,ID,Indonesia,
-1970-03-31,IE,Ireland,2.6593
-1970-03-31,IL,Israel,
-1970-03-31,IN,India,
-1970-03-31,IS,Iceland,
-1970-03-31,IT,Italy,2.3831
+1970-03-31,GB,United Kingdom,2.3554
+1970-03-31,IE,Ireland,2.6598
+1970-03-31,IT,Italy,2.381
 1970-03-31,JP,Japan,31.25
-1970-03-31,KR,Korea,
-1970-03-31,LT,Lithuania,
-1970-03-31,LU,Luxembourg,
-1970-03-31,LV,Latvia,
-1970-03-31,MA,Morocco,
-1970-03-31,MK,North Macedonia,
-1970-03-31,MT,Malta,
-1970-03-31,MX,Mexico,
-1970-03-31,MY,Malaysia,
-1970-03-31,NL,Netherlands,7.5196
+1970-03-31,NL,Netherlands,7.7021
 1970-03-31,NO,Norway,4.653
-1970-03-31,NZ,New Zealand,2.5147
-1970-03-31,PE,Peru,
-1970-03-31,PH,Philippines,
-1970-03-31,PL,Poland,
-1970-03-31,PT,Portugal,
-1970-03-31,RO,Romania,
-1970-03-31,RS,Serbia,
-1970-03-31,RU,Russia,
+1970-03-31,NZ,New Zealand,2.5151
 1970-03-31,SE,Sweden,6.5893
-1970-03-31,SG,Singapore,
-1970-03-31,SI,Slovenia,
-1970-03-31,SK,Slovak Republic,
-1970-03-31,TH,Thailand,
-1970-03-31,TR,Türkiye,
-1970-03-31,US,United States,10.6054
-1970-03-31,XM,Euro area,
-1970-03-31,XW,World,
-1970-03-31,ZA,South Africa,1.6178
-1970-06-30,4T,Emerging market economies (aggregate),
-1970-06-30,5R,Advanced economies,
-1970-06-30,AE,United Arab Emirates,
-1970-06-30,AT,Austria,
+1970-03-31,US,United States,10.5731
+1970-03-31,ZA,South Africa,1.6158
 1970-06-30,AU,Australia,3.1846
-1970-06-30,BE,Belgium,8.5542
-1970-06-30,BG,Bulgaria,
-1970-06-30,BR,Brazil,
-1970-06-30,CA,Canada,6.5661
-1970-06-30,CH,Switzerland,24.6166
-1970-06-30,CL,Chile,
-1970-06-30,CN,China,
-1970-06-30,CO,Colombia,
-1970-06-30,CY,Cyprus,
-1970-06-30,CZ,Czechia,
-1970-06-30,DE,Germany,39.315
+1970-06-30,BE,Belgium,8.627
+1970-06-30,CA,Canada,6.617
+1970-06-30,CH,Switzerland,24.6157
+1970-06-30,DE,Germany,39.3151
 1970-06-30,DK,Denmark,7.7176
-1970-06-30,EE,Estonia,
-1970-06-30,ES,Spain,
 1970-06-30,FI,Finland,6.8634
 1970-06-30,FR,France,6.2249
-1970-06-30,GB,United Kingdom,2.3562
-1970-06-30,GR,Greece,
-1970-06-30,HK,Hong Kong SAR,
-1970-06-30,HR,Croatia,
-1970-06-30,HU,Hungary,
-1970-06-30,ID,Indonesia,
-1970-06-30,IE,Ireland,2.6593
-1970-06-30,IL,Israel,
-1970-06-30,IN,India,
-1970-06-30,IS,Iceland,
-1970-06-30,IT,Italy,2.4309
+1970-06-30,GB,United Kingdom,2.3554
+1970-06-30,IE,Ireland,2.6598
+1970-06-30,IT,Italy,2.4276
 1970-06-30,JP,Japan,32.6844
-1970-06-30,KR,Korea,
-1970-06-30,LT,Lithuania,
-1970-06-30,LU,Luxembourg,
-1970-06-30,LV,Latvia,
-1970-06-30,MA,Morocco,
-1970-06-30,MK,North Macedonia,
-1970-06-30,MT,Malta,
-1970-06-30,MX,Mexico,
-1970-06-30,MY,Malaysia,
-1970-06-30,NL,Netherlands,7.8844
+1970-06-30,NL,Netherlands,8.0757
 1970-06-30,NO,Norway,4.653
-1970-06-30,NZ,New Zealand,2.5714
-1970-06-30,PE,Peru,
-1970-06-30,PH,Philippines,
-1970-06-30,PL,Poland,
-1970-06-30,PT,Portugal,
-1970-06-30,RO,Romania,
-1970-06-30,RS,Serbia,
-1970-06-30,RU,Russia,
+1970-06-30,NZ,New Zealand,2.5719
 1970-06-30,SE,Sweden,6.7544
-1970-06-30,SG,Singapore,
-1970-06-30,SI,Slovenia,
-1970-06-30,SK,Slovak Republic,
-1970-06-30,TH,Thailand,
-1970-06-30,TR,Türkiye,
-1970-06-30,US,United States,10.6835
-1970-06-30,XM,Euro area,
-1970-06-30,XW,World,
-1970-06-30,ZA,South Africa,1.689
-1970-09-30,4T,Emerging market economies (aggregate),
-1970-09-30,5R,Advanced economies,
-1970-09-30,AE,United Arab Emirates,
-1970-09-30,AT,Austria,
+1970-06-30,US,United States,10.6508
+1970-06-30,ZA,South Africa,1.687
 1970-09-30,AU,Australia,3.2736
-1970-09-30,BE,Belgium,8.4554
-1970-09-30,BG,Bulgaria,
-1970-09-30,BR,Brazil,
-1970-09-30,CA,Canada,6.6203
-1970-09-30,CH,Switzerland,25.414
-1970-09-30,CL,Chile,
-1970-09-30,CN,China,
-1970-09-30,CO,Colombia,
-1970-09-30,CY,Cyprus,
-1970-09-30,CZ,Czechia,
+1970-09-30,BE,Belgium,8.5273
+1970-09-30,CA,Canada,6.6716
+1970-09-30,CH,Switzerland,25.4131
 1970-09-30,DE,Germany,39.7142
 1970-09-30,DK,Denmark,7.7176
-1970-09-30,EE,Estonia,
-1970-09-30,ES,Spain,
 1970-09-30,FI,Finland,6.9109
 1970-09-30,FR,France,6.3708
-1970-09-30,GB,United Kingdom,2.477
-1970-09-30,GR,Greece,
-1970-09-30,HK,Hong Kong SAR,
-1970-09-30,HR,Croatia,
-1970-09-30,HU,Hungary,
-1970-09-30,ID,Indonesia,
-1970-09-30,IE,Ireland,2.7991
-1970-09-30,IL,Israel,
-1970-09-30,IN,India,
-1970-09-30,IS,Iceland,
-1970-09-30,IT,Italy,2.4262
+1970-09-30,GB,United Kingdom,2.4762
+1970-09-30,IE,Ireland,2.7996
+1970-09-30,IT,Italy,2.4271
 1970-09-30,JP,Japan,34.1346
-1970-09-30,KR,Korea,
-1970-09-30,LT,Lithuania,
-1970-09-30,LU,Luxembourg,
-1970-09-30,LV,Latvia,
-1970-09-30,MA,Morocco,
-1970-09-30,MK,North Macedonia,
-1970-09-30,MT,Malta,
-1970-09-30,MX,Mexico,
-1970-09-30,MY,Malaysia,
-1970-09-30,NL,Netherlands,8.1048
+1970-09-30,NL,Netherlands,8.3015
 1970-09-30,NO,Norway,4.653
-1970-09-30,NZ,New Zealand,2.6281
-1970-09-30,PE,Peru,
-1970-09-30,PH,Philippines,
-1970-09-30,PL,Poland,
-1970-09-30,PT,Portugal,
-1970-09-30,RO,Romania,
-1970-09-30,RS,Serbia,
-1970-09-30,RU,Russia,
+1970-09-30,NZ,New Zealand,2.6288
 1970-09-30,SE,Sweden,6.7544
-1970-09-30,SG,Singapore,
-1970-09-30,SI,Slovenia,
-1970-09-30,SK,Slovak Republic,
-1970-09-30,TH,Thailand,
-1970-09-30,TR,Türkiye,
-1970-09-30,US,United States,10.8515
-1970-09-30,XM,Euro area,
-1970-09-30,XW,World,
-1970-09-30,ZA,South Africa,1.7297
-1970-12-31,4T,Emerging market economies (aggregate),
-1970-12-31,5R,Advanced economies,
-1970-12-31,AE,United Arab Emirates,
-1970-12-31,AT,Austria,
+1970-09-30,US,United States,10.8184
+1970-09-30,ZA,South Africa,1.7276
 1970-12-31,AU,Australia,3.3753
-1970-12-31,BE,Belgium,8.1245
-1970-12-31,BG,Bulgaria,
-1970-12-31,BR,Brazil,
-1970-12-31,CA,Canada,6.8098
-1970-12-31,CH,Switzerland,25.4642
-1970-12-31,CL,Chile,
-1970-12-31,CN,China,
-1970-12-31,CO,Colombia,
-1970-12-31,CY,Cyprus,
-1970-12-31,CZ,Czechia,
+1970-12-31,BE,Belgium,8.1937
+1970-12-31,CA,Canada,6.8626
+1970-12-31,CH,Switzerland,25.4632
 1970-12-31,DE,Germany,40.2131
 1970-12-31,DK,Denmark,7.7176
-1970-12-31,EE,Estonia,
-1970-12-31,ES,Spain,
 1970-12-31,FI,Finland,7.0496
 1970-12-31,FR,France,6.3541
-1970-12-31,GB,United Kingdom,2.477
-1970-12-31,GR,Greece,
-1970-12-31,HK,Hong Kong SAR,
-1970-12-31,HR,Croatia,
-1970-12-31,HU,Hungary,
-1970-12-31,ID,Indonesia,
-1970-12-31,IE,Ireland,2.9598
-1970-12-31,IL,Israel,
-1970-12-31,IN,India,
-1970-12-31,IS,Iceland,
-1970-12-31,IT,Italy,2.4502
+1970-12-31,GB,United Kingdom,2.4762
+1970-12-31,IE,Ireland,2.9603
+1970-12-31,IT,Italy,2.4546
 1970-12-31,JP,Japan,35.4808
-1970-12-31,KR,Korea,
-1970-12-31,LT,Lithuania,
-1970-12-31,LU,Luxembourg,
-1970-12-31,LV,Latvia,
-1970-12-31,MA,Morocco,
-1970-12-31,MK,North Macedonia,
-1970-12-31,MT,Malta,
-1970-12-31,MX,Mexico,
-1970-12-31,MY,Malaysia,
-1970-12-31,NL,Netherlands,8.2454
+1970-12-31,NL,Netherlands,8.4455
 1970-12-31,NO,Norway,4.653
-1970-12-31,NZ,New Zealand,2.701
-1970-12-31,PE,Peru,
-1970-12-31,PH,Philippines,
-1970-12-31,PL,Poland,
-1970-12-31,PT,Portugal,
-1970-12-31,RO,Romania,
-1970-12-31,RS,Serbia,
-1970-12-31,RU,Russia,
+1970-12-31,NZ,New Zealand,2.6998
 1970-12-31,SE,Sweden,6.9026
-1970-12-31,SG,Singapore,
-1970-12-31,SI,Slovenia,
-1970-12-31,SK,Slovak Republic,
-1970-12-31,TH,Thailand,
-1970-12-31,TR,Türkiye,
-1970-12-31,US,United States,10.9896
-1970-12-31,XM,Euro area,
-1970-12-31,XW,World,
-1970-12-31,ZA,South Africa,1.7501
-1971-03-31,4T,Emerging market economies (aggregate),
-1971-03-31,5R,Advanced economies,
-1971-03-31,AE,United Arab Emirates,
-1971-03-31,AT,Austria,
+1970-12-31,US,United States,10.956
+1970-12-31,ZA,South Africa,1.7479
 1971-03-31,AU,Australia,3.4707
-1971-03-31,BE,Belgium,8.2405
-1971-03-31,BG,Bulgaria,
-1971-03-31,BR,Brazil,
-1971-03-31,CA,Canada,6.8639
-1971-03-31,CH,Switzerland,27.2282
-1971-03-31,CL,Chile,
-1971-03-31,CN,China,
-1971-03-31,CO,Colombia,
-1971-03-31,CY,Cyprus,
-1971-03-31,CZ,Czechia,
+1971-03-31,BE,Belgium,8.3107
+1971-03-31,CA,Canada,6.9172
+1971-03-31,CH,Switzerland,27.2272
 1971-03-31,DE,Germany,41.5103
 1971-03-31,DK,Denmark,8.4084
-1971-03-31,EE,Estonia,
 1971-03-31,ES,Spain,1.5527
 1971-03-31,FI,Finland,7.1525
 1971-03-31,FR,France,6.3541
-1971-03-31,GB,United Kingdom,2.5375
-1971-03-31,GR,Greece,
-1971-03-31,HK,Hong Kong SAR,
-1971-03-31,HR,Croatia,
-1971-03-31,HU,Hungary,
-1971-03-31,ID,Indonesia,
-1971-03-31,IE,Ireland,2.9179
-1971-03-31,IL,Israel,
-1971-03-31,IN,India,
-1971-03-31,IS,Iceland,
+1971-03-31,GB,United Kingdom,2.5366
+1971-03-31,IE,Ireland,2.9184
 1971-03-31,IT,Italy,2.4189
 1971-03-31,JP,Japan,36.8269
-1971-03-31,KR,Korea,
-1971-03-31,LT,Lithuania,
-1971-03-31,LU,Luxembourg,
-1971-03-31,LV,Latvia,
-1971-03-31,MA,Morocco,
-1971-03-31,MK,North Macedonia,
-1971-03-31,MT,Malta,
-1971-03-31,MX,Mexico,
-1971-03-31,MY,Malaysia,
-1971-03-31,NL,Netherlands,8.4848
+1971-03-31,NL,Netherlands,8.6907
 1971-03-31,NO,Norway,4.906
-1971-03-31,NZ,New Zealand,2.786
-1971-03-31,PE,Peru,
-1971-03-31,PH,Philippines,
-1971-03-31,PL,Poland,
-1971-03-31,PT,Portugal,
-1971-03-31,RO,Romania,
-1971-03-31,RS,Serbia,
-1971-03-31,RU,Russia,
+1971-03-31,NZ,New Zealand,2.7851
 1971-03-31,SE,Sweden,6.9397
-1971-03-31,SG,Singapore,
-1971-03-31,SI,Slovenia,
-1971-03-31,SK,Slovak Republic,
-1971-03-31,TH,Thailand,
-1971-03-31,TR,Türkiye,
-1971-03-31,US,United States,11.2897
-1971-03-31,XM,Euro area,
-1971-03-31,XW,World,
-1971-03-31,ZA,South Africa,1.7704
-1971-06-30,4T,Emerging market economies (aggregate),
-1971-06-30,5R,Advanced economies,
-1971-06-30,AE,United Arab Emirates,
-1971-06-30,AT,Austria,
+1971-03-31,US,United States,11.2552
+1971-03-31,ZA,South Africa,1.7683
 1971-06-30,AU,Australia,3.5501
-1971-06-30,BE,Belgium,8.3608
-1971-06-30,BG,Bulgaria,
-1971-06-30,BR,Brazil,
-1971-06-30,CA,Canada,6.9452
-1971-06-30,CH,Switzerland,27.1585
-1971-06-30,CL,Chile,
-1971-06-30,CN,China,
-1971-06-30,CO,Colombia,
-1971-06-30,CY,Cyprus,
-1971-06-30,CZ,Czechia,
+1971-06-30,BE,Belgium,8.432
+1971-06-30,CA,Canada,6.999
+1971-06-30,CH,Switzerland,27.1575
 1971-06-30,DE,Germany,43.506
 1971-06-30,DK,Denmark,8.4798
-1971-06-30,EE,Estonia,
 1971-06-30,ES,Spain,1.6054
 1971-06-30,FI,Finland,7.0614
 1971-06-30,FR,France,6.5376
-1971-06-30,GB,United Kingdom,2.5979
-1971-06-30,GR,Greece,
-1971-06-30,HK,Hong Kong SAR,
-1971-06-30,HR,Croatia,
-1971-06-30,HU,Hungary,
-1971-06-30,ID,Indonesia,
-1971-06-30,IE,Ireland,2.8969
-1971-06-30,IL,Israel,
-1971-06-30,IN,India,
-1971-06-30,IS,Iceland,
+1971-06-30,GB,United Kingdom,2.597
+1971-06-30,IE,Ireland,2.8974
 1971-06-30,IT,Italy,2.4738
 1971-06-30,JP,Japan,38.1657
-1971-06-30,KR,Korea,
-1971-06-30,LT,Lithuania,
-1971-06-30,LU,Luxembourg,
-1971-06-30,LV,Latvia,
-1971-06-30,MA,Morocco,
-1971-06-30,MK,North Macedonia,
-1971-06-30,MT,Malta,
-1971-06-30,MX,Mexico,
-1971-06-30,MY,Malaysia,
-1971-06-30,NL,Netherlands,8.7925
+1971-06-30,NL,Netherlands,9.0059
 1971-06-30,NO,Norway,4.906
-1971-06-30,NZ,New Zealand,2.8711
-1971-06-30,PE,Peru,
-1971-06-30,PH,Philippines,
-1971-06-30,PL,Poland,
-1971-06-30,PT,Portugal,
-1971-06-30,RO,Romania,
-1971-06-30,RS,Serbia,
-1971-06-30,RU,Russia,
+1971-06-30,NZ,New Zealand,2.8703
 1971-06-30,SE,Sweden,7.1047
-1971-06-30,SG,Singapore,
-1971-06-30,SI,Slovenia,
-1971-06-30,SK,Slovak Republic,
-1971-06-30,TH,Thailand,
-1971-06-30,TR,Türkiye,
-1971-06-30,US,United States,11.5958
-1971-06-30,XM,Euro area,
-1971-06-30,XW,World,
-1971-06-30,ZA,South Africa,1.8111
-1971-09-30,4T,Emerging market economies (aggregate),
-1971-09-30,5R,Advanced economies,
-1971-09-30,AE,United Arab Emirates,
-1971-09-30,AT,Austria,
+1971-06-30,US,United States,11.5603
+1971-06-30,ZA,South Africa,1.8089
 1971-09-30,AU,Australia,3.6582
-1971-09-30,BE,Belgium,8.4511
-1971-09-30,BG,Bulgaria,
-1971-09-30,BR,Brazil,
-1971-09-30,CA,Canada,6.9181
-1971-09-30,CH,Switzerland,28.372
-1971-09-30,CL,Chile,
-1971-09-30,CN,China,
-1971-09-30,CO,Colombia,
-1971-09-30,CY,Cyprus,
-1971-09-30,CZ,Czechia,
+1971-09-30,BE,Belgium,8.523
+1971-09-30,CA,Canada,6.9717
+1971-09-30,CH,Switzerland,28.371
 1971-09-30,DE,Germany,44.1047
 1971-09-30,DK,Denmark,8.726
-1971-09-30,EE,Estonia,
 1971-09-30,ES,Spain,1.623
 1971-09-30,FI,Finland,7.3109
 1971-09-30,FR,France,6.8002
-1971-09-30,GB,United Kingdom,2.7791
-1971-09-30,GR,Greece,
-1971-09-30,HK,Hong Kong SAR,
-1971-09-30,HR,Croatia,
-1971-09-30,HU,Hungary,
-1971-09-30,ID,Indonesia,
-1971-09-30,IE,Ireland,3.1974
-1971-09-30,IL,Israel,
-1971-09-30,IN,India,
-1971-09-30,IS,Iceland,
+1971-09-30,GB,United Kingdom,2.7782
+1971-09-30,IE,Ireland,3.198
 1971-09-30,IT,Italy,2.5343
 1971-09-30,JP,Japan,39.5192
-1971-09-30,KR,Korea,
-1971-09-30,LT,Lithuania,
-1971-09-30,LU,Luxembourg,
-1971-09-30,LV,Latvia,
-1971-09-30,MA,Morocco,
-1971-09-30,MK,North Macedonia,
-1971-09-30,MT,Malta,
-1971-09-30,MX,Mexico,
-1971-09-30,MY,Malaysia,
-1971-09-30,NL,Netherlands,8.8723
+1971-09-30,NL,Netherlands,9.0876
 1971-09-30,NO,Norway,4.906
-1971-09-30,NZ,New Zealand,2.9278
-1971-09-30,PE,Peru,
-1971-09-30,PH,Philippines,
-1971-09-30,PL,Poland,
-1971-09-30,PT,Portugal,
-1971-09-30,RO,Romania,
-1971-09-30,RS,Serbia,
-1971-09-30,RU,Russia,
+1971-09-30,NZ,New Zealand,2.9272
 1971-09-30,SE,Sweden,7.1047
-1971-09-30,SG,Singapore,
-1971-09-30,SI,Slovenia,
-1971-09-30,SK,Slovak Republic,
-1971-09-30,TH,Thailand,
-1971-09-30,TR,Türkiye,
-1971-09-30,US,United States,11.7218
-1971-09-30,XM,Euro area,
-1971-09-30,XW,World,
-1971-09-30,ZA,South Africa,1.8315
-1971-12-31,4T,Emerging market economies (aggregate),
-1971-12-31,5R,Advanced economies,
-1971-12-31,AE,United Arab Emirates,
-1971-12-31,AT,Austria,
+1971-09-30,US,United States,11.686
+1971-09-30,ZA,South Africa,1.8292
 1971-12-31,AU,Australia,3.798
-1971-12-31,BE,Belgium,8.3308
-1971-12-31,BG,Bulgaria,
-1971-12-31,BR,Brazil,
-1971-12-31,CA,Canada,7.2701
-1971-12-31,CH,Switzerland,28.9074
-1971-12-31,CL,Chile,
-1971-12-31,CN,China,
-1971-12-31,CO,Colombia,
-1971-12-31,CY,Cyprus,
-1971-12-31,CZ,Czechia,
+1971-12-31,BE,Belgium,8.4017
+1971-12-31,CA,Canada,7.3265
+1971-12-31,CH,Switzerland,28.9063
 1971-12-31,DE,Germany,44.2045
 1971-12-31,DK,Denmark,9.1786
-1971-12-31,EE,Estonia,
 1971-12-31,ES,Spain,1.6405
 1971-12-31,FI,Finland,7.3941
 1971-12-31,FR,France,6.8628
-1971-12-31,GB,United Kingdom,2.9
-1971-12-31,GR,Greece,
-1971-12-31,HK,Hong Kong SAR,
-1971-12-31,HR,Croatia,
-1971-12-31,HU,Hungary,
-1971-12-31,ID,Indonesia,
-1971-12-31,IE,Ireland,3.4421
-1971-12-31,IL,Israel,
-1971-12-31,IN,India,
-1971-12-31,IS,Iceland,
+1971-12-31,GB,United Kingdom,2.899
+1971-12-31,IE,Ireland,3.4427
 1971-12-31,IT,Italy,2.5673
 1971-12-31,JP,Japan,40.8173
-1971-12-31,KR,Korea,
-1971-12-31,LT,Lithuania,
-1971-12-31,LU,Luxembourg,
-1971-12-31,LV,Latvia,
-1971-12-31,MA,Morocco,
-1971-12-31,MK,North Macedonia,
-1971-12-31,MT,Malta,
-1971-12-31,MX,Mexico,
-1971-12-31,MY,Malaysia,
-1971-12-31,NL,Netherlands,9.1003
+1971-12-31,NL,Netherlands,9.3212
 1971-12-31,NO,Norway,4.906
-1971-12-31,NZ,New Zealand,2.9966
-1971-12-31,PE,Peru,
-1971-12-31,PH,Philippines,
-1971-12-31,PL,Poland,
-1971-12-31,PT,Portugal,
-1971-12-31,RO,Romania,
-1971-12-31,RS,Serbia,
-1971-12-31,RU,Russia,
+1971-12-31,NZ,New Zealand,2.9982
 1971-12-31,SE,Sweden,7.2698
-1971-12-31,SG,Singapore,
-1971-12-31,SI,Slovenia,
-1971-12-31,SK,Slovak Republic,
-1971-12-31,TH,Thailand,
-1971-12-31,TR,Türkiye,
-1971-12-31,US,United States,12.0039
-1971-12-31,XM,Euro area,
-1971-12-31,XW,World,
-1971-12-31,ZA,South Africa,1.8518
-1972-03-31,4T,Emerging market economies (aggregate),
-1972-03-31,5R,Advanced economies,
-1972-03-31,AE,United Arab Emirates,
-1972-03-31,AT,Austria,
+1971-12-31,US,United States,11.9672
+1971-12-31,ZA,South Africa,1.8496
 1972-03-31,AU,Australia,3.8806
-1972-03-31,BE,Belgium,8.6659
-1972-03-31,BG,Bulgaria,
-1972-03-31,BR,Brazil,
-1972-03-31,CA,Canada,7.428
-1972-03-31,CH,Switzerland,30.0913
-1972-03-31,CL,Chile,
-1972-03-31,CN,China,
-1972-03-31,CO,Colombia,
-1972-03-31,CY,Cyprus,
-1972-03-31,CZ,Czechia,
+1972-03-31,BE,Belgium,8.7396
+1972-03-31,CA,Canada,7.4856
+1972-03-31,CH,Switzerland,30.0902
 1972-03-31,DE,Germany,45.1025
 1972-03-31,DK,Denmark,9.7066
-1972-03-31,EE,Estonia,
 1972-03-31,ES,Spain,1.6195
 1972-03-31,FI,Finland,7.6951
 1972-03-31,FR,France,6.9003
-1972-03-31,GB,United Kingdom,3.0812
-1972-03-31,GR,Greece,
-1972-03-31,HK,Hong Kong SAR,
-1972-03-31,HR,Croatia,
-1972-03-31,HU,Hungary,
-1972-03-31,ID,Indonesia,
-1972-03-31,IE,Ireland,3.3232
-1972-03-31,IL,Israel,
-1972-03-31,IN,India,
-1972-03-31,IS,Iceland,
+1972-03-31,GB,United Kingdom,3.0802
+1972-03-31,IE,Ireland,3.3238
 1972-03-31,IT,Italy,2.6058
 1972-03-31,JP,Japan,42.1154
-1972-03-31,KR,Korea,
-1972-03-31,LT,Lithuania,
-1972-03-31,LU,Luxembourg,
-1972-03-31,LV,Latvia,
-1972-03-31,MA,Morocco,
-1972-03-31,MK,North Macedonia,
-1972-03-31,MT,Malta,
-1972-03-31,MX,Mexico,
-1972-03-31,MY,Malaysia,
-1972-03-31,NL,Netherlands,9.4537
+1972-03-31,NL,Netherlands,9.6831
 1972-03-31,NO,Norway,5.2824
-1972-03-31,NZ,New Zealand,3.11
-1972-03-31,PE,Peru,
-1972-03-31,PH,Philippines,
-1972-03-31,PL,Poland,
-1972-03-31,PT,Portugal,
-1972-03-31,RO,Romania,
-1972-03-31,RS,Serbia,
-1972-03-31,RU,Russia,
+1972-03-31,NZ,New Zealand,3.1119
 1972-03-31,SE,Sweden,7.4551
-1972-03-31,SG,Singapore,
-1972-03-31,SI,Slovenia,
-1972-03-31,SK,Slovak Republic,
-1972-03-31,TH,Thailand,
-1972-03-31,TR,Türkiye,
-1972-03-31,US,United States,12.0399
-1972-03-31,XM,Euro area,
-1972-03-31,XW,World,
-1972-03-31,ZA,South Africa,1.862
-1972-06-30,4T,Emerging market economies (aggregate),
-1972-06-30,5R,Advanced economies,
-1972-06-30,AE,United Arab Emirates,
-1972-06-30,AT,Austria,
+1972-03-31,US,United States,12.0031
+1972-03-31,ZA,South Africa,1.8597
 1972-06-30,AU,Australia,3.9474
-1972-06-30,BE,Belgium,9.0096
-1972-06-30,BG,Bulgaria,
-1972-06-30,BR,Brazil,
-1972-06-30,CA,Canada,7.428
-1972-06-30,CH,Switzerland,31.976
-1972-06-30,CL,Chile,
-1972-06-30,CN,China,
-1972-06-30,CO,Colombia,
-1972-06-30,CY,Cyprus,
-1972-06-30,CZ,Czechia,
+1972-06-30,BE,Belgium,9.0863
+1972-06-30,CA,Canada,7.4856
+1972-06-30,CH,Switzerland,31.9748
 1972-06-30,DE,Germany,46.2002
 1972-06-30,DK,Denmark,10.1631
-1972-06-30,EE,Estonia,
 1972-06-30,ES,Spain,1.6757
 1972-06-30,FI,Finland,7.806
 1972-06-30,FR,France,7.1171
-1972-06-30,GB,United Kingdom,3.3833
-1972-06-30,GR,Greece,
-1972-06-30,HK,Hong Kong SAR,
-1972-06-30,HR,Croatia,
-1972-06-30,HU,Hungary,
-1972-06-30,ID,Indonesia,
-1972-06-30,IE,Ireland,3.2603
-1972-06-30,IL,Israel,
-1972-06-30,IN,India,
-1972-06-30,IS,Iceland,
+1972-06-30,GB,United Kingdom,3.3822
+1972-06-30,IE,Ireland,3.2609
 1972-06-30,IT,Italy,2.6882
 1972-06-30,JP,Japan,43.9904
-1972-06-30,KR,Korea,
-1972-06-30,LT,Lithuania,
-1972-06-30,LU,Luxembourg,
-1972-06-30,LV,Latvia,
-1972-06-30,MA,Morocco,
-1972-06-30,MK,North Macedonia,
-1972-06-30,MT,Malta,
-1972-06-30,MX,Mexico,
-1972-06-30,MY,Malaysia,
-1972-06-30,NL,Netherlands,9.8489
+1972-06-30,NL,Netherlands,10.0879
 1972-06-30,NO,Norway,5.674
-1972-06-30,NZ,New Zealand,3.2396
-1972-06-30,PE,Peru,
-1972-06-30,PH,Philippines,
-1972-06-30,PL,Poland,
-1972-06-30,PT,Portugal,
-1972-06-30,RO,Romania,
-1972-06-30,RS,Serbia,
-1972-06-30,RU,Russia,
+1972-06-30,NZ,New Zealand,3.2398
 1972-06-30,SE,Sweden,7.637
-1972-06-30,SG,Singapore,
-1972-06-30,SI,Slovenia,
-1972-06-30,SK,Slovak Republic,
-1972-06-30,TH,Thailand,
-1972-06-30,TR,Türkiye,
-1972-06-30,US,United States,12.382
-1972-06-30,XM,Euro area,
-1972-06-30,XW,World,
-1972-06-30,ZA,South Africa,1.862
-1972-09-30,4T,Emerging market economies (aggregate),
-1972-09-30,5R,Advanced economies,
-1972-09-30,AE,United Arab Emirates,
-1972-09-30,AT,Austria,
+1972-06-30,US,United States,12.3442
+1972-06-30,ZA,South Africa,1.8597
 1972-09-30,AU,Australia,4.0586
-1972-09-30,BE,Belgium,9.3232
-1972-09-30,BG,Bulgaria,
-1972-09-30,BR,Brazil,
-1972-09-30,CA,Canada,7.5364
-1972-09-30,CH,Switzerland,33.4632
-1972-09-30,CL,Chile,
-1972-09-30,CN,China,
-1972-09-30,CO,Colombia,
-1972-09-30,CY,Cyprus,
-1972-09-30,CZ,Czechia,
+1972-09-30,BE,Belgium,9.4026
+1972-09-30,CA,Canada,7.5948
+1972-09-30,CH,Switzerland,33.462
 1972-09-30,DE,Germany,46.6991
 1972-09-30,DK,Denmark,10.2306
-1972-09-30,EE,Estonia,
 1972-09-30,ES,Spain,1.7248
 1972-09-30,FI,Finland,7.8416
 1972-09-30,FR,France,7.4256
-1972-09-30,GB,United Kingdom,3.8666
-1972-09-30,GR,Greece,
-1972-09-30,HK,Hong Kong SAR,
-1972-09-30,HR,Croatia,
-1972-09-30,HU,Hungary,
-1972-09-30,ID,Indonesia,
-1972-09-30,IE,Ireland,3.4421
-1972-09-30,IL,Israel,
-1972-09-30,IN,India,
-1972-09-30,IS,Iceland,
+1972-09-30,GB,United Kingdom,3.8653
+1972-09-30,IE,Ireland,3.4427
 1972-09-30,IT,Italy,2.7542
 1972-09-30,JP,Japan,45.8654
-1972-09-30,KR,Korea,
-1972-09-30,LT,Lithuania,
-1972-09-30,LU,Luxembourg,
-1972-09-30,LV,Latvia,
-1972-09-30,MA,Morocco,
-1972-09-30,MK,North Macedonia,
-1972-09-30,MT,Malta,
-1972-09-30,MX,Mexico,
-1972-09-30,MY,Malaysia,
-1972-09-30,NL,Netherlands,9.9362
+1972-09-30,NL,Netherlands,10.1774
 1972-09-30,NO,Norway,5.6589
-1972-09-30,NZ,New Zealand,3.3408
-1972-09-30,PE,Peru,
-1972-09-30,PH,Philippines,
-1972-09-30,PL,Poland,
-1972-09-30,PT,Portugal,
-1972-09-30,RO,Romania,
-1972-09-30,RS,Serbia,
-1972-09-30,RU,Russia,
+1972-09-30,NZ,New Zealand,3.3392
 1972-09-30,SE,Sweden,7.637
-1972-09-30,SG,Singapore,
-1972-09-30,SI,Slovenia,
-1972-09-30,SK,Slovak Republic,
-1972-09-30,TH,Thailand,
-1972-09-30,TR,Türkiye,
-1972-09-30,US,United States,12.6281
-1972-09-30,XM,Euro area,
-1972-09-30,XW,World,
-1972-09-30,ZA,South Africa,1.9231
-1972-12-31,4T,Emerging market economies (aggregate),
-1972-12-31,5R,Advanced economies,
-1972-12-31,AE,United Arab Emirates,
-1972-12-31,AT,Austria,
+1972-09-30,US,United States,12.5895
+1972-09-30,ZA,South Africa,1.9207
 1972-12-31,AU,Australia,4.2779
-1972-12-31,BE,Belgium,9.3147
-1972-12-31,BG,Bulgaria,
-1972-12-31,BR,Brazil,
-1972-12-31,CA,Canada,7.8884
-1972-12-31,CH,Switzerland,35.1538
-1972-12-31,CL,Chile,
-1972-12-31,CN,China,
-1972-12-31,CO,Colombia,
-1972-12-31,CY,Cyprus,
-1972-12-31,CZ,Czechia,
-1972-12-31,DE,Germany,46.9984
+1972-12-31,BE,Belgium,9.3939
+1972-12-31,CA,Canada,7.9495
+1972-12-31,CH,Switzerland,35.1525
+1972-12-31,DE,Germany,46.9985
 1972-12-31,DK,Denmark,10.6871
-1972-12-31,EE,Estonia,
 1972-12-31,ES,Spain,1.7705
 1972-12-31,FI,Finland,8.2298
 1972-12-31,FR,France,7.5174
-1972-12-31,GB,United Kingdom,4.1687
-1972-12-31,GR,Greece,
-1972-12-31,HK,Hong Kong SAR,
-1972-12-31,HR,Croatia,
-1972-12-31,HU,Hungary,
-1972-12-31,ID,Indonesia,
-1972-12-31,IE,Ireland,3.6238
-1972-12-31,IL,Israel,
-1972-12-31,IN,India,
-1972-12-31,IS,Iceland,
+1972-12-31,GB,United Kingdom,4.1673
+1972-12-31,IE,Ireland,3.6244
 1972-12-31,IT,Italy,2.7707
 1972-12-31,JP,Japan,50.0962
-1972-12-31,KR,Korea,
-1972-12-31,LT,Lithuania,
-1972-12-31,LU,Luxembourg,
-1972-12-31,LV,Latvia,
-1972-12-31,MA,Morocco,
-1972-12-31,MK,North Macedonia,
-1972-12-31,MT,Malta,
-1972-12-31,MX,Mexico,
-1972-12-31,MY,Malaysia,
-1972-12-31,NL,Netherlands,10.4454
+1972-12-31,NL,Netherlands,10.6989
 1972-12-31,NO,Norway,5.5234
-1972-12-31,NZ,New Zealand,3.4825
-1972-12-31,PE,Peru,
-1972-12-31,PH,Philippines,
-1972-12-31,PL,Poland,
-1972-12-31,PT,Portugal,
-1972-12-31,RO,Romania,
-1972-12-31,RS,Serbia,
-1972-12-31,RU,Russia,
+1972-12-31,NZ,New Zealand,3.4814
 1972-12-31,SE,Sweden,7.8223
-1972-12-31,SG,Singapore,
-1972-12-31,SI,Slovenia,
-1972-12-31,SK,Slovak Republic,
-1972-12-31,TH,Thailand,
-1972-12-31,TR,Türkiye,
-1972-12-31,US,United States,12.9042
-1972-12-31,XM,Euro area,
-1972-12-31,XW,World,
-1972-12-31,ZA,South Africa,1.9841
-1973-03-31,4T,Emerging market economies (aggregate),
-1973-03-31,5R,Advanced economies,
-1973-03-31,AE,United Arab Emirates,
-1973-03-31,AT,Austria,
+1972-12-31,US,United States,12.8648
+1972-12-31,ZA,South Africa,1.9817
 1973-03-31,AU,Australia,4.3987
-1973-03-31,BE,Belgium,9.7228
-1973-03-31,BG,Bulgaria,
-1973-03-31,BR,Brazil,
-1973-03-31,CA,Canada,8.2945
-1973-03-31,CH,Switzerland,37.7774
-1973-03-31,CL,Chile,
-1973-03-31,CN,China,
-1973-03-31,CO,Colombia,
-1973-03-31,CY,Cyprus,
-1973-03-31,CZ,Czechia,
+1973-03-31,BE,Belgium,9.8056
+1973-03-31,CA,Canada,8.3588
+1973-03-31,CH,Switzerland,37.7761
 1973-03-31,DE,Germany,47.6969
 1973-03-31,DK,Denmark,11.1794
-1973-03-31,EE,Estonia,
 1973-03-31,ES,Spain,1.9462
 1973-03-31,FI,Finland,8.8238
 1973-03-31,FR,France,7.5716
-1973-03-31,GB,United Kingdom,4.652
-1973-03-31,GR,Greece,
-1973-03-31,HK,Hong Kong SAR,
-1973-03-31,HR,Croatia,
-1973-03-31,HU,Hungary,
-1973-03-31,ID,Indonesia,
-1973-03-31,IE,Ireland,3.6203
-1973-03-31,IL,Israel,
-1973-03-31,IN,India,
-1973-03-31,IS,Iceland,
+1973-03-31,GB,United Kingdom,4.6505
+1973-03-31,IE,Ireland,3.6209
 1973-03-31,IT,Italy,2.8257
 1973-03-31,JP,Japan,54.3269
-1973-03-31,KR,Korea,
-1973-03-31,LT,Lithuania,
-1973-03-31,LU,Luxembourg,
-1973-03-31,LV,Latvia,
-1973-03-31,MA,Morocco,
-1973-03-31,MK,North Macedonia,
-1973-03-31,MT,Malta,
-1973-03-31,MX,Mexico,
-1973-03-31,MY,Malaysia,
-1973-03-31,NL,Netherlands,10.814
+1973-03-31,NL,Netherlands,11.0764
 1973-03-31,NO,Norway,5.7492
-1973-03-31,NZ,New Zealand,3.6931
-1973-03-31,PE,Peru,
-1973-03-31,PH,Philippines,
-1973-03-31,PL,Poland,
-1973-03-31,PT,Portugal,
-1973-03-31,RO,Romania,
-1973-03-31,RS,Serbia,
-1973-03-31,RU,Russia,
+1973-03-31,NZ,New Zealand,3.6945
 1973-03-31,SE,Sweden,8.0042
-1973-03-31,SG,Singapore,
-1973-03-31,SI,Slovenia,
-1973-03-31,SK,Slovak Republic,
-1973-03-31,TH,Thailand,
-1973-03-31,TR,Türkiye,
-1973-03-31,US,United States,13.4744
-1973-03-31,XM,Euro area,
-1973-03-31,XW,World,
-1973-03-31,ZA,South Africa,2.0757
-1973-06-30,4T,Emerging market economies (aggregate),
-1973-06-30,5R,Advanced economies,
-1973-06-30,AE,United Arab Emirates,
-1973-06-30,AT,Austria,
+1973-03-31,US,United States,13.4332
+1973-03-31,ZA,South Africa,2.0731
 1973-06-30,AU,Australia,4.6593
-1973-06-30,BE,Belgium,10.1439
-1973-06-30,BG,Bulgaria,
-1973-06-30,BR,Brazil,
-1973-06-30,CA,Canada,8.7277
-1973-06-30,CH,Switzerland,37.4745
-1973-06-30,CL,Chile,
-1973-06-30,CN,China,
-1973-06-30,CO,Colombia,
-1973-06-30,CY,Cyprus,
-1973-06-30,CZ,Czechia,
+1973-06-30,BE,Belgium,10.2302
+1973-06-30,CA,Canada,8.7954
+1973-06-30,CH,Switzerland,37.4731
 1973-06-30,DE,Germany,49.8922
 1973-06-30,DK,Denmark,11.493
-1973-06-30,EE,Estonia,
 1973-06-30,ES,Spain,1.9321
 1973-06-30,FI,Finland,9.7902
 1973-06-30,FR,France,7.8384
-1973-06-30,GB,United Kingdom,4.8937
-1973-06-30,GR,Greece,
-1973-06-30,HK,Hong Kong SAR,
-1973-06-30,HR,Croatia,
-1973-06-30,HU,Hungary,
-1973-06-30,ID,Indonesia,
-1973-06-30,IE,Ireland,3.6972
-1973-06-30,IL,Israel,
-1973-06-30,IN,India,
-1973-06-30,IS,Iceland,
+1973-06-30,GB,United Kingdom,4.8921
+1973-06-30,IE,Ireland,3.6978
 1973-06-30,IT,Italy,3.0291
 1973-06-30,JP,Japan,58.7734
-1973-06-30,KR,Korea,
-1973-06-30,LT,Lithuania,
-1973-06-30,LU,Luxembourg,
-1973-06-30,LV,Latvia,
-1973-06-30,MA,Morocco,
-1973-06-30,MK,North Macedonia,
-1973-06-30,MT,Malta,
-1973-06-30,MX,Mexico,
-1973-06-30,MY,Malaysia,
-1973-06-30,NL,Netherlands,11.4789
+1973-06-30,NL,Netherlands,11.7575
 1973-06-30,NO,Norway,6.0052
 1973-06-30,NZ,New Zealand,3.9644
-1973-06-30,PE,Peru,
-1973-06-30,PH,Philippines,
-1973-06-30,PL,Poland,
-1973-06-30,PT,Portugal,
-1973-06-30,RO,Romania,
-1973-06-30,RS,Serbia,
-1973-06-30,RU,Russia,
 1973-06-30,SE,Sweden,8.1895
-1973-06-30,SG,Singapore,
-1973-06-30,SI,Slovenia,
-1973-06-30,SK,Slovak Republic,
-1973-06-30,TH,Thailand,
-1973-06-30,TR,Türkiye,
-1973-06-30,US,United States,13.7985
-1973-06-30,XM,Euro area,
-1973-06-30,XW,World,
-1973-06-30,ZA,South Africa,2.1367
-1973-09-30,4T,Emerging market economies (aggregate),
-1973-09-30,5R,Advanced economies,
-1973-09-30,AE,United Arab Emirates,
-1973-09-30,AT,Austria,
+1973-06-30,US,United States,13.7563
+1973-06-30,ZA,South Africa,2.1341
 1973-09-30,AU,Australia,5.0375
-1973-09-30,BE,Belgium,10.5177
-1973-09-30,BG,Bulgaria,
-1973-09-30,BR,Brazil,
-1973-09-30,CA,Canada,9.3776
-1973-09-30,CH,Switzerland,38.2601
-1973-09-30,CL,Chile,
-1973-09-30,CN,China,
-1973-09-30,CO,Colombia,
-1973-09-30,CY,Cyprus,
-1973-09-30,CZ,Czechia,
+1973-09-30,BE,Belgium,10.6072
+1973-09-30,CA,Canada,9.4503
+1973-09-30,CH,Switzerland,38.2587
 1973-09-30,DE,Germany,50.3911
 1973-09-30,DK,Denmark,12.0528
-1973-09-30,EE,Estonia,
 1973-09-30,ES,Spain,2.0972
 1973-09-30,FI,Finland,10.3803
 1973-09-30,FR,France,8.222
-1973-09-30,GB,United Kingdom,5.1958
-1973-09-30,GR,Greece,
-1973-09-30,HK,Hong Kong SAR,
-1973-09-30,HR,Croatia,
-1973-09-30,HU,Hungary,
-1973-09-30,ID,Indonesia,
-1973-09-30,IE,Ireland,3.7216
-1973-09-30,IL,Israel,
-1973-09-30,IN,India,
-1973-09-30,IS,Iceland,
+1973-09-30,GB,United Kingdom,5.194
+1973-09-30,IE,Ireland,3.7223
 1973-09-30,IT,Italy,3.3699
 1973-09-30,JP,Japan,63.2693
-1973-09-30,KR,Korea,
-1973-09-30,LT,Lithuania,
-1973-09-30,LU,Luxembourg,
-1973-09-30,LV,Latvia,
-1973-09-30,MA,Morocco,
-1973-09-30,MK,North Macedonia,
-1973-09-30,MT,Malta,
-1973-09-30,MX,Mexico,
-1973-09-30,MY,Malaysia,
-1973-09-30,NL,Netherlands,11.6993
+1973-09-30,NL,Netherlands,11.9832
 1973-09-30,NO,Norway,5.8095
-1973-09-30,NZ,New Zealand,4.2641
-1973-09-30,PE,Peru,
-1973-09-30,PH,Philippines,
-1973-09-30,PL,Poland,
-1973-09-30,PT,Portugal,
-1973-09-30,RO,Romania,
-1973-09-30,RS,Serbia,
-1973-09-30,RU,Russia,
+1973-09-30,NZ,New Zealand,4.2629
 1973-09-30,SE,Sweden,8.1895
-1973-09-30,SG,Singapore,
-1973-09-30,SI,Slovenia,
-1973-09-30,SK,Slovak Republic,
-1973-09-30,TH,Thailand,
-1973-09-30,TR,Türkiye,
-1973-09-30,US,United States,14.1526
-1973-09-30,XM,Euro area,
-1973-09-30,XW,World,
-1973-09-30,ZA,South Africa,2.2588
-1973-12-31,4T,Emerging market economies (aggregate),
-1973-12-31,5R,Advanced economies,
-1973-12-31,AE,United Arab Emirates,
-1973-12-31,AT,Austria,
+1973-09-30,US,United States,14.1094
+1973-09-30,ZA,South Africa,2.2561
 1973-12-31,AU,Australia,5.3871
-1973-12-31,BE,Belgium,10.6422
-1973-12-31,BG,Bulgaria,
-1973-12-31,BR,Brazil,
-1973-12-31,CA,Canada,10.2666
-1973-12-31,CH,Switzerland,37.7152
-1973-12-31,CL,Chile,
-1973-12-31,CN,China,
-1973-12-31,CO,Colombia,
-1973-12-31,CY,Cyprus,
-1973-12-31,CZ,Czechia,
+1973-12-31,BE,Belgium,10.7328
+1973-12-31,CA,Canada,10.3462
+1973-12-31,CH,Switzerland,37.7138
 1973-12-31,DE,Germany,50.3911
 1973-12-31,DK,Denmark,12.3704
-1973-12-31,EE,Estonia,
 1973-12-31,ES,Spain,2.2272
 1973-12-31,FI,Finland,10.8634
 1973-12-31,FR,France,8.4013
-1973-12-31,GB,United Kingdom,5.2562
-1973-12-31,GR,Greece,
-1973-12-31,HK,Hong Kong SAR,
-1973-12-31,HR,Croatia,
-1973-12-31,HU,Hungary,
-1973-12-31,ID,Indonesia,
-1973-12-31,IE,Ireland,3.7845
-1973-12-31,IL,Israel,
-1973-12-31,IN,India,
-1973-12-31,IS,Iceland,
+1973-12-31,GB,United Kingdom,5.2544
+1973-12-31,IE,Ireland,3.7852
 1973-12-31,IT,Italy,3.7877
 1973-12-31,JP,Japan,65.9135
-1973-12-31,KR,Korea,
-1973-12-31,LT,Lithuania,
-1973-12-31,LU,Luxembourg,
-1973-12-31,LV,Latvia,
-1973-12-31,MA,Morocco,
-1973-12-31,MK,North Macedonia,
-1973-12-31,MT,Malta,
-1973-12-31,MX,Mexico,
-1973-12-31,MY,Malaysia,
-1973-12-31,NL,Netherlands,12.3453
+1973-12-31,NL,Netherlands,12.6449
 1973-12-31,NO,Norway,5.5776
-1973-12-31,NZ,New Zealand,4.6609
-1973-12-31,PE,Peru,
-1973-12-31,PH,Philippines,
-1973-12-31,PL,Poland,
-1973-12-31,PT,Portugal,
-1973-12-31,RO,Romania,
-1973-12-31,RS,Serbia,
-1973-12-31,RU,Russia,
+1973-12-31,NZ,New Zealand,4.6607
 1973-12-31,SE,Sweden,8.3714
-1973-12-31,SG,Singapore,
-1973-12-31,SI,Slovenia,
-1973-12-31,SK,Slovak Republic,
-1973-12-31,TH,Thailand,
-1973-12-31,TR,Türkiye,
-1973-12-31,US,United States,14.4527
-1973-12-31,XM,Euro area,
-1973-12-31,XW,World,
-1973-12-31,ZA,South Africa,2.3504
-1974-03-31,4T,Emerging market economies (aggregate),
-1974-03-31,5R,Advanced economies,
-1974-03-31,AE,United Arab Emirates,
-1974-03-31,AT,Austria,
+1973-12-31,US,United States,14.4086
+1973-12-31,ZA,South Africa,2.3475
 1974-03-31,AU,Australia,5.7368
-1974-03-31,BE,Belgium,10.9129
-1974-03-31,BG,Bulgaria,
-1974-03-31,BR,Brazil,
-1974-03-31,CA,Canada,11.3497
-1974-03-31,CH,Switzerland,37.5438
-1974-03-31,CL,Chile,
-1974-03-31,CN,China,
-1974-03-31,CO,Colombia,
-1974-03-31,CY,Cyprus,
-1974-03-31,CZ,Czechia,
-1974-03-31,DE,Germany,51.4887
+1974-03-31,BE,Belgium,11.0058
+1974-03-31,CA,Canada,11.4377
+1974-03-31,CH,Switzerland,37.5425
+1974-03-31,DE,Germany,51.4888
 1974-03-31,DK,Denmark,12.3704
-1974-03-31,EE,Estonia,
 1974-03-31,ES,Spain,2.459
 1974-03-31,FI,Finland,11.4615
 1974-03-31,FR,France,8.6222
-1974-03-31,GB,United Kingdom,5.3166
-1974-03-31,GR,Greece,
-1974-03-31,HK,Hong Kong SAR,
-1974-03-31,HR,Croatia,
-1974-03-31,HU,Hungary,
-1974-03-31,ID,Indonesia,
-1974-03-31,IE,Ireland,4.0466
-1974-03-31,IL,Israel,
-1974-03-31,IN,India,
-1974-03-31,IS,Iceland,
+1974-03-31,GB,United Kingdom,5.3148
+1974-03-31,IE,Ireland,4.0473
 1974-03-31,IT,Italy,4.255
 1974-03-31,JP,Japan,68.5577
-1974-03-31,KR,Korea,
-1974-03-31,LT,Lithuania,
-1974-03-31,LU,Luxembourg,
-1974-03-31,LV,Latvia,
-1974-03-31,MA,Morocco,
-1974-03-31,MK,North Macedonia,
-1974-03-31,MT,Malta,
-1974-03-31,MX,Mexico,
-1974-03-31,MY,Malaysia,
-1974-03-31,NL,Netherlands,13.0292
+1974-03-31,NL,Netherlands,13.3454
 1974-03-31,NO,Norway,5.5655
-1974-03-31,NZ,New Zealand,5.1874
-1974-03-31,PE,Peru,
-1974-03-31,PH,Philippines,
-1974-03-31,PL,Poland,
-1974-03-31,PT,Portugal,
-1974-03-31,RO,Romania,
-1974-03-31,RS,Serbia,
-1974-03-31,RU,Russia,
+1974-03-31,NZ,New Zealand,5.1865
 1974-03-31,SE,Sweden,8.5567
-1974-03-31,SG,Singapore,
-1974-03-31,SI,Slovenia,
-1974-03-31,SK,Slovak Republic,
-1974-03-31,TH,Thailand,
-1974-03-31,TR,Türkiye,
-1974-03-31,US,United States,14.8068
-1974-03-31,XM,Euro area,
-1974-03-31,XW,World,
-1974-03-31,ZA,South Africa,2.3504
-1974-06-30,4T,Emerging market economies (aggregate),
-1974-06-30,5R,Advanced economies,
-1974-06-30,AE,United Arab Emirates,
-1974-06-30,AT,Austria,
+1974-03-31,US,United States,14.7616
+1974-03-31,ZA,South Africa,2.3475
 1974-06-30,AU,Australia,5.9306
-1974-06-30,BE,Belgium,11.8152
-1974-06-30,BG,Bulgaria,
-1974-06-30,BR,Brazil,
-1974-06-30,CA,Canada,11.8596
-1974-06-30,CH,Switzerland,37.6314
-1974-06-30,CL,Chile,
-1974-06-30,CN,China,
-1974-06-30,CO,Colombia,
-1974-06-30,CY,Cyprus,
-1974-06-30,CZ,Czechia,
+1974-06-30,BE,Belgium,11.9157
+1974-06-30,CA,Canada,11.9516
+1974-06-30,CH,Switzerland,37.63
 1974-06-30,DE,Germany,53.5842
 1974-06-30,DK,Denmark,11.9496
-1974-06-30,EE,Estonia,
 1974-06-30,ES,Spain,2.7471
 1974-06-30,FI,Finland,12.0714
 1974-06-30,FR,France,9.0017
-1974-06-30,GB,United Kingdom,5.3166
-1974-06-30,GR,Greece,
-1974-06-30,HK,Hong Kong SAR,
-1974-06-30,HR,Croatia,
-1974-06-30,HU,Hungary,
-1974-06-30,ID,Indonesia,
-1974-06-30,IE,Ireland,4.3087
-1974-06-30,IL,Israel,
-1974-06-30,IN,India,
-1974-06-30,IS,Iceland,
+1974-06-30,GB,United Kingdom,5.3148
+1974-06-30,IE,Ireland,4.3094
 1974-06-30,IT,Italy,4.7497
 1974-06-30,JP,Japan,69.1315
-1974-06-30,KR,Korea,
-1974-06-30,LT,Lithuania,
-1974-06-30,LU,Luxembourg,
-1974-06-30,LV,Latvia,
-1974-06-30,MA,Morocco,
-1974-06-30,MK,North Macedonia,
-1974-06-30,MT,Malta,
-1974-06-30,MX,Mexico,
-1974-06-30,MY,Malaysia,
-1974-06-30,NL,Netherlands,13.8044
+1974-06-30,NL,Netherlands,14.1394
 1974-06-30,NO,Norway,5.9872
-1974-06-30,NZ,New Zealand,5.6976
-1974-06-30,PE,Peru,
-1974-06-30,PH,Philippines,
-1974-06-30,PL,Poland,
-1974-06-30,PT,Portugal,
-1974-06-30,RO,Romania,
-1974-06-30,RS,Serbia,
-1974-06-30,RU,Russia,
+1974-06-30,NZ,New Zealand,5.698
 1974-06-30,SE,Sweden,8.7386
-1974-06-30,SG,Singapore,
-1974-06-30,SI,Slovenia,
-1974-06-30,SK,Slovak Republic,
-1974-06-30,TH,Thailand,
-1974-06-30,TR,Türkiye,
-1974-06-30,US,United States,15.0949
-1974-06-30,XM,Euro area,
-1974-06-30,XW,World,
-1974-06-30,ZA,South Africa,2.3911
-1974-09-30,4T,Emerging market economies (aggregate),
-1974-09-30,5R,Advanced economies,
-1974-09-30,AE,United Arab Emirates,
-1974-09-30,AT,Austria,
+1974-06-30,US,United States,15.0488
+1974-06-30,ZA,South Africa,2.3882
 1974-09-30,AU,Australia,6.0005
-1974-09-30,BE,Belgium,12.305
-1974-09-30,BG,Bulgaria,
-1974-09-30,BR,Brazil,
-1974-09-30,CA,Canada,11.7513
-1974-09-30,CH,Switzerland,37.9035
-1974-09-30,CL,Chile,
-1974-09-30,CN,China,
-1974-09-30,CO,Colombia,
-1974-09-30,CY,Cyprus,
-1974-09-30,CZ,Czechia,
+1974-09-30,BE,Belgium,12.4097
+1974-09-30,CA,Canada,11.8424
+1974-09-30,CH,Switzerland,37.9021
 1974-09-30,DE,Germany,54.0831
 1974-09-30,DK,Denmark,12.0885
-1974-09-30,EE,Estonia,
 1974-09-30,ES,Spain,2.863
 1974-09-30,FI,Finland,12.2179
 1974-09-30,FR,France,9.4853
-1974-09-30,GB,United Kingdom,5.377
-1974-09-30,GR,Greece,
-1974-09-30,HK,Hong Kong SAR,
-1974-09-30,HR,Croatia,
-1974-09-30,HU,Hungary,
-1974-09-30,ID,Indonesia,
-1974-09-30,IE,Ireland,4.5778
-1974-09-30,IL,Israel,
-1974-09-30,IN,India,
-1974-09-30,IS,Iceland,
+1974-09-30,GB,United Kingdom,5.3752
+1974-09-30,IE,Ireland,4.5786
 1974-09-30,IT,Italy,5.195
 1974-09-30,JP,Japan,69.7116
-1974-09-30,KR,Korea,
-1974-09-30,LT,Lithuania,
-1974-09-30,LU,Luxembourg,
-1974-09-30,LV,Latvia,
-1974-09-30,MA,Morocco,
-1974-09-30,MK,North Macedonia,
-1974-09-30,MT,Malta,
-1974-09-30,MX,Mexico,
-1974-09-30,MY,Malaysia,
-1974-09-30,NL,Netherlands,14.1615
+1974-09-30,NL,Netherlands,14.5052
 1974-09-30,NO,Norway,6.201
-1974-09-30,NZ,New Zealand,6.054
-1974-09-30,PE,Peru,
-1974-09-30,PH,Philippines,
-1974-09-30,PL,Poland,
-1974-09-30,PT,Portugal,
-1974-09-30,RO,Romania,
-1974-09-30,RS,Serbia,
-1974-09-30,RU,Russia,
+1974-09-30,NZ,New Zealand,6.0533
 1974-09-30,SE,Sweden,8.9407
-1974-09-30,SG,Singapore,
-1974-09-30,SI,Slovenia,
-1974-09-30,SK,Slovak Republic,
-1974-09-30,TH,Thailand,
-1974-09-30,TR,Türkiye,
-1974-09-30,US,United States,15.497
-1974-09-30,XM,Euro area,
-1974-09-30,XW,World,
-1974-09-30,ZA,South Africa,2.4013
-1974-12-31,4T,Emerging market economies (aggregate),
-1974-12-31,5R,Advanced economies,
-1974-12-31,AE,United Arab Emirates,
-1974-12-31,AT,Austria,
+1974-09-30,US,United States,15.4497
+1974-09-30,ZA,South Africa,2.3983
 1974-12-31,AU,Australia,6.1436
-1974-12-31,BE,Belgium,12.1503
-1974-12-31,BG,Bulgaria,
-1974-12-31,BR,Brazil,
-1974-12-31,CA,Canada,11.7784
-1974-12-31,CH,Switzerland,37.63
-1974-12-31,CL,Chile,
-1974-12-31,CN,China,
-1974-12-31,CO,Colombia,
-1974-12-31,CY,Cyprus,
-1974-12-31,CZ,Czechia,
+1974-12-31,BE,Belgium,12.2537
+1974-12-31,CA,Canada,11.8697
+1974-12-31,CH,Switzerland,37.6287
 1974-12-31,DE,Germany,53.7838
 1974-12-31,DK,Denmark,12.9659
-1974-12-31,EE,Estonia,
 1974-12-31,ES,Spain,2.8701
 1974-12-31,FI,Finland,12.412
 1974-12-31,FR,France,9.6688
-1974-12-31,GB,United Kingdom,5.4374
-1974-12-31,GR,Greece,
-1974-12-31,HK,Hong Kong SAR,
-1974-12-31,HR,Croatia,
-1974-12-31,HU,Hungary,
-1974-12-31,ID,Indonesia,
-1974-12-31,IE,Ireland,5.0111
-1974-12-31,IL,Israel,
-1974-12-31,IN,India,
-1974-12-31,IS,Iceland,
+1974-12-31,GB,United Kingdom,5.4356
+1974-12-31,IE,Ireland,5.012
 1974-12-31,IT,Italy,5.4864
 1974-12-31,JP,Japan,67.6923
-1974-12-31,KR,Korea,
-1974-12-31,LT,Lithuania,
-1974-12-31,LU,Luxembourg,
-1974-12-31,LV,Latvia,
-1974-12-31,MA,Morocco,
-1974-12-31,MK,North Macedonia,
-1974-12-31,MT,Malta,
-1974-12-31,MX,Mexico,
-1974-12-31,MY,Malaysia,
-1974-12-31,NL,Netherlands,14.8645
+1974-12-31,NL,Netherlands,15.2252
 1974-12-31,NO,Norway,6.3937
-1974-12-31,NZ,New Zealand,6.224
-1974-12-31,PE,Peru,
-1974-12-31,PH,Philippines,
-1974-12-31,PL,Poland,
-1974-12-31,PT,Portugal,
-1974-12-31,RO,Romania,
-1974-12-31,RS,Serbia,
-1974-12-31,RU,Russia,
+1974-12-31,NZ,New Zealand,6.2238
 1974-12-31,SE,Sweden,9.4898
-1974-12-31,SG,Singapore,
-1974-12-31,SI,Slovenia,
-1974-12-31,SK,Slovak Republic,
-1974-12-31,TH,Thailand,
-1974-12-31,TR,Türkiye,
-1974-12-31,US,United States,15.593
-1974-12-31,XM,Euro area,
-1974-12-31,XW,World,
-1974-12-31,ZA,South Africa,2.4114
-1975-03-31,4T,Emerging market economies (aggregate),
-1975-03-31,5R,Advanced economies,
-1975-03-31,AE,United Arab Emirates,
-1975-03-31,AT,Austria,
+1974-12-31,US,United States,15.5454
+1974-12-31,ZA,South Africa,2.4085
 1975-03-31,AU,Australia,6.2675
-1975-03-31,BE,Belgium,12.9709
-1975-03-31,BG,Bulgaria,
-1975-03-31,BR,Brazil,
-1975-03-31,CA,Canada,12.4011
-1975-03-31,CH,Switzerland,36.2198
-1975-03-31,CL,Chile,
-1975-03-31,CN,China,
-1975-03-31,CO,Colombia,
-1975-03-31,CY,Cyprus,
-1975-03-31,CZ,Czechia,
-1975-03-31,DE,Germany,53.988
+1975-03-31,BE,Belgium,13.0813
+1975-03-31,CA,Canada,12.4973
+1975-03-31,CH,Switzerland,36.2185
+1975-03-31,DE,Germany,53.9403
 1975-03-31,DK,Denmark,13.8393
-1975-03-31,EE,Estonia,
 1975-03-31,ES,Spain,2.8701
 1975-03-31,FI,Finland,12.3367
 1975-03-31,FR,France,9.7105
-1975-03-31,GB,United Kingdom,5.4978
-1975-03-31,GR,Greece,
-1975-03-31,HK,Hong Kong SAR,
-1975-03-31,HR,Croatia,
-1975-03-31,HU,Hungary,
-1975-03-31,ID,Indonesia,
-1975-03-31,IE,Ireland,5.3256
-1975-03-31,IL,Israel,
-1975-03-31,IN,India,
-1975-03-31,IS,Iceland,
+1975-03-31,GB,United Kingdom,5.496
+1975-03-31,IE,Ireland,5.3265
 1975-03-31,IT,Italy,5.6513
 1975-03-31,JP,Japan,65.6731
-1975-03-31,KR,Korea,6.2601
-1975-03-31,LT,Lithuania,
-1975-03-31,LU,Luxembourg,
-1975-03-31,LV,Latvia,
-1975-03-31,MA,Morocco,
-1975-03-31,MK,North Macedonia,
-1975-03-31,MT,Malta,
-1975-03-31,MX,Mexico,
-1975-03-31,MY,Malaysia,
-1975-03-31,NL,Netherlands,15.1874
+1975-03-31,KR,Korea,6.2599
+1975-03-31,NL,Netherlands,15.556
 1975-03-31,NO,Norway,6.5985
-1975-03-31,NZ,New Zealand,6.2524
-1975-03-31,PE,Peru,
-1975-03-31,PH,Philippines,
-1975-03-31,PL,Poland,
-1975-03-31,PT,Portugal,
-1975-03-31,RO,Romania,
-1975-03-31,RS,Serbia,
-1975-03-31,RU,Russia,
+1975-03-31,NZ,New Zealand,6.2522
 1975-03-31,SE,Sweden,9.8402
-1975-03-31,SG,Singapore,
-1975-03-31,SI,Slovenia,
-1975-03-31,SK,Slovak Republic,
-1975-03-31,TH,Thailand,
-1975-03-31,TR,Türkiye,
-1975-03-31,US,United States,16.0072
-1975-03-31,XM,Euro area,12.6236
-1975-03-31,XW,World,
-1975-03-31,ZA,South Africa,2.5539
-1975-06-30,4T,Emerging market economies (aggregate),
-1975-06-30,5R,Advanced economies,
-1975-06-30,AE,United Arab Emirates,
-1975-06-30,AT,Austria,
+1975-03-31,US,United States,15.9583
+1975-03-31,XM,Euro area,12.5845
+1975-03-31,ZA,South Africa,2.5508
 1975-06-30,AU,Australia,6.5281
-1975-06-30,BE,Belgium,13.4091
-1975-06-30,BG,Bulgaria,
-1975-06-30,BR,Brazil,
-1975-06-30,CA,Canada,12.8073
-1975-06-30,CH,Switzerland,35.7636
-1975-06-30,CL,Chile,
-1975-06-30,CN,China,
-1975-06-30,CO,Colombia,
-1975-06-30,CY,Cyprus,
-1975-06-30,CZ,Czechia,
-1975-06-30,DE,Germany,54.6445
+1975-06-30,BE,Belgium,13.5233
+1975-06-30,CA,Canada,12.9066
+1975-06-30,CH,Switzerland,35.7623
+1975-06-30,DE,Germany,54.7126
 1975-06-30,DK,Denmark,14.3316
-1975-06-30,EE,Estonia,
 1975-06-30,ES,Spain,2.9719
 1975-06-30,FI,Finland,12.4476
 1975-06-30,FR,France,10.0648
-1975-06-30,GB,United Kingdom,5.6187
-1975-06-30,GR,Greece,
-1975-06-30,HK,Hong Kong SAR,
-1975-06-30,HR,Croatia,
-1975-06-30,HU,Hungary,
-1975-06-30,ID,Indonesia,
-1975-06-30,IE,Ireland,5.6191
-1975-06-30,IL,Israel,
-1975-06-30,IN,India,
-1975-06-30,IS,Iceland,
+1975-06-30,GB,United Kingdom,5.6168
+1975-06-30,IE,Ireland,5.6201
 1975-06-30,IT,Italy,5.7448
 1975-06-30,JP,Japan,65.8643
-1975-06-30,KR,Korea,6.9858
-1975-06-30,LT,Lithuania,
-1975-06-30,LU,Luxembourg,
-1975-06-30,LV,Latvia,
-1975-06-30,MA,Morocco,
-1975-06-30,MK,North Macedonia,
-1975-06-30,MT,Malta,
-1975-06-30,MX,Mexico,
-1975-06-30,MY,Malaysia,
-1975-06-30,NL,Netherlands,15.841
+1975-06-30,KR,Korea,6.9856
+1975-06-30,NL,Netherlands,16.2254
 1975-06-30,NO,Norway,6.8816
-1975-06-30,NZ,New Zealand,6.2524
-1975-06-30,PE,Peru,
-1975-06-30,PH,Philippines,
-1975-06-30,PL,Poland,
-1975-06-30,PT,Portugal,
-1975-06-30,RO,Romania,
-1975-06-30,RS,Serbia,
-1975-06-30,RU,Russia,
+1975-06-30,NZ,New Zealand,6.2522
 1975-06-30,SE,Sweden,10.3893
-1975-06-30,SG,Singapore,
-1975-06-30,SI,Slovenia,
-1975-06-30,SK,Slovak Republic,
-1975-06-30,TH,Thailand,
-1975-06-30,TR,Türkiye,
-1975-06-30,US,United States,16.4633
-1975-06-30,XM,Euro area,12.8962
-1975-06-30,XW,World,
-1975-06-30,ZA,South Africa,2.5946
-1975-09-30,4T,Emerging market economies (aggregate),
-1975-09-30,5R,Advanced economies,
-1975-09-30,AE,United Arab Emirates,
-1975-09-30,AT,Austria,
+1975-06-30,US,United States,16.4131
+1975-06-30,XM,Euro area,12.8566
+1975-06-30,ZA,South Africa,2.5914
 1975-09-30,AU,Australia,6.7125
-1975-09-30,BE,Belgium,13.7915
-1975-09-30,BG,Bulgaria,
-1975-09-30,BR,Brazil,
-1975-09-30,CA,Canada,13.2134
-1975-09-30,CH,Switzerland,35.4096
-1975-09-30,CL,Chile,
-1975-09-30,CN,China,
-1975-09-30,CO,Colombia,
-1975-09-30,CY,Cyprus,
-1975-09-30,CZ,Czechia,
-1975-09-30,DE,Germany,54.6865
+1975-09-30,BE,Belgium,13.9089
+1975-09-30,CA,Canada,13.3159
+1975-09-30,CH,Switzerland,35.4083
+1975-09-30,DE,Germany,54.7137
 1975-09-30,DK,Denmark,14.9985
-1975-09-30,EE,Estonia,
 1975-09-30,ES,Spain,3.0106
 1975-09-30,FI,Finland,12.5427
 1975-09-30,FR,France,10.5652
-1975-09-30,GB,United Kingdom,5.7999
-1975-09-30,GR,Greece,
-1975-09-30,HK,Hong Kong SAR,
-1975-09-30,HR,Croatia,
-1975-09-30,HU,Hungary,
-1975-09-30,ID,Indonesia,
-1975-09-30,IE,Ireland,6.014
-1975-09-30,IL,Israel,
-1975-09-30,IN,India,
-1975-09-30,IS,Iceland,
+1975-09-30,GB,United Kingdom,5.798
+1975-09-30,IE,Ireland,6.015
 1975-09-30,IT,Italy,5.9152
 1975-09-30,JP,Japan,66.0577
-1975-09-30,KR,Korea,7.7052
-1975-09-30,LT,Lithuania,
-1975-09-30,LU,Luxembourg,
-1975-09-30,LV,Latvia,
-1975-09-30,MA,Morocco,
-1975-09-30,MK,North Macedonia,
-1975-09-30,MT,Malta,
-1975-09-30,MX,Mexico,
-1975-09-30,MY,Malaysia,
-1975-09-30,NL,Netherlands,16.4262
+1975-09-30,KR,Korea,7.705
+1975-09-30,NL,Netherlands,16.8248
 1975-09-30,NO,Norway,6.7612
 1975-09-30,NZ,New Zealand,6.3374
-1975-09-30,PE,Peru,
-1975-09-30,PH,Philippines,
-1975-09-30,PL,Poland,
-1975-09-30,PT,Portugal,
-1975-09-30,RO,Romania,
-1975-09-30,RS,Serbia,
-1975-09-30,RU,Russia,
 1975-09-30,SE,Sweden,10.7565
-1975-09-30,SG,Singapore,
-1975-09-30,SI,Slovenia,
-1975-09-30,SK,Slovak Republic,
-1975-09-30,TH,Thailand,
-1975-09-30,TR,Türkiye,
-1975-09-30,US,United States,16.7574
-1975-09-30,XM,Euro area,13.1129
-1975-09-30,XW,World,
-1975-09-30,ZA,South Africa,2.6048
-1975-12-31,4T,Emerging market economies (aggregate),
-1975-12-31,5R,Advanced economies,
-1975-12-31,AE,United Arab Emirates,
-1975-12-31,AT,Austria,
+1975-09-30,US,United States,16.7063
+1975-09-30,XM,Euro area,13.0699
+1975-09-30,ZA,South Africa,2.6016
 1975-12-31,AU,Australia,6.9095
-1975-12-31,BE,Belgium,14.3157
-1975-12-31,BG,Bulgaria,
-1975-12-31,BR,Brazil,
-1975-12-31,CA,Canada,13.755
-1975-12-31,CH,Switzerland,35.2491
-1975-12-31,CL,Chile,
-1975-12-31,CN,China,
-1975-12-31,CO,Colombia,
-1975-12-31,CY,Cyprus,
-1975-12-31,CZ,Czechia,
-1975-12-31,DE,Germany,54.6143
+1975-12-31,BE,Belgium,14.4375
+1975-12-31,CA,Canada,13.8616
+1975-12-31,CH,Switzerland,35.2478
+1975-12-31,DE,Germany,54.5662
 1975-12-31,DK,Denmark,15.0303
-1975-12-31,EE,Estonia,
 1975-12-31,ES,Spain,3.0668
 1975-12-31,FI,Finland,13.0219
 1975-12-31,FR,France,10.8237
-1975-12-31,GB,United Kingdom,5.8603
-1975-12-31,GR,Greece,
-1975-12-31,HK,Hong Kong SAR,
-1975-12-31,HR,Croatia,
-1975-12-31,HU,Hungary,
-1975-12-31,ID,Indonesia,
-1975-12-31,IE,Ireland,6.297
-1975-12-31,IL,Israel,
-1975-12-31,IN,India,
-1975-12-31,IS,Iceland,
+1975-12-31,GB,United Kingdom,5.8584
+1975-12-31,IE,Ireland,6.2981
 1975-12-31,IT,Italy,6.1351
 1975-12-31,JP,Japan,66.3462
-1975-12-31,KR,Korea,8.2321
-1975-12-31,LT,Lithuania,
-1975-12-31,LU,Luxembourg,
-1975-12-31,LV,Latvia,
-1975-12-31,MA,Morocco,
-1975-12-31,MK,North Macedonia,
-1975-12-31,MT,Malta,
-1975-12-31,MX,Mexico,
-1975-12-31,MY,Malaysia,
-1975-12-31,NL,Netherlands,17.2583
+1975-12-31,KR,Korea,8.2318
+1975-12-31,NL,Netherlands,17.6771
 1975-12-31,NO,Norway,6.5925
-1975-12-31,NZ,New Zealand,6.4792
-1975-12-31,PE,Peru,
-1975-12-31,PH,Philippines,
-1975-12-31,PL,Poland,
-1975-12-31,PT,Portugal,
-1975-12-31,RO,Romania,
-1975-12-31,RS,Serbia,
-1975-12-31,RU,Russia,
+1975-12-31,NZ,New Zealand,6.4795
 1975-12-31,SE,Sweden,11.1439
-1975-12-31,SG,Singapore,
-1975-12-31,SI,Slovenia,
-1975-12-31,SK,Slovak Republic,
-1975-12-31,TH,Thailand,
-1975-12-31,TR,Türkiye,
-1975-12-31,US,United States,17.0695
-1975-12-31,XM,Euro area,13.2731
-1975-12-31,XW,World,
-1975-12-31,ZA,South Africa,2.6658
-1976-03-31,4T,Emerging market economies (aggregate),
-1976-03-31,5R,Advanced economies,
-1976-03-31,AE,United Arab Emirates,
-1976-03-31,AT,Austria,
+1975-12-31,US,United States,17.0174
+1975-12-31,XM,Euro area,13.2291
+1975-12-31,ZA,South Africa,2.6626
 1976-03-31,AU,Australia,7.1765
-1976-03-31,BE,Belgium,15.7636
-1976-03-31,BG,Bulgaria,
-1976-03-31,BR,Brazil,
-1976-03-31,CA,Canada,14.3461
-1976-03-31,CH,Switzerland,34.4576
-1976-03-31,CL,Chile,
-1976-03-31,CN,China,
-1976-03-31,CO,Colombia,
-1976-03-31,CY,Cyprus,
-1976-03-31,CZ,Czechia,
-1976-03-31,DE,Germany,54.7118
+1976-03-31,BE,Belgium,15.8977
+1976-03-31,CA,Canada,14.4574
+1976-03-31,CH,Switzerland,34.4564
+1976-03-31,DE,Germany,54.6725
 1976-03-31,DK,Denmark,15.4868
-1976-03-31,EE,Estonia,
 1976-03-31,ES,Spain,3.137
 1976-03-31,FI,Finland,13.2238
 1976-03-31,FR,France,11.0738
-1976-03-31,GB,United Kingdom,5.9812
-1976-03-31,GR,Greece,
-1976-03-31,HK,Hong Kong SAR,
-1976-03-31,HR,Croatia,
-1976-03-31,HU,Hungary,
-1976-03-31,ID,Indonesia,
-1976-03-31,IE,Ireland,6.6046
-1976-03-31,IL,Israel,
-1976-03-31,IN,India,
-1976-03-31,IS,Iceland,
+1976-03-31,GB,United Kingdom,5.9792
+1976-03-31,IE,Ireland,6.6057
 1976-03-31,IT,Italy,6.3715
 1976-03-31,JP,Japan,66.6346
-1976-03-31,KR,Korea,8.4734
-1976-03-31,LT,Lithuania,
-1976-03-31,LU,Luxembourg,
-1976-03-31,LV,Latvia,
-1976-03-31,MA,Morocco,
-1976-03-31,MK,North Macedonia,
-1976-03-31,MT,Malta,
-1976-03-31,MX,Mexico,
-1976-03-31,MY,Malaysia,
-1976-03-31,NL,Netherlands,18.1094
+1976-03-31,KR,Korea,8.4731
+1976-03-31,NL,Netherlands,18.5489
 1976-03-31,NO,Norway,6.3275
-1976-03-31,NZ,New Zealand,6.6209
-1976-03-31,PE,Peru,
-1976-03-31,PH,Philippines,
-1976-03-31,PL,Poland,
-1976-03-31,PT,Portugal,
-1976-03-31,RO,Romania,
-1976-03-31,RS,Serbia,
-1976-03-31,RU,Russia,
+1976-03-31,NZ,New Zealand,6.6217
 1976-03-31,SE,Sweden,11.5111
-1976-03-31,SG,Singapore,
-1976-03-31,SI,Slovenia,
-1976-03-31,SK,Slovak Republic,
-1976-03-31,TH,Thailand,
-1976-03-31,TR,Türkiye,
-1976-03-31,US,United States,16.6244
-1976-03-31,XM,Euro area,13.606
-1976-03-31,XW,World,
-1976-03-31,ZA,South Africa,2.7167
-1976-06-30,4T,Emerging market economies (aggregate),
-1976-06-30,5R,Advanced economies,
-1976-06-30,AE,United Arab Emirates,
-1976-06-30,AT,Austria,
+1976-03-31,US,United States,16.5585
+1976-03-31,XM,Euro area,13.5589
+1976-03-31,ZA,South Africa,2.7134
 1976-06-30,AU,Australia,7.3449
-1976-06-30,BE,Belgium,16.1073
-1976-06-30,BG,Bulgaria,
-1976-06-30,BR,Brazil,
-1976-06-30,CA,Canada,14.5086
-1976-06-30,CH,Switzerland,34.6417
-1976-06-30,CL,Chile,
-1976-06-30,CN,China,
-1976-06-30,CO,Colombia,
-1976-06-30,CY,Cyprus,
-1976-06-30,CZ,Czechia,
-1976-06-30,DE,Germany,55.4874
+1976-06-30,BE,Belgium,16.2444
+1976-06-30,CA,Canada,14.6211
+1976-06-30,CH,Switzerland,34.6404
+1976-06-30,DE,Germany,55.5387
 1976-06-30,DK,Denmark,15.6615
-1976-06-30,EE,Estonia,
 1976-06-30,ES,Spain,3.4602
 1976-06-30,FI,Finland,13.1248
 1976-06-30,FR,France,11.6534
-1976-06-30,GB,United Kingdom,6.1624
-1976-06-30,GR,Greece,
-1976-06-30,HK,Hong Kong SAR,
-1976-06-30,HR,Croatia,
-1976-06-30,HU,Hungary,
-1976-06-30,ID,Indonesia,
-1976-06-30,IE,Ireland,6.6779
-1976-06-30,IL,Israel,
-1976-06-30,IN,India,
-1976-06-30,IS,Iceland,
+1976-06-30,GB,United Kingdom,6.1604
+1976-06-30,IE,Ireland,6.6791
 1976-06-30,IT,Italy,6.6408
 1976-06-30,JP,Japan,67.2116
-1976-06-30,KR,Korea,8.9217
-1976-06-30,LT,Lithuania,
-1976-06-30,LU,Luxembourg,
-1976-06-30,LV,Latvia,
-1976-06-30,MA,Morocco,
-1976-06-30,MK,North Macedonia,
-1976-06-30,MT,Malta,
-1976-06-30,MX,Mexico,
-1976-06-30,MY,Malaysia,
-1976-06-30,NL,Netherlands,20.0739
+1976-06-30,KR,Korea,8.9213
+1976-06-30,NL,Netherlands,20.561
 1976-06-30,NO,Norway,7.1165
-1976-06-30,NZ,New Zealand,6.7505
-1976-06-30,PE,Peru,
-1976-06-30,PH,Philippines,
-1976-06-30,PL,Poland,
-1976-06-30,PT,Portugal,
-1976-06-30,RO,Romania,
-1976-06-30,RS,Serbia,
-1976-06-30,RU,Russia,
+1976-06-30,NZ,New Zealand,6.7495
 1976-06-30,SE,Sweden,12.1343
-1976-06-30,SG,Singapore,
-1976-06-30,SI,Slovenia,
-1976-06-30,SK,Slovak Republic,
-1976-06-30,TH,Thailand,
-1976-06-30,TR,Türkiye,
-1976-06-30,US,United States,17.1391
-1976-06-30,XM,Euro area,14.348
-1976-06-30,XW,World,
-1976-06-30,ZA,South Africa,2.7777
-1976-09-30,4T,Emerging market economies (aggregate),
-1976-09-30,5R,Advanced economies,
-1976-09-30,AE,United Arab Emirates,
-1976-09-30,AT,Austria,
+1976-06-30,US,United States,17.0959
+1976-06-30,XM,Euro area,14.3032
+1976-06-30,ZA,South Africa,2.7743
 1976-09-30,AU,Australia,7.3354
-1976-09-30,BE,Belgium,16.8033
-1976-09-30,BG,Bulgaria,
-1976-09-30,BR,Brazil,
-1976-09-30,CA,Canada,14.5357
-1976-09-30,CH,Switzerland,34.2662
-1976-09-30,CL,Chile,
-1976-09-30,CN,China,
-1976-09-30,CO,Colombia,
-1976-09-30,CY,Cyprus,
-1976-09-30,CZ,Czechia,
-1976-09-30,DE,Germany,55.8761
+1976-09-30,BE,Belgium,16.9463
+1976-09-30,CA,Canada,14.6484
+1976-09-30,CH,Switzerland,34.265
+1976-09-30,DE,Germany,55.8271
 1976-09-30,DK,Denmark,15.9791
-1976-09-30,EE,Estonia,
 1976-09-30,ES,Spain,3.6359
 1976-09-30,FI,Finland,13.4536
 1976-09-30,FR,France,12.333
-1976-09-30,GB,United Kingdom,6.2832
-1976-09-30,GR,Greece,
-1976-09-30,HK,Hong Kong SAR,
-1976-09-30,HR,Croatia,
-1976-09-30,HU,Hungary,
-1976-09-30,ID,Indonesia,
-1976-09-30,IE,Ireland,7.0449
-1976-09-30,IL,Israel,
-1976-09-30,IN,India,
-1976-09-30,IS,Iceland,
+1976-09-30,GB,United Kingdom,6.2812
+1976-09-30,IE,Ireland,7.0461
 1976-09-30,IT,Italy,6.9487
 1976-09-30,JP,Japan,67.7885
-1976-09-30,KR,Korea,9.6364
-1976-09-30,LT,Lithuania,
-1976-09-30,LU,Luxembourg,
-1976-09-30,LV,Latvia,
-1976-09-30,MA,Morocco,
-1976-09-30,MK,North Macedonia,
-1976-09-30,MT,Malta,
-1976-09-30,MX,Mexico,
-1976-09-30,MY,Malaysia,
-1976-09-30,NL,Netherlands,21.3924
+1976-09-30,KR,Korea,9.636
+1976-09-30,NL,Netherlands,21.9115
 1976-09-30,NO,Norway,7.1527
-1976-09-30,NZ,New Zealand,6.8193
-1976-09-30,PE,Peru,
-1976-09-30,PH,Philippines,
-1976-09-30,PL,Poland,
-1976-09-30,PT,Portugal,
-1976-09-30,RO,Romania,
-1976-09-30,RS,Serbia,
-1976-09-30,RU,Russia,
+1976-09-30,NZ,New Zealand,6.8206
 1976-09-30,SE,Sweden,12.8148
-1976-09-30,SG,Singapore,
-1976-09-30,SI,Slovenia,
-1976-09-30,SK,Slovak Republic,
-1976-09-30,TH,Thailand,
-1976-09-30,TR,Türkiye,
-1976-09-30,US,United States,17.5791
-1976-09-30,XM,Euro area,14.8913
-1976-09-30,XW,World,
-1976-09-30,ZA,South Africa,2.7777
-1976-12-31,4T,Emerging market economies (aggregate),
-1976-12-31,5R,Advanced economies,
-1976-12-31,AE,United Arab Emirates,
-1976-12-31,AT,Austria,
+1976-09-30,US,United States,17.5281
+1976-09-30,XM,Euro area,14.8448
+1976-09-30,ZA,South Africa,2.7743
 1976-12-31,AU,Australia,7.5738
-1976-12-31,BE,Belgium,17.349
-1976-12-31,BG,Bulgaria,
-1976-12-31,BR,Brazil,
-1976-12-31,CA,Canada,15.0772
-1976-12-31,CH,Switzerland,35.3134
-1976-12-31,CL,Chile,
-1976-12-31,CN,China,
-1976-12-31,CO,Colombia,
-1976-12-31,CY,Cyprus,
-1976-12-31,CZ,Czechia,
-1976-12-31,DE,Germany,56.6529
+1976-12-31,BE,Belgium,17.4966
+1976-12-31,CA,Canada,15.1941
+1976-12-31,CH,Switzerland,35.3121
+1976-12-31,DE,Germany,56.6901
 1976-12-31,DK,Denmark,16.6421
-1976-12-31,EE,Estonia,
 1976-12-31,ES,Spain,3.7659
 1976-12-31,FI,Finland,13.612
 1976-12-31,FR,France,12.6415
-1976-12-31,GB,United Kingdom,6.4041
-1976-12-31,GR,Greece,
-1976-12-31,HK,Hong Kong SAR,
-1976-12-31,HR,Croatia,
-1976-12-31,HU,Hungary,
-1976-12-31,ID,Indonesia,
-1976-12-31,IE,Ireland,7.7647
-1976-12-31,IL,Israel,
-1976-12-31,IN,India,
-1976-12-31,IS,Iceland,
+1976-12-31,GB,United Kingdom,6.4019
+1976-12-31,IE,Ireland,7.7661
 1976-12-31,IT,Italy,7.2181
 1976-12-31,JP,Japan,68.5096
-1976-12-31,KR,Korea,9.9358
-1976-12-31,LT,Lithuania,
-1976-12-31,LU,Luxembourg,
-1976-12-31,LV,Latvia,
-1976-12-31,MA,Morocco,
-1976-12-31,MK,North Macedonia,
-1976-12-31,MT,Malta,
-1976-12-31,MX,Mexico,
-1976-12-31,MY,Malaysia,
-1976-12-31,NL,Netherlands,22.9769
+1976-12-31,KR,Korea,9.9354
+1976-12-31,NL,Netherlands,23.5345
 1976-12-31,NO,Norway,7.0744
-1976-12-31,NZ,New Zealand,6.9327
-1976-12-31,PE,Peru,
-1976-12-31,PH,Philippines,
-1976-12-31,PL,Poland,
-1976-12-31,PT,Portugal,
-1976-12-31,RO,Romania,
-1976-12-31,RS,Serbia,
-1976-12-31,RU,Russia,
+1976-12-31,NZ,New Zealand,6.9342
 1976-12-31,SE,Sweden,12.8316
-1976-12-31,SG,Singapore,
-1976-12-31,SI,Slovenia,
-1976-12-31,SK,Slovak Republic,
-1976-12-31,TH,Thailand,
-1976-12-31,TR,Türkiye,
-1976-12-31,US,United States,18.2936
-1976-12-31,XM,Euro area,15.2549
-1976-12-31,XW,World,
-1976-12-31,ZA,South Africa,2.7676
-1977-03-31,4T,Emerging market economies (aggregate),
-1977-03-31,5R,Advanced economies,
-1977-03-31,AE,United Arab Emirates,
-1977-03-31,AT,Austria,
+1976-12-31,US,United States,18.2411
+1976-12-31,XM,Euro area,15.204
+1976-12-31,ZA,South Africa,2.7642
 1977-03-31,AU,Australia,7.7708
-1977-03-31,BE,Belgium,18.161
-1977-03-31,BG,Bulgaria,
-1977-03-31,BR,Brazil,
-1977-03-31,CA,Canada,15.2126
-1977-03-31,CH,Switzerland,35.2942
-1977-03-31,CL,Chile,
-1977-03-31,CN,China,
-1977-03-31,CO,Colombia,
-1977-03-31,CY,Cyprus,
-1977-03-31,CZ,Czechia,
-1977-03-31,DE,Germany,57.2547
+1977-03-31,BE,Belgium,18.3156
+1977-03-31,CA,Canada,15.3306
+1977-03-31,CH,Switzerland,35.2929
+1977-03-31,DE,Germany,57.1682
 1977-03-31,DK,Denmark,16.7135
-1977-03-31,EE,Estonia,
 1977-03-31,ES,Spain,4.1593
 1977-03-31,FI,Finland,13.5763
 1977-03-31,FR,France,12.8792
-1977-03-31,GB,United Kingdom,6.4041
-1977-03-31,GR,Greece,
-1977-03-31,HK,Hong Kong SAR,
-1977-03-31,HR,Croatia,
-1977-03-31,HU,Hungary,
-1977-03-31,ID,Indonesia,
-1977-03-31,IE,Ireland,7.6844
-1977-03-31,IL,Israel,
-1977-03-31,IN,India,
-1977-03-31,IS,Iceland,
+1977-03-31,GB,United Kingdom,6.4019
+1977-03-31,IE,Ireland,7.6857
 1977-03-31,IT,Italy,7.372
 1977-03-31,JP,Japan,69.2308
-1977-03-31,KR,Korea,10.7709
-1977-03-31,LT,Lithuania,
-1977-03-31,LU,Luxembourg,
-1977-03-31,LV,Latvia,
-1977-03-31,MA,Morocco,
-1977-03-31,MK,North Macedonia,
-1977-03-31,MT,Malta,
-1977-03-31,MX,Mexico,
-1977-03-31,MY,Malaysia,
-1977-03-31,NL,Netherlands,25.5987
+1977-03-31,KR,Korea,10.7706
+1977-03-31,NL,Netherlands,26.2199
 1977-03-31,NO,Norway,8.005
-1977-03-31,NZ,New Zealand,7.0906
-1977-03-31,PE,Peru,
-1977-03-31,PH,Philippines,
-1977-03-31,PL,Poland,
-1977-03-31,PT,Portugal,
-1977-03-31,RO,Romania,
-1977-03-31,RS,Serbia,
-1977-03-31,RU,Russia,
+1977-03-31,NZ,New Zealand,7.0905
 1977-03-31,SE,Sweden,13.347
-1977-03-31,SG,Singapore,
-1977-03-31,SI,Slovenia,
-1977-03-31,SK,Slovak Republic,
-1977-03-31,TH,Thailand,
-1977-03-31,TR,Türkiye,
-1977-03-31,US,United States,19.0487
-1977-03-31,XM,Euro area,15.6365
-1977-03-31,XW,World,
-1977-03-31,ZA,South Africa,2.7777
-1977-06-30,4T,Emerging market economies (aggregate),
-1977-06-30,5R,Advanced economies,
-1977-06-30,AE,United Arab Emirates,
-1977-06-30,AT,Austria,
+1977-03-31,US,United States,19.0019
+1977-03-31,XM,Euro area,15.5889
+1977-03-31,ZA,South Africa,2.7743
 1977-06-30,AU,Australia,7.9552
-1977-06-30,BE,Belgium,18.7152
-1977-06-30,BG,Bulgaria,
-1977-06-30,BR,Brazil,
-1977-06-30,CA,Canada,15.2668
-1977-06-30,CH,Switzerland,35.6279
-1977-06-30,CL,Chile,
-1977-06-30,CN,China,
-1977-06-30,CO,Colombia,
-1977-06-30,CY,Cyprus,
-1977-06-30,CZ,Czechia,
-1977-06-30,DE,Germany,58.4467
+1977-06-30,BE,Belgium,18.8745
+1977-06-30,CA,Canada,15.3851
+1977-06-30,CH,Switzerland,35.6266
+1977-06-30,DE,Germany,58.5294
 1977-06-30,DK,Denmark,17.7656
-1977-06-30,EE,Estonia,
 1977-06-30,ES,Spain,4.5984
 1977-06-30,FI,Finland,13.8536
 1977-06-30,FR,France,13.4545
-1977-06-30,GB,United Kingdom,6.5249
-1977-06-30,GR,Greece,
-1977-06-30,HK,Hong Kong SAR,
-1977-06-30,HR,Croatia,
-1977-06-30,HU,Hungary,
-1977-06-30,ID,Indonesia,
-1977-06-30,IE,Ireland,7.9534
-1977-06-30,IL,Israel,
-1977-06-30,IN,India,
-1977-06-30,IS,Iceland,
+1977-06-30,GB,United Kingdom,6.5227
+1977-06-30,IE,Ireland,7.9548
 1977-06-30,IT,Italy,7.4984
 1977-06-30,JP,Japan,69.9958
-1977-06-30,KR,Korea,11.5587
-1977-06-30,LT,Lithuania,
-1977-06-30,LU,Luxembourg,
-1977-06-30,LV,Latvia,
-1977-06-30,MA,Morocco,
-1977-06-30,MK,North Macedonia,
-1977-06-30,MT,Malta,
-1977-06-30,MX,Mexico,
-1977-06-30,MY,Malaysia,
-1977-06-30,NL,Netherlands,29.2426
+1977-06-30,KR,Korea,11.5583
+1977-06-30,NL,Netherlands,29.9522
 1977-06-30,NO,Norway,8.3784
-1977-06-30,NZ,New Zealand,7.2486
-1977-06-30,PE,Peru,
-1977-06-30,PH,Philippines,
-1977-06-30,PL,Poland,
-1977-06-30,PT,Portugal,
-1977-06-30,RO,Romania,
-1977-06-30,RS,Serbia,
-1977-06-30,RU,Russia,
+1977-06-30,NZ,New Zealand,7.2469
 1977-06-30,SE,Sweden,14.1353
-1977-06-30,SG,Singapore,
-1977-06-30,SI,Slovenia,
-1977-06-30,SK,Slovak Republic,
-1977-06-30,TH,Thailand,
-1977-06-30,TR,Türkiye,
-1977-06-30,US,United States,19.933
-1977-06-30,XM,Euro area,16.2878
-1977-06-30,XW,World,
-1977-06-30,ZA,South Africa,2.8184
-1977-09-30,4T,Emerging market economies (aggregate),
-1977-09-30,5R,Advanced economies,
-1977-09-30,AE,United Arab Emirates,
-1977-09-30,AT,Austria,
+1977-06-30,US,United States,19.8903
+1977-06-30,XM,Euro area,16.2411
+1977-06-30,ZA,South Africa,2.815
 1977-09-30,AU,Australia,7.9806
-1977-09-30,BE,Belgium,19.5101
-1977-09-30,BG,Bulgaria,
-1977-09-30,BR,Brazil,
-1977-09-30,CA,Canada,15.2126
-1977-09-30,CH,Switzerland,36.3887
-1977-09-30,CL,Chile,
-1977-09-30,CN,China,
-1977-09-30,CO,Colombia,
-1977-09-30,CY,Cyprus,
-1977-09-30,CZ,Czechia,
-1977-09-30,DE,Germany,59.3291
+1977-09-30,BE,Belgium,19.6761
+1977-09-30,CA,Canada,15.3306
+1977-09-30,CH,Switzerland,36.3874
+1977-09-30,DE,Germany,59.3929
 1977-09-30,DK,Denmark,18.4325
-1977-09-30,EE,Estonia,
 1977-09-30,ES,Spain,4.9708
 1977-09-30,FI,Finland,13.7387
 1977-09-30,FR,France,14.1717
-1977-09-30,GB,United Kingdom,6.7062
-1977-09-30,GR,Greece,
-1977-09-30,HK,Hong Kong SAR,
-1977-09-30,HR,Croatia,
-1977-09-30,HU,Hungary,
-1977-09-30,ID,Indonesia,
-1977-09-30,IE,Ireland,8.8061
-1977-09-30,IL,Israel,
-1977-09-30,IN,India,
-1977-09-30,IS,Iceland,
+1977-09-30,GB,United Kingdom,6.7039
+1977-09-30,IE,Ireland,8.8076
 1977-09-30,IT,Italy,7.6194
 1977-09-30,JP,Japan,70.7693
-1977-09-30,KR,Korea,12.8498
-1977-09-30,LT,Lithuania,
-1977-09-30,LU,Luxembourg,
-1977-09-30,LV,Latvia,
-1977-09-30,MA,Morocco,
-1977-09-30,MK,North Macedonia,
-1977-09-30,MT,Malta,
-1977-09-30,MX,Mexico,
-1977-09-30,MY,Malaysia,
-1977-09-30,NL,Netherlands,29.482
+1977-09-30,KR,Korea,12.8493
+1977-09-30,NL,Netherlands,30.1974
 1977-09-30,NO,Norway,8.4537
-1977-09-30,NZ,New Zealand,7.289
-1977-09-30,PE,Peru,
-1977-09-30,PH,Philippines,
-1977-09-30,PL,Poland,
-1977-09-30,PT,Portugal,
-1977-09-30,RO,Romania,
-1977-09-30,RS,Serbia,
-1977-09-30,RU,Russia,
+1977-09-30,NZ,New Zealand,7.2895
 1977-09-30,SE,Sweden,14.5227
-1977-09-30,SG,Singapore,
-1977-09-30,SI,Slovenia,
-1977-09-30,SK,Slovak Republic,
-1977-09-30,TH,Thailand,
-1977-09-30,TR,Türkiye,
-1977-09-30,US,United States,20.6387
-1977-09-30,XM,Euro area,16.884
-1977-09-30,XW,World,
-1977-09-30,ZA,South Africa,2.8184
-1977-12-31,4T,Emerging market economies (aggregate),
-1977-12-31,5R,Advanced economies,
-1977-12-31,AE,United Arab Emirates,
-1977-12-31,AT,Austria,
+1977-09-30,US,United States,20.6032
+1977-09-30,XM,Euro area,16.8332
+1977-09-30,ZA,South Africa,2.815
 1977-12-31,AU,Australia,8.1268
-1977-12-31,BE,Belgium,20.4811
-1977-12-31,BG,Bulgaria,
-1977-12-31,BR,Brazil,
-1977-12-31,CA,Canada,15.6458
-1977-12-31,CH,Switzerland,36.2719
-1977-12-31,CL,Chile,
-1977-12-31,CN,China,
-1977-12-31,CO,Colombia,
-1977-12-31,CY,Cyprus,
-1977-12-31,CZ,Czechia,
-1977-12-31,DE,Germany,60.0702
+1977-12-31,BE,Belgium,20.6554
+1977-12-31,CA,Canada,15.7671
+1977-12-31,CH,Switzerland,36.2706
+1977-12-31,DE,Germany,60.0093
 1977-12-31,DK,Denmark,19.3774
-1977-12-31,EE,Estonia,
 1977-12-31,ES,Spain,5.4169
 1977-12-31,FI,Finland,13.7387
 1977-12-31,FR,France,14.4635
-1977-12-31,GB,United Kingdom,6.9478
-1977-12-31,GR,Greece,
-1977-12-31,HK,Hong Kong SAR,
-1977-12-31,HR,Croatia,
-1977-12-31,HU,Hungary,
-1977-12-31,ID,Indonesia,
-1977-12-31,IE,Ireland,9.0821
-1977-12-31,IL,Israel,
-1977-12-31,IN,India,
-1977-12-31,IS,Iceland,
+1977-12-31,GB,United Kingdom,6.9455
+1977-12-31,IE,Ireland,9.0837
 1977-12-31,IT,Italy,7.7458
 1977-12-31,JP,Japan,71.6346
-1977-12-31,KR,Korea,14.1707
-1977-12-31,LT,Lithuania,
-1977-12-31,LU,Luxembourg,
-1977-12-31,LV,Latvia,
-1977-12-31,MA,Morocco,
-1977-12-31,MK,North Macedonia,
-1977-12-31,MT,Malta,
-1977-12-31,MX,Mexico,
-1977-12-31,MY,Malaysia,
-1977-12-31,NL,Netherlands,30.0329
+1977-12-31,KR,Korea,14.1702
+1977-12-31,NL,Netherlands,30.7617
 1977-12-31,NO,Norway,8.3724
-1977-12-31,NZ,New Zealand,7.2769
-1977-12-31,PE,Peru,
-1977-12-31,PH,Philippines,
-1977-12-31,PL,Poland,
-1977-12-31,PT,Portugal,
-1977-12-31,RO,Romania,
-1977-12-31,RS,Serbia,
-1977-12-31,RU,Russia,
+1977-12-31,NZ,New Zealand,7.2753
 1977-12-31,SE,Sweden,14.8899
-1977-12-31,SG,Singapore,
-1977-12-31,SI,Slovenia,
-1977-12-31,SK,Slovak Republic,
-1977-12-31,TH,Thailand,
-1977-12-31,TR,Türkiye,
-1977-12-31,US,United States,21.2203
-1977-12-31,XM,Euro area,17.3245
-1977-12-31,XW,World,
-1977-12-31,ZA,South Africa,2.8388
-1978-03-31,4T,Emerging market economies (aggregate),
-1978-03-31,5R,Advanced economies,
-1978-03-31,AE,United Arab Emirates,
-1978-03-31,AT,Austria,
+1977-12-31,US,United States,21.1842
+1977-12-31,XM,Euro area,17.2745
+1977-12-31,ZA,South Africa,2.8353
 1978-03-31,AU,Australia,8.3429
-1978-03-31,BE,Belgium,20.7474
-1978-03-31,BG,Bulgaria,
-1978-03-31,BR,Brazil,
-1978-03-31,CA,Canada,15.5917
-1978-03-31,CH,Switzerland,35.8808
-1978-03-31,CL,Chile,
-1978-03-31,CN,China,
-1978-03-31,CO,Colombia,
-1978-03-31,CY,Cyprus,
-1978-03-31,CZ,Czechia,
-1978-03-31,DE,Germany,61.144
+1978-03-31,BE,Belgium,20.924
+1978-03-31,CA,Canada,15.7126
+1978-03-31,CH,Switzerland,35.8795
+1978-03-31,DE,Germany,61.1264
 1978-03-31,DK,Denmark,20.0443
-1978-03-31,EE,Estonia,
 1978-03-31,ES,Spain,5.8877
 1978-03-31,FI,Finland,14.107
 1978-03-31,FR,France,14.6053
-1978-03-31,GB,United Kingdom,7.0686
-1978-03-31,GR,Greece,
-1978-03-31,HK,Hong Kong SAR,
-1978-03-31,HR,Croatia,
-1978-03-31,HU,Hungary,
-1978-03-31,ID,Indonesia,
-1978-03-31,IE,Ireland,10.0326
-1978-03-31,IL,Israel,
-1978-03-31,IN,India,
-1978-03-31,IS,Iceland,
+1978-03-31,GB,United Kingdom,7.0663
+1978-03-31,IE,Ireland,10.0344
 1978-03-31,IT,Italy,7.9602
 1978-03-31,JP,Japan,72.5
-1978-03-31,KR,Korea,16.317
-1978-03-31,LT,Lithuania,
-1978-03-31,LU,Luxembourg,
-1978-03-31,LV,Latvia,
-1978-03-31,MA,Morocco,
-1978-03-31,MK,North Macedonia,
-1978-03-31,MT,Malta,
-1978-03-31,MX,Mexico,
-1978-03-31,MY,Malaysia,
-1978-03-31,NL,Netherlands,30.7625
+1978-03-31,KR,Korea,16.3164
+1978-03-31,NL,Netherlands,31.509
 1978-03-31,NO,Norway,8.9717
-1978-03-31,NZ,New Zealand,7.289
-1978-03-31,PE,Peru,
-1978-03-31,PH,Philippines,
-1978-03-31,PL,Poland,
-1978-03-31,PT,Portugal,
-1978-03-31,RO,Romania,
-1978-03-31,RS,Serbia,
-1978-03-31,RU,Russia,
+1978-03-31,NZ,New Zealand,7.2895
 1978-03-31,SE,Sweden,15.0179
-1978-03-31,SG,Singapore,
-1978-03-31,SI,Slovenia,
-1978-03-31,SK,Slovak Republic,
-1978-03-31,TH,Thailand,
-1978-03-31,TR,Türkiye,
-1978-03-31,US,United States,22.1315
-1978-03-31,XM,Euro area,17.8111
-1978-03-31,XW,World,
-1978-03-31,ZA,South Africa,2.8693
-1978-06-30,4T,Emerging market economies (aggregate),
-1978-06-30,5R,Advanced economies,
-1978-06-30,AE,United Arab Emirates,
-1978-06-30,AT,Austria,
+1978-03-31,US,United States,22.0944
+1978-03-31,XM,Euro area,17.7586
+1978-03-31,ZA,South Africa,2.8658
 1978-06-30,AU,Australia,8.3175
-1978-06-30,BE,Belgium,21.0267
-1978-06-30,BG,Bulgaria,
-1978-06-30,BR,Brazil,
-1978-06-30,CA,Canada,16.0475
-1978-06-30,CH,Switzerland,36.7774
-1978-06-30,CL,Chile,
-1978-06-30,CN,China,
-1978-06-30,CO,Colombia,
-1978-06-30,CY,Cyprus,
-1978-06-30,CZ,Czechia,
-1978-06-30,DE,Germany,62.5534
+1978-06-30,BE,Belgium,21.2057
+1978-06-30,CA,Canada,16.1719
+1978-06-30,CH,Switzerland,36.776
+1978-06-30,DE,Germany,62.6205
 1978-06-30,DK,Denmark,20.8503
-1978-06-30,EE,Estonia,
 1978-06-30,ES,Spain,6.3373
 1978-06-30,FI,Finland,14.3763
 1978-06-30,FR,France,15.0764
-1978-06-30,GB,United Kingdom,7.4311
-1978-06-30,GR,Greece,
-1978-06-30,HK,Hong Kong SAR,
-1978-06-30,HR,Croatia,
-1978-06-30,HU,Hungary,
-1978-06-30,ID,Indonesia,
-1978-06-30,IE,Ireland,10.6232
-1978-06-30,IL,Israel,
-1978-06-30,IN,India,
-1978-06-30,IS,Iceland,
+1978-06-30,GB,United Kingdom,7.4287
+1978-06-30,IE,Ireland,10.6251
 1978-06-30,IT,Italy,8.411
 1978-06-30,JP,Japan,73.6953
-1978-06-30,KR,Korea,18.0329
-1978-06-30,LT,Lithuania,
-1978-06-30,LU,Luxembourg,
-1978-06-30,LV,Latvia,
-1978-06-30,MA,Morocco,
-1978-06-30,MK,North Macedonia,
-1978-06-30,MT,Malta,
-1978-06-30,MX,Mexico,
-1978-06-30,MY,Malaysia,
-1978-06-30,NL,Netherlands,32.5863
+1978-06-30,KR,Korea,18.0323
+1978-06-30,NL,Netherlands,33.3771
 1978-06-30,NO,Norway,9.1855
-1978-06-30,NZ,New Zealand,7.3336
-1978-06-30,PE,Peru,
-1978-06-30,PH,Philippines,
-1978-06-30,PL,Poland,
-1978-06-30,PT,Portugal,
-1978-06-30,RO,Romania,
-1978-06-30,RS,Serbia,
-1978-06-30,RU,Russia,
+1978-06-30,NZ,New Zealand,7.3321
 1978-06-30,SE,Sweden,15.9915
-1978-06-30,SG,Singapore,
-1978-06-30,SI,Slovenia,
-1978-06-30,SK,Slovak Republic,
-1978-06-30,TH,Thailand,
-1978-06-30,TR,Türkiye,
-1978-06-30,US,United States,22.8815
-1978-06-30,XM,Euro area,18.3837
-1978-06-30,XW,World,
-1978-06-30,ZA,South Africa,2.8795
-1978-09-30,4T,Emerging market economies (aggregate),
-1978-09-30,5R,Advanced economies,
-1978-09-30,AE,United Arab Emirates,
-1978-09-30,AT,Austria,
+1978-06-30,US,United States,22.8465
+1978-06-30,XM,Euro area,18.3299
+1978-06-30,ZA,South Africa,2.876
 1978-09-30,AU,Australia,8.3588
-1978-09-30,BE,Belgium,21.929
-1978-09-30,BG,Bulgaria,
-1978-09-30,BR,Brazil,
-1978-09-30,CA,Canada,16.0204
-1978-09-30,CH,Switzerland,37.415
-1978-09-30,CL,Chile,
-1978-09-30,CN,China,
-1978-09-30,CO,Colombia,
-1978-09-30,CY,Cyprus,
-1978-09-30,CZ,Czechia,
-1978-09-30,DE,Germany,63.8175
+1978-09-30,BE,Belgium,22.1156
+1978-09-30,CA,Canada,16.1446
+1978-09-30,CH,Switzerland,37.4136
+1978-09-30,DE,Germany,63.8178
 1978-09-30,DK,Denmark,21.3743
-1978-09-30,EE,Estonia,
 1978-09-30,ES,Spain,6.5551
 1978-09-30,FI,Finland,14.1585
 1978-09-30,FR,France,15.706
-1978-09-30,GB,United Kingdom,7.9145
-1978-09-30,GR,Greece,
-1978-09-30,HK,Hong Kong SAR,
-1978-09-30,HR,Croatia,
-1978-09-30,HU,Hungary,
-1978-09-30,ID,Indonesia,
-1978-09-30,IE,Ireland,11.371
-1978-09-30,IL,Israel,
-1978-09-30,IN,India,
-1978-09-30,IS,Iceland,
+1978-09-30,GB,United Kingdom,7.9118
+1978-09-30,IE,Ireland,11.373
 1978-09-30,IT,Italy,8.9442
 1978-09-30,JP,Japan,74.9039
-1978-09-30,KR,Korea,19.406
-1978-09-30,LT,Lithuania,
-1978-09-30,LU,Luxembourg,
-1978-09-30,LV,Latvia,
-1978-09-30,MA,Morocco,
-1978-09-30,MK,North Macedonia,
-1978-09-30,MT,Malta,
-1978-09-30,MX,Mexico,
-1978-09-30,MY,Malaysia,
-1978-09-30,NL,Netherlands,30.2419
+1978-09-30,KR,Korea,19.4053
+1978-09-30,NL,Netherlands,30.9758
 1978-09-30,NO,Norway,9.3301
-1978-09-30,NZ,New Zealand,7.4024
-1978-09-30,PE,Peru,
-1978-09-30,PH,Philippines,
-1978-09-30,PL,Poland,
-1978-09-30,PT,Portugal,
-1978-09-30,RO,Romania,
-1978-09-30,RS,Serbia,
-1978-09-30,RU,Russia,
+1978-09-30,NZ,New Zealand,7.4032
 1978-09-30,SE,Sweden,16.7596
-1978-09-30,SG,Singapore,
-1978-09-30,SI,Slovenia,
-1978-09-30,SK,Slovak Republic,
-1978-09-30,TH,Thailand,
-1978-09-30,TR,Türkiye,
-1978-09-30,US,United States,23.821
-1978-09-30,XM,Euro area,18.9357
-1978-09-30,XW,World,
-1978-09-30,ZA,South Africa,2.9405
-1978-12-31,4T,Emerging market economies (aggregate),
-1978-12-31,5R,Advanced economies,
-1978-12-31,AE,United Arab Emirates,
-1978-12-31,AT,Austria,
+1978-09-30,US,United States,23.7835
+1978-09-30,XM,Euro area,18.8818
+1978-09-30,ZA,South Africa,2.9369
 1978-12-31,AU,Australia,8.451
-1978-12-31,BE,Belgium,22.1438
-1978-12-31,BG,Bulgaria,
-1978-12-31,BR,Brazil,
-1978-12-31,CA,Canada,16.7785
-1978-12-31,CH,Switzerland,38.5588
-1978-12-31,CL,Chile,
-1978-12-31,CN,China,
-1978-12-31,CO,Colombia,
-1978-12-31,CY,Cyprus,
-1978-12-31,CZ,Czechia,
-1978-12-31,DE,Germany,64.7703
+1978-12-31,BE,Belgium,22.3322
+1978-12-31,CA,Canada,16.9086
+1978-12-31,CH,Switzerland,38.5574
+1978-12-31,DE,Germany,64.7209
 1978-12-31,DK,Denmark,21.5847
-1978-12-31,EE,Estonia,
 1978-12-31,ES,Spain,6.6254
 1978-12-31,FI,Finland,14.3169
 1978-12-31,FR,France,15.9812
-1978-12-31,GB,United Kingdom,8.5186
-1978-12-31,GR,Greece,
-1978-12-31,HK,Hong Kong SAR,
-1978-12-31,HR,Croatia,
-1978-12-31,HU,Hungary,
-1978-12-31,ID,Indonesia,
-1978-12-31,IE,Ireland,11.3431
-1978-12-31,IL,Israel,
-1978-12-31,IN,India,
-1978-12-31,IS,Iceland,
+1978-12-31,GB,United Kingdom,8.5158
+1978-12-31,IE,Ireland,11.3451
 1978-12-31,IT,Italy,9.4005
 1978-12-31,JP,Japan,76.4423
-1978-12-31,KR,Korea,19.7734
-1978-12-31,LT,Lithuania,
-1978-12-31,LU,Luxembourg,
-1978-12-31,LV,Latvia,
-1978-12-31,MA,Morocco,
-1978-12-31,MK,North Macedonia,
-1978-12-31,MT,Malta,
-1978-12-31,MX,Mexico,
-1978-12-31,MY,Malaysia,
-1978-12-31,NL,Netherlands,30.2799
+1978-12-31,KR,Korea,19.7727
+1978-12-31,NL,Netherlands,31.0147
 1978-12-31,NO,Norway,9.5771
-1978-12-31,NZ,New Zealand,7.4875
-1978-12-31,PE,Peru,
-1978-12-31,PH,Philippines,
-1978-12-31,PL,Poland,
-1978-12-31,PT,Portugal,
-1978-12-31,RO,Romania,
-1978-12-31,RS,Serbia,
-1978-12-31,RU,Russia,
+1978-12-31,NZ,New Zealand,7.4884
 1978-12-31,SE,Sweden,16.7259
-1978-12-31,SG,Singapore,
-1978-12-31,SI,Slovenia,
-1978-12-31,SK,Slovak Republic,
-1978-12-31,TH,Thailand,
-1978-12-31,TR,Türkiye,
-1978-12-31,US,United States,24.5129
-1978-12-31,XM,Euro area,19.4821
-1978-12-31,XW,World,
-1978-12-31,ZA,South Africa,3.0423
-1979-03-31,4T,Emerging market economies (aggregate),
-1979-03-31,5R,Advanced economies,
-1979-03-31,AE,United Arab Emirates,
-1979-03-31,AT,Austria,
+1978-12-31,US,United States,24.4645
+1978-12-31,XM,Euro area,19.4254
+1978-12-31,ZA,South Africa,3.0386
 1979-03-31,AU,Australia,8.9055
-1979-03-31,BE,Belgium,22.8312
-1979-03-31,BG,Bulgaria,
-1979-03-31,BR,Brazil,
-1979-03-31,CA,Canada,17.3472
-1979-03-31,CH,Switzerland,39.0521
-1979-03-31,CL,Chile,
-1979-03-31,CN,China,
-1979-03-31,CO,Colombia,
-1979-03-31,CY,Cyprus,
-1979-03-31,CZ,Czechia,
-1979-03-31,DE,Germany,66.0535
+1979-03-31,BE,Belgium,23.0255
+1979-03-31,CA,Canada,17.4816
+1979-03-31,CH,Switzerland,39.0507
+1979-03-31,DE,Germany,65.9965
 1979-03-31,DK,Denmark,22.1087
-1979-03-31,EE,Estonia,
 1979-03-31,ES,Spain,6.6465
 1979-03-31,FI,Finland,14.4912
 1979-03-31,FR,France,16.2022
-1979-03-31,GB,United Kingdom,8.9415
-1979-03-31,GR,Greece,
-1979-03-31,HK,Hong Kong SAR,
-1979-03-31,HR,Croatia,
-1979-03-31,HU,Hungary,
-1979-03-31,ID,Indonesia,
-1979-03-31,IE,Ireland,12.1782
-1979-03-31,IL,Israel,
-1979-03-31,IN,India,
-1979-03-31,IS,Iceland,
+1979-03-31,GB,United Kingdom,8.9386
+1979-03-31,IE,Ireland,12.1804
 1979-03-31,IT,Italy,9.7963
 1979-03-31,JP,Japan,77.9808
-1979-03-31,KR,Korea,20.4754
-1979-03-31,LT,Lithuania,
-1979-03-31,LU,Luxembourg,
-1979-03-31,LV,Latvia,
-1979-03-31,MA,Morocco,
-1979-03-31,MK,North Macedonia,
-1979-03-31,MT,Malta,
-1979-03-31,MX,Mexico,
-1979-03-31,MY,Malaysia,
-1979-03-31,NL,Netherlands,29.7935
+1979-03-31,KR,Korea,20.4747
+1979-03-31,NL,Netherlands,30.5166
 1979-03-31,NO,Norway,9.8812
-1979-03-31,NZ,New Zealand,7.6292
-1979-03-31,PE,Peru,
-1979-03-31,PH,Philippines,
-1979-03-31,PL,Poland,
-1979-03-31,PT,Portugal,
-1979-03-31,RO,Romania,
-1979-03-31,RS,Serbia,
-1979-03-31,RU,Russia,
+1979-03-31,NZ,New Zealand,7.6305
 1979-03-31,SE,Sweden,16.9078
-1979-03-31,SG,Singapore,
-1979-03-31,SI,Slovenia,
-1979-03-31,SK,Slovak Republic,
-1979-03-31,TH,Thailand,
-1979-03-31,TR,Türkiye,
-1979-03-31,US,United States,25.6005
-1979-03-31,XM,Euro area,20.3514
-1979-03-31,XW,World,
-1979-03-31,ZA,South Africa,3.1135
-1979-06-30,4T,Emerging market economies (aggregate),
-1979-06-30,5R,Advanced economies,
-1979-06-30,AE,United Arab Emirates,
-1979-06-30,AT,Austria,
+1979-03-31,US,United States,25.5604
+1979-03-31,XM,Euro area,20.2921
+1979-03-31,ZA,South Africa,3.1097
 1979-06-30,AU,Australia,9.4648
-1979-06-30,BE,Belgium,23.0074
-1979-06-30,BG,Bulgaria,
-1979-06-30,BR,Brazil,
-1979-06-30,CA,Canada,17.7262
-1979-06-30,CH,Switzerland,39.0635
-1979-06-30,CL,Chile,
-1979-06-30,CN,China,
-1979-06-30,CO,Colombia,
-1979-06-30,CY,Cyprus,
-1979-06-30,CZ,Czechia,
-1979-06-30,DE,Germany,68.4337
+1979-06-30,BE,Belgium,23.2032
+1979-06-30,CA,Canada,17.8637
+1979-06-30,CH,Switzerland,39.062
+1979-06-30,DE,Germany,68.5338
 1979-06-30,DK,Denmark,23.125
-1979-06-30,EE,Estonia,
 1979-06-30,ES,Spain,6.6394
 1979-06-30,FI,Finland,14.6813
 1979-06-30,FR,France,16.8734
-1979-06-30,GB,United Kingdom,9.6665
-1979-06-30,GR,Greece,
-1979-06-30,HK,Hong Kong SAR,
-1979-06-30,HR,Croatia,
-1979-06-30,HU,Hungary,
-1979-06-30,ID,Indonesia,
-1979-06-30,IE,Ireland,13.272
-1979-06-30,IL,Israel,
-1979-06-30,IN,India,
-1979-06-30,IS,Iceland,
+1979-06-30,GB,United Kingdom,9.6633
+1979-06-30,IE,Ireland,13.2743
 1979-06-30,IT,Italy,10.1372
 1979-06-30,JP,Japan,80.1801
-1979-06-30,KR,Korea,21.8962
-1979-06-30,LT,Lithuania,
-1979-06-30,LU,Luxembourg,
-1979-06-30,LV,Latvia,
-1979-06-30,MA,Morocco,
-1979-06-30,MK,North Macedonia,
-1979-06-30,MT,Malta,
-1979-06-30,MX,Mexico,
-1979-06-30,MY,Malaysia,
-1979-06-30,NL,Netherlands,29.9911
+1979-06-30,KR,Korea,21.8954
+1979-06-30,NL,Netherlands,30.7189
 1979-06-30,NO,Norway,10.0017
-1979-06-30,NZ,New Zealand,7.7304
-1979-06-30,PE,Peru,
-1979-06-30,PH,Philippines,
-1979-06-30,PL,Poland,
-1979-06-30,PT,Portugal,
-1979-06-30,RO,Romania,
-1979-06-30,RS,Serbia,
-1979-06-30,RU,Russia,
+1979-06-30,NZ,New Zealand,7.73
 1979-06-30,SE,Sweden,17.8275
-1979-06-30,SG,Singapore,
-1979-06-30,SI,Slovenia,
-1979-06-30,SK,Slovak Republic,
-1979-06-30,TH,Thailand,
-1979-06-30,TR,Türkiye,
-1979-06-30,US,United States,26.747
-1979-06-30,XM,Euro area,21.1082
-1979-06-30,XW,World,
-1979-06-30,ZA,South Africa,3.2153
-1979-09-30,4T,Emerging market economies (aggregate),
-1979-09-30,5R,Advanced economies,
-1979-09-30,AE,United Arab Emirates,
-1979-09-30,AT,Austria,
+1979-06-30,US,United States,26.7056
+1979-06-30,XM,Euro area,21.0437
+1979-06-30,ZA,South Africa,3.2113
 1979-09-30,AU,Australia,9.6746
-1979-09-30,BE,Belgium,23.712
-1979-09-30,BG,Bulgaria,
-1979-09-30,BR,Brazil,
-1979-09-30,CA,Canada,17.645
-1979-09-30,CH,Switzerland,40.6231
-1979-09-30,CL,Chile,
-1979-09-30,CN,China,
-1979-09-30,CO,Colombia,
-1979-09-30,CY,Cyprus,
-1979-09-30,CZ,Czechia,
-1979-09-30,DE,Germany,69.821
+1979-09-30,BE,Belgium,23.9138
+1979-09-30,CA,Canada,17.7818
+1979-09-30,CH,Switzerland,40.6217
+1979-09-30,DE,Germany,69.8472
 1979-09-30,DK,Denmark,23.4784
-1979-09-30,EE,Estonia,
 1979-09-30,ES,Spain,6.7589
 1979-09-30,FI,Finland,14.9506
 1979-09-30,FR,France,17.8616
-1979-09-30,GB,United Kingdom,10.3915
-1979-09-30,GR,Greece,
-1979-09-30,HK,Hong Kong SAR,
-1979-09-30,HR,Croatia,
-1979-09-30,HU,Hungary,
-1979-09-30,ID,Indonesia,
-1979-09-30,IE,Ireland,13.7018
-1979-09-30,IL,Israel,
-1979-09-30,IN,India,
-1979-09-30,IS,Iceland,
+1979-09-30,GB,United Kingdom,10.3881
+1979-09-30,IE,Ireland,13.7042
 1979-09-30,IT,Italy,10.511
 1979-09-30,JP,Japan,82.4039
-1979-09-30,KR,Korea,21.8777
-1979-09-30,LT,Lithuania,
-1979-09-30,LU,Luxembourg,
-1979-09-30,LV,Latvia,
-1979-09-30,MA,Morocco,
-1979-09-30,MK,North Macedonia,
-1979-09-30,MT,Malta,
-1979-09-30,MX,Mexico,
-1979-09-30,MY,Malaysia,
-1979-09-30,NL,Netherlands,29.2084
+1979-09-30,KR,Korea,21.8769
+1979-09-30,NL,Netherlands,29.9172
 1979-09-30,NO,Norway,9.9053
-1979-09-30,NZ,New Zealand,7.8155
-1979-09-30,PE,Peru,
-1979-09-30,PH,Philippines,
-1979-09-30,PL,Poland,
-1979-09-30,PT,Portugal,
-1979-09-30,RO,Romania,
-1979-09-30,RS,Serbia,
-1979-09-30,RU,Russia,
+1979-09-30,NZ,New Zealand,7.8152
 1979-09-30,SE,Sweden,18.4878
-1979-09-30,SG,Singapore,
-1979-09-30,SI,Slovenia,
-1979-09-30,SK,Slovak Republic,
-1979-09-30,TH,Thailand,
-1979-09-30,TR,Türkiye,
-1979-09-30,US,United States,27.7308
-1979-09-30,XM,Euro area,21.5875
-1979-09-30,XW,World,
-1979-09-30,ZA,South Africa,3.3475
-1979-12-31,4T,Emerging market economies (aggregate),
-1979-12-31,5R,Advanced economies,
-1979-12-31,AE,United Arab Emirates,
-1979-12-31,AT,Austria,
+1979-09-30,US,United States,27.6847
+1979-09-30,XM,Euro area,21.5197
+1979-09-30,ZA,South Africa,3.3434
 1979-12-31,AU,Australia,9.8431
-1979-12-31,BE,Belgium,23.5358
-1979-12-31,BG,Bulgaria,
-1979-12-31,BR,Brazil,
-1979-12-31,CA,Canada,18.4257
-1979-12-31,CH,Switzerland,41.8477
-1979-12-31,CL,Chile,
-1979-12-31,CN,China,
-1979-12-31,CO,Colombia,
-1979-12-31,CY,Cyprus,
-1979-12-31,CZ,Czechia,
-1979-12-31,DE,Germany,70.3591
+1979-12-31,BE,Belgium,23.7361
+1979-12-31,CA,Canada,18.5686
+1979-12-31,CH,Switzerland,41.8462
+1979-12-31,DE,Germany,70.2897
 1979-12-31,DK,Denmark,23.4426
-1979-12-31,EE,Estonia,
 1979-12-31,ES,Spain,6.6921
 1979-12-31,FI,Finland,15.5486
 1979-12-31,FR,France,18.4953
-1979-12-31,GB,United Kingdom,11.0561
-1979-12-31,GR,Greece,
+1979-12-31,GB,United Kingdom,11.0524
 1979-12-31,HK,Hong Kong SAR,10.9338
-1979-12-31,HR,Croatia,
-1979-12-31,HU,Hungary,
-1979-12-31,ID,Indonesia,
-1979-12-31,IE,Ireland,13.6319
-1979-12-31,IL,Israel,
-1979-12-31,IN,India,
-1979-12-31,IS,Iceland,
+1979-12-31,IE,Ireland,13.6343
 1979-12-31,IT,Italy,10.9838
 1979-12-31,JP,Japan,85.1443
-1979-12-31,KR,Korea,21.5513
-1979-12-31,LT,Lithuania,
-1979-12-31,LU,Luxembourg,
-1979-12-31,LV,Latvia,
-1979-12-31,MA,Morocco,
-1979-12-31,MK,North Macedonia,
-1979-12-31,MT,Malta,
-1979-12-31,MX,Mexico,
-1979-12-31,MY,Malaysia,
-1979-12-31,NL,Netherlands,28.4218
+1979-12-31,KR,Korea,21.5505
+1979-12-31,NL,Netherlands,29.1116
 1979-12-31,NO,Norway,9.9595
-1979-12-31,NZ,New Zealand,7.9127
-1979-12-31,PE,Peru,
-1979-12-31,PH,Philippines,
-1979-12-31,PL,Poland,
-1979-12-31,PT,Portugal,
-1979-12-31,RO,Romania,
-1979-12-31,RS,Serbia,
-1979-12-31,RU,Russia,
+1979-12-31,NZ,New Zealand,7.9147
 1979-12-31,SE,Sweden,18.3395
-1979-12-31,SG,Singapore,
-1979-12-31,SI,Slovenia,
-1979-12-31,SK,Slovak Republic,
-1979-12-31,TH,Thailand,
-1979-12-31,TR,Türkiye,
-1979-12-31,US,United States,28.7182
-1979-12-31,XM,Euro area,21.7002
-1979-12-31,XW,World,
-1979-12-31,ZA,South Africa,3.4798
-1980-03-31,4T,Emerging market economies (aggregate),
-1980-03-31,5R,Advanced economies,
-1980-03-31,AE,United Arab Emirates,
-1980-03-31,AT,Austria,
+1979-12-31,US,United States,28.6645
+1979-12-31,XM,Euro area,21.6288
+1979-12-31,ZA,South Africa,3.4755
 1980-03-31,AU,Australia,10.0624
-1980-03-31,BE,Belgium,24.1932
-1980-03-31,BG,Bulgaria,
-1980-03-31,BR,Brazil,
-1980-03-31,CA,Canada,18.6965
-1980-03-31,CH,Switzerland,43.5615
-1980-03-31,CL,Chile,
-1980-03-31,CN,China,
-1980-03-31,CO,Colombia,
-1980-03-31,CY,Cyprus,
-1980-03-31,CZ,Czechia,
-1980-03-31,DE,Germany,71.6589
+1980-03-31,BE,Belgium,24.3991
+1980-03-31,CA,Canada,18.8414
+1980-03-31,CH,Switzerland,43.5599
+1980-03-31,DE,Germany,71.6182
 1980-03-31,DK,Denmark,23.0218
-1980-03-31,EE,Estonia,
 1980-03-31,ES,Spain,6.9732
 1980-03-31,FI,Finland,16.3763
 1980-03-31,FR,France,19.2416
-1980-03-31,GB,United Kingdom,11.5394
-1980-03-31,GR,Greece,
+1980-03-31,GB,United Kingdom,11.5356
 1980-03-31,HK,Hong Kong SAR,12.1928
-1980-03-31,HR,Croatia,
-1980-03-31,HU,Hungary,
-1980-03-31,ID,Indonesia,
-1980-03-31,IE,Ireland,14.572
-1980-03-31,IL,Israel,
-1980-03-31,IN,India,
-1980-03-31,IS,Iceland,
+1980-03-31,IE,Ireland,14.5745
 1980-03-31,IT,Italy,11.7644
 1980-03-31,JP,Japan,87.8847
-1980-03-31,KR,Korea,23.1295
-1980-03-31,LT,Lithuania,
-1980-03-31,LU,Luxembourg,
-1980-03-31,LV,Latvia,
-1980-03-31,MA,Morocco,
-1980-03-31,MK,North Macedonia,
-1980-03-31,MT,Malta,
-1980-03-31,MX,Mexico,
-1980-03-31,MY,Malaysia,
-1980-03-31,NL,Netherlands,28.0913
+1980-03-31,KR,Korea,23.1287
+1980-03-31,NL,Netherlands,28.773
 1980-03-31,NO,Norway,9.7788
 1980-03-31,NZ,New Zealand,8.0882
-1980-03-31,PE,Peru,
-1980-03-31,PH,Philippines,
-1980-03-31,PL,Poland,
-1980-03-31,PT,Portugal,
-1980-03-31,RO,Romania,
-1980-03-31,RS,Serbia,
-1980-03-31,RU,Russia,
 1980-03-31,SE,Sweden,18.1374
-1980-03-31,SG,Singapore,
-1980-03-31,SI,Slovenia,
-1980-03-31,SK,Slovak Republic,
-1980-03-31,TH,Thailand,
-1980-03-31,TR,Türkiye,
-1980-03-31,US,United States,29.3484
-1980-03-31,XM,Euro area,22.1651
-1980-03-31,XW,World,
-1980-03-31,ZA,South Africa,3.6121
-1980-06-30,4T,Emerging market economies (aggregate),
-1980-06-30,5R,Advanced economies,
-1980-06-30,AE,United Arab Emirates,
-1980-06-30,AT,Austria,
+1980-03-31,US,United States,29.3129
+1980-03-31,XM,Euro area,22.0889
+1980-03-31,ZA,South Africa,3.6077
 1980-06-30,AU,Australia,10.5772
-1980-06-30,BE,Belgium,23.5831
-1980-06-30,BG,Bulgaria,
-1980-06-30,BR,Brazil,
-1980-06-30,CA,Canada,19.4546
-1980-06-30,CH,Switzerland,42.8488
-1980-06-30,CL,Chile,
-1980-06-30,CN,China,
-1980-06-30,CO,Colombia,
-1980-06-30,CY,Cyprus,
-1980-06-30,CZ,Czechia,
-1980-06-30,DE,Germany,73.3817
+1980-06-30,BE,Belgium,23.7838
+1980-06-30,CA,Canada,19.6055
+1980-06-30,CH,Switzerland,42.8472
+1980-06-30,DE,Germany,73.4531
 1980-06-30,DK,Denmark,22.3191
-1980-06-30,EE,Estonia,
 1980-06-30,ES,Spain,7.0785
 1980-06-30,FI,Finland,16.8674
 1980-06-30,FR,France,20.3799
-1980-06-30,GB,United Kingdom,11.9623
-1980-06-30,GR,Greece,
+1980-06-30,GB,United Kingdom,11.9583
 1980-06-30,HK,Hong Kong SAR,12.1928
-1980-06-30,HR,Croatia,
-1980-06-30,HU,Hungary,
-1980-06-30,ID,Indonesia,
-1980-06-30,IE,Ireland,14.9389
-1980-06-30,IL,Israel,
-1980-06-30,IN,India,
-1980-06-30,IS,Iceland,
+1980-06-30,IE,Ireland,14.9415
 1980-06-30,IT,Italy,13.0453
 1980-06-30,JP,Japan,90.7693
-1980-06-30,KR,Korea,23.978
-1980-06-30,LT,Lithuania,
-1980-06-30,LU,Luxembourg,
-1980-06-30,LV,Latvia,
-1980-06-30,MA,Morocco,
-1980-06-30,MK,North Macedonia,
-1980-06-30,MT,Malta,
-1980-06-30,MX,Mexico,
-1980-06-30,MY,Malaysia,
-1980-06-30,NL,Netherlands,27.8405
+1980-06-30,KR,Korea,23.9772
+1980-06-30,NL,Netherlands,28.5161
 1980-06-30,NO,Norway,10.5197
 1980-06-30,NZ,New Zealand,8.3446
-1980-06-30,PE,Peru,
-1980-06-30,PH,Philippines,
-1980-06-30,PL,Poland,
-1980-06-30,PT,Portugal,
-1980-06-30,RO,Romania,
-1980-06-30,RS,Serbia,
-1980-06-30,RU,Russia,
 1980-06-30,SE,Sweden,18.4305
-1980-06-30,SG,Singapore,
-1980-06-30,SI,Slovenia,
-1980-06-30,SK,Slovak Republic,
-1980-06-30,TH,Thailand,
-1980-06-30,TR,Türkiye,
-1980-06-30,US,United States,29.7281
-1980-06-30,XM,Euro area,23.1109
-1980-06-30,XW,World,
-1980-06-30,ZA,South Africa,3.8563
-1980-09-30,4T,Emerging market economies (aggregate),
-1980-09-30,5R,Advanced economies,
-1980-09-30,AE,United Arab Emirates,
-1980-09-30,AT,Austria,
+1980-06-30,US,United States,29.6857
+1980-06-30,XM,Euro area,23.0333
+1980-06-30,ZA,South Africa,3.8516
 1980-09-30,AU,Australia,10.9141
-1980-09-30,BE,Belgium,23.4757
-1980-09-30,BG,Bulgaria,
-1980-09-30,BR,Brazil,
-1980-09-30,CA,Canada,20.2534
-1980-09-30,CH,Switzerland,43.7936
-1980-09-30,CL,Chile,
-1980-09-30,CN,China,
-1980-09-30,CO,Colombia,
-1980-09-30,CY,Cyprus,
-1980-09-30,CZ,Czechia,
-1980-09-30,DE,Germany,74.3549
+1980-09-30,BE,Belgium,23.6755
+1980-09-30,CA,Canada,20.4104
+1980-09-30,CH,Switzerland,43.792
+1980-09-30,DE,Germany,74.3696
 1980-09-30,DK,Denmark,22.7042
-1980-09-30,EE,Estonia,
 1980-09-30,ES,Spain,7.061
 1980-09-30,FI,Finland,17.5249
 1980-09-30,FR,France,21.6348
-1980-09-30,GB,United Kingdom,12.4456
-1980-09-30,GR,Greece,
+1980-09-30,GB,United Kingdom,12.4415
 1980-09-30,HK,Hong Kong SAR,13.4519
-1980-09-30,HR,Croatia,
-1980-09-30,HU,Hungary,
-1980-09-30,ID,Indonesia,
-1980-09-30,IE,Ireland,16.2773
-1980-09-30,IL,Israel,
-1980-09-30,IN,India,
-1980-09-30,IS,Iceland,
+1980-09-30,IE,Ireland,16.2801
 1980-09-30,IT,Italy,14.5351
 1980-09-30,JP,Japan,93.6539
-1980-09-30,KR,Korea,24.0642
-1980-09-30,LT,Lithuania,
-1980-09-30,LU,Luxembourg,
-1980-09-30,LV,Latvia,
-1980-09-30,MA,Morocco,
-1980-09-30,MK,North Macedonia,
-1980-09-30,MT,Malta,
-1980-09-30,MX,Mexico,
-1980-09-30,MY,Malaysia,
-1980-09-30,NL,Netherlands,25.9444
+1980-09-30,KR,Korea,24.0634
+1980-09-30,NL,Netherlands,26.574
 1980-09-30,NO,Norway,11.2515
 1980-09-30,NZ,New Zealand,8.6218
-1980-09-30,PE,Peru,
-1980-09-30,PH,Philippines,
-1980-09-30,PL,Poland,
-1980-09-30,PT,Portugal,
-1980-09-30,RO,Romania,
-1980-09-30,RS,Serbia,
-1980-09-30,RU,Russia,
 1980-09-30,SE,Sweden,18.7067
-1980-09-30,SG,Singapore,
-1980-09-30,SI,Slovenia,
-1980-09-30,SK,Slovak Republic,
-1980-09-30,TH,Thailand,
-1980-09-30,TR,Türkiye,
-1980-09-30,US,United States,30.6734
-1980-09-30,XM,Euro area,24.4337
-1980-09-30,XW,World,
-1980-09-30,ZA,South Africa,4.2124
-1980-12-31,4T,Emerging market economies (aggregate),
-1980-12-31,5R,Advanced economies,
-1980-12-31,AE,United Arab Emirates,
-1980-12-31,AT,Austria,
+1980-09-30,US,United States,30.6343
+1980-09-30,XM,Euro area,24.3507
+1980-09-30,ZA,South Africa,4.2072
 1980-12-31,AU,Australia,11.2828
-1980-12-31,BE,Belgium,22.5863
-1980-12-31,BG,Bulgaria,
-1980-12-31,BR,Brazil,
-1980-12-31,CA,Canada,21.535
-1980-12-31,CH,Switzerland,44.6184
-1980-12-31,CL,Chile,
-1980-12-31,CN,China,
-1980-12-31,CO,Colombia,
-1980-12-31,CY,Cyprus,
-1980-12-31,CZ,Czechia,
-1980-12-31,DE,Germany,75.6989
+1980-12-31,BE,Belgium,22.7785
+1980-12-31,CA,Canada,21.702
+1980-12-31,CH,Switzerland,44.6167
+1980-12-31,DE,Germany,75.6538
 1980-12-31,DK,Denmark,22.74
-1980-12-31,EE,Estonia,
 1980-12-31,ES,Spain,6.9661
 1980-12-31,FI,Finland,17.6833
 1980-12-31,FR,France,21.9517
-1980-12-31,GB,United Kingdom,12.5061
-1980-12-31,GR,Greece,
+1980-12-31,GB,United Kingdom,12.5019
 1980-12-31,HK,Hong Kong SAR,14.8434
-1980-12-31,HR,Croatia,
-1980-12-31,HU,Hungary,
-1980-12-31,ID,Indonesia,
-1980-12-31,IE,Ireland,17.06
-1980-12-31,IL,Israel,
-1980-12-31,IN,India,
-1980-12-31,IS,Iceland,
+1980-12-31,IE,Ireland,17.063
 1980-12-31,IT,Italy,15.9149
 1980-12-31,JP,Japan,96.1539
-1980-12-31,KR,Korea,24.6553
-1980-12-31,LT,Lithuania,
-1980-12-31,LU,Luxembourg,
-1980-12-31,LV,Latvia,
-1980-12-31,MA,Morocco,
-1980-12-31,MK,North Macedonia,
-1980-12-31,MT,Malta,
-1980-12-31,MX,Mexico,
-1980-12-31,MY,Malaysia,
-1980-12-31,NL,Netherlands,25.8532
+1980-12-31,KR,Korea,24.6545
+1980-12-31,NL,Netherlands,26.4806
 1980-12-31,NO,Norway,11.887
 1980-12-31,NZ,New Zealand,8.8921
-1980-12-31,PE,Peru,
-1980-12-31,PH,Philippines,
-1980-12-31,PL,Poland,
-1980-12-31,PT,Portugal,
-1980-12-31,RO,Romania,
-1980-12-31,RS,Serbia,
-1980-12-31,RU,Russia,
 1980-12-31,SE,Sweden,18.1947
-1980-12-31,SG,Singapore,
-1980-12-31,SI,Slovenia,
-1980-12-31,SK,Slovak Republic,
-1980-12-31,TH,Thailand,
-1980-12-31,TR,Türkiye,
-1980-12-31,US,United States,31.3109
-1980-12-31,XM,Euro area,25.4279
-1980-12-31,XW,World,
-1980-12-31,ZA,South Africa,4.6092
-1981-03-31,4T,Emerging market economies (aggregate),
-1981-03-31,5R,Advanced economies,
-1981-03-31,AE,United Arab Emirates,
-1981-03-31,AT,Austria,
+1980-12-31,US,United States,31.2776
+1980-12-31,XM,Euro area,25.3435
+1980-12-31,ZA,South Africa,4.6036
 1981-03-31,AU,Australia,12.0011
-1981-03-31,BE,Belgium,22.4918
-1981-03-31,BG,Bulgaria,
-1981-03-31,BR,Brazil,
-1981-03-31,CA,Canada,22.3563
-1981-03-31,CH,Switzerland,46.4741
-1981-03-31,CL,Chile,
-1981-03-31,CN,China,
-1981-03-31,CO,Colombia,
-1981-03-31,CY,Cyprus,
-1981-03-31,CZ,Czechia,
-1981-03-31,DE,Germany,77.0321
+1981-03-31,BE,Belgium,22.6832
+1981-03-31,CA,Canada,22.5297
+1981-03-31,CH,Switzerland,46.4724
+1981-03-31,DE,Germany,76.9282
 1981-03-31,DK,Denmark,22.601
-1981-03-31,EE,Estonia,
 1981-03-31,ES,Spain,7.191
 1981-03-31,FI,Finland,18.816
 1981-03-31,FR,France,22.1644
-1981-03-31,GB,United Kingdom,12.5061
-1981-03-31,GR,Greece,
+1981-03-31,GB,United Kingdom,12.5019
 1981-03-31,HK,Hong Kong SAR,16.1025
-1981-03-31,HR,Croatia,
-1981-03-31,HU,Hungary,
-1981-03-31,ID,Indonesia,
-1981-03-31,IE,Ireland,17.2837
-1981-03-31,IL,Israel,
-1981-03-31,IN,India,
-1981-03-31,IS,Iceland,
+1981-03-31,IE,Ireland,17.2867
+1981-03-31,IS,Iceland,2.2024
 1981-03-31,IT,Italy,17.1793
 1981-03-31,JP,Japan,98.6539
-1981-03-31,KR,Korea,25.0576
-1981-03-31,LT,Lithuania,
-1981-03-31,LU,Luxembourg,
-1981-03-31,LV,Latvia,
-1981-03-31,MA,Morocco,
-1981-03-31,MK,North Macedonia,
-1981-03-31,MT,Malta,
-1981-03-31,MX,Mexico,
-1981-03-31,MY,Malaysia,
-1981-03-31,NL,Netherlands,25.9596
+1981-03-31,KR,Korea,25.0567
+1981-03-31,NL,Netherlands,26.5896
 1981-03-31,NO,Norway,12.6791
 1981-03-31,NZ,New Zealand,9.2595
-1981-03-31,PE,Peru,
-1981-03-31,PH,Philippines,
-1981-03-31,PL,Poland,
-1981-03-31,PT,Portugal,
-1981-03-31,RO,Romania,
-1981-03-31,RS,Serbia,
-1981-03-31,RU,Russia,
 1981-03-31,SE,Sweden,18.3025
-1981-03-31,SG,Singapore,
-1981-03-31,SI,Slovenia,
-1981-03-31,SK,Slovak Republic,
-1981-03-31,TH,Thailand,
-1981-03-31,TR,Türkiye,
-1981-03-31,US,United States,31.9048
-1981-03-31,XM,Euro area,26.5625
-1981-03-31,XW,World,
-1981-03-31,ZA,South Africa,5.006
-1981-06-30,4T,Emerging market economies (aggregate),
-1981-06-30,5R,Advanced economies,
-1981-06-30,AE,United Arab Emirates,
-1981-06-30,AT,Austria,
+1981-03-31,US,United States,31.8549
+1981-03-31,XM,Euro area,26.4817
+1981-03-31,ZA,South Africa,4.9999
 1981-06-30,AU,Australia,12.3952
-1981-06-30,BE,Belgium,22.2125
-1981-06-30,BG,Bulgaria,
-1981-06-30,BR,Brazil,
-1981-06-30,CA,Canada,22.5278
-1981-06-30,CH,Switzerland,47.8015
-1981-06-30,CL,Chile,
-1981-06-30,CN,China,
-1981-06-30,CO,Colombia,
-1981-06-30,CY,Cyprus,
-1981-06-30,CZ,Czechia,
-1981-06-30,DE,Germany,79.2917
+1981-06-30,BE,Belgium,22.4016
+1981-06-30,CA,Canada,22.7025
+1981-06-30,CH,Switzerland,47.7997
+1981-06-30,DE,Germany,79.3364
 1981-06-30,DK,Denmark,21.6879
-1981-06-30,EE,Estonia,
 1981-06-30,ES,Spain,7.4017
 1981-06-30,FI,Finland,19.208
 1981-06-30,FR,France,22.8273
-1981-06-30,GB,United Kingdom,12.8686
-1981-06-30,GR,Greece,
+1981-06-30,GB,United Kingdom,12.8643
 1981-06-30,HK,Hong Kong SAR,16.1688
-1981-06-30,HR,Croatia,
-1981-06-30,HU,Hungary,
-1981-06-30,ID,Indonesia,
-1981-06-30,IE,Ireland,17.4165
-1981-06-30,IL,Israel,
-1981-06-30,IN,India,
-1981-06-30,IS,Iceland,
+1981-06-30,IE,Ireland,17.4195
+1981-06-30,IS,Iceland,2.4434
 1981-06-30,IT,Italy,18.2788
 1981-06-30,JP,Japan,100.9966
-1981-06-30,KR,Korea,25.4661
-1981-06-30,LT,Lithuania,
-1981-06-30,LU,Luxembourg,
-1981-06-30,LV,Latvia,
-1981-06-30,MA,Morocco,
-1981-06-30,MK,North Macedonia,
-1981-06-30,MT,Malta,
-1981-06-30,MX,Mexico,
-1981-06-30,MY,Malaysia,
-1981-06-30,NL,Netherlands,24.9033
+1981-06-30,KR,Korea,25.4652
+1981-06-30,NL,Netherlands,25.5077
 1981-06-30,NO,Norway,13.8867
 1981-06-30,NZ,New Zealand,10.0565
-1981-06-30,PE,Peru,
-1981-06-30,PH,Philippines,
-1981-06-30,PL,Poland,
-1981-06-30,PT,Portugal,
-1981-06-30,RO,Romania,
-1981-06-30,RS,Serbia,
-1981-06-30,RU,Russia,
 1981-06-30,SE,Sweden,18.4305
-1981-06-30,SG,Singapore,
-1981-06-30,SI,Slovenia,
-1981-06-30,SK,Slovak Republic,
-1981-06-30,TH,Thailand,
-1981-06-30,TR,Türkiye,
-1981-06-30,US,United States,32.294
-1981-06-30,XM,Euro area,27.3825
-1981-06-30,XW,World,
-1981-06-30,ZA,South Africa,5.4334
-1981-09-30,4T,Emerging market economies (aggregate),
-1981-09-30,5R,Advanced economies,
-1981-09-30,AE,United Arab Emirates,
-1981-09-30,AT,Austria,
+1981-06-30,US,United States,32.2553
+1981-06-30,XM,Euro area,27.3022
+1981-06-30,ZA,South Africa,5.4267
 1981-09-30,AU,Australia,12.1632
-1981-09-30,BE,Belgium,22.1782
-1981-09-30,BG,Bulgaria,
-1981-09-30,BR,Brazil,
-1981-09-30,CA,Canada,23.101
-1981-09-30,CH,Switzerland,48.1663
-1981-09-30,CL,Chile,
-1981-09-30,CN,China,
-1981-09-30,CO,Colombia,
-1981-09-30,CY,Cyprus,
-1981-09-30,CZ,Czechia,
-1981-09-30,DE,Germany,79.8995
+1981-09-30,BE,Belgium,22.3669
+1981-09-30,CA,Canada,23.2801
+1981-09-30,CH,Switzerland,48.1645
+1981-09-30,DE,Germany,79.9948
 1981-09-30,DK,Denmark,20.9177
-1981-09-30,EE,Estonia,
 1981-09-30,ES,Spain,7.3174
 1981-09-30,FI,Finland,20.016
 1981-09-30,FR,France,23.657
-1981-09-30,GB,United Kingdom,13.0498
-1981-09-30,GR,Greece,
+1981-09-30,GB,United Kingdom,13.0455
 1981-09-30,HK,Hong Kong SAR,16.3013
-1981-09-30,HR,Croatia,
-1981-09-30,HU,Hungary,
-1981-09-30,ID,Indonesia,
-1981-09-30,IE,Ireland,18.657
-1981-09-30,IL,Israel,
-1981-09-30,IN,India,
-1981-09-30,IS,Iceland,
+1981-09-30,IE,Ireland,18.6603
+1981-09-30,IS,Iceland,2.9426
 1981-09-30,IT,Italy,19.0759
 1981-09-30,JP,Japan,103.3654
-1981-09-30,KR,Korea,26.3308
-1981-09-30,LT,Lithuania,
-1981-09-30,LU,Luxembourg,
-1981-09-30,LV,Latvia,
-1981-09-30,MA,Morocco,
-1981-09-30,MK,North Macedonia,
-1981-09-30,MT,Malta,
-1981-09-30,MX,Mexico,
-1981-09-30,MY,Malaysia,
-1981-09-30,NL,Netherlands,23.733
+1981-09-30,KR,Korea,26.3299
+1981-09-30,NL,Netherlands,24.3089
 1981-09-30,NO,Norway,14.6969
 1981-09-30,NZ,New Zealand,10.8189
-1981-09-30,PE,Peru,
-1981-09-30,PH,Philippines,
-1981-09-30,PL,Poland,
-1981-09-30,PT,Portugal,
-1981-09-30,RO,Romania,
-1981-09-30,RS,Serbia,
-1981-09-30,RU,Russia,
 1981-09-30,SE,Sweden,18.2284
-1981-09-30,SG,Singapore,
-1981-09-30,SI,Slovenia,
-1981-09-30,SK,Slovak Republic,
-1981-09-30,TH,Thailand,
-1981-09-30,TR,Türkiye,
-1981-09-30,US,United States,32.6055
-1981-09-30,XM,Euro area,27.5287
-1981-09-30,XW,World,
-1981-09-30,ZA,South Africa,5.8607
-1981-12-31,4T,Emerging market economies (aggregate),
-1981-12-31,5R,Advanced economies,
-1981-12-31,AE,United Arab Emirates,
-1981-12-31,AT,Austria,
+1981-09-30,US,United States,32.5534
+1981-09-30,XM,Euro area,27.4394
+1981-09-30,ZA,South Africa,5.8535
 1981-12-31,AU,Australia,12.7384
-1981-12-31,BE,Belgium,21.8602
-1981-12-31,BG,Bulgaria,
-1981-12-31,BR,Brazil,
-1981-12-31,CA,Canada,23.4304
-1981-12-31,CH,Switzerland,48.9596
-1981-12-31,CL,Chile,
-1981-12-31,CN,China,
-1981-12-31,CO,Colombia,
-1981-12-31,CY,Cyprus,
-1981-12-31,CZ,Czechia,
-1981-12-31,DE,Germany,79.6541
+1981-12-31,BE,Belgium,22.0463
+1981-12-31,CA,Canada,23.612
+1981-12-31,CH,Switzerland,48.9578
+1981-12-31,DE,Germany,79.6162
 1981-12-31,DK,Denmark,21.3028
-1981-12-31,EE,Estonia,
 1981-12-31,ES,Spain,7.1312
 1981-12-31,FI,Finland,20.4754
 1981-12-31,FR,France,23.6945
-1981-12-31,GB,United Kingdom,12.8081
-1981-12-31,GR,Greece,
+1981-12-31,GB,United Kingdom,12.8039
 1981-12-31,HK,Hong Kong SAR,15.97
-1981-12-31,HR,Croatia,
-1981-12-31,HU,Hungary,
-1981-12-31,ID,Indonesia,
-1981-12-31,IE,Ireland,19.1637
-1981-12-31,IL,Israel,
-1981-12-31,IN,India,
-1981-12-31,IS,Iceland,
+1981-12-31,IE,Ireland,19.1671
+1981-12-31,IS,Iceland,3.1939
 1981-12-31,IT,Italy,19.4772
 1981-12-31,JP,Japan,105.4808
-1981-12-31,KR,Korea,26.1486
-1981-12-31,LT,Lithuania,
-1981-12-31,LU,Luxembourg,
-1981-12-31,LV,Latvia,
-1981-12-31,MA,Morocco,
-1981-12-31,MK,North Macedonia,
-1981-12-31,MT,Malta,
-1981-12-31,MX,Mexico,
-1981-12-31,MY,Malaysia,
-1981-12-31,NL,Netherlands,22.3119
+1981-12-31,KR,Korea,26.1477
+1981-12-31,NL,Netherlands,22.8534
 1981-12-31,NO,Norway,15.254
 1981-12-31,NZ,New Zealand,11.6991
-1981-12-31,PE,Peru,
-1981-12-31,PH,Philippines,
-1981-12-31,PL,Poland,
-1981-12-31,PT,Portugal,
-1981-12-31,RO,Romania,
-1981-12-31,RS,Serbia,
-1981-12-31,RU,Russia,
 1981-12-31,SE,Sweden,17.8275
-1981-12-31,SG,Singapore,
-1981-12-31,SI,Slovenia,
-1981-12-31,SK,Slovak Republic,
-1981-12-31,TH,Thailand,
-1981-12-31,TR,Türkiye,
-1981-12-31,US,United States,32.9816
-1981-12-31,XM,Euro area,27.5188
-1981-12-31,XW,World,
-1981-12-31,ZA,South Africa,6.2169
-1982-03-31,4T,Emerging market economies (aggregate),
-1982-03-31,5R,Advanced economies,
-1982-03-31,AE,United Arab Emirates,
-1982-03-31,AT,Austria,
+1981-12-31,US,United States,32.9472
+1981-12-31,XM,Euro area,27.4263
+1981-12-31,ZA,South Africa,6.2092
 1982-03-31,AU,Australia,12.6018
-1982-03-31,BE,Belgium,21.1599
-1982-03-31,BG,Bulgaria,
-1982-03-31,BR,Brazil,
-1982-03-31,CA,Canada,22.4782
-1982-03-31,CH,Switzerland,50.1957
-1982-03-31,CL,Chile,
-1982-03-31,CN,China,
-1982-03-31,CO,Colombia,
-1982-03-31,CY,Cyprus,
-1982-03-31,CZ,Czechia,
-1982-03-31,DE,Germany,79.6662
+1982-03-31,BE,Belgium,21.34
+1982-03-31,CA,Canada,22.6525
+1982-03-31,CH,Switzerland,50.1939
+1982-03-31,DE,Germany,79.7476
 1982-03-31,DK,Denmark,21.1282
-1982-03-31,EE,Estonia,
 1982-03-31,ES,Spain,7.3104
 1982-03-31,FI,Finland,22.1744
 1982-03-31,FR,France,23.5986
-1982-03-31,GB,United Kingdom,12.5061
-1982-03-31,GR,Greece,
+1982-03-31,GB,United Kingdom,12.5019
 1982-03-31,HK,Hong Kong SAR,14.9097
-1982-03-31,HR,Croatia,
-1982-03-31,HU,Hungary,
-1982-03-31,ID,Indonesia,
-1982-03-31,IE,Ireland,19.3244
-1982-03-31,IL,Israel,
-1982-03-31,IN,India,
-1982-03-31,IS,Iceland,
+1982-03-31,IE,Ireland,19.3278
+1982-03-31,IS,Iceland,3.8258
 1982-03-31,IT,Italy,19.8071
 1982-03-31,JP,Japan,107.5962
-1982-03-31,KR,Korea,26.2149
-1982-03-31,LT,Lithuania,
-1982-03-31,LU,Luxembourg,
-1982-03-31,LV,Latvia,
-1982-03-31,MA,Morocco,
-1982-03-31,MK,North Macedonia,
-1982-03-31,MT,Malta,
-1982-03-31,MX,Mexico,
-1982-03-31,MY,Malaysia,
-1982-03-31,NL,Netherlands,21.685
+1982-03-31,KR,Korea,26.214
+1982-03-31,NL,Netherlands,22.2112
 1982-03-31,NO,Norway,16.2931
 1982-03-31,NZ,New Zealand,12.6971
-1982-03-31,PE,Peru,
-1982-03-31,PH,Philippines,
-1982-03-31,PL,Poland,
-1982-03-31,PT,Portugal,
-1982-03-31,RO,Romania,
-1982-03-31,RS,Serbia,
-1982-03-31,RU,Russia,
 1982-03-31,SE,Sweden,18.0296
-1982-03-31,SG,Singapore,
-1982-03-31,SI,Slovenia,
-1982-03-31,SK,Slovak Republic,
-1982-03-31,TH,Thailand,
-1982-03-31,TR,Türkiye,
-1982-03-31,US,United States,33.1282
-1982-03-31,XM,Euro area,27.8185
-1982-03-31,XW,World,
-1982-03-31,ZA,South Africa,6.4712
-1982-06-30,4T,Emerging market economies (aggregate),
-1982-06-30,5R,Advanced economies,
-1982-06-30,AE,United Arab Emirates,
-1982-06-30,AT,Austria,
+1982-03-31,US,United States,33.0763
+1982-03-31,XM,Euro area,27.7277
+1982-03-31,ZA,South Africa,6.4633
 1982-06-30,AU,Australia,12.9895
-1982-06-30,BE,Belgium,21.0052
-1982-06-30,BG,Bulgaria,
-1982-06-30,BR,Brazil,
-1982-06-30,CA,Canada,21.535
-1982-06-30,CH,Switzerland,49.7483
-1982-06-30,CL,Chile,
-1982-06-30,CN,China,
-1982-06-30,CO,Colombia,
-1982-06-30,CY,Cyprus,
-1982-06-30,CZ,Czechia,
-1982-06-30,DE,Germany,79.7649
+1982-06-30,BE,Belgium,21.184
+1982-06-30,CA,Canada,21.702
+1982-06-30,CH,Switzerland,49.7465
+1982-06-30,DE,Germany,79.7546
 1982-06-30,DK,Denmark,21.3028
-1982-06-30,EE,Estonia,
 1982-06-30,ES,Spain,7.4369
 1982-06-30,FI,Finland,22.8397
 1982-06-30,FR,France,24.1281
-1982-06-30,GB,United Kingdom,13.0498
-1982-06-30,GR,Greece,
+1982-06-30,GB,United Kingdom,13.0455
 1982-06-30,HK,Hong Kong SAR,14.3796
-1982-06-30,HR,Croatia,
-1982-06-30,HU,Hungary,
-1982-06-30,ID,Indonesia,
-1982-06-30,IE,Ireland,19.3699
-1982-06-30,IL,Israel,
-1982-06-30,IN,India,
-1982-06-30,IS,Iceland,
+1982-06-30,IE,Ireland,19.3733
+1982-06-30,IS,Iceland,4.4436
 1982-06-30,IT,Italy,20.4008
 1982-06-30,JP,Japan,109.3174
-1982-06-30,KR,Korea,26.4779
-1982-06-30,LT,Lithuania,
-1982-06-30,LU,Luxembourg,
-1982-06-30,LV,Latvia,
-1982-06-30,MA,Morocco,
-1982-06-30,MK,North Macedonia,
-1982-06-30,MT,Malta,
-1982-06-30,MX,Mexico,
-1982-06-30,MY,Malaysia,
-1982-06-30,NL,Netherlands,21.5558
+1982-06-30,KR,Korea,26.4769
+1982-06-30,NL,Netherlands,22.0789
 1982-06-30,NO,Norway,17.3923
 1982-06-30,NZ,New Zealand,13.7644
-1982-06-30,PE,Peru,
-1982-06-30,PH,Philippines,
-1982-06-30,PL,Poland,
-1982-06-30,PT,Portugal,
-1982-06-30,RO,Romania,
-1982-06-30,RS,Serbia,
-1982-06-30,RU,Russia,
 1982-06-30,SE,Sweden,18.4878
-1982-06-30,SG,Singapore,
-1982-06-30,SI,Slovenia,
-1982-06-30,SK,Slovak Republic,
-1982-06-30,TH,Thailand,
-1982-06-30,TR,Türkiye,
-1982-06-30,US,United States,33.1841
-1982-06-30,XM,Euro area,28.1728
-1982-06-30,XW,World,
-1982-06-30,ZA,South Africa,6.6849
-1982-09-30,4T,Emerging market economies (aggregate),
-1982-09-30,5R,Advanced economies,
-1982-09-30,AE,United Arab Emirates,
-1982-09-30,AT,Austria,
+1982-06-30,US,United States,33.1466
+1982-06-30,XM,Euro area,28.0847
+1982-06-30,ZA,South Africa,6.6767
 1982-09-30,AU,Australia,12.7607
-1982-09-30,BE,Belgium,21.8516
-1982-09-30,BG,Bulgaria,
-1982-09-30,BR,Brazil,
-1982-09-30,CA,Canada,21.1289
-1982-09-30,CH,Switzerland,50.1007
-1982-09-30,CL,Chile,
-1982-09-30,CN,China,
-1982-09-30,CO,Colombia,
-1982-09-30,CY,Cyprus,
-1982-09-30,CZ,Czechia,
-1982-09-30,DE,Germany,79.7468
+1982-09-30,BE,Belgium,22.0376
+1982-09-30,CA,Canada,21.2927
+1982-09-30,CH,Switzerland,50.0988
+1982-09-30,DE,Germany,79.7749
 1982-09-30,DK,Denmark,20.8145
-1982-09-30,EE,Estonia,
 1982-09-30,ES,Spain,7.5247
 1982-09-30,FI,Finland,23.4813
 1982-09-30,FR,France,24.912
-1982-09-30,GB,United Kingdom,13.3519
-1982-09-30,GR,Greece,
+1982-09-30,GB,United Kingdom,13.3474
 1982-09-30,HK,Hong Kong SAR,13.6507
-1982-09-30,HR,Croatia,
-1982-09-30,HU,Hungary,
-1982-09-30,ID,Indonesia,
-1982-09-30,IE,Ireland,19.9709
-1982-09-30,IL,Israel,
-1982-09-30,IN,India,
-1982-09-30,IS,Iceland,
+1982-09-30,IE,Ireland,19.9744
+1982-09-30,IS,Iceland,5.1954
 1982-09-30,IT,Italy,20.9725
 1982-09-30,JP,Japan,111.0577
-1982-09-30,KR,Korea,27.3326
-1982-09-30,LT,Lithuania,
-1982-09-30,LU,Luxembourg,
-1982-09-30,LV,Latvia,
-1982-09-30,MA,Morocco,
-1982-09-30,MK,North Macedonia,
-1982-09-30,MT,Malta,
-1982-09-30,MX,Mexico,
-1982-09-30,MY,Malaysia,
-1982-09-30,NL,Netherlands,21.7647
+1982-09-30,KR,Korea,27.3317
+1982-09-30,NL,Netherlands,22.2929
 1982-09-30,NO,Norway,17.6061
 1982-09-30,NZ,New Zealand,14.0763
-1982-09-30,PE,Peru,
-1982-09-30,PH,Philippines,
-1982-09-30,PL,Poland,
-1982-09-30,PT,Portugal,
-1982-09-30,RO,Romania,
-1982-09-30,RS,Serbia,
-1982-09-30,RU,Russia,
 1982-09-30,SE,Sweden,18.6528
-1982-09-30,SG,Singapore,
-1982-09-30,SI,Slovenia,
-1982-09-30,SK,Slovak Republic,
-1982-09-30,TH,Thailand,
-1982-09-30,TR,Türkiye,
-1982-09-30,US,United States,33.2081
-1982-09-30,XM,Euro area,28.6489
-1982-09-30,XW,World,
-1982-09-30,ZA,South Africa,6.8681
-1982-12-31,4T,Emerging market economies (aggregate),
-1982-12-31,5R,Advanced economies,
-1982-12-31,AE,United Arab Emirates,
-1982-12-31,AT,Austria,
+1982-09-30,US,United States,33.1713
+1982-09-30,XM,Euro area,28.5607
+1982-09-30,ZA,South Africa,6.8596
 1982-12-31,AU,Australia,12.7067
-1982-12-31,BE,Belgium,21.4692
-1982-12-31,BG,Bulgaria,
-1982-12-31,BR,Brazil,
-1982-12-31,CA,Canada,21.5847
-1982-12-31,CH,Switzerland,50.8442
-1982-12-31,CL,Chile,
-1982-12-31,CN,China,
-1982-12-31,CO,Colombia,
-1982-12-31,CY,Cyprus,
-1982-12-31,CZ,Czechia,
-1982-12-31,DE,Germany,79.5383
+1982-12-31,BE,Belgium,21.652
+1982-12-31,CA,Canada,21.752
+1982-12-31,CH,Switzerland,50.8423
+1982-12-31,DE,Germany,79.4407
 1982-12-31,DK,Denmark,21.3028
-1982-12-31,EE,Estonia,
 1982-12-31,ES,Spain,7.7355
 1982-12-31,FI,Finland,24.5823
 1982-12-31,FR,France,24.8869
-1982-12-31,GB,United Kingdom,13.5331
-1982-12-31,GR,Greece,
+1982-12-31,GB,United Kingdom,13.5286
 1982-12-31,HK,Hong Kong SAR,12.9218
-1982-12-31,HR,Croatia,
-1982-12-31,HU,Hungary,
-1982-12-31,ID,Indonesia,
-1982-12-31,IE,Ireland,20.2575
-1982-12-31,IL,Israel,
-1982-12-31,IN,India,
-1982-12-31,IS,Iceland,
+1982-12-31,IE,Ireland,20.261
+1982-12-31,IS,Iceland,5.4168
 1982-12-31,IT,Italy,21.4508
 1982-12-31,JP,Japan,112.452
-1982-12-31,KR,Korea,28.5473
-1982-12-31,LT,Lithuania,
-1982-12-31,LU,Luxembourg,
-1982-12-31,LV,Latvia,
-1982-12-31,MA,Morocco,
-1982-12-31,MK,North Macedonia,
-1982-12-31,MT,Malta,
-1982-12-31,MX,Mexico,
-1982-12-31,MY,Malaysia,
-1982-12-31,NL,Netherlands,21.21
+1982-12-31,KR,Korea,28.5463
+1982-12-31,NL,Netherlands,21.7247
 1982-12-31,NO,Norway,17.8079
 1982-12-31,NZ,New Zealand,14.3882
-1982-12-31,PE,Peru,
-1982-12-31,PH,Philippines,
-1982-12-31,PL,Poland,
-1982-12-31,PT,Portugal,
-1982-12-31,RO,Romania,
-1982-12-31,RS,Serbia,
-1982-12-31,RU,Russia,
 1982-12-31,SE,Sweden,18.4305
-1982-12-31,SG,Singapore,
-1982-12-31,SI,Slovenia,
-1982-12-31,SK,Slovak Republic,
-1982-12-31,TH,Thailand,
-1982-12-31,TR,Türkiye,
-1982-12-31,US,United States,33.4339
-1982-12-31,XM,Euro area,28.8373
-1982-12-31,XW,World,
-1982-12-31,ZA,South Africa,7.0614
-1983-03-31,4T,Emerging market economies (aggregate),
-1983-03-31,5R,Advanced economies,
-1983-03-31,AE,United Arab Emirates,
-1983-03-31,AT,Austria,
+1982-12-31,US,United States,33.3961
+1982-12-31,XM,Euro area,28.7491
+1982-12-31,ZA,South Africa,7.0527
 1983-03-31,AU,Australia,13.0404
-1983-03-31,BE,Belgium,21.0654
-1983-03-31,BG,Bulgaria,
-1983-03-31,BR,Brazil,
-1983-03-31,CA,Canada,23.0603
-1983-03-31,CH,Switzerland,51.0153
-1983-03-31,CL,Chile,
-1983-03-31,CN,China,
-1983-03-31,CO,Colombia,
-1983-03-31,CY,Cyprus,
-1983-03-31,CZ,Czechia,
-1983-03-31,DE,Germany,79.5845
+1983-03-31,BE,Belgium,21.2447
+1983-03-31,CA,Canada,23.2391
+1983-03-31,CH,Switzerland,51.0134
+1983-03-31,DE,Germany,79.487
 1983-03-31,DK,Denmark,23.125
-1983-03-31,EE,Estonia,
 1983-03-31,ES,Spain,8.5821
 1983-03-31,FI,Finland,26.7804
 1983-03-31,FR,France,24.7744
-1983-03-31,GB,United Kingdom,13.956
-1983-03-31,GR,Greece,
+1983-03-31,GB,United Kingdom,13.9514
 1983-03-31,HK,Hong Kong SAR,12.2591
-1983-03-31,HR,Croatia,
-1983-03-31,HU,Hungary,
-1983-03-31,ID,Indonesia,
-1983-03-31,IE,Ireland,19.9954
-1983-03-31,IL,Israel,
-1983-03-31,IN,India,
-1983-03-31,IS,Iceland,
+1983-03-31,IE,Ireland,19.9989
+1983-03-31,IS,Iceland,5.9607
 1983-03-31,IT,Italy,21.8411
 1983-03-31,JP,Japan,113.8462
-1983-03-31,KR,Korea,30.4542
-1983-03-31,LT,Lithuania,
-1983-03-31,LU,Luxembourg,
-1983-03-31,LV,Latvia,
-1983-03-31,MA,Morocco,
-1983-03-31,MK,North Macedonia,
-1983-03-31,MT,Malta,
-1983-03-31,MX,Mexico,
-1983-03-31,MY,Malaysia,
-1983-03-31,NL,Netherlands,21.4798
+1983-03-31,KR,Korea,30.4532
+1983-03-31,NL,Netherlands,22.001
 1983-03-31,NO,Norway,17.9163
 1983-03-31,NZ,New Zealand,14.5892
-1983-03-31,PE,Peru,
-1983-03-31,PH,Philippines,
-1983-03-31,PL,Poland,
-1983-03-31,PT,Portugal,
-1983-03-31,RO,Romania,
-1983-03-31,RS,Serbia,
-1983-03-31,RU,Russia,
 1983-03-31,SE,Sweden,18.3025
-1983-03-31,SG,Singapore,
-1983-03-31,SI,Slovenia,
-1983-03-31,SK,Slovak Republic,
-1983-03-31,TH,Thailand,
-1983-03-31,TR,Türkiye,
-1983-03-31,US,United States,33.7868
-1983-03-31,XM,Euro area,29.3103
-1983-03-31,XW,World,
-1983-03-31,ZA,South Africa,7.4785
-1983-06-30,4T,Emerging market economies (aggregate),
-1983-06-30,5R,Advanced economies,
-1983-06-30,AE,United Arab Emirates,
-1983-06-30,AT,Austria,
+1983-03-31,US,United States,33.7522
+1983-03-31,XM,Euro area,29.2294
+1983-03-31,ZA,South Africa,7.4694
 1983-06-30,AU,Australia,13.498
-1983-06-30,BE,Belgium,20.9322
-1983-06-30,BG,Bulgaria,
-1983-06-30,BR,Brazil,
-1983-06-30,CA,Canada,23.0468
-1983-06-30,CH,Switzerland,51.8013
-1983-06-30,CL,Chile,
-1983-06-30,CN,China,
-1983-06-30,CO,Colombia,
-1983-06-30,CY,Cyprus,
-1983-06-30,CZ,Czechia,
-1983-06-30,DE,Germany,80.1391
+1983-06-30,BE,Belgium,21.1103
+1983-06-30,CA,Canada,23.2255
+1983-06-30,CH,Switzerland,51.7994
+1983-06-30,DE,Germany,80.1663
 1983-06-30,DK,Denmark,26.035
-1983-06-30,EE,Estonia,
 1983-06-30,ES,Spain,8.9755
 1983-06-30,FI,Finland,27.4259
 1983-06-30,FR,France,25.3497
-1983-06-30,GB,United Kingdom,14.4394
-1983-06-30,GR,Greece,
+1983-06-30,GB,United Kingdom,14.4346
 1983-06-30,HK,Hong Kong SAR,12.3254
-1983-06-30,HR,Croatia,
-1983-06-30,HU,Hungary,
-1983-06-30,ID,Indonesia,
-1983-06-30,IE,Ireland,19.4118
-1983-06-30,IL,Israel,
-1983-06-30,IN,India,
-1983-06-30,IS,Iceland,
+1983-06-30,IE,Ireland,19.4152
+1983-06-30,IS,Iceland,6.5649
 1983-06-30,IT,Italy,22.1875
 1983-06-30,JP,Japan,114.9459
-1983-06-30,KR,Korea,31.732
-1983-06-30,LT,Lithuania,
-1983-06-30,LU,Luxembourg,
-1983-06-30,LV,Latvia,
-1983-06-30,MA,Morocco,
-1983-06-30,MK,North Macedonia,
-1983-06-30,MT,Malta,
-1983-06-30,MX,Mexico,
-1983-06-30,MY,Malaysia,
-1983-06-30,NL,Netherlands,22.2891
+1983-06-30,KR,Korea,31.7309
+1983-06-30,NL,Netherlands,22.83
 1983-06-30,NO,Norway,17.9133
 1983-06-30,NZ,New Zealand,14.8595
-1983-06-30,PE,Peru,
-1983-06-30,PH,Philippines,
-1983-06-30,PL,Poland,
-1983-06-30,PT,Portugal,
-1983-06-30,RO,Romania,
-1983-06-30,RS,Serbia,
-1983-06-30,RU,Russia,
 1983-06-30,SE,Sweden,18.5248
-1983-06-30,SG,Singapore,
-1983-06-30,SI,Slovenia,
-1983-06-30,SK,Slovak Republic,
-1983-06-30,TH,Thailand,
-1983-06-30,TR,Türkiye,
-1983-06-30,US,United States,34.2318
-1983-06-30,XM,Euro area,29.7213
-1983-06-30,XW,World,
-1983-06-30,ZA,South Africa,7.9364
-1983-09-30,4T,Emerging market economies (aggregate),
-1983-09-30,5R,Advanced economies,
-1983-09-30,AE,United Arab Emirates,
-1983-09-30,AT,Austria,
+1983-06-30,US,United States,34.1939
+1983-06-30,XM,Euro area,29.6452
+1983-06-30,ZA,South Africa,7.9267
 1983-09-30,AU,Australia,13.4122
-1983-09-30,BE,Belgium,21.1513
-1983-09-30,BG,Bulgaria,
-1983-09-30,BR,Brazil,
-1983-09-30,CA,Canada,22.7535
-1983-09-30,CH,Switzerland,53.1835
-1983-09-30,CL,Chile,
-1983-09-30,CN,China,
-1983-09-30,CO,Colombia,
-1983-09-30,CY,Cyprus,
-1983-09-30,CZ,Czechia,
-1983-09-30,DE,Germany,80.2682
+1983-09-30,BE,Belgium,21.3313
+1983-09-30,CA,Canada,22.9299
+1983-09-30,CH,Switzerland,53.1816
+1983-09-30,DE,Germany,80.2874
 1983-09-30,DK,Denmark,26.3844
-1983-09-30,EE,Estonia,
 1983-09-30,ES,Spain,9.102
 1983-09-30,FI,Finland,28.6022
 1983-09-30,FR,France,26.2045
-1983-09-30,GB,United Kingdom,15.0435
-1983-09-30,GR,Greece,
+1983-09-30,GB,United Kingdom,15.0385
 1983-09-30,HK,Hong Kong SAR,11.8615
-1983-09-30,HR,Croatia,
-1983-09-30,HU,Hungary,
-1983-09-30,ID,Indonesia,
-1983-09-30,IE,Ireland,20.4182
-1983-09-30,IL,Israel,
-1983-09-30,IN,India,
-1983-09-30,IS,Iceland,
+1983-09-30,IE,Ireland,20.4218
+1983-09-30,IS,Iceland,7.3104
 1983-09-30,IT,Italy,22.4623
 1983-09-30,JP,Japan,116.0577
-1983-09-30,KR,Korea,32.8008
-1983-09-30,LT,Lithuania,
-1983-09-30,LU,Luxembourg,
-1983-09-30,LV,Latvia,
-1983-09-30,MA,Morocco,
-1983-09-30,MK,North Macedonia,
-1983-09-30,MT,Malta,
-1983-09-30,MX,Mexico,
-1983-09-30,MY,Malaysia,
-1983-09-30,NL,Netherlands,22.3271
+1983-09-30,KR,Korea,32.7996
+1983-09-30,NL,Netherlands,22.8689
 1983-09-30,NO,Norway,18.2627
 1983-09-30,NZ,New Zealand,15.2268
-1983-09-30,PE,Peru,
-1983-09-30,PH,Philippines,
-1983-09-30,PL,Poland,
-1983-09-30,PT,Portugal,
-1983-09-30,RO,Romania,
-1983-09-30,RS,Serbia,
-1983-09-30,RU,Russia,
 1983-09-30,SE,Sweden,18.5619
-1983-09-30,SG,Singapore,
-1983-09-30,SI,Slovenia,
-1983-09-30,SK,Slovak Republic,
-1983-09-30,TH,Thailand,
-1983-09-30,TR,Türkiye,
-1983-09-30,US,United States,34.6943
-1983-09-30,XM,Euro area,30.2537
-1983-09-30,XW,World,
-1983-09-30,ZA,South Africa,8.3332
-1983-12-31,4T,Emerging market economies (aggregate),
-1983-12-31,5R,Advanced economies,
-1983-12-31,AE,United Arab Emirates,
-1983-12-31,AT,Austria,
+1983-09-30,US,United States,34.661
+1983-09-30,XM,Euro area,30.1732
+1983-09-30,ZA,South Africa,8.323
 1983-12-31,AU,Australia,14.0288
-1983-12-31,BE,Belgium,20.9494
-1983-12-31,BG,Bulgaria,
-1983-12-31,BR,Brazil,
-1983-12-31,CA,Canada,22.8347
-1983-12-31,CH,Switzerland,53.9224
-1983-12-31,CL,Chile,
-1983-12-31,CN,China,
-1983-12-31,CO,Colombia,
-1983-12-31,CY,Cyprus,
-1983-12-31,CZ,Czechia,
-1983-12-31,DE,Germany,79.5199
+1983-12-31,BE,Belgium,21.1277
+1983-12-31,CA,Canada,23.0117
+1983-12-31,CH,Switzerland,53.9204
+1983-12-31,DE,Germany,79.5692
 1983-12-31,DK,Denmark,27.1546
-1983-12-31,EE,Estonia,
 1983-12-31,ES,Spain,9.1512
 1983-12-31,FI,Finland,29.7507
 1983-12-31,FR,France,26.1794
-1983-12-31,GB,United Kingdom,15.1644
-1983-12-31,GR,Greece,
+1983-12-31,GB,United Kingdom,15.1593
 1983-12-31,HK,Hong Kong SAR,11.2651
-1983-12-31,HR,Croatia,
-1983-12-31,HU,Hungary,
-1983-12-31,ID,Indonesia,
-1983-12-31,IE,Ireland,19.8416
-1983-12-31,IL,Israel,
-1983-12-31,IN,India,
-1983-12-31,IS,Iceland,
+1983-12-31,IE,Ireland,19.8451
+1983-12-31,IS,Iceland,7.9817
 1983-12-31,IT,Italy,22.6437
 1983-12-31,JP,Japan,117.0193
-1983-12-31,KR,Korea,33.6673
-1983-12-31,LT,Lithuania,
-1983-12-31,LU,Luxembourg,
-1983-12-31,LV,Latvia,
-1983-12-31,MA,Morocco,
-1983-12-31,MK,North Macedonia,
-1983-12-31,MT,Malta,
-1983-12-31,MX,Mexico,
-1983-12-31,MY,Malaysia,
-1983-12-31,NL,Netherlands,21.6584
+1983-12-31,KR,Korea,33.6661
+1983-12-31,NL,Netherlands,22.184
 1983-12-31,NO,Norway,18.6933
 1983-12-31,NZ,New Zealand,15.7258
-1983-12-31,PE,Peru,
-1983-12-31,PH,Philippines,
-1983-12-31,PL,Poland,
-1983-12-31,PT,Portugal,
-1983-12-31,RO,Romania,
-1983-12-31,RS,Serbia,
-1983-12-31,RU,Russia,
 1983-12-31,SE,Sweden,18.7067
-1983-12-31,SG,Singapore,
-1983-12-31,SI,Slovenia,
-1983-12-31,SK,Slovak Republic,
-1983-12-31,TH,Thailand,
-1983-12-31,TR,Türkiye,
-1983-12-31,US,United States,35.1314
-1983-12-31,XM,Euro area,30.1077
-1983-12-31,XW,World,
-1983-12-31,ZA,South Africa,8.8115
-1984-03-31,4T,Emerging market economies (aggregate),
-1984-03-31,5R,Advanced economies,
-1984-03-31,AE,United Arab Emirates,
-1984-03-31,AT,Austria,
+1983-12-31,US,United States,35.0998
+1983-12-31,XM,Euro area,30.0307
+1983-12-31,ZA,South Africa,8.8006
 1984-03-31,AU,Australia,14.4897
-1984-03-31,BE,Belgium,21.2158
-1984-03-31,BG,Bulgaria,
-1984-03-31,BR,Brazil,
-1984-03-31,CA,Canada,22.8121
-1984-03-31,CH,Switzerland,54.7302
-1984-03-31,CL,Chile,
-1984-03-31,CN,China,
-1984-03-31,CO,Colombia,
-1984-03-31,CY,Cyprus,
-1984-03-31,CZ,Czechia,
-1984-03-31,DE,Germany,78.7766
+1984-03-31,BE,Belgium,21.3963
+1984-03-31,CA,Canada,22.989
+1984-03-31,CH,Switzerland,54.7282
+1984-03-31,DE,Germany,78.7296
 1984-03-31,DK,Denmark,28.6989
-1984-03-31,EE,Estonia,
 1984-03-31,ES,Spain,9.4814
 1984-03-31,FI,Finland,31.0378
 1984-03-31,FR,France,25.9752
-1984-03-31,GB,United Kingdom,15.2852
-1984-03-31,GR,Greece,
+1984-03-31,GB,United Kingdom,15.2801
 1984-03-31,HK,Hong Kong SAR,11.5964
-1984-03-31,HR,Croatia,
-1984-03-31,HU,Hungary,
-1984-03-31,ID,Indonesia,
-1984-03-31,IE,Ireland,20.1736
-1984-03-31,IL,Israel,
-1984-03-31,IN,India,
-1984-03-31,IS,Iceland,
+1984-03-31,IE,Ireland,20.1771
+1984-03-31,IS,Iceland,8.6359
 1984-03-31,IT,Italy,22.7702
 1984-03-31,JP,Japan,117.9808
-1984-03-31,KR,Korea,35.1203
-1984-03-31,LT,Lithuania,
-1984-03-31,LU,Luxembourg,
-1984-03-31,LV,Latvia,
-1984-03-31,MA,Morocco,
-1984-03-31,MK,North Macedonia,
-1984-03-31,MT,Malta,
-1984-03-31,MX,Mexico,
-1984-03-31,MY,Malaysia,
-1984-03-31,NL,Netherlands,21.7951
+1984-03-31,KR,Korea,35.119
+1984-03-31,NL,Netherlands,22.3241
 1984-03-31,NO,Norway,19.2023
 1984-03-31,NZ,New Zealand,16.2803
-1984-03-31,PE,Peru,
-1984-03-31,PH,Philippines,
-1984-03-31,PL,Poland,
-1984-03-31,PT,Portugal,
-1984-03-31,RO,Romania,
-1984-03-31,RS,Serbia,
-1984-03-31,RU,Russia,
 1984-03-31,SE,Sweden,18.6899
-1984-03-31,SG,Singapore,
-1984-03-31,SI,Slovenia,
-1984-03-31,SK,Slovak Republic,
-1984-03-31,TH,Thailand,
-1984-03-31,TR,Türkiye,
-1984-03-31,US,United States,35.5547
-1984-03-31,XM,Euro area,30.1513
-1984-03-31,XW,World,
-1984-03-31,ZA,South Africa,9.015
-1984-06-30,4T,Emerging market economies (aggregate),
-1984-06-30,5R,Advanced economies,
-1984-06-30,AE,United Arab Emirates,
-1984-06-30,AT,Austria,
+1984-03-31,US,United States,35.5117
+1984-03-31,XM,Euro area,30.076
+1984-03-31,ZA,South Africa,9.0039
 1984-06-30,AU,Australia,14.8297
-1984-06-30,BE,Belgium,21.3489
-1984-06-30,BG,Bulgaria,
-1984-06-30,BR,Brazil,
-1984-06-30,CA,Canada,22.943
-1984-06-30,CH,Switzerland,55.9377
-1984-06-30,CL,Chile,
-1984-06-30,CN,China,
-1984-06-30,CO,Colombia,
-1984-06-30,CY,Cyprus,
-1984-06-30,CZ,Czechia,
-1984-06-30,DE,Germany,78.377
+1984-06-30,BE,Belgium,21.5306
+1984-06-30,CA,Canada,23.1209
+1984-06-30,CH,Switzerland,55.9357
+1984-06-30,DE,Germany,78.4014
 1984-06-30,DK,Denmark,29.2944
-1984-06-30,EE,Estonia,
 1984-06-30,ES,Spain,9.6359
 1984-06-30,FI,Finland,31.1804
 1984-06-30,FR,France,26.4046
-1984-06-30,GB,United Kingdom,15.7685
-1984-06-30,GR,Greece,
+1984-06-30,GB,United Kingdom,15.7633
 1984-06-30,HK,Hong Kong SAR,11.6627
-1984-06-30,HR,Croatia,
-1984-06-30,HU,Hungary,
-1984-06-30,ID,Indonesia,
-1984-06-30,IE,Ireland,19.9185
-1984-06-30,IL,Israel,
-1984-06-30,IN,India,
-1984-06-30,IS,Iceland,
+1984-06-30,IE,Ireland,19.922
+1984-06-30,IS,Iceland,9.2582
 1984-06-30,IT,Italy,22.8471
 1984-06-30,JP,Japan,118.7981
-1984-06-30,KR,Korea,36.2112
-1984-06-30,LT,Lithuania,
-1984-06-30,LU,Luxembourg,
-1984-06-30,LV,Latvia,
-1984-06-30,MA,Morocco,
-1984-06-30,MK,North Macedonia,
-1984-06-30,MT,Malta,
-1984-06-30,MX,Mexico,
-1984-06-30,MY,Malaysia,
-1984-06-30,NL,Netherlands,21.8027
+1984-06-30,KR,Korea,36.2099
+1984-06-30,NL,Netherlands,22.3318
 1984-06-30,NO,Norway,19.8016
 1984-06-30,NZ,New Zealand,16.8209
-1984-06-30,PE,Peru,
-1984-06-30,PH,Philippines,
-1984-06-30,PL,Poland,
-1984-06-30,PT,Portugal,
-1984-06-30,RO,Romania,
-1984-06-30,RS,Serbia,
-1984-06-30,RU,Russia,
 1984-06-30,SE,Sweden,19.2761
-1984-06-30,SG,Singapore,
-1984-06-30,SI,Slovenia,
-1984-06-30,SK,Slovak Republic,
-1984-06-30,TH,Thailand,
-1984-06-30,TR,Türkiye,
-1984-06-30,US,United States,36.0201
-1984-06-30,XM,Euro area,30.2975
-1984-06-30,XW,World,
-1984-06-30,ZA,South Africa,8.9946
-1984-09-30,4T,Emerging market economies (aggregate),
-1984-09-30,5R,Advanced economies,
-1984-09-30,AE,United Arab Emirates,
-1984-09-30,AT,Austria,
+1984-06-30,US,United States,35.9781
+1984-06-30,XM,Euro area,30.2267
+1984-06-30,ZA,South Africa,8.9836
 1984-09-30,AU,Australia,15.4463
-1984-09-30,BE,Belgium,21.7485
-1984-09-30,BG,Bulgaria,
-1984-09-30,BR,Brazil,
-1984-09-30,CA,Canada,22.5188
-1984-09-30,CH,Switzerland,55.9437
-1984-09-30,CL,Chile,
-1984-09-30,CN,China,
-1984-09-30,CO,Colombia,
-1984-09-30,CY,Cyprus,
-1984-09-30,CZ,Czechia,
-1984-09-30,DE,Germany,77.9141
+1984-09-30,BE,Belgium,21.9336
+1984-09-30,CA,Canada,22.6934
+1984-09-30,CH,Switzerland,55.9416
+1984-09-30,DE,Germany,77.9497
 1984-09-30,DK,Denmark,29.608
-1984-09-30,EE,Estonia,
 1984-09-30,ES,Spain,9.6676
 1984-09-30,FI,Finland,31.8497
 1984-09-30,FR,France,27.0884
-1984-09-30,GB,United Kingdom,16.3727
-1984-09-30,GR,Greece,
+1984-09-30,GB,United Kingdom,16.3672
 1984-09-30,HK,Hong Kong SAR,11.0663
-1984-09-30,HR,Croatia,
-1984-09-30,HU,Hungary,
-1984-09-30,ID,Indonesia,
-1984-09-30,IE,Ireland,20.7747
-1984-09-30,IL,Israel,
-1984-09-30,IN,India,
-1984-09-30,IS,Iceland,
+1984-09-30,IE,Ireland,20.7783
+1984-09-30,IS,Iceland,9.6631
 1984-09-30,IT,Italy,22.9241
 1984-09-30,JP,Japan,119.6154
-1984-09-30,KR,Korea,36.9432
-1984-09-30,LT,Lithuania,
-1984-09-30,LU,Luxembourg,
-1984-09-30,LV,Latvia,
-1984-09-30,MA,Morocco,
-1984-09-30,MK,North Macedonia,
-1984-09-30,MT,Malta,
-1984-09-30,MX,Mexico,
-1984-09-30,MY,Malaysia,
-1984-09-30,NL,Netherlands,21.9243
+1984-09-30,KR,Korea,36.9418
+1984-09-30,NL,Netherlands,22.4564
 1984-09-30,NO,Norway,19.9823
 1984-09-30,NZ,New Zealand,17.2922
-1984-09-30,PE,Peru,
-1984-09-30,PH,Philippines,
-1984-09-30,PL,Poland,
-1984-09-30,PT,Portugal,
-1984-09-30,RO,Romania,
-1984-09-30,RS,Serbia,
-1984-09-30,RU,Russia,
 1984-09-30,SE,Sweden,19.4782
-1984-09-30,SG,Singapore,
-1984-09-30,SI,Slovenia,
-1984-09-30,SK,Slovak Republic,
-1984-09-30,TH,Thailand,
-1984-09-30,TR,Türkiye,
-1984-09-30,US,United States,36.5508
-1984-09-30,XM,Euro area,30.5717
-1984-09-30,XW,World,
-1984-09-30,ZA,South Africa,8.8827
-1984-12-31,4T,Emerging market economies (aggregate),
-1984-12-31,5R,Advanced economies,
-1984-12-31,AE,United Arab Emirates,
-1984-12-31,AT,Austria,
+1984-09-30,US,United States,36.5155
+1984-09-30,XM,Euro area,30.4936
+1984-09-30,ZA,South Africa,8.8718
 1984-12-31,AU,Australia,15.4273
-1984-12-31,BE,Belgium,21.4864
-1984-12-31,BG,Bulgaria,
-1984-12-31,BR,Brazil,
-1984-12-31,CA,Canada,22.7986
-1984-12-31,CH,Switzerland,56.3299
-1984-12-31,CL,Chile,
-1984-12-31,CN,China,
-1984-12-31,CO,Colombia,
-1984-12-31,CY,Cyprus,
-1984-12-31,CZ,Czechia,
-1984-12-31,DE,Germany,77.6581
+1984-12-31,BE,Belgium,21.6693
+1984-12-31,CA,Canada,22.9754
+1984-12-31,CH,Switzerland,56.3279
+1984-12-31,DE,Germany,77.6447
 1984-12-31,DK,Denmark,30.9379
-1984-12-31,EE,Estonia,
 1984-12-31,ES,Spain,9.7413
 1984-12-31,FI,Finland,32.02
 1984-12-31,FR,France,27.0342
-1984-12-31,GB,United Kingdom,16.6143
-1984-12-31,GR,Greece,
+1984-12-31,GB,United Kingdom,16.6088
 1984-12-31,HK,Hong Kong SAR,11.1989
-1984-12-31,HR,Croatia,
-1984-12-31,HU,Hungary,
-1984-12-31,ID,Indonesia,
-1984-12-31,IE,Ireland,20.5999
-1984-12-31,IL,Israel,
-1984-12-31,IN,India,
-1984-12-31,IS,Iceland,
+1984-12-31,IE,Ireland,20.6035
+1984-12-31,IS,Iceland,9.6323
 1984-12-31,IT,Italy,23.0066
 1984-12-31,JP,Japan,120.4327
-1984-12-31,KR,Korea,37.3761
-1984-12-31,LT,Lithuania,
-1984-12-31,LU,Luxembourg,
-1984-12-31,LV,Latvia,
-1984-12-31,MA,Morocco,
-1984-12-31,MK,North Macedonia,
-1984-12-31,MT,Malta,
-1984-12-31,MX,Mexico,
-1984-12-31,MY,Malaysia,
-1984-12-31,NL,Netherlands,21.6166
+1984-12-31,KR,Korea,37.3747
+1984-12-31,NL,Netherlands,22.1411
 1984-12-31,NO,Norway,19.8378
 1984-12-31,NZ,New Zealand,17.7773
-1984-12-31,PE,Peru,
-1984-12-31,PH,Philippines,
-1984-12-31,PL,Poland,
-1984-12-31,PT,Portugal,
-1984-12-31,RO,Romania,
-1984-12-31,RS,Serbia,
-1984-12-31,RU,Russia,
 1984-12-31,SE,Sweden,19.495
-1984-12-31,SG,Singapore,
-1984-12-31,SI,Slovenia,
-1984-12-31,SK,Slovak Republic,
-1984-12-31,TH,Thailand,
-1984-12-31,TR,Türkiye,
-1984-12-31,US,United States,36.8158
-1984-12-31,XM,Euro area,30.4819
-1984-12-31,XW,World,
-1984-12-31,ZA,South Africa,8.6283
-1985-03-31,4T,Emerging market economies (aggregate),
-1985-03-31,5R,Advanced economies,
-1985-03-31,AE,United Arab Emirates,
-1985-03-31,AT,Austria,
+1984-12-31,US,United States,36.7686
+1984-12-31,XM,Euro area,30.4052
+1984-12-31,ZA,South Africa,8.6177
 1985-03-31,AU,Australia,16.2123
-1985-03-31,BE,Belgium,21.5208
-1985-03-31,BG,Bulgaria,
-1985-03-31,BR,Brazil,
-1985-03-31,CA,Canada,23.277
-1985-03-31,CH,Switzerland,59.3294
-1985-03-31,CL,Chile,
-1985-03-31,CN,China,
-1985-03-31,CO,Colombia,
-1985-03-31,CY,Cyprus,
-1985-03-31,CZ,Czechia,
-1985-03-31,DE,Germany,77.4886
+1985-03-31,BE,Belgium,21.704
+1985-03-31,CA,Canada,23.4574
+1985-03-31,CH,Switzerland,59.3805
+1985-03-31,DE,Germany,77.4683
 1985-03-31,DK,Denmark,32.1647
-1985-03-31,EE,Estonia,
 1985-03-31,ES,Spain,10.3245
 1985-03-31,FI,Finland,32.9428
 1985-03-31,FR,France,26.7923
-1985-03-31,GB,United Kingdom,16.6143
-1985-03-31,GR,Greece,
+1985-03-31,GB,United Kingdom,16.6088
 1985-03-31,HK,Hong Kong SAR,11.6627
-1985-03-31,HR,Croatia,
-1985-03-31,HU,Hungary,
-1985-03-31,ID,Indonesia,
-1985-03-31,IE,Ireland,20.4671
-1985-03-31,IL,Israel,
-1985-03-31,IN,India,
-1985-03-31,IS,Iceland,
+1985-03-31,IE,Ireland,20.4707
+1985-03-31,IS,Iceland,10.1454
 1985-03-31,IT,Italy,23.133
 1985-03-31,JP,Japan,121.25
-1985-03-31,KR,Korea,37.9787
-1985-03-31,LT,Lithuania,
-1985-03-31,LU,Luxembourg,
-1985-03-31,LV,Latvia,
-1985-03-31,MA,Morocco,
-1985-03-31,MK,North Macedonia,
-1985-03-31,MT,Malta,
-1985-03-31,MX,Mexico,
-1985-03-31,MY,Malaysia,
-1985-03-31,NL,Netherlands,21.6318
+1985-03-31,KR,Korea,37.9773
+1985-03-31,NL,Netherlands,22.1567
 1985-03-31,NO,Norway,19.7745
 1985-03-31,NZ,New Zealand,18.4011
-1985-03-31,PE,Peru,
-1985-03-31,PH,Philippines,
-1985-03-31,PL,Poland,
-1985-03-31,PT,Portugal,
-1985-03-31,RO,Romania,
-1985-03-31,RS,Serbia,
-1985-03-31,RU,Russia,
 1985-03-31,SE,Sweden,19.6803
-1985-03-31,SG,Singapore,
-1985-03-31,SI,Slovenia,
-1985-03-31,SK,Slovak Republic,
-1985-03-31,TH,Thailand,
-1985-03-31,TR,Türkiye,
-1985-03-31,US,United States,37.2515
-1985-03-31,XM,Euro area,30.6424
-1985-03-31,XW,World,
-1985-03-31,ZA,South Africa,8.3739
-1985-06-30,4T,Emerging market economies (aggregate),
-1985-06-30,5R,Advanced economies,
-1985-06-30,AE,United Arab Emirates,
-1985-06-30,AT,Austria,
+1985-03-31,US,United States,37.2088
+1985-03-31,XM,Euro area,30.5738
+1985-03-31,ZA,South Africa,8.3637
 1985-06-30,AU,Australia,16.3744
-1985-06-30,BE,Belgium,21.3275
-1985-06-30,BG,Bulgaria,
-1985-06-30,BR,Brazil,
-1985-06-30,CA,Canada,23.8185
-1985-06-30,CH,Switzerland,58.0924
-1985-06-30,CL,Chile,
-1985-06-30,CN,China,
-1985-06-30,CO,Colombia,
-1985-06-30,CY,Cyprus,
-1985-06-30,CZ,Czechia,
-1985-06-30,DE,Germany,77.2354
+1985-06-30,BE,Belgium,21.509
+1985-06-30,CA,Canada,24.0032
+1985-06-30,CH,Switzerland,58.0664
+1985-06-30,DE,Germany,77.1663
 1985-06-30,DK,Denmark,33.6375
-1985-06-30,EE,Estonia,
 1985-06-30,ES,Spain,10.5774
 1985-06-30,FI,Finland,32.9151
 1985-06-30,FR,France,27.2551
-1985-06-30,GB,United Kingdom,17.2185
-1985-06-30,GR,Greece,
+1985-06-30,GB,United Kingdom,17.2128
 1985-06-30,HK,Hong Kong SAR,12.2591
-1985-06-30,HR,Croatia,
-1985-06-30,HU,Hungary,
-1985-06-30,ID,Indonesia,
-1985-06-30,IE,Ireland,20.3169
-1985-06-30,IL,Israel,
-1985-06-30,IN,India,
-1985-06-30,IS,Iceland,
+1985-06-30,IE,Ireland,20.3204
+1985-06-30,IS,Iceland,10.8105
 1985-06-30,IT,Italy,23.2484
 1985-06-30,JP,Japan,121.8716
-1985-06-30,KR,Korea,38.673
-1985-06-30,LT,Lithuania,
-1985-06-30,LU,Luxembourg,
-1985-06-30,LV,Latvia,
-1985-06-30,MA,Morocco,
-1985-06-30,MK,North Macedonia,
-1985-06-30,MT,Malta,
-1985-06-30,MX,Mexico,
-1985-06-30,MY,Malaysia,
-1985-06-30,NL,Netherlands,22.0611
+1985-06-30,KR,Korea,38.6716
+1985-06-30,NL,Netherlands,22.5965
 1985-06-30,NO,Norway,20.1841
 1985-06-30,NZ,New Zealand,19.108
-1985-06-30,PE,Peru,
-1985-06-30,PH,Philippines,
-1985-06-30,PL,Poland,
-1985-06-30,PT,Portugal,
-1985-06-30,RO,Romania,
-1985-06-30,RS,Serbia,
-1985-06-30,RU,Russia,
 1985-06-30,SE,Sweden,20.1755
-1985-06-30,SG,Singapore,
-1985-06-30,SI,Slovenia,
-1985-06-30,SK,Slovak Republic,
-1985-06-30,TH,Thailand,
-1985-06-30,TR,Türkiye,
-1985-06-30,US,United States,38.0741
-1985-06-30,XM,Euro area,30.8214
-1985-06-30,XW,World,
-1985-06-30,ZA,South Africa,8.2213
-1985-09-30,4T,Emerging market economies (aggregate),
-1985-09-30,5R,Advanced economies,
-1985-09-30,AE,United Arab Emirates,
-1985-09-30,AT,Austria,
+1985-06-30,US,United States,38.0335
+1985-06-30,XM,Euro area,30.7525
+1985-06-30,ZA,South Africa,8.2112
 1985-09-30,AU,Australia,16.7494
-1985-09-30,BE,Belgium,22.1739
-1985-09-30,BG,Bulgaria,
-1985-09-30,BR,Brazil,
-1985-09-30,CA,Canada,23.9358
-1985-09-30,CH,Switzerland,58.578
-1985-09-30,CL,Chile,
-1985-09-30,CN,China,
-1985-09-30,CO,Colombia,
-1985-09-30,CY,Cyprus,
-1985-09-30,CZ,Czechia,
-1985-09-30,DE,Germany,77.3997
+1985-09-30,BE,Belgium,22.3626
+1985-09-30,CA,Canada,24.1214
+1985-09-30,CH,Switzerland,58.5693
+1985-09-30,DE,Germany,77.4482
 1985-09-30,DK,Denmark,36.0195
-1985-09-30,EE,Estonia,
 1985-09-30,ES,Spain,10.6898
 1985-09-30,FI,Finland,32.6933
 1985-09-30,FR,France,27.9931
-1985-09-30,GB,United Kingdom,17.581
-1985-09-30,GR,Greece,
+1985-09-30,GB,United Kingdom,17.5751
 1985-09-30,HK,Hong Kong SAR,12.988
-1985-09-30,HR,Croatia,
-1985-09-30,HU,Hungary,
-1985-09-30,ID,Indonesia,
-1985-09-30,IE,Ireland,21.1346
-1985-09-30,IL,Israel,
-1985-09-30,IN,India,
-1985-09-30,IS,Iceland,
+1985-09-30,IE,Ireland,21.1383
+1985-09-30,IS,Iceland,10.8128
 1985-09-30,IT,Italy,23.4079
 1985-09-30,JP,Japan,122.5
-1985-09-30,KR,Korea,39.3276
-1985-09-30,LT,Lithuania,
-1985-09-30,LU,Luxembourg,
-1985-09-30,LV,Latvia,
-1985-09-30,MA,Morocco,
-1985-09-30,MK,North Macedonia,
-1985-09-30,MT,Malta,
-1985-09-30,MX,Mexico,
-1985-09-30,MY,Malaysia,
-1985-09-30,NL,Netherlands,21.7647
+1985-09-30,KR,Korea,39.3262
+1985-09-30,NL,Netherlands,22.2929
 1985-09-30,NO,Norway,20.9912
 1985-09-30,NZ,New Zealand,19.8496
-1985-09-30,PE,Peru,
-1985-09-30,PH,Philippines,
-1985-09-30,PL,Poland,
-1985-09-30,PT,Portugal,
-1985-09-30,RO,Romania,
-1985-09-30,RS,Serbia,
-1985-09-30,RU,Russia,
 1985-09-30,SE,Sweden,20.2126
-1985-09-30,SG,Singapore,
-1985-09-30,SI,Slovenia,
-1985-09-30,SK,Slovak Republic,
-1985-09-30,TH,Thailand,
-1985-09-30,TR,Türkiye,
-1985-09-30,US,United States,38.4008
-1985-09-30,XM,Euro area,31.2616
-1985-09-30,XW,World,
-1985-09-30,ZA,South Africa,8.0992
-1985-12-31,4T,Emerging market economies (aggregate),
-1985-12-31,5R,Advanced economies,
-1985-12-31,AE,United Arab Emirates,
-1985-12-31,AT,Austria,
+1985-09-30,US,United States,38.3584
+1985-09-30,XM,Euro area,31.1883
+1985-09-30,ZA,South Africa,8.0893
 1985-12-31,AU,Australia,16.9941
-1985-12-31,BE,Belgium,22.0493
-1985-12-31,BG,Bulgaria,
-1985-12-31,BR,Brazil,
-1985-12-31,CA,Canada,24.9512
-1985-12-31,CH,Switzerland,58.4766
-1985-12-31,CL,Chile,
-1985-12-31,CN,China,
-1985-12-31,CO,Colombia,
-1985-12-31,CY,Cyprus,
-1985-12-31,CZ,Czechia,
-1985-12-31,DE,Germany,77.395
+1985-12-31,BE,Belgium,22.2369
+1985-12-31,CA,Canada,25.1446
+1985-12-31,CH,Switzerland,58.4528
+1985-12-31,DE,Germany,77.4348
 1985-12-31,DK,Denmark,36.8968
-1985-12-31,EE,Estonia,
 1985-12-31,ES,Spain,10.8058
 1985-12-31,FI,Finland,32.9705
 1985-12-31,FR,France,27.9723
-1985-12-31,GB,United Kingdom,18.1851
-1985-12-31,GR,Greece,
+1985-12-31,GB,United Kingdom,18.1791
 1985-12-31,HK,Hong Kong SAR,13.4519
-1985-12-31,HR,Croatia,
-1985-12-31,HU,Hungary,
-1985-12-31,ID,Indonesia,
-1985-12-31,IE,Ireland,21.6133
-1985-12-31,IL,Israel,
-1985-12-31,IN,India,
-1985-12-31,IS,Iceland,
+1985-12-31,IE,Ireland,21.6171
+1985-12-31,IS,Iceland,11.3792
 1985-12-31,IT,Italy,23.5123
 1985-12-31,JP,Japan,123.1731
-1985-12-31,KR,Korea,39.8573
-1985-12-31,LT,Lithuania,
-1985-12-31,LU,Luxembourg,
-1985-12-31,LV,Latvia,
-1985-12-31,MA,Morocco,
-1985-12-31,MK,North Macedonia,
-1985-12-31,MT,Malta,
-1985-12-31,MX,Mexico,
-1985-12-31,MY,Malaysia,
-1985-12-31,NL,Netherlands,21.8331
+1985-12-31,KR,Korea,39.8559
+1985-12-31,NL,Netherlands,22.363
 1985-12-31,NO,Norway,22.235
 1985-12-31,NZ,New Zealand,20.4734
-1985-12-31,PE,Peru,
-1985-12-31,PH,Philippines,
-1985-12-31,PL,Poland,
-1985-12-31,PT,Portugal,
-1985-12-31,RO,Romania,
-1985-12-31,RS,Serbia,
-1985-12-31,RU,Russia,
 1985-12-31,SE,Sweden,20.0644
-1985-12-31,SG,Singapore,
-1985-12-31,SI,Slovenia,
-1985-12-31,SK,Slovak Republic,
-1985-12-31,TH,Thailand,
-1985-12-31,TR,Türkiye,
-1985-12-31,US,United States,39.1552
-1985-12-31,XM,Euro area,31.4016
-1985-12-31,XW,World,
-1985-12-31,ZA,South Africa,8.0789
-1986-03-31,4T,Emerging market economies (aggregate),
-1986-03-31,5R,Advanced economies,
-1986-03-31,AE,United Arab Emirates,
-1986-03-31,AT,Austria,
+1985-12-31,US,United States,39.0996
+1985-12-31,XM,Euro area,31.3276
+1985-12-31,ZA,South Africa,8.069
 1986-03-31,AU,Australia,17.3692
-1986-03-31,BE,Belgium,22.075
-1986-03-31,BG,Bulgaria,
-1986-03-31,BR,Brazil,
-1986-03-31,CA,Canada,26.4043
-1986-03-31,CH,Switzerland,60.5646
-1986-03-31,CL,Chile,
-1986-03-31,CN,China,
-1986-03-31,CO,Colombia,
-1986-03-31,CY,Cyprus,
-1986-03-31,CZ,Czechia,
-1986-03-31,DE,Germany,77.475
+1986-03-31,BE,Belgium,22.2629
+1986-03-31,CA,Canada,26.609
+1986-03-31,CH,Switzerland,60.646
+1986-03-31,DE,Germany,77.4215
 1986-03-31,DK,Denmark,39.0009
-1986-03-31,EE,Estonia,
 1986-03-31,ES,Spain,11.1746
 1986-03-31,FI,Finland,34.0636
 1986-03-31,FR,France,27.9014
-1986-03-31,GB,United Kingdom,18.5476
-1986-03-31,GR,Greece,
+1986-03-31,GB,United Kingdom,18.5415
 1986-03-31,HK,Hong Kong SAR,13.5181
-1986-03-31,HR,Croatia,
-1986-03-31,HU,Hungary,
-1986-03-31,ID,Indonesia,
-1986-03-31,IE,Ireland,21.1521
-1986-03-31,IL,Israel,
-1986-03-31,IN,India,
-1986-03-31,IS,Iceland,
+1986-03-31,IE,Ireland,21.1558
+1986-03-31,IS,Iceland,11.2167
 1986-03-31,IT,Italy,23.6882
 1986-03-31,JP,Japan,123.8462
-1986-03-31,KR,Korea,42.3817
-1986-03-31,LT,Lithuania,
-1986-03-31,LU,Luxembourg,
-1986-03-31,LV,Latvia,
-1986-03-31,MA,Morocco,
-1986-03-31,MK,North Macedonia,
-1986-03-31,MT,Malta,
-1986-03-31,MX,Mexico,
-1986-03-31,MY,Malaysia,
-1986-03-31,NL,Netherlands,22.3879
+1986-03-31,KR,Korea,42.3793
+1986-03-31,NL,Netherlands,22.9312
 1986-03-31,NO,Norway,24.042
 1986-03-31,NZ,New Zealand,20.8892
-1986-03-31,PE,Peru,
-1986-03-31,PH,Philippines,
-1986-03-31,PL,Poland,
-1986-03-31,PT,Portugal,
-1986-03-31,RO,Romania,
-1986-03-31,RS,Serbia,
-1986-03-31,RU,Russia,
 1986-03-31,SE,Sweden,20.3781
-1986-03-31,SG,Singapore,
-1986-03-31,SI,Slovenia,
-1986-03-31,SK,Slovak Republic,
-1986-03-31,TH,Thailand,
-1986-03-31,TR,Türkiye,
-1986-03-31,US,United States,39.9458
-1986-03-31,XM,Euro area,31.4955
-1986-03-31,XW,World,
-1986-03-31,ZA,South Africa,7.9873
-1986-06-30,4T,Emerging market economies (aggregate),
-1986-06-30,5R,Advanced economies,
-1986-06-30,AE,United Arab Emirates,
-1986-06-30,AT,Austria,
+1986-03-31,US,United States,39.8901
+1986-03-31,XM,Euro area,31.4264
+1986-03-31,ZA,South Africa,7.9775
 1986-06-30,AU,Australia,17.8395
-1986-06-30,BE,Belgium,22.3457
-1986-06-30,BG,Bulgaria,
-1986-06-30,BR,Brazil,
-1986-06-30,CA,Canada,27.7356
-1986-06-30,CH,Switzerland,58.6165
-1986-06-30,CL,Chile,
-1986-06-30,CN,China,
-1986-06-30,CO,Colombia,
-1986-06-30,CY,Cyprus,
-1986-06-30,CZ,Czechia,
-1986-06-30,DE,Germany,77.8939
+1986-06-30,BE,Belgium,22.5359
+1986-06-30,CA,Canada,27.9506
+1986-06-30,CH,Switzerland,58.5818
+1986-06-30,DE,Germany,77.9144
 1986-06-30,DK,Denmark,39.1399
-1986-06-30,EE,Estonia,
 1986-06-30,ES,Spain,11.698
 1986-06-30,FI,Finland,33.8141
 1986-06-30,FR,France,28.4684
-1986-06-30,GB,United Kingdom,19.3935
-1986-06-30,GR,Greece,
+1986-06-30,GB,United Kingdom,19.387
 1986-06-30,HK,Hong Kong SAR,13.6507
-1986-06-30,HR,Croatia,
-1986-06-30,HU,Hungary,
-1986-06-30,ID,Indonesia,
-1986-06-30,IE,Ireland,21.18
-1986-06-30,IL,Israel,
-1986-06-30,IN,India,
-1986-06-30,IS,Iceland,
+1986-06-30,IE,Ireland,21.1837
+1986-06-30,IS,Iceland,11.6222
 1986-06-30,IT,Italy,23.9136
 1986-06-30,JP,Japan,124.7068
-1986-06-30,KR,Korea,41.9227
-1986-06-30,LT,Lithuania,
-1986-06-30,LU,Luxembourg,
-1986-06-30,LV,Latvia,
-1986-06-30,MA,Morocco,
-1986-06-30,MK,North Macedonia,
-1986-06-30,MT,Malta,
-1986-06-30,MX,Mexico,
-1986-06-30,MY,Malaysia,
-1986-06-30,NL,Netherlands,22.7793
+1986-06-30,KR,Korea,41.9143
+1986-06-30,NL,Netherlands,23.3321
 1986-06-30,NO,Norway,26.2586
 1986-06-30,NZ,New Zealand,21.1803
-1986-06-30,PE,Peru,
-1986-06-30,PH,Philippines,
-1986-06-30,PL,Poland,
-1986-06-30,PT,Portugal,
-1986-06-30,RO,Romania,
-1986-06-30,RS,Serbia,
-1986-06-30,RU,Russia,
 1986-06-30,SE,Sweden,20.7453
-1986-06-30,SG,Singapore,
-1986-06-30,SI,Slovenia,
-1986-06-30,SK,Slovak Republic,
-1986-06-30,TH,Thailand,
-1986-06-30,TR,Türkiye,
-1986-06-30,US,United States,40.7125
-1986-06-30,XM,Euro area,31.9642
-1986-06-30,XW,World,
-1986-06-30,ZA,South Africa,7.8448
-1986-09-30,4T,Emerging market economies (aggregate),
-1986-09-30,5R,Advanced economies,
-1986-09-30,AE,United Arab Emirates,
-1986-09-30,AT,Austria,
+1986-06-30,US,United States,40.6669
+1986-06-30,XM,Euro area,31.8928
+1986-06-30,ZA,South Africa,7.8352
+1986-09-30,AT,Austria,34.2565
 1986-09-30,AU,Australia,17.3501
-1986-09-30,BE,Belgium,23.5058
-1986-09-30,BG,Bulgaria,
-1986-09-30,BR,Brazil,
-1986-09-30,CA,Canada,28.2094
-1986-09-30,CH,Switzerland,59.4424
-1986-09-30,CL,Chile,
-1986-09-30,CN,China,
-1986-09-30,CO,Colombia,
-1986-09-30,CY,Cyprus,
-1986-09-30,CZ,Czechia,
-1986-09-30,DE,Germany,77.7089
+1986-09-30,BE,Belgium,23.7058
+1986-09-30,CA,Canada,28.4281
+1986-09-30,CH,Switzerland,59.438
+1986-09-30,DE,Germany,77.7359
 1986-09-30,DK,Denmark,38.1236
-1986-09-30,EE,Estonia,
 1986-09-30,ES,Spain,12.4674
 1986-09-30,FI,Finland,34.119
 1986-09-30,FR,France,29.3065
-1986-09-30,GB,United Kingdom,20.2393
-1986-09-30,GR,Greece,
+1986-09-30,GB,United Kingdom,20.2326
 1986-09-30,HK,Hong Kong SAR,14.3133
-1986-09-30,HR,Croatia,
-1986-09-30,HU,Hungary,
-1986-09-30,ID,Indonesia,
-1986-09-30,IE,Ireland,22.2179
-1986-09-30,IL,Israel,
-1986-09-30,IN,India,
-1986-09-30,IS,Iceland,
+1986-09-30,IE,Ireland,22.2218
+1986-09-30,IS,Iceland,12.4273
 1986-09-30,IT,Italy,24.106
 1986-09-30,JP,Japan,125.577
-1986-09-30,KR,Korea,41.6167
-1986-09-30,LT,Lithuania,
-1986-09-30,LU,Luxembourg,
-1986-09-30,LV,Latvia,
-1986-09-30,MA,Morocco,
-1986-09-30,MK,North Macedonia,
-1986-09-30,MT,Malta,
-1986-09-30,MX,Mexico,
-1986-09-30,MY,Malaysia,
-1986-09-30,NL,Netherlands,23.1858
+1986-09-30,KR,Korea,41.5973
+1986-09-30,NL,Netherlands,23.7485
 1986-09-30,NO,Norway,28.2433
 1986-09-30,NZ,New Zealand,21.6516
-1986-09-30,PE,Peru,
-1986-09-30,PH,Philippines,
-1986-09-30,PL,Poland,
-1986-09-30,PT,Portugal,
-1986-09-30,RO,Romania,
-1986-09-30,RS,Serbia,
-1986-09-30,RU,Russia,
 1986-09-30,SE,Sweden,21.296
-1986-09-30,SG,Singapore,
-1986-09-30,SI,Slovenia,
-1986-09-30,SK,Slovak Republic,
-1986-09-30,TH,Thailand,
-1986-09-30,TR,Türkiye,
-1986-09-30,US,United States,41.6738
-1986-09-30,XM,Euro area,32.5525
-1986-09-30,XW,World,
-1986-09-30,ZA,South Africa,7.794
-1986-12-31,4T,Emerging market economies (aggregate),
-1986-12-31,5R,Advanced economies,
-1986-12-31,AE,United Arab Emirates,
-1986-12-31,AT,Austria,
+1986-09-30,US,United States,41.5988
+1986-09-30,XM,Euro area,32.4837
+1986-09-30,ZA,South Africa,7.7844
+1986-12-31,AT,Austria,32.3709
 1986-12-31,AU,Australia,17.5503
-1986-12-31,BE,Belgium,23.205
-1986-12-31,BG,Bulgaria,
-1986-12-31,BR,Brazil,
-1986-12-31,CA,Canada,30.1544
-1986-12-31,CH,Switzerland,59.0106
-1986-12-31,CL,Chile,
-1986-12-31,CN,China,
-1986-12-31,CO,Colombia,
-1986-12-31,CY,Cyprus,
-1986-12-31,CZ,Czechia,
-1986-12-31,DE,Germany,77.2412
+1986-12-31,BE,Belgium,23.4025
+1986-12-31,CA,Canada,30.3882
+1986-12-31,CH,Switzerland,58.9613
+1986-12-31,DE,Germany,77.2461
 1986-12-31,DK,Denmark,38.6833
-1986-12-31,EE,Estonia,
 1986-12-31,ES,Spain,13.5634
 1986-12-31,FI,Finland,34.9349
 1986-12-31,FR,France,29.4524
-1986-12-31,GB,United Kingdom,20.8434
-1986-12-31,GR,Greece,
+1986-12-31,GB,United Kingdom,20.8365
 1986-12-31,HK,Hong Kong SAR,15.0422
-1986-12-31,HR,Croatia,
-1986-12-31,HU,Hungary,
-1986-12-31,ID,Indonesia,
-1986-12-31,IE,Ireland,21.9139
-1986-12-31,IL,Israel,
-1986-12-31,IN,India,
-1986-12-31,IS,Iceland,
+1986-12-31,IE,Ireland,21.9177
+1986-12-31,IS,Iceland,13.4112
 1986-12-31,IT,Italy,24.2435
 1986-12-31,JP,Japan,127.5001
-1986-12-31,KR,Korea,41.3617
-1986-12-31,LT,Lithuania,
-1986-12-31,LU,Luxembourg,
-1986-12-31,LV,Latvia,
-1986-12-31,MA,Morocco,
-1986-12-31,MK,North Macedonia,
-1986-12-31,MT,Malta,
-1986-12-31,MX,Mexico,
-1986-12-31,MY,Malaysia,
-1986-12-31,NL,Netherlands,23.0832
+1986-12-31,KR,Korea,41.3859
+1986-12-31,NL,Netherlands,23.6434
 1986-12-31,NO,Norway,29.463
 1986-12-31,NZ,New Zealand,22.0952
-1986-12-31,PE,Peru,
-1986-12-31,PH,Philippines,
-1986-12-31,PL,Poland,
-1986-12-31,PT,Portugal,
-1986-12-31,RO,Romania,
-1986-12-31,RS,Serbia,
-1986-12-31,RU,Russia,
 1986-12-31,SE,Sweden,21.8468
-1986-12-31,SG,Singapore,
-1986-12-31,SI,Slovenia,
-1986-12-31,SK,Slovak Republic,
-1986-12-31,TH,Thailand,
-1986-12-31,TR,Türkiye,
-1986-12-31,US,United States,42.3222
-1986-12-31,XM,Euro area,32.8533
-1986-12-31,XW,World,
-1986-12-31,ZA,South Africa,7.8448
-1987-03-31,4T,Emerging market economies (aggregate),
-1987-03-31,5R,Advanced economies,
-1987-03-31,AE,United Arab Emirates,
-1987-03-31,AT,Austria,
+1986-12-31,US,United States,42.2545
+1986-12-31,XM,Euro area,32.7931
+1986-12-31,ZA,South Africa,7.8352
+1987-03-31,AT,Austria,35.0422
 1987-03-31,AU,Australia,17.7474
-1987-03-31,BE,Belgium,23.8194
-1987-03-31,BG,Bulgaria,
-1987-03-31,BR,Brazil,
-1987-03-31,CA,Canada,32.6951
-1987-03-31,CH,Switzerland,60.4257
-1987-03-31,CL,Chile,
-1987-03-31,CN,China,
-1987-03-31,CO,Colombia,
-1987-03-31,CY,Cyprus,
-1987-03-31,CZ,Czechia,
-1987-03-31,DE,Germany,76.8641
+1987-03-31,BE,Belgium,24.0221
+1987-03-31,CA,Canada,32.9486
+1987-03-31,CH,Switzerland,60.433
+1987-03-31,DE,Germany,76.8894
 1987-03-31,DK,Denmark,36.1267
-1987-03-31,EE,Estonia,
 1987-03-31,ES,Spain,15.3901
 1987-03-31,FI,Finland,35.9963
 1987-03-31,FR,France,29.4941
-1987-03-31,GB,United Kingdom,21.4476
-1987-03-31,GR,Greece,
+1987-03-31,GB,United Kingdom,21.4405
 1987-03-31,HK,Hong Kong SAR,16.3013
-1987-03-31,HR,Croatia,
-1987-03-31,HU,Hungary,
-1987-03-31,ID,Indonesia,
-1987-03-31,IE,Ireland,21.5085
-1987-03-31,IL,Israel,
-1987-03-31,IN,India,
-1987-03-31,IS,Iceland,
+1987-03-31,IE,Ireland,21.5123
+1987-03-31,IS,Iceland,14.7731
 1987-03-31,IT,Italy,24.5788
 1987-03-31,JP,Japan,129.4231
-1987-03-31,KR,Korea,41.1067
-1987-03-31,LT,Lithuania,
-1987-03-31,LU,Luxembourg,
-1987-03-31,LV,Latvia,
-1987-03-31,MA,Morocco,
-1987-03-31,MK,North Macedonia,
-1987-03-31,MT,Malta,
-1987-03-31,MX,Mexico,
-1987-03-31,MY,Malaysia,
-1987-03-31,NL,Netherlands,23.581
+1987-03-31,KR,Korea,41.09
+1987-03-31,NL,Netherlands,24.1533
 1987-03-31,NO,Norway,32.565
 1987-03-31,NZ,New Zealand,23.3566
-1987-03-31,PE,Peru,
-1987-03-31,PH,Philippines,
-1987-03-31,PL,Poland,
-1987-03-31,PT,Portugal,
-1987-03-31,RO,Romania,
-1987-03-31,RS,Serbia,
-1987-03-31,RU,Russia,
 1987-03-31,SE,Sweden,22.7647
-1987-03-31,SG,Singapore,
-1987-03-31,SI,Slovenia,
-1987-03-31,SK,Slovak Republic,
-1987-03-31,TH,Thailand,
-1987-03-31,TR,Türkiye,
-1987-03-31,US,United States,43.7198
-1987-03-31,XM,Euro area,33.542
-1987-03-31,XW,World,
-1987-03-31,ZA,South Africa,8.1196
-1987-06-30,4T,Emerging market economies (aggregate),
-1987-06-30,5R,Advanced economies,
-1987-06-30,AE,United Arab Emirates,
-1987-06-30,AT,Austria,
+1987-03-31,US,United States,43.6455
+1987-03-31,XM,Euro area,33.4942
+1987-03-31,ZA,South Africa,8.1096
+1987-06-30,AT,Austria,38.4207
 1987-06-30,AU,Australia,17.9444
-1987-06-30,BE,Belgium,23.828
-1987-06-30,BG,Bulgaria,
-1987-06-30,BR,Brazil,
-1987-06-30,CA,Canada,32.3025
-1987-06-30,CH,Switzerland,61.2975
-1987-06-30,CL,Chile,
-1987-06-30,CN,China,
-1987-06-30,CO,Colombia,
-1987-06-30,CY,Cyprus,
-1987-06-30,CZ,Czechia,
-1987-06-30,DE,Germany,76.8289
+1987-06-30,BE,Belgium,24.0308
+1987-06-30,CA,Canada,32.553
+1987-06-30,CH,Switzerland,61.3319
+1987-06-30,DE,Germany,76.7892
 1987-06-30,DK,Denmark,36.0552
-1987-06-30,EE,Estonia,
 1987-06-30,ES,Spain,16.3843
 1987-06-30,FI,Finland,37.2002
 1987-06-30,FR,France,30.3363
-1987-06-30,GB,United Kingdom,22.4143
-1987-06-30,GR,Greece,
+1987-06-30,GB,United Kingdom,22.4068
 1987-06-30,HK,Hong Kong SAR,17.3615
-1987-06-30,HR,Croatia,
-1987-06-30,HU,Hungary,
-1987-06-30,ID,Indonesia,
-1987-06-30,IE,Ireland,20.7886
-1987-06-30,IL,Israel,
-1987-06-30,IN,India,
-1987-06-30,IS,Iceland,
+1987-06-30,IE,Ireland,20.7923
+1987-06-30,IS,Iceland,15.6834
 1987-06-30,IT,Italy,25.0901
 1987-06-30,JP,Japan,133.3915
-1987-06-30,KR,Korea,41.1577
-1987-06-30,LT,Lithuania,
-1987-06-30,LU,Luxembourg,
-1987-06-30,LV,Latvia,
-1987-06-30,MA,Morocco,
-1987-06-30,MK,North Macedonia,
-1987-06-30,MT,Malta,
-1987-06-30,MX,Mexico,
-1987-06-30,MY,Malaysia,
-1987-06-30,NL,Netherlands,24.113
+1987-06-30,KR,Korea,41.09
+1987-06-30,NL,Netherlands,24.6981
 1987-06-30,NO,Norway,33.2185
 1987-06-30,NZ,New Zealand,24.5209
-1987-06-30,PE,Peru,
-1987-06-30,PH,Philippines,
-1987-06-30,PL,Poland,
-1987-06-30,PT,Portugal,
-1987-06-30,RO,Romania,
-1987-06-30,RS,Serbia,
-1987-06-30,RU,Russia,
 1987-06-30,SE,Sweden,23.3155
-1987-06-30,SG,Singapore,
-1987-06-30,SI,Slovenia,
-1987-06-30,SK,Slovak Republic,
-1987-06-30,TH,Thailand,
-1987-06-30,TR,Türkiye,
-1987-06-30,US,United States,44.7022
-1987-06-30,XM,Euro area,34.1562
-1987-06-30,XW,World,
-1987-06-30,ZA,South Africa,8.4655
-1987-09-30,4T,Emerging market economies (aggregate),
-1987-09-30,5R,Advanced economies,
-1987-09-30,AE,United Arab Emirates,
-1987-09-30,AT,Austria,
+1987-06-30,US,United States,44.6116
+1987-06-30,XM,Euro area,34.1163
+1987-06-30,ZA,South Africa,8.4551
+1987-09-30,AT,Austria,34.0994
 1987-09-30,AU,Australia,18.2527
-1987-09-30,BE,Belgium,24.683
-1987-09-30,BG,Bulgaria,
-1987-09-30,BR,Brazil,
-1987-09-30,CA,Canada,32.3025
-1987-09-30,CH,Switzerland,61.3746
-1987-09-30,CL,Chile,
-1987-09-30,CN,China,
-1987-09-30,CO,Colombia,
-1987-09-30,CY,Cyprus,
-1987-09-30,CZ,Czechia,
-1987-09-30,DE,Germany,76.7918
+1987-09-30,BE,Belgium,24.893
+1987-09-30,CA,Canada,32.553
+1987-09-30,CH,Switzerland,61.38
+1987-09-30,DE,Germany,76.7908
 1987-09-30,DK,Denmark,35.8091
-1987-09-30,EE,Estonia,
 1987-09-30,ES,Spain,17.252
 1987-09-30,FI,Finland,38.4636
 1987-09-30,FR,France,31.5829
-1987-09-30,GB,United Kingdom,23.5017
-1987-09-30,GR,Greece,
+1987-09-30,GB,United Kingdom,23.4939
 1987-09-30,HK,Hong Kong SAR,17.9579
-1987-09-30,HR,Croatia,
-1987-09-30,HU,Hungary,
-1987-09-30,ID,Indonesia,
-1987-09-30,IE,Ireland,22.1794
-1987-09-30,IL,Israel,
-1987-09-30,IN,India,
-1987-09-30,IS,Iceland,
+1987-09-30,IE,Ireland,22.1833
+1987-09-30,IS,Iceland,16.9983
 1987-09-30,IT,Italy,25.6453
 1987-09-30,JP,Japan,137.4039
-1987-09-30,KR,Korea,41.8207
-1987-09-30,LT,Lithuania,
-1987-09-30,LU,Luxembourg,
-1987-09-30,LV,Latvia,
-1987-09-30,MA,Morocco,
-1987-09-30,MK,North Macedonia,
-1987-09-30,MT,Malta,
-1987-09-30,MX,Mexico,
-1987-09-30,MY,Malaysia,
-1987-09-30,NL,Netherlands,24.0142
+1987-09-30,KR,Korea,41.8086
+1987-09-30,NL,Netherlands,24.5969
 1987-09-30,NO,Norway,33.4595
 1987-09-30,NZ,New Zealand,25.713
-1987-09-30,PE,Peru,
-1987-09-30,PH,Philippines,
-1987-09-30,PL,Poland,
-1987-09-30,PT,Portugal,
-1987-09-30,RO,Romania,
-1987-09-30,RS,Serbia,
-1987-09-30,RU,Russia,
 1987-09-30,SE,Sweden,24.0498
-1987-09-30,SG,Singapore,
-1987-09-30,SI,Slovenia,
-1987-09-30,SK,Slovak Republic,
-1987-09-30,TH,Thailand,
-1987-09-30,TR,Türkiye,
-1987-09-30,US,United States,45.6751
-1987-09-30,XM,Euro area,34.6463
-1987-09-30,XW,World,
-1987-09-30,ZA,South Africa,8.7708
-1987-12-31,4T,Emerging market economies (aggregate),
-1987-12-31,5R,Advanced economies,
-1987-12-31,AE,United Arab Emirates,
-1987-12-31,AT,Austria,
+1987-09-30,US,United States,45.5921
+1987-09-30,XM,Euro area,34.6017
+1987-09-30,ZA,South Africa,8.76
+1987-12-31,AT,Austria,37.1636
 1987-12-31,AU,Australia,19.1299
-1987-12-31,BE,Belgium,24.6357
-1987-12-31,BG,Bulgaria,
-1987-12-31,BR,Brazil,
-1987-12-31,CA,Canada,34.0715
-1987-12-31,CH,Switzerland,61.1142
-1987-12-31,CL,Chile,
-1987-12-31,CN,China,
-1987-12-31,CO,Colombia,
-1987-12-31,CY,Cyprus,
-1987-12-31,CZ,Czechia,
-1987-12-31,DE,Germany,77.0329
+1987-12-31,BE,Belgium,24.8454
+1987-12-31,CA,Canada,34.3357
+1987-12-31,CH,Switzerland,61.0588
+1987-12-31,DE,Germany,77.0483
 1987-12-31,DK,Denmark,35.4597
-1987-12-31,EE,Estonia,
 1987-12-31,ES,Spain,18.3445
 1987-12-31,FI,Finland,40.9824
 1987-12-31,FR,France,31.904
-1987-12-31,GB,United Kingdom,24.9517
-1987-12-31,GR,Greece,
+1987-12-31,GB,United Kingdom,24.9434
 1987-12-31,HK,Hong Kong SAR,18.0905
-1987-12-31,HR,Croatia,
-1987-12-31,HU,Hungary,
-1987-12-31,ID,Indonesia,
-1987-12-31,IE,Ireland,23.3466
-1987-12-31,IL,Israel,
-1987-12-31,IN,India,
-1987-12-31,IS,Iceland,
+1987-12-31,IE,Ireland,23.3507
+1987-12-31,IS,Iceland,18.675
 1987-12-31,IT,Italy,26.1731
 1987-12-31,JP,Japan,138.7981
-1987-12-31,KR,Korea,43.9118
-1987-12-31,LT,Lithuania,
-1987-12-31,LU,Luxembourg,
-1987-12-31,LV,Latvia,
-1987-12-31,MA,Morocco,
-1987-12-31,MK,North Macedonia,
-1987-12-31,MT,Malta,
-1987-12-31,MX,Mexico,
-1987-12-31,MY,Malaysia,
-1987-12-31,NL,Netherlands,24.0484
+1987-12-31,KR,Korea,43.9223
+1987-12-31,NL,Netherlands,24.632
 1987-12-31,NO,Norway,33.7546
 1987-12-31,NZ,New Zealand,26.8912
-1987-12-31,PE,Peru,
-1987-12-31,PH,Philippines,
-1987-12-31,PL,Poland,
-1987-12-31,PT,Portugal,
-1987-12-31,RO,Romania,
-1987-12-31,RS,Serbia,
-1987-12-31,RU,Russia,
 1987-12-31,SE,Sweden,24.9678
-1987-12-31,SG,Singapore,
-1987-12-31,SI,Slovenia,
-1987-12-31,SK,Slovak Republic,
-1987-12-31,TH,Thailand,
-1987-12-31,TR,Türkiye,
-1987-12-31,US,United States,46.603
-1987-12-31,XM,Euro area,35.553
-1987-12-31,XW,World,
-1987-12-31,ZA,South Africa,9.1778
-1988-03-31,4T,Emerging market economies (aggregate),
-1988-03-31,5R,Advanced economies,
-1988-03-31,AE,United Arab Emirates,
-1988-03-31,AT,Austria,
+1987-12-31,US,United States,46.5096
+1987-12-31,XM,Euro area,35.5104
+1987-12-31,ZA,South Africa,9.1665
+1988-03-31,AT,Austria,35.4351
 1988-03-31,AU,Australia,19.9753
-1988-03-31,BE,Belgium,25.0525
-1988-03-31,BG,Bulgaria,
-1988-03-31,BR,Brazil,
-1988-03-31,CA,Canada,37.226
-1988-03-31,CH,Switzerland,62.3979
-1988-03-31,CL,Chile,
-1988-03-31,CN,China,
-1988-03-31,CO,Colombia,5.4577
-1988-03-31,CY,Cyprus,
-1988-03-31,CZ,Czechia,
-1988-03-31,DE,Germany,77.2732
+1988-03-31,BE,Belgium,25.2657
+1988-03-31,CA,Canada,37.5146
+1988-03-31,CH,Switzerland,62.3667
+1988-03-31,CO,Colombia,5.5547
+1988-03-31,DE,Germany,77.1786
 1988-03-31,DK,Denmark,35.952
-1988-03-31,EE,Estonia,
 1988-03-31,ES,Spain,19.5951
 1988-03-31,FI,Finland,46.0557
 1988-03-31,FR,France,32.2417
-1988-03-31,GB,United Kingdom,25.9788
-1988-03-31,GR,Greece,
+1988-03-31,GB,United Kingdom,25.9702
 1988-03-31,HK,Hong Kong SAR,18.7531
-1988-03-31,HR,Croatia,
-1988-03-31,HU,Hungary,
-1988-03-31,ID,Indonesia,
-1988-03-31,IE,Ireland,22.8643
-1988-03-31,IL,Israel,
-1988-03-31,IN,India,
-1988-03-31,IS,Iceland,
+1988-03-31,IE,Ireland,22.8684
+1988-03-31,IS,Iceland,20.6845
 1988-03-31,IT,Italy,26.9207
 1988-03-31,JP,Japan,140.1924
-1988-03-31,KR,Korea,45.7988
-1988-03-31,LT,Lithuania,
-1988-03-31,LU,Luxembourg,
-1988-03-31,LV,Latvia,
-1988-03-31,MA,Morocco,
-1988-03-31,MK,North Macedonia,
-1988-03-31,MT,Malta,
-1988-03-31,MX,Mexico,
+1988-03-31,KR,Korea,45.8035
 1988-03-31,MY,Malaysia,31.4536
-1988-03-31,NL,Netherlands,24.2156
+1988-03-31,NL,Netherlands,24.8032
 1988-03-31,NO,Norway,34.2003
 1988-03-31,NZ,New Zealand,27.6675
-1988-03-31,PE,Peru,
-1988-03-31,PH,Philippines,
-1988-03-31,PL,Poland,
-1988-03-31,PT,Portugal,
-1988-03-31,RO,Romania,
-1988-03-31,RS,Serbia,
-1988-03-31,RU,Russia,
+1988-03-31,PT,Portugal,35.7311
 1988-03-31,SE,Sweden,26.2529
-1988-03-31,SG,Singapore,
-1988-03-31,SI,Slovenia,
-1988-03-31,SK,Slovak Republic,
-1988-03-31,TH,Thailand,
-1988-03-31,TR,Türkiye,
-1988-03-31,US,United States,47.3312
-1988-03-31,XM,Euro area,36.0879
-1988-03-31,XW,World,
-1988-03-31,ZA,South Africa,9.5135
-1988-06-30,4T,Emerging market economies (aggregate),
-1988-06-30,5R,Advanced economies,
-1988-06-30,AE,United Arab Emirates,
-1988-06-30,AT,Austria,
+1988-03-31,US,United States,47.2334
+1988-03-31,XM,Euro area,36.0538
+1988-03-31,ZA,South Africa,9.5019
+1988-06-30,AT,Austria,38.0279
 1988-06-30,AU,Australia,21.0464
-1988-06-30,BE,Belgium,25.8473
-1988-06-30,BG,Bulgaria,
-1988-06-30,BR,Brazil,
-1988-06-30,CA,Canada,38.0202
-1988-06-30,CH,Switzerland,62.9211
-1988-06-30,CL,Chile,
-1988-06-30,CN,China,
-1988-06-30,CO,Colombia,5.3249
-1988-06-30,CY,Cyprus,
-1988-06-30,CZ,Czechia,
-1988-06-30,DE,Germany,78.0209
+1988-06-30,BE,Belgium,26.0673
+1988-06-30,CA,Canada,38.315
+1988-06-30,CH,Switzerland,62.8728
+1988-06-30,CO,Colombia,5.4217
+1988-06-30,DE,Germany,78.0673
 1988-06-30,DK,Denmark,35.8448
-1988-06-30,EE,Estonia,
 1988-06-30,ES,Spain,20.6946
 1988-06-30,FI,Finland,48.6577
 1988-06-30,FR,France,33.4675
-1988-06-30,GB,United Kingdom,27.5496
-1988-06-30,GR,Greece,
+1988-06-30,GB,United Kingdom,27.5404
 1988-06-30,HK,Hong Kong SAR,20.4097
-1988-06-30,HR,Croatia,
-1988-06-30,HU,Hungary,
-1988-06-30,ID,Indonesia,
-1988-06-30,IE,Ireland,22.3402
-1988-06-30,IL,Israel,
-1988-06-30,IN,India,
-1988-06-30,IS,Iceland,
+1988-06-30,IE,Ireland,22.3441
+1988-06-30,IS,Iceland,21.6024
 1988-06-30,IT,Italy,28.0916
 1988-06-30,JP,Japan,141.6347
-1988-06-30,KR,Korea,48.2978
-1988-06-30,LT,Lithuania,
-1988-06-30,LU,Luxembourg,
-1988-06-30,LV,Latvia,
-1988-06-30,MA,Morocco,
-1988-06-30,MK,North Macedonia,
-1988-06-30,MT,Malta,
-1988-06-30,MX,Mexico,
+1988-06-30,KR,Korea,48.2976
 1988-06-30,MY,Malaysia,31.6868
-1988-06-30,NL,Netherlands,25.1541
+1988-06-30,NL,Netherlands,25.7645
 1988-06-30,NO,Norway,33.9022
 1988-06-30,NZ,New Zealand,28.4645
-1988-06-30,PE,Peru,
-1988-06-30,PH,Philippines,
-1988-06-30,PL,Poland,
-1988-06-30,PT,Portugal,
-1988-06-30,RO,Romania,
-1988-06-30,RS,Serbia,
-1988-06-30,RU,Russia,
+1988-06-30,PT,Portugal,37.1018
 1988-06-30,SE,Sweden,27.3544
-1988-06-30,SG,Singapore,
-1988-06-30,SI,Slovenia,
-1988-06-30,SK,Slovak Republic,
-1988-06-30,TH,Thailand,
-1988-06-30,TR,Türkiye,
-1988-06-30,US,United States,48.5198
-1988-06-30,XM,Euro area,37.0748
-1988-06-30,XW,World,
-1988-06-30,ZA,South Africa,9.717
-1988-09-30,4T,Emerging market economies (aggregate),
-1988-09-30,5R,Advanced economies,
-1988-09-30,AE,United Arab Emirates,
-1988-09-30,AT,Austria,
+1988-06-30,US,United States,48.4148
+1988-06-30,XM,Euro area,37.0474
+1988-06-30,ZA,South Africa,9.7051
+1988-09-30,AT,Austria,45.492
 1988-09-30,AU,Australia,23.1059
-1988-09-30,BE,Belgium,26.7968
-1988-09-30,BG,Bulgaria,
-1988-09-30,BR,Brazil,
-1988-09-30,CA,Canada,38.3993
-1988-09-30,CH,Switzerland,64.8833
-1988-09-30,CL,Chile,
-1988-09-30,CN,China,
-1988-09-30,CO,Colombia,6.3148
-1988-09-30,CY,Cyprus,
-1988-09-30,CZ,Czechia,
-1988-09-30,DE,Germany,78.5717
+1988-09-30,BE,Belgium,27.0249
+1988-09-30,CA,Canada,38.697
+1988-09-30,CH,Switzerland,64.8804
+1988-09-30,CO,Colombia,6.4157
+1988-09-30,DE,Germany,78.6528
 1988-09-30,DK,Denmark,36.5118
-1988-09-30,EE,Estonia,
 1988-09-30,ES,Spain,21.4675
 1988-09-30,FI,Finland,52.8597
 1988-09-30,FR,France,35.1686
-1988-09-30,GB,United Kingdom,31.1745
-1988-09-30,GR,Greece,
+1988-09-30,GB,United Kingdom,31.1642
 1988-09-30,HK,Hong Kong SAR,21.8676
-1988-09-30,HR,Croatia,
-1988-09-30,HU,Hungary,
-1988-09-30,ID,Indonesia,
-1988-09-30,IE,Ireland,23.8638
-1988-09-30,IL,Israel,
-1988-09-30,IN,India,
-1988-09-30,IS,Iceland,
+1988-09-30,IE,Ireland,23.868
+1988-09-30,IS,Iceland,21.7286
 1988-09-30,IT,Italy,29.2461
 1988-09-30,JP,Japan,143.077
-1988-09-30,KR,Korea,49.9809
-1988-09-30,LT,Lithuania,
-1988-09-30,LU,Luxembourg,
-1988-09-30,LV,Latvia,
-1988-09-30,MA,Morocco,
-1988-09-30,MK,North Macedonia,
-1988-09-30,MT,Malta,
-1988-09-30,MX,Mexico,
+1988-09-30,KR,Korea,49.9674
 1988-09-30,MY,Malaysia,32.7809
-1988-09-30,NL,Netherlands,25.3935
+1988-09-30,NL,Netherlands,26.0097
 1988-09-30,NO,Norway,32.8421
 1988-09-30,NZ,New Zealand,28.6516
-1988-09-30,PE,Peru,
-1988-09-30,PH,Philippines,
-1988-09-30,PL,Poland,
-1988-09-30,PT,Portugal,
-1988-09-30,RO,Romania,
-1988-09-30,RS,Serbia,
-1988-09-30,RU,Russia,
+1988-09-30,PT,Portugal,38.8463
 1988-09-30,SE,Sweden,29.0067
-1988-09-30,SG,Singapore,
-1988-09-30,SI,Slovenia,
-1988-09-30,SK,Slovak Republic,
-1988-09-30,TH,Thailand,
-1988-09-30,TR,Türkiye,
-1988-09-30,US,United States,49.8651
-1988-09-30,XM,Euro area,38.3117
-1988-09-30,XW,World,
-1988-09-30,ZA,South Africa,10.0833
-1988-12-31,4T,Emerging market economies (aggregate),
-1988-12-31,5R,Advanced economies,
-1988-12-31,AE,United Arab Emirates,
-1988-12-31,AT,Austria,
+1988-09-30,US,United States,49.7631
+1988-09-30,XM,Euro area,38.2792
+1988-09-30,ZA,South Africa,10.0709
+1988-12-31,AT,Austria,42.3492
 1988-12-31,AU,Australia,25.4197
-1988-12-31,BE,Belgium,27.0675
-1988-12-31,BG,Bulgaria,
-1988-12-31,BR,Brazil,
-1988-12-31,CA,Canada,41.5222
-1988-12-31,CH,Switzerland,67.7023
-1988-12-31,CL,Chile,
-1988-12-31,CN,China,
-1988-12-31,CO,Colombia,6.2637
-1988-12-31,CY,Cyprus,
-1988-12-31,CZ,Czechia,
-1988-12-31,DE,Germany,78.8397
+1988-12-31,BE,Belgium,27.2978
+1988-12-31,CA,Canada,41.8441
+1988-12-31,CH,Switzerland,67.7748
+1988-12-31,CO,Colombia,6.37
+1988-12-31,DE,Germany,78.8063
 1988-12-31,DK,Denmark,36.7897
-1988-12-31,EE,Estonia,
 1988-12-31,ES,Spain,22.4616
 1988-12-31,FI,Finland,58.0994
 1988-12-31,FR,France,35.7648
-1988-12-31,GB,United Kingdom,33.1078
-1988-12-31,GR,Greece,
+1988-12-31,GB,United Kingdom,33.0968
 1988-12-31,HK,Hong Kong SAR,23.3917
-1988-12-31,HR,Croatia,
-1988-12-31,HU,Hungary,
-1988-12-31,ID,Indonesia,
-1988-12-31,IE,Ireland,24.6675
-1988-12-31,IL,Israel,
-1988-12-31,IN,India,
-1988-12-31,IS,Iceland,
+1988-12-31,IE,Ireland,24.6718
+1988-12-31,IS,Iceland,24.0654
 1988-12-31,IT,Italy,30.3016
 1988-12-31,JP,Japan,145.4328
-1988-12-31,KR,Korea,50.0319
-1988-12-31,LT,Lithuania,
-1988-12-31,LU,Luxembourg,
-1988-12-31,LV,Latvia,
-1988-12-31,MA,Morocco,
-1988-12-31,MK,North Macedonia,
-1988-12-31,MT,Malta,
-1988-12-31,MX,Mexico,
+1988-12-31,KR,Korea,50.0097
 1988-12-31,MY,Malaysia,33.0605
-1988-12-31,NL,Netherlands,25.3935
+1988-12-31,NL,Netherlands,26.0097
 1988-12-31,NO,Norway,31.5471
 1988-12-31,NZ,New Zealand,28.8249
-1988-12-31,PE,Peru,
-1988-12-31,PH,Philippines,
-1988-12-31,PL,Poland,
-1988-12-31,PT,Portugal,
-1988-12-31,RO,Romania,
-1988-12-31,RS,Serbia,
-1988-12-31,RU,Russia,
+1988-12-31,PT,Portugal,40.84
 1988-12-31,SE,Sweden,29.741
-1988-12-31,SG,Singapore,
-1988-12-31,SI,Slovenia,
-1988-12-31,SK,Slovak Republic,
-1988-12-31,TH,Thailand,
-1988-12-31,TR,Türkiye,
-1988-12-31,US,United States,51.1314
-1988-12-31,XM,Euro area,39.0489
-1988-12-31,XW,World,
-1988-12-31,ZA,South Africa,10.4293
-1989-03-31,4T,Emerging market economies (aggregate),
-1989-03-31,5R,Advanced economies,
-1989-03-31,AE,United Arab Emirates,
-1989-03-31,AT,Austria,
+1988-12-31,US,United States,51.0222
+1988-12-31,XM,Euro area,39.023
+1988-12-31,ZA,South Africa,10.4165
+1989-03-31,AT,Austria,43.5278
 1989-03-31,AU,Australia,27.4792
-1989-03-31,BE,Belgium,28.4123
-1989-03-31,BG,Bulgaria,
-1989-03-31,BR,Brazil,
-1989-03-31,CA,Canada,45.692
-1989-03-31,CH,Switzerland,68.8834
-1989-03-31,CL,Chile,
-1989-03-31,CN,China,
-1989-03-31,CO,Colombia,7.1573
-1989-03-31,CY,Cyprus,
-1989-03-31,CZ,Czechia,
-1989-03-31,DE,Germany,79.3607
+1989-03-31,BE,Belgium,28.6541
+1989-03-31,CA,Canada,46.0462
+1989-03-31,CH,Switzerland,68.9424
+1989-03-31,CO,Colombia,7.2778
+1989-03-31,DE,Germany,79.339
 1989-03-31,DK,Denmark,36.4403
-1989-03-31,EE,Estonia,
 1989-03-31,ES,Spain,24.2392
 1989-03-31,FI,Finland,62.6935
 1989-03-31,FR,France,36.3319
-1989-03-31,GB,United Kingdom,33.8328
-1989-03-31,GR,Greece,
+1989-03-31,GB,United Kingdom,33.8216
 1989-03-31,HK,Hong Kong SAR,26.1086
-1989-03-31,HR,Croatia,
-1989-03-31,HU,Hungary,
-1989-03-31,ID,Indonesia,
-1989-03-31,IE,Ireland,25.4747
-1989-03-31,IL,Israel,
-1989-03-31,IN,India,
-1989-03-31,IS,Iceland,
+1989-03-31,IE,Ireland,25.4792
+1989-03-31,IS,Iceland,24.2458
 1989-03-31,IT,Italy,31.456
 1989-03-31,JP,Japan,147.7885
-1989-03-31,KR,Korea,52.0719
-1989-03-31,LT,Lithuania,
-1989-03-31,LU,Luxembourg,
-1989-03-31,LV,Latvia,
-1989-03-31,MA,Morocco,
-1989-03-31,MK,North Macedonia,
-1989-03-31,MT,Malta,
-1989-03-31,MX,Mexico,
+1989-03-31,KR,Korea,52.0811
 1989-03-31,MY,Malaysia,33.4582
-1989-03-31,NL,Netherlands,25.838
+1989-03-31,NL,Netherlands,26.4651
 1989-03-31,NO,Norway,29.7883
 1989-03-31,NZ,New Zealand,29.5596
-1989-03-31,PE,Peru,
-1989-03-31,PH,Philippines,
-1989-03-31,PL,Poland,
-1989-03-31,PT,Portugal,
-1989-03-31,RO,Romania,
-1989-03-31,RS,Serbia,
-1989-03-31,RU,Russia,
+1989-03-31,PT,Portugal,42.3353
 1989-03-31,SE,Sweden,31.5769
-1989-03-31,SG,Singapore,
-1989-03-31,SI,Slovenia,
-1989-03-31,SK,Slovak Republic,
-1989-03-31,TH,Thailand,
-1989-03-31,TR,Türkiye,
-1989-03-31,US,United States,52.2292
-1989-03-31,XM,Euro area,40.3391
-1989-03-31,XW,World,
-1989-03-31,ZA,South Africa,10.7549
-1989-06-30,4T,Emerging market economies (aggregate),
-1989-06-30,5R,Advanced economies,
-1989-06-30,AE,United Arab Emirates,
-1989-06-30,AT,Austria,
+1989-03-31,US,United States,52.1079
+1989-03-31,XM,Euro area,40.3122
+1989-03-31,ZA,South Africa,10.7417
+1989-06-30,AT,Austria,45.492
 1989-06-30,AU,Australia,28.0163
-1989-06-30,BE,Belgium,29.1598
-1989-06-30,BG,Bulgaria,
-1989-06-30,BR,Brazil,
-1989-06-30,CA,Canada,41.7523
-1989-06-30,CH,Switzerland,68.2216
-1989-06-30,CL,Chile,
-1989-06-30,CN,China,
-1989-06-30,CO,Colombia,7.6851
-1989-06-30,CY,Cyprus,
-1989-06-30,CZ,Czechia,
-1989-06-30,DE,Germany,80.0506
+1989-06-30,BE,Belgium,29.408
+1989-06-30,CA,Canada,42.076
+1989-06-30,CH,Switzerland,68.1665
+1989-06-30,CO,Colombia,7.8172
+1989-06-30,DE,Germany,80.1246
 1989-06-30,DK,Denmark,36.5118
-1989-06-30,EE,Estonia,
 1989-06-30,ES,Spain,25.4898
 1989-06-30,FI,Finland,63.9252
 1989-06-30,FR,France,37.6661
-1989-06-30,GB,United Kingdom,35.0411
-1989-06-30,GR,Greece,
+1989-06-30,GB,United Kingdom,35.0295
 1989-06-30,HK,Hong Kong SAR,27.0363
-1989-06-30,HR,Croatia,
-1989-06-30,HU,Hungary,
-1989-06-30,ID,Indonesia,
-1989-06-30,IE,Ireland,24.4963
-1989-06-30,IL,Israel,
-1989-06-30,IN,India,
-1989-06-30,IS,Iceland,
+1989-06-30,IE,Ireland,24.5006
+1989-06-30,IS,Iceland,25.7636
 1989-06-30,IT,Italy,33.0228
 1989-06-30,JP,Japan,151.2787
-1989-06-30,KR,Korea,56.152
-1989-06-30,LT,Lithuania,
-1989-06-30,LU,Luxembourg,
-1989-06-30,LV,Latvia,
-1989-06-30,MA,Morocco,
-1989-06-30,MK,North Macedonia,
-1989-06-30,MT,Malta,
-1989-06-30,MX,Mexico,
+1989-06-30,KR,Korea,56.1394
 1989-06-30,MY,Malaysia,33.6262
-1989-06-30,NL,Netherlands,26.7462
+1989-06-30,NL,Netherlands,27.3952
 1989-06-30,NO,Norway,29.1769
 1989-06-30,NZ,New Zealand,29.8299
-1989-06-30,PE,Peru,
-1989-06-30,PH,Philippines,
-1989-06-30,PL,Poland,
-1989-06-30,PT,Portugal,
-1989-06-30,RO,Romania,
-1989-06-30,RS,Serbia,
-1989-06-30,RU,Russia,
+1989-06-30,PT,Portugal,43.4879
 1989-06-30,SE,Sweden,33.0456
-1989-06-30,SG,Singapore,
-1989-06-30,SI,Slovenia,
-1989-06-30,SK,Slovak Republic,
-1989-06-30,TH,Thailand,
-1989-06-30,TR,Türkiye,
-1989-06-30,US,United States,53.0162
-1989-06-30,XM,Euro area,41.3953
-1989-06-30,XW,World,
-1989-06-30,ZA,South Africa,11.2534
-1989-09-30,4T,Emerging market economies (aggregate),
-1989-09-30,5R,Advanced economies,
-1989-09-30,AE,United Arab Emirates,
-1989-09-30,AT,Austria,
+1989-06-30,US,United States,52.8933
+1989-06-30,XM,Euro area,41.381
+1989-06-30,ZA,South Africa,11.2396
+1989-09-30,AT,Austria,50.442
 1989-09-30,AU,Australia,28.0163
-1989-09-30,BE,Belgium,30.2941
-1989-09-30,BG,Bulgaria,
-1989-09-30,BR,Brazil,
-1989-09-30,CA,Canada,42.7361
-1989-09-30,CH,Switzerland,69.2875
-1989-09-30,CL,Chile,
-1989-09-30,CN,China,
-1989-09-30,CO,Colombia,7.9083
-1989-09-30,CY,Cyprus,
-1989-09-30,CZ,Czechia,
-1989-09-30,DE,Germany,81.1912
+1989-09-30,BE,Belgium,30.5519
+1989-09-30,CA,Canada,43.0674
+1989-09-30,CH,Switzerland,69.2153
+1989-09-30,CO,Colombia,8.0379
+1989-09-30,DE,Germany,81.1867
 1989-09-30,DK,Denmark,35.8091
-1989-09-30,EE,Estonia,
 1989-09-30,ES,Spain,26.6877
 1989-09-30,FI,Finland,63.3667
 1989-09-30,FR,France,39.3296
-1989-09-30,GB,United Kingdom,36.2495
-1989-09-30,GR,Greece,
+1989-09-30,GB,United Kingdom,36.2374
 1989-09-30,HK,Hong Kong SAR,25.976
-1989-09-30,HR,Croatia,
-1989-09-30,HU,Hungary,
-1989-09-30,ID,Indonesia,
-1989-09-30,IE,Ireland,26.544
-1989-09-30,IL,Israel,
-1989-09-30,IN,India,
-1989-09-30,IS,Iceland,
+1989-09-30,IE,Ireland,26.5487
+1989-09-30,IS,Iceland,25.8881
 1989-09-30,IT,Italy,34.5896
 1989-09-30,JP,Japan,154.8078
-1989-09-30,KR,Korea,56.305
-1989-09-30,LT,Lithuania,
-1989-09-30,LU,Luxembourg,
-1989-09-30,LV,Latvia,
-1989-09-30,MA,Morocco,
-1989-09-30,MK,North Macedonia,
-1989-09-30,MT,Malta,
-1989-09-30,MX,Mexico,
+1989-09-30,KR,Korea,56.2874
 1989-09-30,MY,Malaysia,33.7583
-1989-09-30,NL,Netherlands,27.1223
+1989-09-30,NL,Netherlands,27.7805
 1989-09-30,NO,Norway,28.0716
 1989-09-30,NZ,New Zealand,30.3982
-1989-09-30,PE,Peru,
-1989-09-30,PH,Philippines,
-1989-09-30,PL,Poland,
-1989-09-30,PT,Portugal,
-1989-09-30,RO,Romania,
-1989-09-30,RS,Serbia,
-1989-09-30,RU,Russia,
+1989-09-30,PT,Portugal,46.4473
 1989-09-30,SE,Sweden,34.3307
-1989-09-30,SG,Singapore,
-1989-09-30,SI,Slovenia,
-1989-09-30,SK,Slovak Republic,
-1989-09-30,TH,Thailand,
-1989-09-30,TR,Türkiye,
-1989-09-30,US,United States,53.7328
-1989-09-30,XM,Euro area,42.7523
-1989-09-30,XW,World,
-1989-09-30,ZA,South Africa,11.6604
-1989-12-31,4T,Emerging market economies (aggregate),
-1989-12-31,5R,Advanced economies,
-1989-12-31,AE,United Arab Emirates,
-1989-12-31,AT,Austria,
+1989-09-30,US,United States,53.6092
+1989-09-30,XM,Euro area,42.7321
+1989-09-30,ZA,South Africa,11.6461
+1989-12-31,AT,Austria,51.1491
 1989-12-31,AU,Australia,28.1021
-1989-12-31,BE,Belgium,31.4198
-1989-12-31,BG,Bulgaria,
-1989-12-31,BR,Brazil,
-1989-12-31,CA,Canada,45.182
-1989-12-31,CH,Switzerland,73.0019
-1989-12-31,CL,Chile,
-1989-12-31,CN,China,
-1989-12-31,CO,Colombia,8.3447
-1989-12-31,CY,Cyprus,
-1989-12-31,CZ,Czechia,
-1989-12-31,DE,Germany,82.4731
+1989-12-31,BE,Belgium,31.6872
+1989-12-31,CA,Canada,45.5323
+1989-12-31,CH,Switzerland,73.061
+1989-12-31,CO,Colombia,8.4772
+1989-12-31,DE,Germany,82.4257
 1989-12-31,DK,Denmark,35.285
-1989-12-31,EE,Estonia,
 1989-12-31,ES,Spain,27.4149
 1989-12-31,FI,Finland,61.7984
 1989-12-31,FR,France,39.7883
-1989-12-31,GB,United Kingdom,35.5245
-1989-12-31,GR,Greece,
+1989-12-31,GB,United Kingdom,35.5127
 1989-12-31,HK,Hong Kong SAR,27.4339
-1989-12-31,HR,Croatia,
-1989-12-31,HU,Hungary,
-1989-12-31,ID,Indonesia,
-1989-12-31,IE,Ireland,28.3052
-1989-12-31,IL,Israel,
-1989-12-31,IN,India,
-1989-12-31,IS,Iceland,
+1989-12-31,IE,Ireland,28.3102
+1989-12-31,IS,Iceland,27.1169
 1989-12-31,IT,Italy,35.9749
 1989-12-31,JP,Japan,160.7693
-1989-12-31,KR,Korea,56.968
-1989-12-31,LT,Lithuania,
-1989-12-31,LU,Luxembourg,
-1989-12-31,LV,Latvia,
-1989-12-31,MA,Morocco,
-1989-12-31,MK,North Macedonia,
-1989-12-31,MT,Malta,
-1989-12-31,MX,Mexico,
+1989-12-31,KR,Korea,56.9849
 1989-12-31,MY,Malaysia,33.6072
-1989-12-31,NL,Netherlands,27.1185
+1989-12-31,NL,Netherlands,27.7766
 1989-12-31,NO,Norway,27.3428
 1989-12-31,NZ,New Zealand,30.9318
-1989-12-31,PE,Peru,
-1989-12-31,PH,Philippines,
-1989-12-31,PL,Poland,
-1989-12-31,PT,Portugal,
-1989-12-31,RO,Romania,
-1989-12-31,RS,Serbia,
-1989-12-31,RU,Russia,
+1989-12-31,PT,Portugal,47.8492
 1989-12-31,SE,Sweden,34.5143
-1989-12-31,SG,Singapore,
-1989-12-31,SI,Slovenia,
-1989-12-31,SK,Slovak Republic,
-1989-12-31,TH,Thailand,
-1989-12-31,TR,Türkiye,
-1989-12-31,US,United States,54.3964
-1989-12-31,XM,Euro area,43.7479
-1989-12-31,XW,World,
-1989-12-31,ZA,South Africa,11.9148
-1990-03-31,4T,Emerging market economies (aggregate),
-1990-03-31,5R,Advanced economies,
-1990-03-31,AE,United Arab Emirates,
-1990-03-31,AT,Austria,
+1989-12-31,US,United States,54.2924
+1989-12-31,XM,Euro area,43.7236
+1989-12-31,ZA,South Africa,11.9002
+1990-03-31,AT,Austria,51.8562
 1990-03-31,AU,Australia,28.242
-1990-03-31,BE,Belgium,32.4724
-1990-03-31,BG,Bulgaria,
-1990-03-31,BR,Brazil,
-1990-03-31,CA,Canada,44.3742
-1990-03-31,CH,Switzerland,74.3728
-1990-03-31,CL,Chile,
-1990-03-31,CN,China,
-1990-03-31,CO,Colombia,9.2648
-1990-03-31,CY,Cyprus,
-1990-03-31,CZ,Czechia,
-1990-03-31,DE,Germany,84.6756
+1990-03-31,BE,Belgium,32.7487
+1990-03-31,CA,Canada,44.7183
+1990-03-31,CH,Switzerland,74.4353
+1990-03-31,CO,Colombia,9.4093
+1990-03-31,DE,Germany,84.6675
 1990-03-31,DK,Denmark,33.6732
-1990-03-31,EE,Estonia,
 1990-03-31,ES,Spain,29.2205
 1990-03-31,FI,Finland,60.3964
 1990-03-31,FR,France,39.9675
-1990-03-31,GB,United Kingdom,34.7995
-1990-03-31,GR,Greece,
+1990-03-31,GB,United Kingdom,34.7879
 1990-03-31,HK,Hong Kong SAR,28.3616
-1990-03-31,HR,Croatia,
-1990-03-31,HU,Hungary,
-1990-03-31,ID,Indonesia,
-1990-03-31,IE,Ireland,29.2942
-1990-03-31,IL,Israel,
-1990-03-31,IN,India,
-1990-03-31,IS,Iceland,
+1990-03-31,HU,Hungary,13.7611
+1990-03-31,IE,Ireland,29.2993
+1990-03-31,IS,Iceland,28.4603
 1990-03-31,IT,Italy,37.4327
 1990-03-31,JP,Japan,166.7308
-1990-03-31,KR,Korea,60.1301
-1990-03-31,LT,Lithuania,
-1990-03-31,LU,Luxembourg,
-1990-03-31,LV,Latvia,
-1990-03-31,MA,Morocco,
-1990-03-31,MK,North Macedonia,
-1990-03-31,MT,Malta,
-1990-03-31,MX,Mexico,
-1990-03-31,MY,Malaysia,33.9846
-1990-03-31,NL,Netherlands,27.0615
+1990-03-31,KR,Korea,60.1342
+1990-03-31,MY,Malaysia,33.9845
+1990-03-31,NL,Netherlands,27.7183
 1990-03-31,NO,Norway,27.7193
 1990-03-31,NZ,New Zealand,31.5972
-1990-03-31,PE,Peru,
-1990-03-31,PH,Philippines,
-1990-03-31,PL,Poland,
-1990-03-31,PT,Portugal,
-1990-03-31,RO,Romania,
-1990-03-31,RS,Serbia,
-1990-03-31,RU,Russia,
+1990-03-31,PT,Portugal,49.2198
 1990-03-31,SE,Sweden,36.5337
-1990-03-31,SG,Singapore,
-1990-03-31,SI,Slovenia,
-1990-03-31,SK,Slovak Republic,
-1990-03-31,TH,Thailand,
-1990-03-31,TR,Türkiye,
-1990-03-31,US,United States,55.1522
-1990-03-31,XM,Euro area,45.2789
-1990-03-31,XW,World,
-1990-03-31,ZA,South Africa,12.4235
-1990-06-30,4T,Emerging market economies (aggregate),
-1990-06-30,5R,Advanced economies,
-1990-06-30,AE,United Arab Emirates,
-1990-06-30,AT,Austria,
+1990-03-31,US,United States,55.0495
+1990-03-31,XM,Euro area,45.2607
+1990-03-31,ZA,South Africa,12.4083
+1990-06-30,AT,Austria,58.3775
 1990-06-30,AU,Australia,28.4962
-1990-06-30,BE,Belgium,32.3951
-1990-06-30,BG,Bulgaria,
-1990-06-30,BR,Brazil,
-1990-06-30,CA,Canada,41.4048
-1990-06-30,CH,Switzerland,75.4223
-1990-06-30,CL,Chile,
-1990-06-30,CN,China,
-1990-06-30,CO,Colombia,9.3209
-1990-06-30,CY,Cyprus,
-1990-06-30,CZ,Czechia,
-1990-06-30,DE,Germany,86.9573
+1990-06-30,BE,Belgium,32.6708
+1990-06-30,CA,Canada,41.7258
+1990-06-30,CH,Switzerland,75.471
+1990-06-30,CO,Colombia,9.4776
+1990-06-30,DE,Germany,87.0312
 1990-06-30,DK,Denmark,33.8122
-1990-06-30,EE,Estonia,
 1990-06-30,ES,Spain,29.7158
 1990-06-30,FI,Finland,60.539
 1990-06-30,FR,France,41.1433
-1990-06-30,GB,United Kingdom,34.4974
-1990-06-30,GR,Greece,
+1990-06-30,GB,United Kingdom,34.4859
 1990-06-30,HK,Hong Kong SAR,28.958
-1990-06-30,HR,Croatia,
-1990-06-30,HU,Hungary,
-1990-06-30,ID,Indonesia,
-1990-06-30,IE,Ireland,28.3262
-1990-06-30,IL,Israel,
-1990-06-30,IN,India,
-1990-06-30,IS,Iceland,
+1990-06-30,HU,Hungary,14.22
+1990-06-30,IE,Ireland,28.3312
+1990-06-30,IS,Iceland,28.9754
 1990-06-30,IT,Italy,38.9577
 1990-06-30,JP,Japan,172.516
-1990-06-30,KR,Korea,64.5161
-1990-06-30,LT,Lithuania,
-1990-06-30,LU,Luxembourg,
-1990-06-30,LV,Latvia,
-1990-06-30,MA,Morocco,
-1990-06-30,MK,North Macedonia,
-1990-06-30,MT,Malta,
-1990-06-30,MX,Mexico,
+1990-06-30,KR,Korea,64.5096
 1990-06-30,MY,Malaysia,34.0195
-1990-06-30,NL,Netherlands,27.9431
+1990-06-30,NL,Netherlands,28.6212
 1990-06-30,NO,Norway,28.1138
 1990-06-30,NZ,New Zealand,31.9229
-1990-06-30,PE,Peru,
-1990-06-30,PH,Philippines,
-1990-06-30,PL,Poland,
-1990-06-30,PT,Portugal,
-1990-06-30,RO,Romania,
-1990-06-30,RS,Serbia,
-1990-06-30,RU,Russia,
+1990-06-30,PT,Portugal,50.7774
 1990-06-30,SE,Sweden,37.2681
-1990-06-30,SG,Singapore,
-1990-06-30,SI,Slovenia,
-1990-06-30,SK,Slovak Republic,
-1990-06-30,TH,Thailand,
-1990-06-30,TR,Türkiye,
-1990-06-30,US,United States,55.2074
-1990-06-30,XM,Euro area,46.5903
-1990-06-30,XW,World,
-1990-06-30,ZA,South Africa,12.9933
-1990-09-30,4T,Emerging market economies (aggregate),
-1990-09-30,5R,Advanced economies,
-1990-09-30,AE,United Arab Emirates,
-1990-09-30,AT,Austria,
+1990-06-30,US,United States,55.1112
+1990-06-30,XM,Euro area,46.5797
+1990-06-30,ZA,South Africa,12.9774
+1990-09-30,AT,Austria,64.8203
 1990-09-30,AU,Australia,28.242
-1990-09-30,BE,Belgium,33.3489
-1990-09-30,BG,Bulgaria,
-1990-09-30,BR,Brazil,
-1990-09-30,CA,Canada,41.6259
-1990-09-30,CH,Switzerland,75.2882
-1990-09-30,CL,Chile,
-1990-09-30,CN,China,
-1990-09-30,CO,Colombia,10.1535
-1990-09-30,CY,Cyprus,
-1990-09-30,CZ,Czechia,
-1990-09-30,DE,Germany,88.1299
+1990-09-30,BE,Belgium,33.6327
+1990-09-30,CA,Canada,41.9487
+1990-09-30,CH,Switzerland,75.2827
+1990-09-30,CO,Colombia,10.3112
+1990-09-30,DE,Germany,88.1288
 1990-09-30,DK,Denmark,32.9706
-1990-09-30,EE,Estonia,
 1990-09-30,ES,Spain,30.299
 1990-09-30,FI,Finland,59.5568
 1990-09-30,FR,France,42.661
-1990-09-30,GB,United Kingdom,35.1016
-1990-09-30,GR,Greece,
+1990-09-30,GB,United Kingdom,35.0899
 1990-09-30,HK,Hong Kong SAR,30.0182
-1990-09-30,HR,Croatia,
-1990-09-30,HU,Hungary,
-1990-09-30,ID,Indonesia,
-1990-09-30,IE,Ireland,30.2587
-1990-09-30,IL,Israel,
-1990-09-30,IN,India,
-1990-09-30,IS,Iceland,
+1990-09-30,HU,Hungary,15.3138
+1990-09-30,IE,Ireland,30.264
+1990-09-30,IS,Iceland,29.3488
 1990-09-30,IT,Italy,40.1279
 1990-09-30,JP,Japan,178.3655
-1990-09-30,KR,Korea,65.9442
-1990-09-30,LT,Lithuania,
-1990-09-30,LU,Luxembourg,
-1990-09-30,LV,Latvia,
-1990-09-30,MA,Morocco,
-1990-09-30,MK,North Macedonia,
-1990-09-30,MT,Malta,
-1990-09-30,MX,Mexico,
+1990-09-30,KR,Korea,65.968
 1990-09-30,MY,Malaysia,34.3302
-1990-09-30,NL,Netherlands,27.1223
+1990-09-30,NL,Netherlands,27.7805
 1990-09-30,NO,Norway,27.4392
 1990-09-30,NZ,New Zealand,31.9853
-1990-09-30,PE,Peru,
-1990-09-30,PH,Philippines,
-1990-09-30,PL,Poland,
-1990-09-30,PT,Portugal,
-1990-09-30,RO,Romania,
-1990-09-30,RS,Serbia,
-1990-09-30,RU,Russia,
+1990-09-30,PT,Portugal,52.7088
 1990-09-30,SE,Sweden,38.0024
-1990-09-30,SG,Singapore,
-1990-09-30,SI,Slovenia,
-1990-09-30,SK,Slovak Republic,
-1990-09-30,TH,Thailand,
-1990-09-30,TR,Türkiye,
-1990-09-30,US,United States,55.076
-1990-09-30,XM,Euro area,47.9792
-1990-09-30,XW,World,
-1990-09-30,ZA,South Africa,13.2986
-1990-12-31,4T,Emerging market economies (aggregate),
-1990-12-31,5R,Advanced economies,
-1990-12-31,AE,United Arab Emirates,
-1990-12-31,AT,Austria,
+1990-09-30,US,United States,54.9741
+1990-09-30,XM,Euro area,47.9619
+1990-09-30,ZA,South Africa,13.2823
+1990-12-31,AT,Austria,65.4488
 1990-12-31,AU,Australia,28.4104
-1990-12-31,BE,Belgium,33.7269
-1990-12-31,BG,Bulgaria,
-1990-12-31,BR,Brazil,
-1990-12-31,CA,Canada,41.9599
-1990-12-31,CH,Switzerland,73.6739
-1990-12-31,CL,Chile,
-1990-12-31,CN,China,
-1990-12-31,CO,Colombia,10.5811
-1990-12-31,CY,Cyprus,
-1990-12-31,CZ,Czechia,
-1990-12-31,DE,Germany,88.4914
+1990-12-31,BE,Belgium,34.014
+1990-12-31,CA,Canada,42.2852
+1990-12-31,CH,Switzerland,73.5595
+1990-12-31,CO,Colombia,10.7517
+1990-12-31,DE,Germany,88.4273
 1990-12-31,DK,Denmark,32.7601
-1990-12-31,EE,Estonia,
 1990-12-31,ES,Spain,30.8224
 1990-12-31,FI,Finland,57.541
 1990-12-31,FR,France,42.8194
-1990-12-31,GB,United Kingdom,34.5578
-1990-12-31,GR,Greece,
+1990-12-31,GB,United Kingdom,34.5463
 1990-12-31,HK,Hong Kong SAR,31.3435
-1990-12-31,HR,Croatia,
-1990-12-31,HU,Hungary,
-1990-12-31,ID,Indonesia,
-1990-12-31,IE,Ireland,29.6541
-1990-12-31,IL,Israel,
-1990-12-31,IN,India,
-1990-12-31,IS,Iceland,
+1990-12-31,HU,Hungary,15.414
+1990-12-31,IE,Ireland,29.6593
+1990-12-31,IS,Iceland,30.3406
 1990-12-31,IT,Italy,41.834
 1990-12-31,JP,Japan,180.577
-1990-12-31,KR,Korea,68.8002
-1990-12-31,LT,Lithuania,
-1990-12-31,LU,Luxembourg,
-1990-12-31,LV,Latvia,
-1990-12-31,MA,Morocco,
-1990-12-31,MK,North Macedonia,
-1990-12-31,MT,Malta,
-1990-12-31,MX,Mexico,
+1990-12-31,KR,Korea,68.8426
 1990-12-31,MY,Malaysia,37.5433
-1990-12-31,NL,Netherlands,26.8336
+1990-12-31,NL,Netherlands,27.4848
 1990-12-31,NO,Norway,26.5779
 1990-12-31,NZ,New Zealand,31.7982
-1990-12-31,PE,Peru,
-1990-12-31,PH,Philippines,
-1990-12-31,PL,Poland,
-1990-12-31,PT,Portugal,
-1990-12-31,RO,Romania,
-1990-12-31,RS,Serbia,
-1990-12-31,RU,Russia,
+1990-12-31,PT,Portugal,54.4845
 1990-12-31,SE,Sweden,37.4517
-1990-12-31,SG,Singapore,
-1990-12-31,SI,Slovenia,
-1990-12-31,SK,Slovak Republic,
-1990-12-31,TH,Thailand,
-1990-12-31,TR,Türkiye,
-1990-12-31,US,United States,54.8074
-1990-12-31,XM,Euro area,48.5356
-1990-12-31,XW,World,
-1990-12-31,ZA,South Africa,13.5631
-1991-03-31,4T,Emerging market economies (aggregate),
-1991-03-31,5R,Advanced economies,
-1991-03-31,AE,United Arab Emirates,
-1991-03-31,AT,Austria,
+1990-12-31,US,United States,54.7196
+1990-12-31,XM,Euro area,48.5252
+1990-12-31,ZA,South Africa,13.5465
+1991-03-31,AT,Austria,67.1774
 1991-03-31,AU,Australia,28.3818
-1991-03-31,BE,Belgium,33.9246
-1991-03-31,BG,Bulgaria,
-1991-03-31,BR,Brazil,
-1991-03-31,CA,Canada,43.9861
-1991-03-31,CH,Switzerland,73.8153
-1991-03-31,CL,Chile,
-1991-03-31,CN,China,
-1991-03-31,CO,Colombia,10.7649
-1991-03-31,CY,Cyprus,
-1991-03-31,CZ,Czechia,
-1991-03-31,DE,Germany,89.3617
+1991-03-31,BE,Belgium,34.2133
+1991-03-31,CA,Canada,44.3272
+1991-03-31,CH,Switzerland,73.6886
+1991-03-31,CO,Colombia,10.9435
+1991-03-31,DE,Germany,89.234
 1991-03-31,DK,Denmark,33.4271
-1991-03-31,EE,Estonia,
 1991-03-31,ES,Spain,32.5648
 1991-03-31,FI,Finland,53.7033
 1991-03-31,FR,France,42.8236
-1991-03-31,GB,United Kingdom,34.0745
-1991-03-31,GR,Greece,
+1991-03-31,GB,United Kingdom,34.0632
 1991-03-31,HK,Hong Kong SAR,32.8676
-1991-03-31,HR,Croatia,
-1991-03-31,HU,Hungary,
-1991-03-31,ID,Indonesia,
-1991-03-31,IE,Ireland,30.028
-1991-03-31,IL,Israel,
-1991-03-31,IN,India,
-1991-03-31,IS,Iceland,
+1991-03-31,HU,Hungary,15.7698
+1991-03-31,IE,Ireland,30.0333
+1991-03-31,IS,Iceland,31.4387
 1991-03-31,IT,Italy,44.0271
 1991-03-31,JP,Japan,182.7885
-1991-03-31,KR,Korea,70.6362
-1991-03-31,LT,Lithuania,
-1991-03-31,LU,Luxembourg,
-1991-03-31,LV,Latvia,
-1991-03-31,MA,Morocco,
-1991-03-31,MK,North Macedonia,
-1991-03-31,MT,Malta,
-1991-03-31,MX,Mexico,
+1991-03-31,KR,Korea,70.6604
 1991-03-31,MY,Malaysia,40.5647
-1991-03-31,NL,Netherlands,27.1679
+1991-03-31,NL,Netherlands,27.8272
 1991-03-31,NO,Norway,26.0478
 1991-03-31,NZ,New Zealand,31.2368
-1991-03-31,PE,Peru,
-1991-03-31,PH,Philippines,
-1991-03-31,PL,Poland,
-1991-03-31,PT,Portugal,
-1991-03-31,RO,Romania,
-1991-03-31,RS,Serbia,
-1991-03-31,RU,Russia,
+1991-03-31,PT,Portugal,58.2539
 1991-03-31,SE,Sweden,40.0219
-1991-03-31,SG,Singapore,
-1991-03-31,SI,Slovenia,
-1991-03-31,SK,Slovak Republic,
 1991-03-31,TH,Thailand,51.8031
-1991-03-31,TR,Türkiye,
-1991-03-31,US,United States,54.3979
-1991-03-31,XM,Euro area,49.5268
-1991-03-31,XW,World,
-1991-03-31,ZA,South Africa,13.9905
-1991-06-30,4T,Emerging market economies (aggregate),
-1991-06-30,5R,Advanced economies,
-1991-06-30,AE,United Arab Emirates,
-1991-06-30,AT,Austria,
+1991-03-31,US,United States,54.3199
+1991-03-31,XM,Euro area,49.5248
+1991-03-31,ZA,South Africa,13.9733
+1991-06-30,AT,Austria,71.3416
 1991-06-30,AU,Australia,28.7219
-1991-06-30,BE,Belgium,33.4176
-1991-06-30,BG,Bulgaria,
-1991-06-30,BR,Brazil,
-1991-06-30,CA,Canada,45.5476
-1991-06-30,CH,Switzerland,75.3278
-1991-06-30,CL,Chile,
-1991-06-30,CN,China,
-1991-06-30,CO,Colombia,11.9042
-1991-06-30,CY,Cyprus,
-1991-06-30,CZ,Czechia,
-1991-06-30,DE,Germany,91.0794
+1991-06-30,BE,Belgium,33.702
+1991-06-30,CA,Canada,45.9007
+1991-06-30,CH,Switzerland,75.264
+1991-06-30,CO,Colombia,12.089
+1991-06-30,DE,Germany,91.1805
 1991-06-30,DK,Denmark,33.8479
-1991-06-30,EE,Estonia,
 1991-06-30,ES,Spain,33.8646
 1991-06-30,FI,Finland,52.9191
 1991-06-30,FR,France,43.7158
-1991-06-30,GB,United Kingdom,33.9537
-1991-06-30,GR,Greece,
+1991-06-30,GB,United Kingdom,33.9424
 1991-06-30,HK,Hong Kong SAR,37.1086
-1991-06-30,HR,Croatia,
-1991-06-30,HU,Hungary,
-1991-06-30,ID,Indonesia,
-1991-06-30,IE,Ireland,28.445
-1991-06-30,IL,Israel,
-1991-06-30,IN,India,
-1991-06-30,IS,Iceland,
+1991-06-30,HU,Hungary,16.4272
+1991-06-30,IE,Ireland,28.45
+1991-06-30,IS,Iceland,32.4891
 1991-06-30,IT,Italy,45.6511
 1991-06-30,JP,Japan,182.5495
-1991-06-30,KR,Korea,73.1863
-1991-06-30,LT,Lithuania,
-1991-06-30,LU,Luxembourg,
-1991-06-30,LV,Latvia,
-1991-06-30,MA,Morocco,
-1991-06-30,MK,North Macedonia,
-1991-06-30,MT,Malta,
-1991-06-30,MX,Mexico,
+1991-06-30,KR,Korea,73.1545
 1991-06-30,MY,Malaysia,43.8657
-1991-06-30,NL,Netherlands,27.9279
+1991-06-30,NL,Netherlands,28.6056
 1991-06-30,NO,Norway,26.0478
 1991-06-30,NZ,New Zealand,30.911
-1991-06-30,PE,Peru,
-1991-06-30,PH,Philippines,
-1991-06-30,PL,Poland,
-1991-06-30,PT,Portugal,
-1991-06-30,RO,Romania,
-1991-06-30,RS,Serbia,
-1991-06-30,RU,Russia,
+1991-06-30,PT,Portugal,61.0575
 1991-06-30,SE,Sweden,39.8383
-1991-06-30,SG,Singapore,
-1991-06-30,SI,Slovenia,
-1991-06-30,SK,Slovak Republic,
 1991-06-30,TH,Thailand,57.9825
-1991-06-30,TR,Türkiye,
-1991-06-30,US,United States,54.7928
-1991-06-30,XM,Euro area,50.6309
-1991-06-30,XW,World,
-1991-06-30,ZA,South Africa,14.5806
-1991-09-30,4T,Emerging market economies (aggregate),
-1991-09-30,5R,Advanced economies,
-1991-09-30,AE,United Arab Emirates,
-1991-09-30,AT,Austria,
+1991-06-30,US,United States,54.7
+1991-06-30,XM,Euro area,50.6434
+1991-06-30,ZA,South Africa,14.5627
+1991-09-30,AT,Austria,74.6415
 1991-09-30,AU,Australia,29.5959
-1991-09-30,BE,Belgium,34.8784
-1991-09-30,BG,Bulgaria,
-1991-09-30,BR,Brazil,
-1991-09-30,CA,Canada,42.9843
-1991-09-30,CH,Switzerland,78.964
-1991-09-30,CL,Chile,
-1991-09-30,CN,China,
-1991-09-30,CO,Colombia,11.9534
-1991-09-30,CY,Cyprus,
-1991-09-30,CZ,Czechia,
-1991-09-30,DE,Germany,91.8875
+1991-09-30,BE,Belgium,35.1752
+1991-09-30,CA,Canada,43.3176
+1991-09-30,CH,Switzerland,79.0959
+1991-09-30,CO,Colombia,12.1394
+1991-09-30,DE,Germany,91.918
 1991-09-30,DK,Denmark,33.709
-1991-09-30,EE,Estonia,
 1991-09-30,ES,Spain,34.655
 1991-09-30,FI,Finland,50.5073
 1991-09-30,FR,France,44.6831
-1991-09-30,GB,United Kingdom,34.6182
-1991-09-30,GR,Greece,
+1991-09-30,GB,United Kingdom,34.6067
 1991-09-30,HK,Hong Kong SAR,43.4038
-1991-09-30,HR,Croatia,
-1991-09-30,HU,Hungary,
-1991-09-30,ID,Indonesia,
-1991-09-30,IE,Ireland,30.2237
-1991-09-30,IL,Israel,
-1991-09-30,IN,India,
-1991-09-30,IS,Iceland,
+1991-09-30,HU,Hungary,16.7231
+1991-09-30,IE,Ireland,30.229
+1991-09-30,IS,Iceland,32.8476
 1991-09-30,IT,Italy,46.3302
 1991-09-30,JP,Japan,182.3078
-1991-09-30,KR,Korea,72.2683
-1991-09-30,LT,Lithuania,
-1991-09-30,LU,Luxembourg,
-1991-09-30,LV,Latvia,
-1991-09-30,MA,Morocco,
-1991-09-30,MK,North Macedonia,
-1991-09-30,MT,Malta,
-1991-09-30,MX,Mexico,
+1991-09-30,KR,Korea,72.3091
 1991-09-30,MY,Malaysia,45.1123
-1991-09-30,NL,Netherlands,28.0229
+1991-09-30,NL,Netherlands,28.7029
 1991-09-30,NO,Norway,25.6984
 1991-09-30,NZ,New Zealand,31.1744
-1991-09-30,PE,Peru,
-1991-09-30,PH,Philippines,
-1991-09-30,PL,Poland,
-1991-09-30,PT,Portugal,
-1991-09-30,RO,Romania,
-1991-09-30,RS,Serbia,
-1991-09-30,RU,Russia,
+1991-09-30,PT,Portugal,62.9578
 1991-09-30,SE,Sweden,40.0219
-1991-09-30,SG,Singapore,
-1991-09-30,SI,Slovenia,
-1991-09-30,SK,Slovak Republic,
 1991-09-30,TH,Thailand,58.9065
-1991-09-30,TR,Türkiye,
-1991-09-30,US,United States,54.6041
-1991-09-30,XM,Euro area,51.6759
-1991-09-30,XW,World,
-1991-09-30,ZA,South Africa,15.1402
-1991-12-31,4T,Emerging market economies (aggregate),
-1991-12-31,5R,Advanced economies,
-1991-12-31,AE,United Arab Emirates,
-1991-12-31,AT,Austria,
+1991-09-30,US,United States,54.5274
+1991-09-30,XM,Euro area,51.6821
+1991-09-30,ZA,South Africa,15.1217
+1991-12-31,AT,Austria,76.7629
 1991-12-31,AU,Australia,29.5959
-1991-12-31,BE,Belgium,35.3295
-1991-12-31,BG,Bulgaria,
-1991-12-31,BR,Brazil,
-1991-12-31,CA,Canada,43.5033
-1991-12-31,CH,Switzerland,77.1223
-1991-12-31,CL,Chile,
-1991-12-31,CN,China,
-1991-12-31,CO,Colombia,12.7771
-1991-12-31,CY,Cyprus,
-1991-12-31,CZ,Czechia,
-1991-12-31,DE,Germany,92.731
+1991-12-31,BE,Belgium,35.6302
+1991-12-31,CA,Canada,43.8406
+1991-12-31,CH,Switzerland,77.1668
+1991-12-31,CO,Colombia,12.9727
+1991-12-31,DE,Germany,92.7253
 1991-12-31,DK,Denmark,33.9551
-1991-12-31,EE,Estonia,
 1991-12-31,ES,Spain,36.1655
 1991-12-31,FI,Finland,47.8181
 1991-12-31,FR,France,44.0243
-1991-12-31,GB,United Kingdom,34.3162
-1991-12-31,GR,Greece,
+1991-12-31,GB,United Kingdom,34.3048
 1991-12-31,HK,Hong Kong SAR,48.5063
-1991-12-31,HR,Croatia,
-1991-12-31,HU,Hungary,
-1991-12-31,ID,Indonesia,
-1991-12-31,IE,Ireland,31.3035
-1991-12-31,IL,Israel,
-1991-12-31,IN,India,
-1991-12-31,IS,Iceland,
+1991-12-31,HU,Hungary,17.0927
+1991-12-31,IE,Ireland,31.309
+1991-12-31,IS,Iceland,32.8721
 1991-12-31,IT,Italy,47.4479
 1991-12-31,JP,Japan,180.2885
-1991-12-31,KR,Korea,70.1262
-1991-12-31,LT,Lithuania,
-1991-12-31,LU,Luxembourg,
-1991-12-31,LV,Latvia,
-1991-12-31,MA,Morocco,
-1991-12-31,MK,North Macedonia,
-1991-12-31,MT,Malta,
-1991-12-31,MX,Mexico,
+1991-12-31,KR,Korea,70.1742
 1991-12-31,MY,Malaysia,45.9711
-1991-12-31,NL,Netherlands,28.6346
+1991-12-31,NL,Netherlands,29.3295
 1991-12-31,NO,Norway,25.2106
 1991-12-31,NZ,New Zealand,31.0081
-1991-12-31,PE,Peru,
-1991-12-31,PH,Philippines,
-1991-12-31,PL,Poland,
-1991-12-31,PT,Portugal,
-1991-12-31,RO,Romania,
-1991-12-31,RS,Serbia,
-1991-12-31,RU,Russia,
+1991-12-31,PT,Portugal,65.0761
 1991-12-31,SE,Sweden,39.6547
-1991-12-31,SG,Singapore,
-1991-12-31,SI,Slovenia,
-1991-12-31,SK,Slovak Republic,
 1991-12-31,TH,Thailand,62.3139
-1991-12-31,TR,Türkiye,
-1991-12-31,US,United States,54.4639
-1991-12-31,XM,Euro area,52.3128
-1991-12-31,XW,World,
-1991-12-31,ZA,South Africa,15.5778
-1992-03-31,4T,Emerging market economies (aggregate),
-1992-03-31,5R,Advanced economies,
-1992-03-31,AE,United Arab Emirates,
-1992-03-31,AT,Austria,
+1991-12-31,US,United States,54.3859
+1991-12-31,XM,Euro area,52.321
+1991-12-31,ZA,South Africa,15.5587
+1992-03-31,AT,Austria,82.2628
 1992-03-31,AU,Australia,29.3989
-1992-03-31,BE,Belgium,35.8322
-1992-03-31,BG,Bulgaria,
-1992-03-31,BR,Brazil,
-1992-03-31,CA,Canada,44.2253
-1992-03-31,CH,Switzerland,76.792
-1992-03-31,CL,Chile,
-1992-03-31,CN,China,
-1992-03-31,CO,Colombia,13.3079
-1992-03-31,CY,Cyprus,
-1992-03-31,CZ,Czechia,
-1992-03-31,DE,Germany,94.1656
+1992-03-31,BE,Belgium,36.1371
+1992-03-31,CA,Canada,44.5682
+1992-03-31,CH,Switzerland,76.8321
+1992-03-31,CO,Colombia,13.3429
+1992-03-31,DE,Germany,94.1643
 1992-03-31,DK,Denmark,33.7248
-1992-03-31,EE,Estonia,
 1992-03-31,ES,Spain,34.532
 1992-03-31,FI,Finland,46.4755
 1992-03-31,FR,France,42.7985
-1992-03-31,GB,United Kingdom,33.7724
-1992-03-31,GR,Greece,
+1992-03-31,GB,United Kingdom,33.7612
 1992-03-31,HK,Hong Kong SAR,52.7473
-1992-03-31,HR,Croatia,
-1992-03-31,HU,Hungary,
-1992-03-31,ID,Indonesia,
-1992-03-31,IE,Ireland,31.2301
-1992-03-31,IL,Israel,
-1992-03-31,IN,India,
-1992-03-31,IS,Iceland,
+1992-03-31,HU,Hungary,16.0219
+1992-03-31,IE,Ireland,31.2356
+1992-03-31,IS,Iceland,33.6679
 1992-03-31,IT,Italy,50.497
 1992-03-31,JP,Japan,178.2693
-1992-03-31,KR,Korea,68.4432
-1992-03-31,LT,Lithuania,
-1992-03-31,LU,Luxembourg,
-1992-03-31,LV,Latvia,
-1992-03-31,MA,Morocco,
-1992-03-31,MK,North Macedonia,
-1992-03-31,MT,Malta,
-1992-03-31,MX,Mexico,
+1992-03-31,KR,Korea,68.4621
 1992-03-31,MY,Malaysia,47.4655
-1992-03-31,NL,Netherlands,29.8163
+1992-03-31,NL,Netherlands,30.5399
 1992-03-31,NO,Norway,24.5832
 1992-03-31,NZ,New Zealand,30.8556
-1992-03-31,PE,Peru,
-1992-03-31,PH,Philippines,
-1992-03-31,PL,Poland,
-1992-03-31,PT,Portugal,
-1992-03-31,RO,Romania,
-1992-03-31,RS,Serbia,
-1992-03-31,RU,Russia,
+1992-03-31,PT,Portugal,67.9109
 1992-03-31,SE,Sweden,37.8188
-1992-03-31,SG,Singapore,
-1992-03-31,SI,Slovenia,
-1992-03-31,SK,Slovak Republic,
 1992-03-31,TH,Thailand,63.9309
-1992-03-31,TR,Türkiye,
-1992-03-31,US,United States,54.5888
-1992-03-31,XM,Euro area,52.6893
-1992-03-31,XW,World,
-1992-03-31,ZA,South Africa,15.649
-1992-06-30,4T,Emerging market economies (aggregate),
-1992-06-30,5R,Advanced economies,
-1992-06-30,AE,United Arab Emirates,
-1992-06-30,AT,Austria,
+1992-03-31,US,United States,54.5078
+1992-03-31,XM,Euro area,52.6984
+1992-03-31,ZA,South Africa,15.6298
+1992-06-30,AT,Austria,86.2699
 1992-06-30,AU,Australia,29.4847
-1992-06-30,BE,Belgium,36.7087
-1992-06-30,BG,Bulgaria,
-1992-06-30,BR,Brazil,
-1992-06-30,CA,Canada,44.5683
-1992-06-30,CH,Switzerland,76.4574
-1992-06-30,CL,Chile,
-1992-06-30,CN,China,
-1992-06-30,CO,Colombia,14.0157
-1992-06-30,CY,Cyprus,
-1992-06-30,CZ,Czechia,
-1992-06-30,DE,Germany,95.6831
+1992-06-30,BE,Belgium,37.0211
+1992-06-30,CA,Canada,44.9138
+1992-06-30,CH,Switzerland,76.4927
+1992-06-30,CO,Colombia,14.1853
+1992-06-30,DE,Germany,95.7288
 1992-06-30,DK,Denmark,33.7248
-1992-06-30,EE,Estonia,
 1992-06-30,ES,Spain,33.7487
 1992-06-30,FI,Finland,44.0359
 1992-06-30,FR,France,42.6818
-1992-06-30,GB,United Kingdom,32.9266
-1992-06-30,GR,Greece,
+1992-06-30,GB,United Kingdom,32.9157
 1992-06-30,HK,Hong Kong SAR,57.5184
-1992-06-30,HR,Croatia,
-1992-06-30,HU,Hungary,
-1992-06-30,ID,Indonesia,
-1992-06-30,IE,Ireland,30.1049
-1992-06-30,IL,Israel,
-1992-06-30,IN,India,
-1992-06-30,IS,Iceland,
+1992-06-30,HU,Hungary,16.4007
+1992-06-30,IE,Ireland,30.1102
+1992-06-30,IS,Iceland,33.4633
 1992-06-30,IT,Italy,52.5648
 1992-06-30,JP,Japan,176.0578
-1992-06-30,KR,Korea,67.1682
-1992-06-30,LT,Lithuania,
-1992-06-30,LU,Luxembourg,
-1992-06-30,LV,Latvia,
-1992-06-30,MA,Morocco,
-1992-06-30,MK,North Macedonia,
-1992-06-30,MT,Malta,
-1992-06-30,MX,Mexico,
+1992-06-30,KR,Korea,67.1517
 1992-06-30,MY,Malaysia,49.2491
-1992-06-30,NL,Netherlands,29.235
+1992-06-30,NL,Netherlands,29.9444
 1992-06-30,NO,Norway,24.714
 1992-06-30,NZ,New Zealand,31.3061
-1992-06-30,PE,Peru,
-1992-06-30,PH,Philippines,
-1992-06-30,PL,Poland,
-1992-06-30,PT,Portugal,
-1992-06-30,RO,Romania,
-1992-06-30,RS,Serbia,
-1992-06-30,RU,Russia,
+1992-06-30,PT,Portugal,70.3096
 1992-06-30,SE,Sweden,37.0845
-1992-06-30,SG,Singapore,
-1992-06-30,SI,Slovenia,
-1992-06-30,SK,Slovak Republic,
 1992-06-30,TH,Thailand,64.8549
-1992-06-30,TR,Türkiye,
-1992-06-30,US,United States,54.4843
-1992-06-30,XM,Euro area,53.2801
-1992-06-30,XW,World,
-1992-06-30,ZA,South Africa,15.3641
-1992-09-30,4T,Emerging market economies (aggregate),
-1992-09-30,5R,Advanced economies,
-1992-09-30,AE,United Arab Emirates,
-1992-09-30,AT,Austria,
+1992-06-30,US,United States,54.4033
+1992-06-30,XM,Euro area,53.2924
+1992-06-30,ZA,South Africa,15.3452
+1992-09-30,AT,Austria,83.3628
 1992-09-30,AU,Australia,29.5101
-1992-09-30,BE,Belgium,37.0696
-1992-09-30,BG,Bulgaria,
-1992-09-30,BR,Brazil,
-1992-09-30,CA,Canada,44.6766
-1992-09-30,CH,Switzerland,74.6882
-1992-09-30,CL,Chile,
-1992-09-30,CN,China,
-1992-09-30,CO,Colombia,14.5269
-1992-09-30,CY,Cyprus,
-1992-09-30,CZ,Czechia,
-1992-09-30,DE,Germany,96.7919
+1992-09-30,BE,Belgium,37.385
+1992-09-30,CA,Canada,45.023
+1992-09-30,CH,Switzerland,74.6384
+1992-09-30,CO,Colombia,14.7355
+1992-09-30,DE,Germany,96.8469
 1992-09-30,DK,Denmark,33.0817
-1992-09-30,EE,Estonia,
 1992-09-30,ES,Spain,33.6468
 1992-09-30,FI,Finland,40.927
 1992-09-30,FR,France,43.1363
-1992-09-30,GB,United Kingdom,33.0474
-1992-09-30,GR,Greece,
+1992-09-30,GB,United Kingdom,33.0364
 1992-09-30,HK,Hong Kong SAR,58.7774
-1992-09-30,HR,Croatia,
-1992-09-30,HU,Hungary,
-1992-09-30,ID,Indonesia,
-1992-09-30,IE,Ireland,31.3909
-1992-09-30,IL,Israel,
-1992-09-30,IN,India,
-1992-09-30,IS,Iceland,
+1992-09-30,HU,Hungary,16.3863
+1992-09-30,IE,Ireland,31.3964
+1992-09-30,IS,Iceland,33.904
 1992-09-30,IT,Italy,53.5893
 1992-09-30,JP,Japan,173.8462
-1992-09-30,KR,Korea,66.0972
-1992-09-30,LT,Lithuania,
-1992-09-30,LU,Luxembourg,
-1992-09-30,LV,Latvia,
-1992-09-30,MA,Morocco,
-1992-09-30,MK,North Macedonia,
-1992-09-30,MT,Malta,
-1992-09-30,MX,Mexico,
+1992-09-30,KR,Korea,66.0948
 1992-09-30,MY,Malaysia,49.8712
-1992-09-30,NL,Netherlands,31.0322
+1992-09-30,NL,Netherlands,31.7853
 1992-09-30,NO,Norway,24.8447
 1992-09-30,NZ,New Zealand,31.5071
-1992-09-30,PE,Peru,
-1992-09-30,PH,Philippines,
-1992-09-30,PL,Poland,
-1992-09-30,PT,Portugal,
-1992-09-30,RO,Romania,
-1992-09-30,RS,Serbia,
-1992-09-30,RU,Russia,
+1992-09-30,PT,Portugal,70.0292
 1992-09-30,SE,Sweden,35.983
-1992-09-30,SG,Singapore,
-1992-09-30,SI,Slovenia,
-1992-09-30,SK,Slovak Republic,
 1992-09-30,TH,Thailand,65.4324
-1992-09-30,TR,Türkiye,
-1992-09-30,US,United States,54.4037
-1992-09-30,XM,Euro area,53.8548
-1992-09-30,XW,World,
-1992-09-30,ZA,South Africa,15.2522
-1992-12-31,4T,Emerging market economies (aggregate),
-1992-12-31,5R,Advanced economies,
-1992-12-31,AE,United Arab Emirates,
-1992-12-31,AT,Austria,
+1992-09-30,US,United States,54.3315
+1992-09-30,XM,Euro area,53.8606
+1992-09-30,ZA,South Africa,15.2335
+1992-12-31,AT,Austria,84.3842
 1992-12-31,AU,Australia,29.793
-1992-12-31,BE,Belgium,37.1125
-1992-12-31,BG,Bulgaria,
-1992-12-31,BR,Brazil,
-1992-12-31,CA,Canada,45.6423
-1992-12-31,CH,Switzerland,74.766
-1992-12-31,CL,Chile,
-1992-12-31,CN,China,
-1992-12-31,CO,Colombia,14.8463
-1992-12-31,CY,Cyprus,
-1992-12-31,CZ,Czechia,
-1992-12-31,DE,Germany,97.2348
+1992-12-31,BE,Belgium,37.4284
+1992-12-31,CA,Canada,45.9962
+1992-12-31,CH,Switzerland,74.7308
+1992-12-31,CO,Colombia,15.1426
+1992-12-31,DE,Germany,97.1359
 1992-12-31,DK,Denmark,32.2282
-1992-12-31,EE,Estonia,
 1992-12-31,ES,Spain,33.4817
 1992-12-31,FI,Finland,38.6854
 1992-12-31,FR,France,42.4567
-1992-12-31,GB,United Kingdom,31.7787
-1992-12-31,GR,Greece,
+1992-12-31,GB,United Kingdom,31.7681
 1992-12-31,HK,Hong Kong SAR,56.7894
-1992-12-31,HR,Croatia,
-1992-12-31,HU,Hungary,
-1992-12-31,ID,Indonesia,
-1992-12-31,IE,Ireland,31.4398
-1992-12-31,IL,Israel,
-1992-12-31,IN,India,
-1992-12-31,IS,Iceland,
+1992-12-31,HU,Hungary,16.3368
+1992-12-31,IE,Ireland,31.4453
+1992-12-31,IS,Iceland,33.9437
 1992-12-31,IT,Italy,54.1761
 1992-12-31,JP,Japan,171.6347
-1992-12-31,KR,Korea,65.8932
-1992-12-31,LT,Lithuania,
-1992-12-31,LU,Luxembourg,
-1992-12-31,LV,Latvia,
-1992-12-31,MA,Morocco,
-1992-12-31,MK,North Macedonia,
-1992-12-31,MT,Malta,
-1992-12-31,MX,Mexico,
+1992-12-31,KR,Korea,65.9257
 1992-12-31,MY,Malaysia,50.2484
-1992-12-31,NL,Netherlands,31.0284
+1992-12-31,NL,Netherlands,31.7814
 1992-12-31,NO,Norway,24.1909
 1992-12-31,NZ,New Zealand,31.5417
-1992-12-31,PE,Peru,
-1992-12-31,PH,Philippines,
-1992-12-31,PL,Poland,
-1992-12-31,PT,Portugal,
-1992-12-31,RO,Romania,
-1992-12-31,RS,Serbia,
-1992-12-31,RU,Russia,
+1992-12-31,PT,Portugal,69.8423
 1992-12-31,SE,Sweden,33.5963
-1992-12-31,SG,Singapore,
-1992-12-31,SI,Slovenia,
-1992-12-31,SK,Slovak Republic,
 1992-12-31,TH,Thailand,67.9158
-1992-12-31,TR,Türkiye,
-1992-12-31,US,United States,54.5656
-1992-12-31,XM,Euro area,53.8418
-1992-12-31,XW,World,
-1992-12-31,ZA,South Africa,15.6286
-1993-03-31,4T,Emerging market economies (aggregate),
-1993-03-31,5R,Advanced economies,
-1993-03-31,AE,United Arab Emirates,
-1993-03-31,AT,Austria,
+1992-12-31,US,United States,54.4911
+1992-12-31,XM,Euro area,53.8478
+1992-12-31,ZA,South Africa,15.6095
+1993-03-31,AT,Austria,81.9485
 1993-03-31,AU,Australia,30.0758
-1993-03-31,BE,Belgium,37.3231
-1993-03-31,BG,Bulgaria,
-1993-03-31,BR,Brazil,
-1993-03-31,CA,Canada,46.0349
-1993-03-31,CH,Switzerland,74.6421
-1993-03-31,CL,Chile,
-1993-03-31,CN,China,
-1993-03-31,CO,Colombia,15.7655
-1993-03-31,CY,Cyprus,
-1993-03-31,CZ,Czechia,
-1993-03-31,DE,Germany,98.5226
+1993-03-31,BE,Belgium,37.6407
+1993-03-31,CA,Canada,46.3919
+1993-03-31,CH,Switzerland,74.6105
+1993-03-31,CO,Colombia,16.0329
+1993-03-31,DE,Germany,98.5632
 1993-03-31,DK,Denmark,31.8034
-1993-03-31,EE,Estonia,
 1993-03-31,ES,Spain,33.2041
 1993-03-31,FI,Finland,38.127
 1993-03-31,FR,France,41.7729
-1993-03-31,GB,United Kingdom,31.9599
-1993-03-31,GR,Greece,
+1993-03-31,GB,United Kingdom,31.9493
 1993-03-31,HK,Hong Kong SAR,56.3918
-1993-03-31,HR,Croatia,
-1993-03-31,HU,Hungary,
-1993-03-31,ID,Indonesia,
-1993-03-31,IE,Ireland,30.4648
-1993-03-31,IL,Israel,
-1993-03-31,IN,India,
-1993-03-31,IS,Iceland,
+1993-03-31,HU,Hungary,17.0783
+1993-03-31,IE,Ireland,30.4702
+1993-03-31,IS,Iceland,33.9748
 1993-03-31,IT,Italy,54.7756
 1993-03-31,JP,Japan,169.4231
-1993-03-31,KR,Korea,65.5361
-1993-03-31,LT,Lithuania,
-1993-03-31,LU,Luxembourg,
-1993-03-31,LV,Latvia,
-1993-03-31,MA,Morocco,
-1993-03-31,MK,North Macedonia,
-1993-03-31,MT,Malta,
-1993-03-31,MX,Mexico,
+1993-03-31,KR,Korea,65.5453
 1993-03-31,MY,Malaysia,50.8035
-1993-03-31,NL,Netherlands,31.5756
+1993-03-31,NL,Netherlands,32.3419
 1993-03-31,NO,Norway,23.2756
 1993-03-31,NZ,New Zealand,31.8744
-1993-03-31,PE,Peru,
-1993-03-31,PH,Philippines,
-1993-03-31,PL,Poland,
-1993-03-31,PT,Portugal,
-1993-03-31,RO,Romania,
-1993-03-31,RS,Serbia,
-1993-03-31,RU,Russia,
+1993-03-31,PT,Portugal,69.9669
 1993-03-31,SE,Sweden,32.1277
-1993-03-31,SG,Singapore,
-1993-03-31,SI,Slovenia,
-1993-03-31,SK,Slovak Republic,
 1993-03-31,TH,Thailand,69.0708
-1993-03-31,TR,Türkiye,
-1993-03-31,US,United States,54.7253
-1993-03-31,XM,Euro area,53.7773
-1993-03-31,XW,World,
-1993-03-31,ZA,South Africa,15.883
-1993-06-30,4T,Emerging market economies (aggregate),
-1993-06-30,5R,Advanced economies,
-1993-06-30,AE,United Arab Emirates,
-1993-06-30,AT,Austria,
+1993-03-31,US,United States,54.6572
+1993-03-31,XM,Euro area,53.7893
+1993-03-31,ZA,South Africa,15.8635
+1993-06-30,AT,Austria,85.2485
 1993-06-30,AU,Australia,30.2729
-1993-06-30,BE,Belgium,38.38
-1993-06-30,BG,Bulgaria,
-1993-06-30,BR,Brazil,
-1993-06-30,CA,Canada,46.0349
-1993-06-30,CH,Switzerland,76.3556
-1993-06-30,CL,Chile,
-1993-06-30,CN,China,
-1993-06-30,CO,Colombia,16.8802
-1993-06-30,CY,Cyprus,
-1993-06-30,CZ,Czechia,
-1993-06-30,DE,Germany,99.7247
+1993-06-30,BE,Belgium,38.7066
+1993-06-30,CA,Canada,46.3919
+1993-06-30,CH,Switzerland,76.4282
+1993-06-30,CO,Colombia,17.1617
+1993-06-30,DE,Germany,99.7373
 1993-06-30,DK,Denmark,31.589
-1993-06-30,EE,Estonia,
 1993-06-30,ES,Spain,33.703
 1993-06-30,FI,Finland,38.3804
 1993-06-30,FR,France,41.9813
-1993-06-30,GB,United Kingdom,32.2016
-1993-06-30,GR,Greece,
+1993-06-30,GB,United Kingdom,32.1909
 1993-06-30,HK,Hong Kong SAR,60.3236
-1993-06-30,HR,Croatia,
-1993-06-30,HU,Hungary,
-1993-06-30,ID,Indonesia,
-1993-06-30,IE,Ireland,30.6291
-1993-06-30,IL,Israel,
-1993-06-30,IN,India,
-1993-06-30,IS,Iceland,
+1993-06-30,HU,Hungary,17.9707
+1993-06-30,IE,Ireland,30.6344
+1993-06-30,IS,Iceland,34.0685
 1993-06-30,IT,Italy,55.2252
 1993-06-30,JP,Japan,167.9888
-1993-06-30,KR,Korea,64.9751
-1993-06-30,LT,Lithuania,
-1993-06-30,LU,Luxembourg,
-1993-06-30,LV,Latvia,
-1993-06-30,MA,Morocco,
-1993-06-30,MK,North Macedonia,
-1993-06-30,MT,Malta,
-1993-06-30,MX,Mexico,
+1993-06-30,KR,Korea,64.9957
 1993-06-30,MY,Malaysia,51.361
-1993-06-30,NL,Netherlands,32.3697
+1993-06-30,NL,Netherlands,33.1553
 1993-06-30,NO,Norway,24.4524
 1993-06-30,NZ,New Zealand,32.1724
-1993-06-30,PE,Peru,
-1993-06-30,PH,Philippines,
-1993-06-30,PL,Poland,
-1993-06-30,PT,Portugal,
-1993-06-30,RO,Romania,
-1993-06-30,RS,Serbia,
-1993-06-30,RU,Russia,
+1993-06-30,PT,Portugal,70.6523
 1993-06-30,SE,Sweden,32.1277
-1993-06-30,SG,Singapore,
-1993-06-30,SI,Slovenia,
-1993-06-30,SK,Slovak Republic,
 1993-06-30,TH,Thailand,72.7669
-1993-06-30,TR,Türkiye,
-1993-06-30,US,United States,54.9925
-1993-06-30,XM,Euro area,54.4363
-1993-06-30,XW,World,
-1993-06-30,ZA,South Africa,16.0153
-1993-09-30,4T,Emerging market economies (aggregate),
-1993-09-30,5R,Advanced economies,
-1993-09-30,AE,United Arab Emirates,
-1993-09-30,AT,Austria,
+1993-06-30,US,United States,54.9263
+1993-06-30,XM,Euro area,54.4476
+1993-06-30,ZA,South Africa,15.9956
+1993-09-30,AT,Austria,84.3056
 1993-09-30,AU,Australia,30.3015
-1993-09-30,BE,Belgium,38.7624
-1993-09-30,BG,Bulgaria,
-1993-09-30,BR,Brazil,
-1993-09-30,CA,Canada,45.0196
-1993-09-30,CH,Switzerland,74.5327
-1993-09-30,CL,Chile,
-1993-09-30,CN,China,
-1993-09-30,CO,Colombia,18.2495
-1993-09-30,CY,Cyprus,
-1993-09-30,CZ,Czechia,
-1993-09-30,DE,Germany,100.6184
+1993-09-30,BE,Belgium,39.0922
+1993-09-30,CA,Canada,45.3686
+1993-09-30,CH,Switzerland,74.5125
+1993-09-30,CO,Colombia,18.508
+1993-09-30,DE,Germany,100.6142
 1993-09-30,DK,Denmark,33.0817
-1993-09-30,EE,Estonia,
 1993-09-30,ES,Spain,33.9594
 1993-09-30,FI,Finland,38.6577
 1993-09-30,FR,France,42.6943
-1993-09-30,GB,United Kingdom,32.8662
-1993-09-30,GR,Greece,
+1993-09-30,GB,United Kingdom,32.8553
 1993-09-30,HK,Hong Kong SAR,64.8738
-1993-09-30,HR,Croatia,
-1993-09-30,HU,Hungary,
-1993-09-30,ID,Indonesia,
-1993-09-30,IE,Ireland,32.1527
-1993-09-30,IL,Israel,
-1993-09-30,IN,India,
-1993-09-30,IS,Iceland,
+1993-09-30,HU,Hungary,17.3714
+1993-09-30,IE,Ireland,32.1583
+1993-09-30,IS,Iceland,32.9174
 1993-09-30,IT,Italy,55.7587
 1993-09-30,JP,Japan,166.5385
-1993-09-30,KR,Korea,64.1081
-1993-09-30,LT,Lithuania,
-1993-09-30,LU,Luxembourg,
-1993-09-30,LV,Latvia,
-1993-09-30,MA,Morocco,
-1993-09-30,MK,North Macedonia,
-1993-09-30,MT,Malta,
-1993-09-30,MX,Mexico,
+1993-09-30,KR,Korea,64.1291
 1993-09-30,MY,Malaysia,51.7767
-1993-09-30,NL,Netherlands,33.2551
+1993-09-30,NL,Netherlands,34.0621
 1993-09-30,NO,Norway,25.3678
 1993-09-30,NZ,New Zealand,32.7893
-1993-09-30,PE,Peru,
-1993-09-30,PH,Philippines,
-1993-09-30,PL,Poland,
-1993-09-30,PT,Portugal,
-1993-09-30,RO,Romania,
-1993-09-30,RS,Serbia,
-1993-09-30,RU,Russia,
+1993-09-30,PT,Portugal,70.4654
 1993-09-30,SE,Sweden,31.9441
-1993-09-30,SG,Singapore,
-1993-09-30,SI,Slovenia,
-1993-09-30,SK,Slovak Republic,
 1993-09-30,TH,Thailand,72.9979
-1993-09-30,TR,Türkiye,
-1993-09-30,US,United States,55.3817
-1993-09-30,XM,Euro area,55.094
-1993-09-30,XW,World,
-1993-09-30,ZA,South Africa,16.3714
-1993-12-31,4T,Emerging market economies (aggregate),
-1993-12-31,5R,Advanced economies,
-1993-12-31,AE,United Arab Emirates,
-1993-12-31,AT,Austria,
+1993-09-30,US,United States,55.3114
+1993-09-30,XM,Euro area,55.0985
+1993-09-30,ZA,South Africa,16.3513
+1993-12-31,AT,Austria,86.0342
 1993-12-31,AU,Australia,30.5843
-1993-12-31,BE,Belgium,40.0513
-1993-12-31,BG,Bulgaria,
-1993-12-31,BR,Brazil,
-1993-12-31,CA,Canada,45.5746
-1993-12-31,CH,Switzerland,74.2603
-1993-12-31,CL,Chile,
-1993-12-31,CN,China,
-1993-12-31,CO,Colombia,19.3662
-1993-12-31,CY,Cyprus,
-1993-12-31,CZ,Czechia,
-1993-12-31,DE,Germany,101.3908
+1993-12-31,BE,Belgium,40.3921
+1993-12-31,CA,Canada,45.928
+1993-12-31,CH,Switzerland,74.229
+1993-12-31,CO,Colombia,19.5744
+1993-12-31,DE,Germany,101.3426
 1993-12-31,DK,Denmark,35.0032
-1993-12-31,EE,Estonia,
 1993-12-31,ES,Spain,34.0086
 1993-12-31,FI,Finland,39.9488
 1993-12-31,FR,France,42.169
-1993-12-31,GB,United Kingdom,32.262
-1993-12-31,GR,Greece,
+1993-12-31,GB,United Kingdom,32.2513
 1993-12-31,HK,Hong Kong SAR,64.9622
-1993-12-31,HR,Croatia,
-1993-12-31,HU,Hungary,
-1993-12-31,ID,Indonesia,
-1993-12-31,IE,Ireland,31.6145
-1993-12-31,IL,Israel,
-1993-12-31,IN,India,
-1993-12-31,IS,Iceland,
+1993-12-31,HU,Hungary,18.9304
+1993-12-31,IE,Ireland,31.6201
+1993-12-31,IS,Iceland,33.1839
 1993-12-31,IT,Italy,55.1575
 1993-12-31,JP,Japan,165.4808
-1993-12-31,KR,Korea,63.7511
-1993-12-31,LT,Lithuania,
-1993-12-31,LU,Luxembourg,
-1993-12-31,LV,Latvia,
-1993-12-31,MA,Morocco,
-1993-12-31,MK,North Macedonia,
-1993-12-31,MT,Malta,
-1993-12-31,MX,Mexico,
+1993-12-31,KR,Korea,63.7486
 1993-12-31,MY,Malaysia,52.4058
-1993-12-31,NL,Netherlands,33.8896
+1993-12-31,NL,Netherlands,34.7121
 1993-12-31,NO,Norway,26.1523
 1993-12-31,NZ,New Zealand,33.5309
-1993-12-31,PE,Peru,
-1993-12-31,PH,Philippines,
-1993-12-31,PL,Poland,
-1993-12-31,PT,Portugal,
-1993-12-31,RO,Romania,
-1993-12-31,RS,Serbia,
-1993-12-31,RU,Russia,
+1993-12-31,PT,Portugal,70.5277
 1993-12-31,SE,Sweden,32.3112
-1993-12-31,SG,Singapore,
-1993-12-31,SI,Slovenia,
-1993-12-31,SK,Slovak Republic,
 1993-12-31,TH,Thailand,73.2867
-1993-12-31,TR,Türkiye,
-1993-12-31,US,United States,55.8848
-1993-12-31,XM,Euro area,55.0804
-1993-12-31,XW,World,
-1993-12-31,ZA,South Africa,16.7072
-1994-03-31,4T,Emerging market economies (aggregate),
-1994-03-31,5R,Advanced economies,
-1994-03-31,AE,United Arab Emirates,
-1994-03-31,AT,Austria,
+1993-12-31,US,United States,55.8219
+1993-12-31,XM,Euro area,55.0864
+1993-12-31,ZA,South Africa,16.6867
+1994-03-31,AT,Austria,86.3485
 1994-03-31,AU,Australia,30.9212
-1994-03-31,BE,Belgium,40.1114
-1994-03-31,BG,Bulgaria,
-1994-03-31,BR,Brazil,
-1994-03-31,CA,Canada,47.6234
-1994-03-31,CH,Switzerland,75.5194
-1994-03-31,CL,Chile,
-1994-03-31,CN,China,
-1994-03-31,CO,Colombia,21.054
-1994-03-31,CY,Cyprus,
-1994-03-31,CZ,Czechia,
-1994-03-31,DE,Germany,102.4937
+1994-03-31,BE,Belgium,40.4528
+1994-03-31,CA,Canada,47.9927
+1994-03-31,CH,Switzerland,75.5609
+1994-03-31,CO,Colombia,21.465
+1994-03-31,DE,Germany,102.4428
 1994-03-31,DK,Denmark,37.0318
-1994-03-31,EE,Estonia,
 1994-03-31,ES,Spain,33.696
 1994-03-31,FI,Finland,40.927
 1994-03-31,FR,France,41.5352
-1994-03-31,GB,United Kingdom,32.6245
-1994-03-31,GR,Greece,
+1994-03-31,GB,United Kingdom,32.6137
 1994-03-31,HK,Hong Kong SAR,74.8136
-1994-03-31,HR,Croatia,
-1994-03-31,HU,Hungary,
-1994-03-31,ID,Indonesia,
-1994-03-31,IE,Ireland,32.7223
+1994-03-31,HU,Hungary,19.5418
+1994-03-31,IE,Ireland,32.728
 1994-03-31,IL,Israel,45.6137
-1994-03-31,IN,India,
-1994-03-31,IS,Iceland,
+1994-03-31,IS,Iceland,33.8473
 1994-03-31,IT,Italy,54.7595
 1994-03-31,JP,Japan,164.4231
-1994-03-31,KR,Korea,63.6491
-1994-03-31,LT,Lithuania,
-1994-03-31,LU,Luxembourg,
-1994-03-31,LV,Latvia,
-1994-03-31,MA,Morocco,
-1994-03-31,MK,North Macedonia,
-1994-03-31,MT,Malta,
-1994-03-31,MX,Mexico,
+1994-03-31,KR,Korea,63.643
 1994-03-31,MY,Malaysia,54.0197
-1994-03-31,NL,Netherlands,35.1625
+1994-03-31,NL,Netherlands,36.0158
 1994-03-31,NO,Norway,26.9369
 1994-03-31,NZ,New Zealand,35.4229
-1994-03-31,PE,Peru,
-1994-03-31,PH,Philippines,
-1994-03-31,PL,Poland,
-1994-03-31,PT,Portugal,
-1994-03-31,RO,Romania,
-1994-03-31,RS,Serbia,
-1994-03-31,RU,Russia,
+1994-03-31,PT,Portugal,71.3376
 1994-03-31,SE,Sweden,32.862
-1994-03-31,SG,Singapore,
-1994-03-31,SI,Slovenia,
-1994-03-31,SK,Slovak Republic,
 1994-03-31,TH,Thailand,69.4751
-1994-03-31,TR,Türkiye,
-1994-03-31,US,United States,56.062
-1994-03-31,XM,Euro area,55.0545
-1994-03-31,XW,World,
-1994-03-31,ZA,South Africa,17.1549
-1994-06-30,4T,Emerging market economies (aggregate),
-1994-06-30,5R,Advanced economies,
-1994-06-30,AE,United Arab Emirates,
-1994-06-30,AT,Austria,
+1994-03-31,US,United States,55.9931
+1994-03-31,XM,Euro area,55.0541
+1994-03-31,ZA,South Africa,17.1338
+1994-06-30,AT,Austria,84.7771
 1994-06-30,AU,Australia,31.2899
-1994-06-30,BE,Belgium,40.7301
-1994-06-30,BG,Bulgaria,
-1994-06-30,BR,Brazil,
-1994-06-30,CA,Canada,47.2263
-1994-06-30,CH,Switzerland,74.7017
-1994-06-30,CL,Chile,
-1994-06-30,CN,China,
-1994-06-30,CO,Colombia,22.0429
-1994-06-30,CY,Cyprus,
-1994-06-30,CZ,Czechia,
-1994-06-30,DE,Germany,103.9313
+1994-06-30,BE,Belgium,41.0768
+1994-06-30,CA,Canada,47.5925
+1994-06-30,CH,Switzerland,74.702
+1994-06-30,CO,Colombia,22.3819
+1994-06-30,DE,Germany,103.9185
 1994-06-30,DK,Denmark,37.0318
-1994-06-30,EE,Estonia,
 1994-06-30,ES,Spain,33.8049
 1994-06-30,FI,Finland,41.6003
 1994-06-30,FR,France,41.9438
-1994-06-30,GB,United Kingdom,33.0474
-1994-06-30,GR,Greece,
+1994-06-30,GB,United Kingdom,33.0364
 1994-06-30,HK,Hong Kong SAR,77.3759
-1994-06-30,HR,Croatia,
-1994-06-30,HU,Hungary,
-1994-06-30,ID,Indonesia,
-1994-06-30,IE,Ireland,31.5586
+1994-06-30,HU,Hungary,21.2914
+1994-06-30,IE,Ireland,31.5641
 1994-06-30,IL,Israel,48.3843
-1994-06-30,IN,India,
-1994-06-30,IS,Iceland,
+1994-06-30,IS,Iceland,33.8142
 1994-06-30,IT,Italy,54.2854
 1994-06-30,JP,Japan,163.7538
-1994-06-30,KR,Korea,63.5471
-1994-06-30,LT,Lithuania,
-1994-06-30,LU,Luxembourg,
-1994-06-30,LV,Latvia,
-1994-06-30,MA,Morocco,
-1994-06-30,MK,North Macedonia,
-1994-06-30,MT,Malta,
-1994-06-30,MX,Mexico,
+1994-06-30,KR,Korea,63.5373
 1994-06-30,MY,Malaysia,53.9595
-1994-06-30,NL,Netherlands,35.6261
+1994-06-30,NL,Netherlands,36.4907
 1994-06-30,NO,Norway,27.7215
 1994-06-30,NZ,New Zealand,36.6081
-1994-06-30,PE,Peru,
-1994-06-30,PH,Philippines,
-1994-06-30,PL,Poland,
-1994-06-30,PT,Portugal,
-1994-06-30,RO,Romania,
-1994-06-30,RS,Serbia,
-1994-06-30,RU,Russia,
+1994-06-30,PT,Portugal,71.4622
 1994-06-30,SE,Sweden,33.7799
-1994-06-30,SG,Singapore,
-1994-06-30,SI,Slovenia,
-1994-06-30,SK,Slovak Republic,
 1994-06-30,TH,Thailand,71.9006
-1994-06-30,TR,Türkiye,
-1994-06-30,US,United States,56.3887
-1994-06-30,XM,Euro area,55.3795
-1994-06-30,XW,World,
-1994-06-30,ZA,South Africa,17.8162
-1994-09-30,4T,Emerging market economies (aggregate),
-1994-09-30,5R,Advanced economies,
-1994-09-30,AE,United Arab Emirates,
-1994-09-30,AT,Austria,
+1994-06-30,US,United States,56.3173
+1994-06-30,XM,Euro area,55.3832
+1994-06-30,ZA,South Africa,17.7944
+1994-09-30,AT,Austria,85.0913
 1994-09-30,AU,Australia,31.7698
-1994-09-30,BE,Belgium,41.8343
-1994-09-30,BG,Bulgaria,
-1994-09-30,BR,Brazil,
-1994-09-30,CA,Canada,46.4817
-1994-09-30,CH,Switzerland,74.4247
-1994-09-30,CL,Chile,
-1994-09-30,CN,China,
-1994-09-30,CO,Colombia,23.9549
-1994-09-30,CY,Cyprus,
-1994-09-30,CZ,Czechia,
-1994-09-30,DE,Germany,104.5507
+1994-09-30,BE,Belgium,42.1903
+1994-09-30,CA,Canada,46.8421
+1994-09-30,CH,Switzerland,74.4141
+1994-09-30,CO,Colombia,24.3401
+1994-09-30,DE,Germany,104.6437
 1994-09-30,DK,Denmark,36.4999
-1994-09-30,EE,Estonia,
 1994-09-30,ES,Spain,34.2088
 1994-09-30,FI,Finland,41.1805
 1994-09-30,FR,France,42.6901
-1994-09-30,GB,United Kingdom,33.6516
-1994-09-30,GR,Greece,
+1994-09-30,GB,United Kingdom,33.6404
 1994-09-30,HK,Hong Kong SAR,76.8237
-1994-09-30,HR,Croatia,
-1994-09-30,HU,Hungary,
-1994-09-30,ID,Indonesia,
-1994-09-30,IE,Ireland,32.1422
+1994-09-30,HU,Hungary,22.6443
+1994-09-30,IE,Ireland,32.1478
 1994-09-30,IL,Israel,50.4814
-1994-09-30,IN,India,
-1994-09-30,IS,Iceland,
+1994-09-30,IS,Iceland,32.8519
 1994-09-30,IT,Italy,54.7477
 1994-09-30,JP,Japan,163.077
-1994-09-30,KR,Korea,63.4961
-1994-09-30,LT,Lithuania,
-1994-09-30,LU,Luxembourg,
-1994-09-30,LV,Latvia,
-1994-09-30,MA,Morocco,
-1994-09-30,MK,North Macedonia,
-1994-09-30,MT,Malta,
-1994-09-30,MX,Mexico,
+1994-09-30,KR,Korea,63.495
 1994-09-30,MY,Malaysia,55.8737
-1994-09-30,NL,Netherlands,36.9788
+1994-09-30,NL,Netherlands,37.8762
 1994-09-30,NO,Norway,28.8983
 1994-09-30,NZ,New Zealand,37.7101
-1994-09-30,PE,Peru,
-1994-09-30,PH,Philippines,
-1994-09-30,PL,Poland,
-1994-09-30,PT,Portugal,
-1994-09-30,RO,Romania,
-1994-09-30,RS,Serbia,
-1994-09-30,RU,Russia,
+1994-09-30,PT,Portugal,72.2099
 1994-09-30,SE,Sweden,34.1471
-1994-09-30,SG,Singapore,
-1994-09-30,SI,Slovenia,
-1994-09-30,SK,Slovak Republic,
 1994-09-30,TH,Thailand,71.7274
-1994-09-30,TR,Türkiye,
-1994-09-30,US,United States,56.6552
-1994-09-30,XM,Euro area,56.012
-1994-09-30,XW,World,
-1994-09-30,ZA,South Africa,18.325
-1994-12-31,4T,Emerging market economies (aggregate),
-1994-12-31,5R,Advanced economies,
-1994-12-31,AE,United Arab Emirates,
-1994-12-31,AT,Austria,
+1994-09-30,US,United States,56.5886
+1994-09-30,XM,Euro area,56.0138
+1994-09-30,ZA,South Africa,18.3025
+1994-12-31,AT,Austria,82.6557
 1994-12-31,AU,Australia,31.6268
-1994-12-31,BE,Belgium,41.7441
-1994-12-31,BG,Bulgaria,
-1994-12-31,BR,Brazil,
-1994-12-31,CA,Canada,47.0368
-1994-12-31,CH,Switzerland,73.7896
-1994-12-31,CL,Chile,
-1994-12-31,CN,China,
-1994-12-31,CO,Colombia,25.974
-1994-12-31,CY,Cyprus,
-1994-12-31,CZ,Czechia,
-1994-12-31,DE,Germany,104.4847
+1994-12-31,BE,Belgium,42.0993
+1994-12-31,CA,Canada,47.4015
+1994-12-31,CH,Switzerland,73.7487
+1994-12-31,CO,Colombia,26.333
+1994-12-31,DE,Germany,104.4543
 1994-12-31,DK,Denmark,37.0318
-1994-12-31,EE,Estonia,
 1994-12-31,ES,Spain,34.114
 1994-12-31,FI,Finland,40.6775
 1994-12-31,FR,France,42.144
-1994-12-31,GB,United Kingdom,33.4099
-1994-12-31,GR,Greece,
+1994-12-31,GB,United Kingdom,33.3988
 1994-12-31,HK,Hong Kong SAR,75.5646
-1994-12-31,HR,Croatia,
-1994-12-31,HU,Hungary,
-1994-12-31,ID,Indonesia,
-1994-12-31,IE,Ireland,33.9908
+1994-12-31,HU,Hungary,22.5942
+1994-12-31,IE,Ireland,33.9967
 1994-12-31,IL,Israel,52.248
-1994-12-31,IN,India,
-1994-12-31,IS,Iceland,
+1994-12-31,IS,Iceland,32.9846
 1994-12-31,IT,Italy,54.3929
 1994-12-31,JP,Japan,162.5001
-1994-12-31,KR,Korea,63.5471
-1994-12-31,LT,Lithuania,
-1994-12-31,LU,Luxembourg,
-1994-12-31,LV,Latvia,
-1994-12-31,MA,Morocco,
-1994-12-31,MK,North Macedonia,
-1994-12-31,MT,Malta,
-1994-12-31,MX,Mexico,
+1994-12-31,KR,Korea,63.5584
 1994-12-31,MY,Malaysia,58.967
-1994-12-31,NL,Netherlands,36.5
+1994-12-31,NL,Netherlands,37.3858
 1994-12-31,NO,Norway,28.7676
 1994-12-31,NZ,New Zealand,38.417
-1994-12-31,PE,Peru,
-1994-12-31,PH,Philippines,
-1994-12-31,PL,Poland,
-1994-12-31,PT,Portugal,
-1994-12-31,RO,Romania,
-1994-12-31,RS,Serbia,
-1994-12-31,RU,Russia,
+1994-12-31,PT,Portugal,73.0198
 1994-12-31,SE,Sweden,33.5963
-1994-12-31,SG,Singapore,
-1994-12-31,SI,Slovenia,
-1994-12-31,SK,Slovak Republic,
 1994-12-31,TH,Thailand,74.3839
-1994-12-31,TR,Türkiye,
-1994-12-31,US,United States,56.9035
-1994-12-31,XM,Euro area,55.8417
-1994-12-31,XW,World,
-1994-12-31,ZA,South Africa,18.6302
-1995-03-31,4T,Emerging market economies (aggregate),
-1995-03-31,5R,Advanced economies,
-1995-03-31,AE,United Arab Emirates,
-1995-03-31,AT,Austria,
+1994-12-31,US,United States,56.838
+1994-12-31,XM,Euro area,55.8338
+1994-12-31,ZA,South Africa,18.6074
+1995-03-31,AT,Austria,84.3056
 1995-03-31,AU,Australia,31.9383
-1995-03-31,BE,Belgium,42.1093
-1995-03-31,BG,Bulgaria,
-1995-03-31,BR,Brazil,
-1995-03-31,CA,Canada,45.7687
-1995-03-31,CH,Switzerland,74.1735
-1995-03-31,CL,Chile,
-1995-03-31,CN,China,
-1995-03-31,CO,Colombia,27.0032
-1995-03-31,CY,Cyprus,
-1995-03-31,CZ,Czechia,
-1995-03-31,DE,Germany,104.76
+1995-03-31,BE,Belgium,42.4676
+1995-03-31,CA,Canada,46.1235
+1995-03-31,CH,Switzerland,74.1583
+1995-03-31,CO,Colombia,27.3429
+1995-03-31,DE,Germany,104.7743
 1995-03-31,DK,Denmark,37.8854
-1995-03-31,EE,Estonia,
 1995-03-31,ES,Spain,34.662
 1995-03-31,FI,Finland,40.3686
 1995-03-31,FR,France,41.2058
-1995-03-31,GB,United Kingdom,33.1078
-1995-03-31,GR,Greece,
+1995-03-31,GB,United Kingdom,33.0968
 1995-03-31,HK,Hong Kong SAR,74.151
-1995-03-31,HR,Croatia,
-1995-03-31,HU,Hungary,
-1995-03-31,ID,Indonesia,
-1995-03-31,IE,Ireland,34.8364
+1995-03-31,HU,Hungary,22.9931
+1995-03-31,IE,Ireland,34.8425
 1995-03-31,IL,Israel,53.6968
-1995-03-31,IN,India,
-1995-03-31,IS,Iceland,
+1995-03-31,IS,Iceland,32.3209
 1995-03-31,IT,Italy,54.0771
 1995-03-31,JP,Japan,161.9231
-1995-03-31,KR,Korea,63.4961
-1995-03-31,LT,Lithuania,
-1995-03-31,LU,Luxembourg,
-1995-03-31,LV,Latvia,
-1995-03-31,MA,Morocco,
-1995-03-31,MK,North Macedonia,
-1995-03-31,MT,Malta,
-1995-03-31,MX,Mexico,
+1995-03-31,KR,Korea,63.495
 1995-03-31,MY,Malaysia,62.2706
-1995-03-31,NL,Netherlands,37.0137
+1995-03-31,NL,Netherlands,37.9348
 1995-03-31,NO,Norway,28.8983
 1995-03-31,NZ,New Zealand,39.1655
-1995-03-31,PE,Peru,
-1995-03-31,PH,Philippines,
-1995-03-31,PL,Poland,
-1995-03-31,PT,Portugal,
-1995-03-31,RO,Romania,
-1995-03-31,RS,Serbia,
-1995-03-31,RU,Russia,
+1995-03-31,PT,Portugal,73.1133
 1995-03-31,SE,Sweden,33.5963
-1995-03-31,SG,Singapore,
-1995-03-31,SI,Slovenia,
-1995-03-31,SK,Slovak Republic,
 1995-03-31,TH,Thailand,74.1529
-1995-03-31,TR,Türkiye,
-1995-03-31,US,United States,57.1024
-1995-03-31,XM,Euro area,55.8197
-1995-03-31,XW,World,
-1995-03-31,ZA,South Africa,19.0169
-1995-06-30,4T,Emerging market economies (aggregate),
-1995-06-30,5R,Advanced economies,
-1995-06-30,AE,United Arab Emirates,
-1995-06-30,AT,Austria,
+1995-03-31,US,United States,57.0353
+1995-03-31,XM,Euro area,55.8113
+1995-03-31,ZA,South Africa,18.9935
+1995-06-30,AT,Austria,82.9699
 1995-06-30,AU,Australia,31.7126
-1995-06-30,BE,Belgium,42.3714
-1995-06-30,BG,Bulgaria,
-1995-06-30,BR,Brazil,
-1995-06-30,CA,Canada,44.6044
-1995-06-30,CH,Switzerland,74.5696
-1995-06-30,CL,Chile,
-1995-06-30,CN,China,
-1995-06-30,CO,Colombia,29.4912
-1995-06-30,CY,Cyprus,
-1995-06-30,CZ,Czechia,
-1995-06-30,DE,Germany,105.2059
+1995-06-30,BE,Belgium,42.732
+1995-06-30,CA,Canada,44.9502
+1995-06-30,CH,Switzerland,74.5807
+1995-06-30,CO,Colombia,30.0069
+1995-06-30,DE,Germany,105.2225
 1995-06-30,DK,Denmark,39.2709
-1995-06-30,EE,Estonia,
 1995-06-30,ES,Spain,35.0941
 1995-06-30,FI,Finland,39.9488
 1995-06-30,FR,France,41.5227
-1995-06-30,GB,United Kingdom,33.4703
-1995-06-30,GR,Greece,
+1995-06-30,GB,United Kingdom,33.4592
 1995-06-30,HK,Hong Kong SAR,73.1128
-1995-06-30,HR,Croatia,
-1995-06-30,HU,Hungary,
-1995-06-30,ID,Indonesia,
-1995-06-30,IE,Ireland,33.5609
+1995-06-30,HU,Hungary,23.6598
+1995-06-30,IE,Ireland,33.5668
 1995-06-30,IL,Israel,54.9805
-1995-06-30,IN,India,
-1995-06-30,IS,Iceland,
+1995-06-30,IS,Iceland,32.2547
 1995-06-30,IT,Italy,54.6571
 1995-06-30,JP,Japan,161.3016
-1995-06-30,KR,Korea,63.4961
-1995-06-30,LT,Lithuania,
-1995-06-30,LU,Luxembourg,
-1995-06-30,LV,Latvia,
-1995-06-30,MA,Morocco,
-1995-06-30,MK,North Macedonia,
-1995-06-30,MT,Malta,
-1995-06-30,MX,Mexico,
+1995-06-30,KR,Korea,63.495
 1995-06-30,MY,Malaysia,64.8704
-1995-06-30,NL,Netherlands,37.4607
+1995-06-30,NL,Netherlands,38.4598
 1995-06-30,NO,Norway,30.0752
 1995-06-30,NZ,New Zealand,39.8517
-1995-06-30,PE,Peru,
-1995-06-30,PH,Philippines,
-1995-06-30,PL,Poland,
-1995-06-30,PT,Portugal,
-1995-06-30,RO,Romania,
-1995-06-30,RS,Serbia,
-1995-06-30,RU,Russia,
+1995-06-30,PT,Portugal,72.9575
 1995-06-30,SE,Sweden,34.1471
-1995-06-30,SG,Singapore,
-1995-06-30,SI,Slovenia,
-1995-06-30,SK,Slovak Republic,
 1995-06-30,TH,Thailand,75.308
-1995-06-30,TR,Türkiye,
-1995-06-30,US,United States,57.4633
-1995-06-30,XM,Euro area,56.1408
-1995-06-30,XW,World,
-1995-06-30,ZA,South Africa,19.3628
-1995-09-30,4T,Emerging market economies (aggregate),
-1995-09-30,5R,Advanced economies,
-1995-09-30,AE,United Arab Emirates,
-1995-09-30,AT,Austria,
+1995-06-30,US,United States,57.4023
+1995-06-30,XM,Euro area,56.1394
+1995-06-30,ZA,South Africa,19.3391
+1995-09-30,AT,Austria,87.6841
 1995-09-30,AU,Australia,31.7698
-1995-09-30,BE,Belgium,43.5744
-1995-09-30,BG,Bulgaria,
-1995-09-30,BR,Brazil,
-1995-09-30,CA,Canada,45.0331
-1995-09-30,CH,Switzerland,74.3382
-1995-09-30,CL,Chile,
-1995-09-30,CN,China,
-1995-09-30,CO,Colombia,31.0276
-1995-09-30,CY,Cyprus,
-1995-09-30,CZ,Czechia,
-1995-09-30,DE,Germany,104.9265
+1995-09-30,BE,Belgium,43.9452
+1995-09-30,CA,Canada,45.3823
+1995-09-30,CH,Switzerland,74.3532
+1995-09-30,CO,Colombia,31.4364
+1995-09-30,DE,Germany,104.9065
 1995-09-30,DK,Denmark,40.2316
-1995-09-30,EE,Estonia,
 1995-09-30,ES,Spain,35.326
 1995-09-30,FI,Finland,39.1646
 1995-09-30,FR,France,42.2857
-1995-09-30,GB,United Kingdom,33.7724
-1995-09-30,GR,Greece,
+1995-09-30,GB,United Kingdom,33.7612
 1995-09-30,HK,Hong Kong SAR,69.1369
-1995-09-30,HR,Croatia,
-1995-09-30,HU,Hungary,
-1995-09-30,ID,Indonesia,
-1995-09-30,IE,Ireland,34.9867
+1995-09-30,HU,Hungary,23.5827
+1995-09-30,IE,Ireland,34.9928
 1995-09-30,IL,Israel,57.4969
-1995-09-30,IN,India,
-1995-09-30,IS,Iceland,
+1995-09-30,IS,Iceland,32.2547
 1995-09-30,IT,Italy,55.3251
 1995-09-30,JP,Japan,160.6731
-1995-09-30,KR,Korea,63.3941
-1995-09-30,LT,Lithuania,
-1995-09-30,LU,Luxembourg,
-1995-09-30,LV,Latvia,
-1995-09-30,MA,Morocco,
-1995-09-30,MK,North Macedonia,
-1995-09-30,MT,Malta,
-1995-09-30,MX,Mexico,
+1995-09-30,KR,Korea,63.4316
 1995-09-30,MY,Malaysia,67.1608
-1995-09-30,NL,Netherlands,38.5335
+1995-09-30,NL,Netherlands,39.3786
 1995-09-30,NO,Norway,30.5982
 1995-09-30,NZ,New Zealand,40.9675
-1995-09-30,PE,Peru,
-1995-09-30,PH,Philippines,
-1995-09-30,PL,Poland,
-1995-09-30,PT,Portugal,
-1995-09-30,RO,Romania,
-1995-09-30,RS,Serbia,
-1995-09-30,RU,Russia,
+1995-09-30,PT,Portugal,73.051
 1995-09-30,SE,Sweden,33.7799
-1995-09-30,SG,Singapore,
-1995-09-30,SI,Slovenia,
-1995-09-30,SK,Slovak Republic,
 1995-09-30,TH,Thailand,77.7913
-1995-09-30,TR,Türkiye,
-1995-09-30,US,United States,57.9875
-1995-09-30,XM,Euro area,56.9089
-1995-09-30,XW,World,
-1995-09-30,ZA,South Africa,19.4442
-1995-12-31,4T,Emerging market economies (aggregate),
-1995-12-31,5R,Advanced economies,
-1995-12-31,AE,United Arab Emirates,
-1995-12-31,AT,Austria,
+1995-09-30,US,United States,57.9143
+1995-09-30,XM,Euro area,56.903
+1995-09-30,ZA,South Africa,19.4204
+1995-12-31,AT,Austria,80.77
 1995-12-31,AU,Australia,31.7126
-1995-12-31,BE,Belgium,43.8021
-1995-12-31,BG,Bulgaria,
-1995-12-31,BR,Brazil,
-1995-12-31,CA,Canada,45.1053
-1995-12-31,CH,Switzerland,73.1349
-1995-12-31,CL,Chile,
-1995-12-31,CN,China,
-1995-12-31,CO,Colombia,32.4716
-1995-12-31,CY,Cyprus,
-1995-12-31,CZ,Czechia,
-1995-12-31,DE,Germany,104.5976
+1995-12-31,BE,Belgium,44.1748
+1995-12-31,CA,Canada,45.455
+1995-12-31,CH,Switzerland,73.1133
+1995-12-31,CO,Colombia,32.9758
+1995-12-31,DE,Germany,104.5872
 1995-12-31,DK,Denmark,41.4067
-1995-12-31,EE,Estonia,
 1995-12-31,ES,Spain,35.4349
 1995-12-31,FI,Finland,38.9389
 1995-12-31,FR,France,41.7604
-1995-12-31,GB,United Kingdom,33.2891
-1995-12-31,GR,Greece,
+1995-12-31,GB,United Kingdom,33.278
 1995-12-31,HK,Hong Kong SAR,68.0104
-1995-12-31,HR,Croatia,
-1995-12-31,HU,Hungary,
-1995-12-31,ID,Indonesia,
-1995-12-31,IE,Ireland,36.395
+1995-12-31,HU,Hungary,24.2689
+1995-12-31,IE,Ireland,36.4013
 1995-12-31,IL,Israel,60.2548
-1995-12-31,IN,India,
-1995-12-31,IS,Iceland,
+1995-12-31,IS,Iceland,31.1265
 1995-12-31,IT,Italy,55.8374
 1995-12-31,JP,Japan,159.8558
-1995-12-31,KR,Korea,63.3941
-1995-12-31,LT,Lithuania,
-1995-12-31,LU,Luxembourg,
-1995-12-31,LV,Latvia,
-1995-12-31,MA,Morocco,
-1995-12-31,MK,North Macedonia,
-1995-12-31,MT,Malta,
-1995-12-31,MX,Mexico,
+1995-12-31,KR,Korea,63.4316
 1995-12-31,MY,Malaysia,69.3366
-1995-12-31,NL,Netherlands,38.9806
+1995-12-31,NL,Netherlands,39.9037
 1995-12-31,NO,Norway,30.9905
 1995-12-31,NZ,New Zealand,41.8339
-1995-12-31,PE,Peru,
-1995-12-31,PH,Philippines,
-1995-12-31,PL,Poland,
-1995-12-31,PT,Portugal,
-1995-12-31,RO,Romania,
-1995-12-31,RS,Serbia,
-1995-12-31,RU,Russia,
+1995-12-31,PT,Portugal,73.3313
 1995-12-31,SE,Sweden,33.2292
-1995-12-31,SG,Singapore,
-1995-12-31,SI,Slovenia,
-1995-12-31,SK,Slovak Republic,
 1995-12-31,TH,Thailand,78.5998
-1995-12-31,TR,Türkiye,
-1995-12-31,US,United States,58.2779
-1995-12-31,XM,Euro area,56.8287
-1995-12-31,XW,World,
-1995-12-31,ZA,South Africa,19.546
-1996-03-31,4T,Emerging market economies (aggregate),
-1996-03-31,5R,Advanced economies,
-1996-03-31,AE,United Arab Emirates,
-1996-03-31,AT,Austria,
+1995-12-31,US,United States,58.2175
+1995-12-31,XM,Euro area,56.8184
+1995-12-31,ZA,South Africa,19.522
+1996-03-31,AT,Austria,85.5628
 1996-03-31,AU,Australia,31.6554
-1996-03-31,BE,Belgium,42.9213
-1996-03-31,BG,Bulgaria,
-1996-03-31,BR,Brazil,
-1996-03-31,CA,Canada,44.5593
-1996-03-31,CH,Switzerland,72.3003
-1996-03-31,CL,Chile,
-1996-03-31,CN,China,
-1996-03-31,CO,Colombia,34.069
-1996-03-31,CY,Cyprus,
-1996-03-31,CZ,Czechia,
-1996-03-31,DE,Germany,104.101
+1996-03-31,BE,Belgium,43.2866
+1996-03-31,CA,Canada,44.9047
+1996-03-31,CH,Switzerland,72.2623
+1996-03-31,CO,Colombia,34.4879
+1996-03-31,DE,Germany,104.143
 1996-03-31,DK,Denmark,42.0459
-1996-03-31,EE,Estonia,
 1996-03-31,ES,Spain,35.5683
 1996-03-31,FI,Finland,39.6399
 1996-03-31,FR,France,41.5537
-1996-03-31,GB,United Kingdom,33.7724
-1996-03-31,GR,Greece,
+1996-03-31,GB,United Kingdom,33.7612
 1996-03-31,HK,Hong Kong SAR,72.1188
-1996-03-31,HR,Croatia,
-1996-03-31,HU,Hungary,
-1996-03-31,ID,Indonesia,
-1996-03-31,IE,Ireland,36.5557
+1996-03-31,HU,Hungary,25.3345
+1996-03-31,IE,Ireland,36.5621
 1996-03-31,IL,Israel,63.089
-1996-03-31,IN,India,
-1996-03-31,IS,Iceland,
+1996-03-31,IS,Iceland,31.591
 1996-03-31,IT,Italy,56.398
 1996-03-31,JP,Japan,159.0385
-1996-03-31,KR,Korea,63.6491
-1996-03-31,LT,Lithuania,
-1996-03-31,LU,Luxembourg,
-1996-03-31,LV,Latvia,
-1996-03-31,MA,Morocco,
-1996-03-31,MK,North Macedonia,
-1996-03-31,MT,Malta,
-1996-03-31,MX,Mexico,
+1996-03-31,KR,Korea,63.6218
 1996-03-31,MY,Malaysia,71.9683
-1996-03-31,NL,Netherlands,40.0534
+1996-03-31,NL,Netherlands,40.9538
 1996-03-31,NO,Norway,31.252
 1996-03-31,NZ,New Zealand,43.7883
-1996-03-31,PE,Peru,
-1996-03-31,PH,Philippines,
-1996-03-31,PL,Poland,
-1996-03-31,PT,Portugal,
-1996-03-31,RO,Romania,
-1996-03-31,RS,Serbia,
-1996-03-31,RU,Russia,
+1996-03-31,PT,Portugal,73.6428
 1996-03-31,SE,Sweden,33.4128
-1996-03-31,SG,Singapore,
-1996-03-31,SI,Slovenia,
-1996-03-31,SK,Slovak Republic,
 1996-03-31,TH,Thailand,77.849
-1996-03-31,TR,Türkiye,
-1996-03-31,US,United States,58.7716
-1996-03-31,XM,Euro area,56.9991
-1996-03-31,XW,World,
-1996-03-31,ZA,South Africa,19.8003
-1996-06-30,4T,Emerging market economies (aggregate),
-1996-06-30,5R,Advanced economies,
-1996-06-30,AE,United Arab Emirates,
-1996-06-30,AT,Austria,
+1996-03-31,US,United States,58.7121
+1996-03-31,XM,Euro area,56.9924
+1996-03-31,ZA,South Africa,19.7761
+1996-06-30,AT,Austria,86.5842
 1996-06-30,AU,Australia,32.0495
-1996-06-30,BE,Belgium,43.497
-1996-06-30,BG,Bulgaria,
-1996-06-30,BR,Brazil,
-1996-06-30,CA,Canada,45.516
-1996-06-30,CH,Switzerland,72.5875
-1996-06-30,CL,Chile,
-1996-06-30,CN,China,
-1996-06-30,CO,Colombia,35.6556
-1996-06-30,CY,Cyprus,
-1996-06-30,CZ,Czechia,
-1996-06-30,DE,Germany,103.691
+1996-06-30,BE,Belgium,43.8672
+1996-06-30,CA,Canada,45.8689
+1996-06-30,CH,Switzerland,72.5943
+1996-06-30,CO,Colombia,36.0648
+1996-06-30,DE,Germany,103.7006
 1996-06-30,DK,Denmark,43.1138
-1996-06-30,EE,Estonia,
 1996-06-30,ES,Spain,35.8213
 1996-06-30,FI,Finland,41.0418
 1996-06-30,FR,France,41.5537
-1996-06-30,GB,United Kingdom,33.8328
-1996-06-30,GR,Greece,
+1996-06-30,GB,United Kingdom,33.8216
 1996-06-30,HK,Hong Kong SAR,75.2333
-1996-06-30,HR,Croatia,
-1996-06-30,HU,Hungary,
-1996-06-30,ID,Indonesia,
-1996-06-30,IE,Ireland,37.0834
+1996-06-30,HU,Hungary,26.0922
+1996-06-30,IE,Ireland,37.0899
 1996-06-30,IL,Israel,66.3045
-1996-06-30,IN,India,
-1996-06-30,IS,Iceland,
+1996-06-30,IS,Iceland,32.1882
 1996-06-30,IT,Italy,56.6655
 1996-06-30,JP,Japan,158.3174
-1996-06-30,KR,Korea,63.8021
-1996-06-30,LT,Lithuania,
-1996-06-30,LU,Luxembourg,
-1996-06-30,LV,Latvia,
-1996-06-30,MA,Morocco,
-1996-06-30,MK,North Macedonia,
-1996-06-30,MT,Malta,
-1996-06-30,MX,Mexico,
+1996-06-30,KR,Korea,63.8332
 1996-06-30,MY,Malaysia,74.1316
-1996-06-30,NL,Netherlands,41.4839
+1996-06-30,NL,Netherlands,42.1351
 1996-06-30,NO,Norway,32.6904
 1996-06-30,NZ,New Zealand,44.4675
-1996-06-30,PE,Peru,
-1996-06-30,PH,Philippines,
-1996-06-30,PL,Poland,
-1996-06-30,PT,Portugal,
-1996-06-30,RO,Romania,
-1996-06-30,RS,Serbia,
-1996-06-30,RU,Russia,
+1996-06-30,PT,Portugal,74.2659
 1996-06-30,SE,Sweden,33.7799
-1996-06-30,SG,Singapore,
-1996-06-30,SI,Slovenia,
-1996-06-30,SK,Slovak Republic,
 1996-06-30,TH,Thailand,80.3901
-1996-06-30,TR,Türkiye,
-1996-06-30,US,United States,59.1891
-1996-06-30,XM,Euro area,57.3028
-1996-06-30,XW,World,
-1996-06-30,ZA,South Africa,19.9733
-1996-09-30,4T,Emerging market economies (aggregate),
-1996-09-30,5R,Advanced economies,
-1996-09-30,AE,United Arab Emirates,
-1996-09-30,AT,Austria,
+1996-06-30,US,United States,59.1248
+1996-06-30,XM,Euro area,57.2962
+1996-06-30,ZA,South Africa,19.9488
+1996-09-30,AT,Austria,82.8914
 1996-09-30,AU,Australia,32.1639
-1996-09-30,BE,Belgium,44.4079
-1996-09-30,BG,Bulgaria,
-1996-09-30,BR,Brazil,
-1996-09-30,CA,Canada,44.8887
-1996-09-30,CH,Switzerland,73.0498
-1996-09-30,CL,Chile,
-1996-09-30,CN,China,
-1996-09-30,CO,Colombia,36.0842
-1996-09-30,CY,Cyprus,
-1996-09-30,CZ,Czechia,
-1996-09-30,DE,Germany,103.3547
+1996-09-30,BE,Belgium,44.7858
+1996-09-30,CA,Canada,45.2367
+1996-09-30,CH,Switzerland,73.1076
+1996-09-30,CO,Colombia,36.6351
+1996-09-30,DE,Germany,103.3804
 1996-09-30,DK,Denmark,44.3961
-1996-09-30,EE,Estonia,
 1996-09-30,ES,Spain,35.8424
 1996-09-30,FI,Finland,42.3844
 1996-09-30,FR,France,42.5672
-1996-09-30,GB,United Kingdom,35.162
-1996-09-30,GR,Greece,
+1996-09-30,GB,United Kingdom,35.1503
 1996-09-30,HK,Hong Kong SAR,77.3538
-1996-09-30,HR,Croatia,
-1996-09-30,HU,Hungary,
-1996-09-30,ID,Indonesia,
-1996-09-30,IE,Ireland,41.1929
+1996-09-30,HU,Hungary,28.0323
+1996-09-30,IE,Ireland,41.2001
 1996-09-30,IL,Israel,65.5673
-1996-09-30,IN,India,
-1996-09-30,IS,Iceland,
+1996-09-30,IS,Iceland,31.9227
 1996-09-30,IT,Italy,57.3463
 1996-09-30,JP,Japan,157.5962
-1996-09-30,KR,Korea,63.9041
-1996-09-30,LT,Lithuania,
-1996-09-30,LU,Luxembourg,
-1996-09-30,LV,Latvia,
-1996-09-30,MA,Morocco,
-1996-09-30,MK,North Macedonia,
-1996-09-30,MT,Malta,
-1996-09-30,MX,Mexico,
+1996-09-30,KR,Korea,63.9177
 1996-09-30,MY,Malaysia,75.4836
-1996-09-30,NL,Netherlands,42.9144
+1996-09-30,NL,Netherlands,43.4478
 1996-09-30,NO,Norway,33.3442
 1996-09-30,NZ,New Zealand,44.523
-1996-09-30,PE,Peru,
-1996-09-30,PH,Philippines,
-1996-09-30,PL,Poland,
-1996-09-30,PT,Portugal,
-1996-09-30,RO,Romania,
-1996-09-30,RS,Serbia,
-1996-09-30,RU,Russia,
+1996-09-30,PT,Portugal,74.4216
 1996-09-30,SE,Sweden,34.3307
-1996-09-30,SG,Singapore,
-1996-09-30,SI,Slovenia,
-1996-09-30,SK,Slovak Republic,
 1996-09-30,TH,Thailand,76.694
-1996-09-30,TR,Türkiye,
-1996-09-30,US,United States,59.5202
-1996-09-30,XM,Euro area,58.0711
-1996-09-30,XW,World,
-1996-09-30,ZA,South Africa,20.0852
-1996-12-31,4T,Emerging market economies (aggregate),
-1996-12-31,5R,Advanced economies,
-1996-12-31,AE,United Arab Emirates,
-1996-12-31,AT,Austria,
+1996-09-30,US,United States,59.457
+1996-09-30,XM,Euro area,58.0489
+1996-09-30,ZA,South Africa,20.0606
+1996-12-31,AT,Austria,81.32
 1996-12-31,AU,Australia,32.2466
-1996-12-31,BE,Belgium,44.7516
-1996-12-31,BG,Bulgaria,
-1996-12-31,BR,Brazil,
-1996-12-31,CA,Canada,45.1459
-1996-12-31,CH,Switzerland,70.9097
-1996-12-31,CL,Chile,
-1996-12-31,CN,China,
-1996-12-31,CO,Colombia,36.5727
-1996-12-31,CY,Cyprus,
-1996-12-31,CZ,Czechia,
-1996-12-31,DE,Germany,102.7528
+1996-12-31,BE,Belgium,45.1324
+1996-12-31,CA,Canada,45.4959
+1996-12-31,CH,Switzerland,70.8723
+1996-12-31,CO,Colombia,36.9307
+1996-12-31,DE,Germany,102.676
 1996-12-31,DK,Denmark,46.2104
-1996-12-31,EE,Estonia,
 1996-12-31,ES,Spain,35.9091
 1996-12-31,FI,Finland,44.0359
 1996-12-31,FR,France,42.5672
-1996-12-31,GB,United Kingdom,35.7661
-1996-12-31,GR,Greece,
+1996-12-31,GB,United Kingdom,35.7543
 1996-12-31,HK,Hong Kong SAR,85.1731
-1996-12-31,HR,Croatia,
-1996-12-31,HU,Hungary,
-1996-12-31,ID,Indonesia,
-1996-12-31,IE,Ireland,41.6751
+1996-12-31,HU,Hungary,29.2309
+1996-12-31,IE,Ireland,41.6824
 1996-12-31,IL,Israel,67.6008
-1996-12-31,IN,India,
-1996-12-31,IS,Iceland,
+1996-12-31,IS,Iceland,32.5864
 1996-12-31,IT,Italy,57.9306
 1996-12-31,JP,Japan,157.1154
-1996-12-31,KR,Korea,64.3121
-1996-12-31,LT,Lithuania,
-1996-12-31,LU,Luxembourg,
-1996-12-31,LV,Latvia,
-1996-12-31,MA,Morocco,
-1996-12-31,MK,North Macedonia,
-1996-12-31,MT,Malta,
-1996-12-31,MX,Mexico,
+1996-12-31,KR,Korea,64.2982
 1996-12-31,MY,Malaysia,76.114
-1996-12-31,NL,Netherlands,43.8084
+1996-12-31,NL,Netherlands,44.6291
 1996-12-31,NO,Norway,34.1288
 1996-12-31,NZ,New Zealand,45.2161
-1996-12-31,PE,Peru,
-1996-12-31,PH,Philippines,
-1996-12-31,PL,Poland,
-1996-12-31,PT,Portugal,
-1996-12-31,RO,Romania,
-1996-12-31,RS,Serbia,
-1996-12-31,RU,Russia,
+1996-12-31,PT,Portugal,74.8889
 1996-12-31,SE,Sweden,34.3307
-1996-12-31,SG,Singapore,
-1996-12-31,SI,Slovenia,
-1996-12-31,SK,Slovak Republic,
 1996-12-31,TH,Thailand,77.2715
-1996-12-31,TR,Türkiye,
-1996-12-31,US,United States,59.8941
-1996-12-31,XM,Euro area,58.1601
-1996-12-31,XW,World,
-1996-12-31,ZA,South Africa,20.2989
-1997-03-31,4T,Emerging market economies (aggregate),
-1997-03-31,5R,Advanced economies,
-1997-03-31,AE,United Arab Emirates,
-1997-03-31,AT,Austria,
+1996-12-31,US,United States,59.8341
+1996-12-31,XM,Euro area,58.1379
+1996-12-31,ZA,South Africa,20.274
+1997-03-31,AT,Austria,84.8556
 1997-03-31,AU,Australia,32.5294
-1997-03-31,BE,Belgium,43.0244
-1997-03-31,BG,Bulgaria,
-1997-03-31,BR,Brazil,
-1997-03-31,CA,Canada,45.6784
-1997-03-31,CH,Switzerland,70.9884
-1997-03-31,CL,Chile,
-1997-03-31,CN,China,
-1997-03-31,CO,Colombia,37.1242
-1997-03-31,CY,Cyprus,
-1997-03-31,CZ,Czechia,
-1997-03-31,DE,Germany,102.3242
+1997-03-31,BE,Belgium,43.3906
+1997-03-31,CA,Canada,46.0326
+1997-03-31,CH,Switzerland,70.9772
+1997-03-31,CO,Colombia,37.5833
+1997-03-31,DE,Germany,102.3548
 1997-03-31,DK,Denmark,47.3815
-1997-03-31,EE,Estonia,
 1997-03-31,ES,Spain,35.9794
 1997-03-31,FI,Finland,47.2043
 1997-03-31,FR,France,40.5402
-1997-03-31,GB,United Kingdom,36.2495
-1997-03-31,GR,Greece,
+1997-03-31,GB,United Kingdom,36.2374
+1997-03-31,GR,Greece,40.1558
 1997-03-31,HK,Hong Kong SAR,101.4302
-1997-03-31,HR,Croatia,
-1997-03-31,HU,Hungary,
-1997-03-31,ID,Indonesia,
-1997-03-31,IE,Ireland,41.8359
+1997-03-31,HR,Croatia,48.0071
+1997-03-31,HU,Hungary,29.4958
+1997-03-31,IE,Ireland,41.8432
 1997-03-31,IL,Israel,69.647
-1997-03-31,IN,India,
-1997-03-31,IS,Iceland,
+1997-03-31,IS,Iceland,32.2878
 1997-03-31,IT,Italy,58.8603
 1997-03-31,JP,Japan,156.6347
-1997-03-31,KR,Korea,65.5361
-1997-03-31,LT,Lithuania,
-1997-03-31,LU,Luxembourg,
-1997-03-31,LV,Latvia,
-1997-03-31,MA,Morocco,
-1997-03-31,MK,North Macedonia,
-1997-03-31,MT,Malta,
-1997-03-31,MX,Mexico,
+1997-03-31,KR,Korea,65.5241
 1997-03-31,MY,Malaysia,77.3226
-1997-03-31,NL,Netherlands,45.2389
+1997-03-31,NL,Netherlands,45.8105
 1997-03-31,NO,Norway,34.6518
 1997-03-31,NZ,New Zealand,46.7755
-1997-03-31,PE,Peru,
-1997-03-31,PH,Philippines,
-1997-03-31,PL,Poland,
-1997-03-31,PT,Portugal,
-1997-03-31,RO,Romania,
-1997-03-31,RS,Serbia,
-1997-03-31,RU,Russia,
+1997-03-31,PT,Portugal,75.6054
 1997-03-31,SE,Sweden,34.8815
-1997-03-31,SG,Singapore,
-1997-03-31,SI,Slovenia,
-1997-03-31,SK,Slovak Republic,
 1997-03-31,TH,Thailand,79.8126
-1997-03-31,TR,Türkiye,
-1997-03-31,US,United States,60.3878
-1997-03-31,XM,Euro area,57.7972
-1997-03-31,XW,World,
-1997-03-31,ZA,South Africa,20.5329
-1997-06-30,4T,Emerging market economies (aggregate),
-1997-06-30,5R,Advanced economies,
-1997-06-30,AE,United Arab Emirates,
-1997-06-30,AT,Austria,
+1997-03-31,US,United States,60.3222
+1997-03-31,XM,Euro area,57.7858
+1997-03-31,ZA,South Africa,20.5077
+1997-06-30,AT,Austria,83.2057
 1997-06-30,AU,Australia,32.9521
-1997-06-30,BE,Belgium,44.6098
-1997-06-30,BG,Bulgaria,
-1997-06-30,BR,Brazil,
-1997-06-30,CA,Canada,46.8292
-1997-06-30,CH,Switzerland,70.5673
-1997-06-30,CL,Chile,
-1997-06-30,CN,China,
-1997-06-30,CO,Colombia,38.6154
-1997-06-30,CY,Cyprus,
-1997-06-30,CZ,Czechia,
-1997-06-30,DE,Germany,101.8127
+1997-06-30,BE,Belgium,44.9894
+1997-06-30,CA,Canada,47.1923
+1997-06-30,CH,Switzerland,70.5548
+1997-06-30,CO,Colombia,39.1863
+1997-06-30,DE,Germany,101.7823
 1997-06-30,DK,Denmark,48.6638
-1997-06-30,EE,Estonia,
 1997-06-30,ES,Spain,36.2604
 1997-06-30,FI,Finland,48.828
 1997-06-30,FR,France,42.5672
-1997-06-30,GB,United Kingdom,36.9745
-1997-06-30,GR,Greece,
+1997-06-30,GB,United Kingdom,36.9622
+1997-06-30,GR,Greece,40.9825
 1997-06-30,HK,Hong Kong SAR,110.7295
-1997-06-30,HR,Croatia,
-1997-06-30,HU,Hungary,
-1997-06-30,ID,Indonesia,
-1997-06-30,IE,Ireland,44.0444
+1997-06-30,HR,Croatia,47.9528
+1997-06-30,HU,Hungary,30.9523
+1997-06-30,IE,Ireland,44.0521
 1997-06-30,IL,Israel,71.5915
-1997-06-30,IN,India,
-1997-06-30,IS,Iceland,
+1997-06-30,IS,Iceland,32.885
 1997-06-30,IT,Italy,58.9746
 1997-06-30,JP,Japan,156.2044
-1997-06-30,KR,Korea,65.9442
-1997-06-30,LT,Lithuania,
-1997-06-30,LU,Luxembourg,
-1997-06-30,LV,Latvia,
-1997-06-30,MA,Morocco,
-1997-06-30,MK,North Macedonia,
-1997-06-30,MT,Malta,
-1997-06-30,MX,Mexico,
+1997-06-30,KR,Korea,65.9046
 1997-06-30,MY,Malaysia,77.4917
-1997-06-30,NL,Netherlands,46.4906
+1997-06-30,NL,Netherlands,47.1231
 1997-06-30,NO,Norway,37.1363
 1997-06-30,NZ,New Zealand,47.226
-1997-06-30,PE,Peru,
-1997-06-30,PH,Philippines,
-1997-06-30,PL,Poland,
-1997-06-30,PT,Portugal,
-1997-06-30,RO,Romania,
-1997-06-30,RS,Serbia,
-1997-06-30,RU,Russia,
+1997-06-30,PT,Portugal,76.4154
 1997-06-30,SE,Sweden,36.1666
-1997-06-30,SG,Singapore,
-1997-06-30,SI,Slovenia,
-1997-06-30,SK,Slovak Republic,
 1997-06-30,TH,Thailand,84.5482
-1997-06-30,TR,Türkiye,
-1997-06-30,US,United States,60.9926
-1997-06-30,XM,Euro area,58.7293
-1997-06-30,XW,World,
-1997-06-30,ZA,South Africa,21.1434
-1997-09-30,4T,Emerging market economies (aggregate),
-1997-09-30,5R,Advanced economies,
-1997-09-30,AE,United Arab Emirates,
-1997-09-30,AT,Austria,
+1997-06-30,US,United States,60.9336
+1997-06-30,XM,Euro area,58.7045
+1997-06-30,ZA,South Africa,21.1175
+1997-09-30,AT,Austria,86.977
 1997-09-30,AU,Australia,33.5465
-1997-09-30,BE,Belgium,46.0104
-1997-09-30,BG,Bulgaria,
-1997-09-30,BR,Brazil,
-1997-09-30,CA,Canada,46.0124
-1997-09-30,CH,Switzerland,71.081
-1997-09-30,CL,Chile,
-1997-09-30,CN,China,
-1997-09-30,CO,Colombia,39.8078
-1997-09-30,CY,Cyprus,
-1997-09-30,CZ,Czechia,
-1997-09-30,DE,Germany,101.5257
+1997-09-30,BE,Belgium,46.402
+1997-09-30,CA,Canada,46.3691
+1997-09-30,CH,Switzerland,71.1113
+1997-09-30,CO,Colombia,40.313
+1997-09-30,DE,Germany,101.5159
 1997-09-30,DK,Denmark,49.7317
-1997-09-30,EE,Estonia,
 1997-09-30,ES,Spain,36.4501
 1997-09-30,FI,Finland,49.5845
 1997-09-30,FR,France,42.5672
-1997-09-30,GB,United Kingdom,38.8473
-1997-09-30,GR,Greece,
+1997-09-30,GB,United Kingdom,38.8344
+1997-09-30,GR,Greece,41.8092
 1997-09-30,HK,Hong Kong SAR,112.3419
-1997-09-30,HR,Croatia,
-1997-09-30,HU,Hungary,
-1997-09-30,ID,Indonesia,
-1997-09-30,IE,Ireland,47.1929
+1997-09-30,HR,Croatia,50.159
+1997-09-30,HU,Hungary,31.2753
+1997-09-30,IE,Ireland,47.2012
 1997-09-30,IL,Israel,72.9768
-1997-09-30,IN,India,
-1997-09-30,IS,Iceland,
+1997-09-30,IS,Iceland,32.5533
 1997-09-30,IT,Italy,59.0034
 1997-09-30,JP,Japan,155.7693
-1997-09-30,KR,Korea,65.9442
-1997-09-30,LT,Lithuania,
-1997-09-30,LU,Luxembourg,
-1997-09-30,LV,Latvia,
-1997-09-30,MA,Morocco,
-1997-09-30,MK,North Macedonia,
-1997-09-30,MT,Malta,
-1997-09-30,MX,Mexico,
+1997-09-30,KR,Korea,65.9257
 1997-09-30,MY,Malaysia,75.8627
-1997-09-30,NL,Netherlands,47.8317
+1997-09-30,NL,Netherlands,48.4357
 1997-09-30,NO,Norway,37.3978
 1997-09-30,NZ,New Zealand,47.3715
-1997-09-30,PE,Peru,
-1997-09-30,PH,Philippines,
-1997-09-30,PL,Poland,
-1997-09-30,PT,Portugal,
-1997-09-30,RO,Romania,
-1997-09-30,RS,Serbia,
-1997-09-30,RU,Russia,
+1997-09-30,PT,Portugal,77.5991
 1997-09-30,SE,Sweden,36.9009
-1997-09-30,SG,Singapore,
-1997-09-30,SI,Slovenia,
-1997-09-30,SK,Slovak Republic,
 1997-09-30,TH,Thailand,84.6059
-1997-09-30,TR,Türkiye,
-1997-09-30,US,United States,61.7448
-1997-09-30,XM,Euro area,59.2151
-1997-09-30,XW,World,
-1997-09-30,ZA,South Africa,22.2321
-1997-12-31,4T,Emerging market economies (aggregate),
-1997-12-31,5R,Advanced economies,
-1997-12-31,AE,United Arab Emirates,
-1997-12-31,AT,Austria,
+1997-09-30,US,United States,61.685
+1997-09-30,XM,Euro area,59.1841
+1997-09-30,ZA,South Africa,22.2049
+1997-12-31,AT,Austria,83.7556
 1997-12-31,AU,Australia,34.1948
-1997-12-31,BE,Belgium,46.1436
-1997-12-31,BG,Bulgaria,
-1997-12-31,BR,Brazil,
-1997-12-31,CA,Canada,45.9537
-1997-12-31,CH,Switzerland,70.0974
-1997-12-31,CL,Chile,
-1997-12-31,CN,China,
-1997-12-31,CO,Colombia,41.7994
-1997-12-31,CY,Cyprus,
-1997-12-31,CZ,Czechia,
-1997-12-31,DE,Germany,101.0453
+1997-12-31,BE,Belgium,46.5363
+1997-12-31,CA,Canada,46.31
+1997-12-31,CH,Switzerland,70.0803
+1997-12-31,CO,Colombia,42.1707
+1997-12-31,DE,Germany,101.0551
 1997-12-31,DK,Denmark,50.2637
-1997-12-31,EE,Estonia,
 1997-12-31,ES,Spain,36.7241
 1997-12-31,FI,Finland,50.7053
 1997-12-31,FR,France,42.5672
-1997-12-31,GB,United Kingdom,38.6057
-1997-12-31,GR,Greece,
+1997-12-31,GB,United Kingdom,38.5929
+1997-12-31,GR,Greece,43.9673
 1997-12-31,HK,Hong Kong SAR,107.8801
-1997-12-31,HR,Croatia,
-1997-12-31,HU,Hungary,
-1997-12-31,ID,Indonesia,
-1997-12-31,IE,Ireland,50.7538
+1997-12-31,HR,Croatia,51.4212
+1997-12-31,HU,Hungary,31.0237
+1997-12-31,IE,Ireland,50.7627
 1997-12-31,IL,Israel,72.4558
-1997-12-31,IN,India,
-1997-12-31,IS,Iceland,
+1997-12-31,IS,Iceland,33.1839
 1997-12-31,IT,Italy,59.2743
 1997-12-31,JP,Japan,155.1924
-1997-12-31,KR,Korea,65.8932
-1997-12-31,LT,Lithuania,
-1997-12-31,LU,Luxembourg,
-1997-12-31,LV,Latvia,
-1997-12-31,MA,Morocco,
-1997-12-31,MK,North Macedonia,
-1997-12-31,MT,Malta,
-1997-12-31,MX,Mexico,
+1997-12-31,KR,Korea,65.8835
 1997-12-31,MY,Malaysia,72.6975
-1997-12-31,NL,Netherlands,48.8151
+1997-12-31,NL,Netherlands,49.4858
 1997-12-31,NO,Norway,37.9209
 1997-12-31,NZ,New Zealand,47.4131
-1997-12-31,PE,Peru,
-1997-12-31,PH,Philippines,
-1997-12-31,PL,Poland,
-1997-12-31,PT,Portugal,
-1997-12-31,RO,Romania,
-1997-12-31,RS,Serbia,
-1997-12-31,RU,Russia,
+1997-12-31,PT,Portugal,78.3779
 1997-12-31,SE,Sweden,36.9009
-1997-12-31,SG,Singapore,
-1997-12-31,SI,Slovenia,
-1997-12-31,SK,Slovak Republic,
 1997-12-31,TH,Thailand,83.6242
-1997-12-31,TR,Türkiye,
-1997-12-31,US,United States,62.6712
-1997-12-31,XM,Euro area,59.4693
-1997-12-31,XW,World,
-1997-12-31,ZA,South Africa,23.4023
-1998-03-31,4T,Emerging market economies (aggregate),
-1998-03-31,5R,Advanced economies,
-1998-03-31,AE,United Arab Emirates,
-1998-03-31,AT,Austria,
+1997-12-31,US,United States,62.6118
+1997-12-31,XM,Euro area,59.4254
+1997-12-31,ZA,South Africa,23.3735
+1998-03-31,AT,Austria,82.5771
 1998-03-31,AU,Australia,35.0403
-1998-03-31,BE,Belgium,46.6205
-1998-03-31,BG,Bulgaria,
-1998-03-31,BR,Brazil,
-1998-03-31,CA,Canada,45.525
-1998-03-31,CH,Switzerland,70.4149
-1998-03-31,CL,Chile,
-1998-03-31,CN,China,
-1998-03-31,CO,Colombia,43.0763
-1998-03-31,CY,Cyprus,
-1998-03-31,CZ,Czechia,
-1998-03-31,DE,Germany,100.6521
+1998-03-31,BE,Belgium,47.0173
+1998-03-31,BG,Bulgaria,32.0002
+1998-03-31,CA,Canada,45.878
+1998-03-31,CH,Switzerland,70.4219
+1998-03-31,CO,Colombia,43.5984
+1998-03-31,DE,Germany,100.5966
 1998-03-31,DK,Denmark,51.2244
-1998-03-31,EE,Estonia,
 1998-03-31,ES,Spain,36.8611
 1998-03-31,FI,Finland,52.2736
 1998-03-31,FR,France,41.5537
-1998-03-31,GB,United Kingdom,39.5723
-1998-03-31,GR,Greece,
+1998-03-31,GB,United Kingdom,39.5592
+1998-03-31,GR,Greece,45.9429
 1998-03-31,HK,Hong Kong SAR,92.5507
-1998-03-31,HR,Croatia,
-1998-03-31,HU,Hungary,
-1998-03-31,ID,Indonesia,
-1998-03-31,IE,Ireland,52.8015
+1998-03-31,HR,Croatia,53.1302
+1998-03-31,HU,Hungary,30.4457
+1998-03-31,IE,Ireland,52.8108
 1998-03-31,IL,Israel,72.7989
-1998-03-31,IN,India,
-1998-03-31,IS,Iceland,
+1998-03-31,IS,Iceland,34.279
 1998-03-31,IT,Italy,58.4666
 1998-03-31,JP,Japan,154.6154
-1998-03-31,KR,Korea,64.0061
-1998-03-31,LT,Lithuania,
-1998-03-31,LU,Luxembourg,
-1998-03-31,LV,Latvia,
-1998-03-31,MA,Morocco,
-1998-03-31,MK,North Macedonia,
-1998-03-31,MT,Malta,
-1998-03-31,MX,Mexico,
+1998-03-31,KR,Korea,63.9811
 1998-03-31,MY,Malaysia,71.6025
-1998-03-31,NL,Netherlands,49.9774
+1998-03-31,NL,Netherlands,50.5359
 1998-03-31,NO,Norway,39.49
 1998-03-31,NZ,New Zealand,46.8794
 1998-03-31,PE,Peru,59.0857
-1998-03-31,PH,Philippines,
-1998-03-31,PL,Poland,
-1998-03-31,PT,Portugal,
-1998-03-31,RO,Romania,
-1998-03-31,RS,Serbia,
-1998-03-31,RU,Russia,
+1998-03-31,PT,Portugal,78.6894
 1998-03-31,SE,Sweden,38.0024
 1998-03-31,SG,Singapore,73.9793
-1998-03-31,SI,Slovenia,
-1998-03-31,SK,Slovak Republic,
 1998-03-31,TH,Thailand,86.2807
-1998-03-31,TR,Türkiye,
-1998-03-31,US,United States,63.9287
-1998-03-31,XM,Euro area,59.1979
-1998-03-31,XW,World,
-1998-03-31,ZA,South Africa,24.1552
-1998-06-30,4T,Emerging market economies (aggregate),
-1998-06-30,5R,Advanced economies,
-1998-06-30,AE,United Arab Emirates,
-1998-06-30,AT,Austria,
+1998-03-31,US,United States,63.8644
+1998-03-31,XM,Euro area,59.1498
+1998-03-31,ZA,South Africa,24.1256
+1998-06-30,AT,Austria,79.3557
 1998-06-30,AU,Australia,35.803
-1998-06-30,BE,Belgium,46.8268
-1998-06-30,BG,Bulgaria,
-1998-06-30,BR,Brazil,
-1998-06-30,CA,Canada,45.9176
-1998-06-30,CH,Switzerland,69.9089
-1998-06-30,CL,Chile,
-1998-06-30,CN,China,
-1998-06-30,CO,Colombia,44.4742
-1998-06-30,CY,Cyprus,
-1998-06-30,CZ,Czechia,
-1998-06-30,DE,Germany,100.7683
+1998-06-30,BE,Belgium,47.2253
+1998-06-30,BG,Bulgaria,33.8636
+1998-06-30,CA,Canada,46.2736
+1998-06-30,CH,Switzerland,69.8948
+1998-06-30,CO,Colombia,44.8699
+1998-06-30,DE,Germany,100.7719
 1998-06-30,DK,Denmark,53.3603
-1998-06-30,EE,Estonia,
 1998-06-30,ES,Spain,37.6726
 1998-06-30,FI,Finland,53.5607
 1998-06-30,FR,France,42.5672
-1998-06-30,GB,United Kingdom,41.6869
-1998-06-30,GR,Greece,
+1998-06-30,GB,United Kingdom,41.673
+1998-06-30,GR,Greece,47.5427
 1998-06-30,HK,Hong Kong SAR,82.6992
-1998-06-30,HR,Croatia,
-1998-06-30,HU,Hungary,
-1998-06-30,ID,Indonesia,
-1998-06-30,IE,Ireland,53.9722
+1998-06-30,HR,Croatia,52.9364
+1998-06-30,HU,Hungary,30.6696
+1998-06-30,IE,Ireland,53.9816
 1998-06-30,IL,Israel,73.3327
-1998-06-30,IN,India,
-1998-06-30,IS,Iceland,
+1998-06-30,IS,Iceland,34.8431
 1998-06-30,IT,Italy,59.0991
 1998-06-30,JP,Japan,153.8505
-1998-06-30,KR,Korea,59.467
-1998-06-30,LT,Lithuania,
-1998-06-30,LU,Luxembourg,
-1998-06-30,LV,Latvia,
-1998-06-30,MA,Morocco,
-1998-06-30,MK,North Macedonia,
-1998-06-30,MT,Malta,
-1998-06-30,MX,Mexico,
+1998-06-30,KR,Korea,59.479
 1998-06-30,MY,Malaysia,69.1454
-1998-06-30,NL,Netherlands,51.3185
+1998-06-30,NL,Netherlands,51.8485
 1998-06-30,NO,Norway,41.9745
 1998-06-30,NZ,New Zealand,46.0547
 1998-06-30,PE,Peru,56.7212
-1998-06-30,PH,Philippines,
-1998-06-30,PL,Poland,
-1998-06-30,PT,Portugal,
-1998-06-30,RO,Romania,
-1998-06-30,RS,Serbia,
-1998-06-30,RU,Russia,
+1998-06-30,PT,Portugal,79.7174
 1998-06-30,SE,Sweden,39.2875
 1998-06-30,SG,Singapore,67.8081
-1998-06-30,SI,Slovenia,
-1998-06-30,SK,Slovak Republic,
 1998-06-30,TH,Thailand,77.5603
-1998-06-30,TR,Türkiye,
-1998-06-30,US,United States,64.7818
-1998-06-30,XM,Euro area,59.9144
-1998-06-30,XW,World,
-1998-06-30,ZA,South Africa,24.6334
-1998-09-30,4T,Emerging market economies (aggregate),
-1998-09-30,5R,Advanced economies,
-1998-09-30,AE,United Arab Emirates,
-1998-09-30,AT,Austria,
+1998-06-30,US,United States,64.7173
+1998-06-30,XM,Euro area,59.8683
+1998-06-30,ZA,South Africa,24.6032
+1998-09-30,AT,Austria,81.7128
 1998-09-30,AU,Australia,35.803
-1998-09-30,BE,Belgium,48.9148
-1998-09-30,BG,Bulgaria,
-1998-09-30,BR,Brazil,
-1998-09-30,CA,Canada,45.006
-1998-09-30,CH,Switzerland,70.4304
-1998-09-30,CL,Chile,
-1998-09-30,CN,China,
-1998-09-30,CO,Colombia,43.9748
-1998-09-30,CY,Cyprus,
-1998-09-30,CZ,Czechia,
-1998-09-30,DE,Germany,100.6227
+1998-09-30,BE,Belgium,49.3311
+1998-09-30,BG,Bulgaria,32.4176
+1998-09-30,CA,Canada,45.355
+1998-09-30,CH,Switzerland,70.4419
+1998-09-30,CO,Colombia,44.7132
+1998-09-30,DE,Germany,100.5997
 1998-09-30,DK,Denmark,54.1066
-1998-09-30,EE,Estonia,
 1998-09-30,ES,Spain,38.4314
 1998-09-30,FI,Finland,54.9904
 1998-09-30,FR,France,43.5807
-1998-09-30,GB,United Kingdom,43.4994
-1998-09-30,GR,Greece,
+1998-09-30,GB,United Kingdom,43.4849
+1998-09-30,GR,Greece,47.9936
 1998-09-30,HK,Hong Kong SAR,68.6951
-1998-09-30,HR,Croatia,
-1998-09-30,HU,Hungary,
-1998-09-30,ID,Indonesia,
-1998-09-30,IE,Ireland,56.4463
+1998-09-30,HR,Croatia,53.0999
+1998-09-30,HU,Hungary,32.3017
+1998-09-30,IE,Ireland,56.4562
 1998-09-30,IL,Israel,73.3835
-1998-09-30,IN,India,
-1998-09-30,IS,Iceland,
+1998-09-30,IS,Iceland,35.8717
 1998-09-30,IT,Italy,59.2185
 1998-09-30,JP,Japan,153.077
-1998-09-30,KR,Korea,58.09
-1998-09-30,LT,Lithuania,
-1998-09-30,LU,Luxembourg,
-1998-09-30,LV,Latvia,
-1998-09-30,MA,Morocco,
-1998-09-30,MK,North Macedonia,
-1998-09-30,MT,Malta,
-1998-09-30,MX,Mexico,
+1998-09-30,KR,Korea,58.1051
 1998-09-30,MY,Malaysia,67.0447
-1998-09-30,NL,Netherlands,53.0172
+1998-09-30,NL,Netherlands,53.5549
 1998-09-30,NO,Norway,41.5822
 1998-09-30,NZ,New Zealand,46.1309
 1998-09-30,PE,Peru,59.3654
-1998-09-30,PH,Philippines,
-1998-09-30,PL,Poland,
-1998-09-30,PT,Portugal,
-1998-09-30,RO,Romania,
-1998-09-30,RS,Serbia,
-1998-09-30,RU,Russia,
+1998-09-30,PT,Portugal,80.9324
 1998-09-30,SE,Sweden,40.3891
 1998-09-30,SG,Singapore,58.9276
-1998-09-30,SI,Slovenia,
-1998-09-30,SK,Slovak Republic,
 1998-09-30,TH,Thailand,81.4296
-1998-09-30,TR,Türkiye,
-1998-09-30,US,United States,65.9268
-1998-09-30,XM,Euro area,60.8086
-1998-09-30,XW,World,
-1998-09-30,ZA,South Africa,25.2744
-1998-12-31,4T,Emerging market economies (aggregate),
-1998-12-31,5R,Advanced economies,
-1998-12-31,AE,United Arab Emirates,
-1998-12-31,AT,Austria,
+1998-09-30,US,United States,65.8596
+1998-09-30,XM,Euro area,60.7547
+1998-09-30,ZA,South Africa,25.2434
+1998-12-31,AT,Austria,78.6486
 1998-12-31,AU,Australia,36.3942
-1998-12-31,BE,Belgium,48.8547
-1998-12-31,BG,Bulgaria,
-1998-12-31,BR,Brazil,
-1998-12-31,CA,Canada,45.6468
-1998-12-31,CH,Switzerland,70.1939
-1998-12-31,CL,Chile,
-1998-12-31,CN,China,
-1998-12-31,CO,Colombia,43.4656
-1998-12-31,CY,Cyprus,
-1998-12-31,CZ,Czechia,
-1998-12-31,DE,Germany,100.6508
+1998-12-31,BE,Belgium,49.2704
+1998-12-31,BG,Bulgaria,32.7068
+1998-12-31,CA,Canada,46.0007
+1998-12-31,CH,Switzerland,70.1794
+1998-12-31,CO,Colombia,44.0409
+1998-12-31,DE,Germany,100.7245
 1998-12-31,DK,Denmark,54.9602
-1998-12-31,EE,Estonia,
 1998-12-31,ES,Spain,39.2077
 1998-12-31,FI,Finland,55.5528
 1998-12-31,FR,France,43.5807
-1998-12-31,GB,United Kingdom,43.2577
-1998-12-31,GR,Greece,
+1998-12-31,GB,United Kingdom,43.2433
+1998-12-31,GR,Greece,49.3894
 1998-12-31,HK,Hong Kong SAR,66.3758
-1998-12-31,HR,Croatia,
-1998-12-31,HU,Hungary,
-1998-12-31,ID,Indonesia,
-1998-12-31,IE,Ireland,61.5622
+1998-12-31,HR,Croatia,52.4422
+1998-12-31,HU,Hungary,32.7589
+1998-12-31,IE,Ireland,61.573
 1998-12-31,IL,Israel,77.9208
-1998-12-31,IN,India,
-1998-12-31,IS,Iceland,
+1998-12-31,IS,Iceland,35.8055
 1998-12-31,IT,Italy,59.2345
 1998-12-31,JP,Japan,151.7789
-1998-12-31,KR,Korea,57.478
+1998-12-31,KR,Korea,57.4499
 1998-12-31,LT,Lithuania,35.3928
-1998-12-31,LU,Luxembourg,
-1998-12-31,LV,Latvia,
-1998-12-31,MA,Morocco,
-1998-12-31,MK,North Macedonia,
-1998-12-31,MT,Malta,
-1998-12-31,MX,Mexico,
 1998-12-31,MY,Malaysia,67.0578
-1998-12-31,NL,Netherlands,54.537
+1998-12-31,NL,Netherlands,54.9988
 1998-12-31,NO,Norway,40.4054
 1998-12-31,NZ,New Zealand,46.3319
 1998-12-31,PE,Peru,61.9132
-1998-12-31,PH,Philippines,
-1998-12-31,PL,Poland,
-1998-12-31,PT,Portugal,
-1998-12-31,RO,Romania,
-1998-12-31,RS,Serbia,
-1998-12-31,RU,Russia,
+1998-12-31,PT,Portugal,82.3965
 1998-12-31,SE,Sweden,40.9398
 1998-12-31,SG,Singapore,53.81
-1998-12-31,SI,Slovenia,
-1998-12-31,SK,Slovak Republic,
 1998-12-31,TH,Thailand,80.3901
-1998-12-31,TR,Türkiye,
-1998-12-31,US,United States,67.1764
-1998-12-31,XM,Euro area,61.2461
-1998-12-31,XW,World,
-1998-12-31,ZA,South Africa,25.305
-1999-03-31,4T,Emerging market economies (aggregate),
-1999-03-31,5R,Advanced economies,
-1999-03-31,AE,United Arab Emirates,
-1999-03-31,AT,Austria,
+1998-12-31,US,United States,67.107
+1998-12-31,XM,Euro area,61.1816
+1998-12-31,ZA,South Africa,25.2739
+1999-03-31,AT,Austria,78.9629
 1999-03-31,AU,Australia,37.0457
-1999-03-31,BE,Belgium,49.8214
-1999-03-31,BG,Bulgaria,
-1999-03-31,BR,Brazil,
-1999-03-31,CA,Canada,45.877
-1999-03-31,CH,Switzerland,70.9925
-1999-03-31,CL,Chile,
-1999-03-31,CN,China,
-1999-03-31,CO,Colombia,43.3506
-1999-03-31,CY,Cyprus,
-1999-03-31,CZ,Czechia,
-1999-03-31,DE,Germany,100.593
+1999-03-31,BE,Belgium,50.2454
+1999-03-31,BG,Bulgaria,32.9335
+1999-03-31,CA,Canada,46.2327
+1999-03-31,CH,Switzerland,71.0088
+1999-03-31,CO,Colombia,43.8465
+1999-03-31,DE,Germany,100.5949
 1999-03-31,DK,Denmark,55.8137
-1999-03-31,EE,Estonia,
 1999-03-31,ES,Spain,40.3986
 1999-03-31,FI,Finland,56.3924
 1999-03-31,FR,France,43.5807
-1999-03-31,GB,United Kingdom,43.5598
-1999-03-31,GR,Greece,
+1999-03-31,GB,United Kingdom,43.5453
+1999-03-31,GR,Greece,50.2376
 1999-03-31,HK,Hong Kong SAR,67.922
-1999-03-31,HR,Croatia,
-1999-03-31,HU,Hungary,
-1999-03-31,ID,Indonesia,
-1999-03-31,IE,Ireland,63.7846
+1999-03-31,HR,Croatia,52.0745
+1999-03-31,HU,Hungary,34.4019
+1999-03-31,IE,Ireland,63.7958
 1999-03-31,IL,Israel,77.4759
-1999-03-31,IN,India,
-1999-03-31,IS,Iceland,NaN
+1999-03-31,IS,Iceland,38.0698
 1999-03-31,IT,Italy,59.1092
 1999-03-31,JP,Japan,150.4808
-1999-03-31,KR,Korea,58.294
+1999-03-31,KR,Korea,58.3588
 1999-03-31,LT,Lithuania,37.826
-1999-03-31,LU,Luxembourg,
-1999-03-31,LV,Latvia,
-1999-03-31,MA,Morocco,
-1999-03-31,MK,North Macedonia,
-1999-03-31,MT,Malta,
-1999-03-31,MX,Mexico,
 1999-03-31,MY,Malaysia,65.9959
-1999-03-31,NL,Netherlands,56.6828
+1999-03-31,NL,Netherlands,56.9678
 1999-03-31,NO,Norway,41.9745
 1999-03-31,NZ,New Zealand,47.0943
 1999-03-31,PE,Peru,71.0403
-1999-03-31,PH,Philippines,
-1999-03-31,PL,Poland,
-1999-03-31,PT,Portugal,
-1999-03-31,RO,Romania,
-1999-03-31,RS,Serbia,
-1999-03-31,RU,Russia,
+1999-03-31,PT,Portugal,85.169
 1999-03-31,SE,Sweden,41.4906
 1999-03-31,SG,Singapore,56.7451
-1999-03-31,SI,Slovenia,
-1999-03-31,SK,Slovak Republic,
 1999-03-31,TH,Thailand,79.5816
-1999-03-31,TR,Türkiye,
-1999-03-31,US,United States,68.1877
-1999-03-31,XM,Euro area,61.7236
-1999-03-31,XW,World,
-1999-03-31,ZA,South Africa,25.2439
-1999-06-30,4T,Emerging market economies (aggregate),
-1999-06-30,5R,Advanced economies,
-1999-06-30,AE,United Arab Emirates,
-1999-06-30,AT,Austria,
+1999-03-31,US,United States,68.142
+1999-03-31,XM,Euro area,61.6589
+1999-03-31,ZA,South Africa,25.2129
+1999-06-30,AT,Austria,79.0414
 1999-06-30,AU,Australia,37.8912
-1999-06-30,BE,Belgium,50.7623
-1999-06-30,BG,Bulgaria,
-1999-06-30,BR,Brazil,
-1999-06-30,CA,Canada,47.6731
-1999-06-30,CH,Switzerland,70.9199
-1999-06-30,CL,Chile,
-1999-06-30,CN,China,
-1999-06-30,CO,Colombia,43.4204
-1999-06-30,CY,Cyprus,
-1999-06-30,CZ,Czechia,
-1999-06-30,DE,Germany,100.7041
+1999-06-30,BE,Belgium,51.1943
+1999-06-30,BG,Bulgaria,33.6821
+1999-06-30,CA,Canada,48.0427
+1999-06-30,CH,Switzerland,70.9195
+1999-06-30,CO,Colombia,44.0546
+1999-06-30,DE,Germany,100.7178
 1999-06-30,DK,Denmark,56.6673
-1999-06-30,EE,Estonia,
 1999-06-30,ES,Spain,41.7476
 1999-06-30,FI,Finland,57.933
 1999-06-30,FR,France,44.5942
-1999-06-30,GB,United Kingdom,45.3722
-1999-06-30,GR,Greece,
+1999-06-30,GB,United Kingdom,45.3572
+1999-06-30,GR,Greece,51.5797
 1999-06-30,HK,Hong Kong SAR,67.8558
-1999-06-30,HR,Croatia,
-1999-06-30,HU,Hungary,
-1999-06-30,ID,Indonesia,
-1999-06-30,IE,Ireland,62.5371
+1999-06-30,HR,Croatia,53.5075
+1999-06-30,HU,Hungary,37.5758
+1999-06-30,IE,Ireland,62.5481
 1999-06-30,IL,Israel,76.9549
-1999-06-30,IN,India,
-1999-06-30,IS,Iceland,NaN
+1999-06-30,IS,Iceland,40.3871
 1999-06-30,IT,Italy,59.4886
 1999-06-30,JP,Japan,149.2377
-1999-06-30,KR,Korea,58.702
+1999-06-30,KR,Korea,58.6758
 1999-06-30,LT,Lithuania,31.8535
-1999-06-30,LU,Luxembourg,
-1999-06-30,LV,Latvia,
-1999-06-30,MA,Morocco,
-1999-06-30,MK,North Macedonia,
-1999-06-30,MT,Malta,
-1999-06-30,MX,Mexico,
 1999-06-30,MY,Malaysia,66.2785
-1999-06-30,NL,Netherlands,59.0967
+1999-06-30,NL,Netherlands,59.4617
 1999-06-30,NO,Norway,45.3743
 1999-06-30,NZ,New Zealand,47.4408
 1999-06-30,PE,Peru,66.2189
-1999-06-30,PH,Philippines,
-1999-06-30,PL,Poland,
-1999-06-30,PT,Portugal,
-1999-06-30,RO,Romania,
-1999-06-30,RS,Serbia,
-1999-06-30,RU,Russia,
+1999-06-30,PT,Portugal,86.6643
 1999-06-30,SE,Sweden,43.1429
 1999-06-30,SG,Singapore,63.4431
-1999-06-30,SI,Slovenia,
-1999-06-30,SK,Slovak Republic,
 1999-06-30,TH,Thailand,63.0646
-1999-06-30,TR,Türkiye,
-1999-06-30,US,United States,69.5636
-1999-06-30,XM,Euro area,62.584
-1999-06-30,XW,World,
-1999-06-30,ZA,South Africa,25.8239
-1999-09-30,4T,Emerging market economies (aggregate),
-1999-09-30,5R,Advanced economies,
-1999-09-30,AE,United Arab Emirates,
-1999-09-30,AT,Austria,
+1999-06-30,US,United States,69.4902
+1999-06-30,XM,Euro area,62.527
+1999-06-30,ZA,South Africa,25.7922
+1999-09-30,AT,Austria,78.57
 1999-09-30,AU,Australia,38.5967
-1999-09-30,BE,Belgium,52.5324
-1999-09-30,BG,Bulgaria,
-1999-09-30,BR,Brazil,
-1999-09-30,CA,Canada,47.2579
-1999-09-30,CH,Switzerland,70.7289
-1999-09-30,CL,Chile,
-1999-09-30,CN,China,
-1999-09-30,CO,Colombia,42.575
-1999-09-30,CY,Cyprus,
-1999-09-30,CZ,Czechia,
-1999-09-30,DE,Germany,100.8276
+1999-09-30,BE,Belgium,52.9795
+1999-09-30,BG,Bulgaria,32.4843
+1999-09-30,CA,Canada,47.6243
+1999-09-30,CH,Switzerland,70.7157
+1999-09-30,CO,Colombia,42.8212
+1999-09-30,DE,Germany,100.8339
 1999-09-30,DK,Denmark,57.7352
-1999-09-30,EE,Estonia,
 1999-09-30,ES,Spain,42.8858
 1999-09-30,FI,Finland,60.0043
 1999-09-30,FR,France,46.6212
-1999-09-30,GB,United Kingdom,48.0305
-1999-09-30,GR,Greece,
+1999-09-30,GB,United Kingdom,48.0146
+1999-09-30,GR,Greece,52.2669
 1999-09-30,HK,Hong Kong SAR,66.0887
-1999-09-30,HR,Croatia,
-1999-09-30,HU,Hungary,
-1999-09-30,ID,Indonesia,
-1999-09-30,IE,Ireland,68.649
+1999-09-30,HR,Croatia,53.716
+1999-09-30,HU,Hungary,39.904
+1999-09-30,IE,Ireland,68.661
 1999-09-30,IL,Israel,77.8826
-1999-09-30,IN,India,
-1999-09-30,IS,Iceland,NaN
+1999-09-30,IS,Iceland,42.3733
 1999-09-30,IT,Italy,59.7807
 1999-09-30,JP,Japan,147.9808
-1999-09-30,KR,Korea,59.263
+1999-09-30,KR,Korea,59.3099
 1999-09-30,LT,Lithuania,29.5308
-1999-09-30,LU,Luxembourg,
-1999-09-30,LV,Latvia,
-1999-09-30,MA,Morocco,
-1999-09-30,MK,North Macedonia,
-1999-09-30,MT,Malta,
-1999-09-30,MX,Mexico,
 1999-09-30,MY,Malaysia,67.3384
-1999-09-30,NL,Netherlands,62.2259
+1999-09-30,NL,Netherlands,62.4808
 1999-09-30,NO,Norway,46.2896
 1999-09-30,NZ,New Zealand,47.3715
 1999-09-30,PE,Peru,66.7405
-1999-09-30,PH,Philippines,
-1999-09-30,PL,Poland,
-1999-09-30,PT,Portugal,
-1999-09-30,RO,Romania,
-1999-09-30,RS,Serbia,
-1999-09-30,RU,Russia,
+1999-09-30,PT,Portugal,88.9072
 1999-09-30,SE,Sweden,44.428
 1999-09-30,SG,Singapore,68.5607
-1999-09-30,SI,Slovenia,
-1999-09-30,SK,Slovak Republic,
 1999-09-30,TH,Thailand,76.9827
-1999-09-30,TR,Türkiye,
-1999-09-30,US,United States,70.9293
-1999-09-30,XM,Euro area,64.0442
-1999-09-30,XW,World,
-1999-09-30,ZA,South Africa,26.18
-1999-12-31,4T,Emerging market economies (aggregate),
-1999-12-31,5R,Advanced economies,
-1999-12-31,AE,United Arab Emirates,
-1999-12-31,AT,Austria,
+1999-09-30,US,United States,70.8559
+1999-09-30,XM,Euro area,63.9741
+1999-09-30,ZA,South Africa,26.1479
+1999-12-31,AT,Austria,77.7058
 1999-12-31,AU,Australia,39.8649
-1999-12-31,BE,Belgium,51.686
-1999-12-31,BG,Bulgaria,
-1999-12-31,BR,Brazil,
-1999-12-31,CA,Canada,47.9438
-1999-12-31,CH,Switzerland,70.5709
-1999-12-31,CL,Chile,
-1999-12-31,CN,China,
-1999-12-31,CO,Colombia,43.212
-1999-12-31,CY,Cyprus,
-1999-12-31,CZ,Czechia,
-1999-12-31,DE,Germany,100.9638
+1999-12-31,BE,Belgium,52.1259
+1999-12-31,BG,Bulgaria,32.9693
+1999-12-31,CA,Canada,48.3156
+1999-12-31,CH,Switzerland,70.5581
+1999-12-31,CO,Colombia,43.8344
+1999-12-31,DE,Germany,100.9421
 1999-12-31,DK,Denmark,57.8424
-1999-12-31,EE,Estonia,
 1999-12-31,ES,Spain,42.9385
 1999-12-31,FI,Finland,61.3786
 1999-12-31,FR,France,46.6212
-1999-12-31,GB,United Kingdom,49.2993
-1999-12-31,GR,Greece,
+1999-12-31,GB,United Kingdom,49.2829
+1999-12-31,GR,Greece,53.7701
 1999-12-31,HK,Hong Kong SAR,63.1288
-1999-12-31,HR,Croatia,
-1999-12-31,HU,Hungary,
-1999-12-31,ID,Indonesia,
-1999-12-31,IE,Ireland,71.6752
+1999-12-31,HR,Croatia,54.0598
+1999-12-31,HU,Hungary,41.4987
+1999-12-31,IE,Ireland,71.6877
 1999-12-31,IL,Israel,77.5649
-1999-12-31,IN,India,
-1999-12-31,IS,Iceland,NaN
+1999-12-31,IS,Iceland,43.6975
 1999-12-31,IT,Italy,60.116
 1999-12-31,JP,Japan,146.5385
-1999-12-31,KR,Korea,59.671
+1999-12-31,KR,Korea,59.627
 1999-12-31,LT,Lithuania,30.0838
-1999-12-31,LU,Luxembourg,
-1999-12-31,LV,Latvia,
-1999-12-31,MA,Morocco,
-1999-12-31,MK,North Macedonia,
-1999-12-31,MT,Malta,
-1999-12-31,MX,Mexico,
 1999-12-31,MY,Malaysia,68.6809
-1999-12-31,NL,Netherlands,64.908
+1999-12-31,NL,Netherlands,65.2373
 1999-12-31,NO,Norway,47.9895
 1999-12-31,NZ,New Zealand,47.3923
 1999-12-31,PE,Peru,69.4937
-1999-12-31,PH,Philippines,
-1999-12-31,PL,Poland,
-1999-12-31,PT,Portugal,
-1999-12-31,RO,Romania,
-1999-12-31,RS,Serbia,
-1999-12-31,RU,Russia,
+1999-12-31,PT,Portugal,89.8729
 1999-12-31,SE,Sweden,44.428
 1999-12-31,SG,Singapore,72.1731
-1999-12-31,SI,Slovenia,
-1999-12-31,SK,Slovak Republic,
 1999-12-31,TH,Thailand,74.1529
-1999-12-31,TR,Türkiye,
-1999-12-31,US,United States,72.4576
-1999-12-31,XM,Euro area,64.408
-1999-12-31,XW,World,
-1999-12-31,ZA,South Africa,27.0042
-2000-03-31,4T,Emerging market economies (aggregate),
-2000-03-31,5R,Advanced economies,
-2000-03-31,AE,United Arab Emirates,
+1999-12-31,US,United States,72.3782
+1999-12-31,XM,Euro area,64.3337
+1999-12-31,ZA,South Africa,26.971
 2000-03-31,AT,Austria,80.2986
 2000-03-31,AU,Australia,40.599
-2000-03-31,BE,Belgium,53.2714
-2000-03-31,BG,Bulgaria,
-2000-03-31,BR,Brazil,
-2000-03-31,CA,Canada,48.1785
-2000-03-31,CH,Switzerland,70.7995
-2000-03-31,CL,Chile,
-2000-03-31,CN,China,
-2000-03-31,CO,Colombia,43.7369
-2000-03-31,CY,Cyprus,
-2000-03-31,CZ,Czechia,
-2000-03-31,DE,Germany,101.1839
+2000-03-31,BE,Belgium,53.7248
+2000-03-31,BG,Bulgaria,32.6924
+2000-03-31,CA,Canada,48.552
+2000-03-31,CH,Switzerland,70.7968
+2000-03-31,CO,Colombia,43.6275
+2000-03-31,DE,Germany,101.1762
 2000-03-31,DK,Denmark,58.6959
-2000-03-31,EE,Estonia,
 2000-03-31,ES,Spain,44.3366
 2000-03-31,FI,Finland,62.4717
 2000-03-31,FR,France,47.8076
-2000-03-31,GB,United Kingdom,50.5076
-2000-03-31,GR,Greece,
+2000-03-31,GB,United Kingdom,50.4908
+2000-03-31,GR,Greece,55.1014
 2000-03-31,HK,Hong Kong SAR,64.1228
-2000-03-31,HR,Croatia,
-2000-03-31,HU,Hungary,
-2000-03-31,ID,Indonesia,
-2000-03-31,IE,Ireland,72.0106
+2000-03-31,HR,Croatia,55.1148
+2000-03-31,HU,Hungary,45.8982
+2000-03-31,IE,Ireland,72.0233
 2000-03-31,IL,Israel,74.1969
-2000-03-31,IN,India,
-2000-03-31,IS,Iceland,45.8138
+2000-03-31,IS,Iceland,45.8153
 2000-03-31,IT,Italy,60.9704
 2000-03-31,JP,Japan,145.0962
-2000-03-31,KR,Korea,59.926
+2000-03-31,KR,Korea,59.9229
 2000-03-31,LT,Lithuania,31.3005
-2000-03-31,LU,Luxembourg,
-2000-03-31,LV,Latvia,
-2000-03-31,MA,Morocco,
-2000-03-31,MK,North Macedonia,56.74
-2000-03-31,MT,Malta,
-2000-03-31,MX,Mexico,
+2000-03-31,MK,North Macedonia,56.8314
 2000-03-31,MY,Malaysia,69.1756
-2000-03-31,NL,Netherlands,67.8584
+2000-03-31,NL,Netherlands,67.9938
 2000-03-31,NO,Norway,50.8663
 2000-03-31,NZ,New Zealand,47.4755
 2000-03-31,PE,Peru,65.0931
-2000-03-31,PH,Philippines,
-2000-03-31,PL,Poland,
-2000-03-31,PT,Portugal,
-2000-03-31,RO,Romania,
+2000-03-31,PT,Portugal,91.3994
 2000-03-31,RS,Serbia,19.648
-2000-03-31,RU,Russia,
 2000-03-31,SE,Sweden,45.7131
 2000-03-31,SG,Singapore,74.4309
-2000-03-31,SI,Slovenia,
-2000-03-31,SK,Slovak Republic,
 2000-03-31,TH,Thailand,74.5572
-2000-03-31,TR,Türkiye,
-2000-03-31,US,United States,74.2481
-2000-03-31,XM,Euro area,65.4923
-2000-03-31,XW,World,
-2000-03-31,ZA,South Africa,31.0605
-2000-06-30,4T,Emerging market economies (aggregate),
-2000-06-30,5R,Advanced economies,
-2000-06-30,AE,United Arab Emirates,
+2000-03-31,US,United States,74.1602
+2000-03-31,XM,Euro area,65.4218
+2000-03-31,ZA,South Africa,31.0218
 2000-06-30,AT,Austria,78.9629
 2000-06-30,AU,Australia,41.5589
-2000-06-30,BE,Belgium,53.4905
-2000-06-30,BG,Bulgaria,
-2000-06-30,BR,Brazil,
-2000-06-30,CA,Canada,49.1172
-2000-06-30,CH,Switzerland,70.6735
-2000-06-30,CL,Chile,
-2000-06-30,CN,China,
-2000-06-30,CO,Colombia,44.6727
-2000-06-30,CY,Cyprus,
-2000-06-30,CZ,Czechia,
-2000-06-30,DE,Germany,101.4033
+2000-06-30,BE,Belgium,53.9457
+2000-06-30,BG,Bulgaria,32.7837
+2000-06-30,CA,Canada,49.498
+2000-06-30,CH,Switzerland,70.6704
+2000-06-30,CO,Colombia,44.8096
+2000-06-30,DE,Germany,101.4097
 2000-06-30,DK,Denmark,60.2958
-2000-06-30,EE,Estonia,
 2000-06-30,ES,Spain,45.5802
 2000-06-30,FI,Finland,63.3667
 2000-06-30,FR,France,49.2107
-2000-06-30,GB,United Kingdom,53.2867
-2000-06-30,GR,Greece,
+2000-06-30,GB,United Kingdom,53.269
+2000-06-30,GR,Greece,56.6475
 2000-06-30,HK,Hong Kong SAR,59.683
-2000-06-30,HR,Croatia,
-2000-06-30,HU,Hungary,
-2000-06-30,ID,Indonesia,
-2000-06-30,IE,Ireland,73.2791
+2000-06-30,HR,Croatia,53.9377
+2000-06-30,HU,Hungary,50.8217
+2000-06-30,IE,Ireland,73.292
 2000-06-30,IL,Israel,75.0357
-2000-06-30,IN,India,
-2000-06-30,IS,Iceland,48.1045
+2000-06-30,IS,Iceland,48.0924
 2000-06-30,IT,Italy,61.4877
 2000-06-30,JP,Japan,143.6539
-2000-06-30,KR,Korea,60.1301
+2000-06-30,KR,Korea,60.1343
 2000-06-30,LT,Lithuania,28.8672
-2000-06-30,LU,Luxembourg,
-2000-06-30,LV,Latvia,
-2000-06-30,MA,Morocco,
-2000-06-30,MK,North Macedonia,59.04
-2000-06-30,MT,Malta,
-2000-06-30,MX,Mexico,
+2000-06-30,MK,North Macedonia,58.9915
 2000-06-30,MY,Malaysia,71.154
-2000-06-30,NL,Netherlands,70.5405
+2000-06-30,NL,Netherlands,70.619
 2000-06-30,NO,Norway,54.2661
 2000-06-30,NZ,New Zealand,47.3369
 2000-06-30,PE,Peru,66.3565
-2000-06-30,PH,Philippines,
-2000-06-30,PL,Poland,
-2000-06-30,PT,Portugal,
-2000-06-30,RO,Romania,
+2000-06-30,PT,Portugal,93.6734
 2000-06-30,RS,Serbia,23.4046
-2000-06-30,RU,Russia,
 2000-06-30,SE,Sweden,47.9161
 2000-06-30,SG,Singapore,75.5597
-2000-06-30,SI,Slovenia,
-2000-06-30,SK,Slovak Republic,
 2000-06-30,TH,Thailand,77.0405
-2000-06-30,TR,Türkiye,
-2000-06-30,US,United States,76.1467
-2000-06-30,XM,Euro area,66.4964
-2000-06-30,XW,World,
-2000-06-30,ZA,South Africa,30.8557
-2000-09-30,4T,Emerging market economies (aggregate),
-2000-09-30,5R,Advanced economies,
-2000-09-30,AE,United Arab Emirates,
+2000-06-30,US,United States,76.0676
+2000-06-30,XM,Euro area,66.4281
+2000-06-30,ZA,South Africa,30.8189
 2000-09-30,AT,Austria,77.6272
 2000-09-30,AU,Australia,41.5017
-2000-09-30,BE,Belgium,54.2424
-2000-09-30,BG,Bulgaria,
-2000-09-30,BR,Brazil,
-2000-09-30,CA,Canada,49.0134
-2000-09-30,CH,Switzerland,71.0604
-2000-09-30,CL,Chile,
-2000-09-30,CN,China,
-2000-09-30,CO,Colombia,43.2798
-2000-09-30,CY,Cyprus,
-2000-09-30,CZ,Czechia,
-2000-09-30,DE,Germany,101.4621
+2000-09-30,BE,Belgium,54.704
+2000-09-30,BG,Bulgaria,33.1673
+2000-09-30,CA,Canada,49.3934
+2000-09-30,CH,Switzerland,71.0581
+2000-09-30,CO,Colombia,43.5907
+2000-09-30,DE,Germany,101.4585
 2000-09-30,DK,Denmark,61.6853
-2000-09-30,EE,Estonia,
 2000-09-30,ES,Spain,46.202
 2000-09-30,FI,Finland,62.135
 2000-09-30,FR,France,50.9146
-2000-09-30,GB,United Kingdom,54.3138
-2000-09-30,GR,Greece,
+2000-09-30,GB,United Kingdom,54.2957
+2000-09-30,GR,Greece,57.9145
 2000-09-30,HK,Hong Kong SAR,57.8718
-2000-09-30,HR,Croatia,
-2000-09-30,HU,Hungary,
-2000-09-30,ID,Indonesia,
-2000-09-30,IE,Ireland,76.7876
+2000-09-30,HR,Croatia,50.8439
+2000-09-30,HU,Hungary,53.9857
+2000-09-30,IE,Ireland,76.8011
 2000-09-30,IL,Israel,73.4471
-2000-09-30,IN,India,
-2000-09-30,IS,Iceland,48.4252
+2000-09-30,IS,Iceland,48.4222
 2000-09-30,IT,Italy,62.3285
 2000-09-30,JP,Japan,142.2116
-2000-09-30,KR,Korea,60.1301
+2000-09-30,KR,Korea,60.1131
 2000-09-30,LT,Lithuania,26.8764
-2000-09-30,LU,Luxembourg,
-2000-09-30,LV,Latvia,
-2000-09-30,MA,Morocco,
-2000-09-30,MK,North Macedonia,61.75
-2000-09-30,MT,Malta,
-2000-09-30,MX,Mexico,
+2000-09-30,MK,North Macedonia,62.0316
 2000-09-30,MY,Malaysia,71.6486
-2000-09-30,NL,Netherlands,73.5803
+2000-09-30,NL,Netherlands,73.5068
 2000-09-30,NO,Norway,52.697
 2000-09-30,NZ,New Zealand,46.9695
 2000-09-30,PE,Peru,64.7339
-2000-09-30,PH,Philippines,
-2000-09-30,PL,Poland,
-2000-09-30,PT,Portugal,
-2000-09-30,RO,Romania,
+2000-09-30,PT,Portugal,95.1999
 2000-09-30,RS,Serbia,27.1819
-2000-09-30,RU,Russia,
 2000-09-30,SE,Sweden,49.5684
 2000-09-30,SG,Singapore,73.4525
-2000-09-30,SI,Slovenia,
-2000-09-30,SK,Slovak Republic,
 2000-09-30,TH,Thailand,74.9037
-2000-09-30,TR,Türkiye,
-2000-09-30,US,United States,77.8014
-2000-09-30,XM,Euro area,67.613
-2000-09-30,XW,World,
-2000-09-30,ZA,South Africa,30.257
-2000-12-31,4T,Emerging market economies (aggregate),
-2000-12-31,5R,Advanced economies,
-2000-12-31,AE,United Arab Emirates,
+2000-09-30,US,United States,77.7111
+2000-09-30,XM,Euro area,67.5341
+2000-09-30,ZA,South Africa,30.22
 2000-12-31,AT,Austria,77.3915
 2000-12-31,AU,Australia,42.4901
-2000-12-31,BE,Belgium,54.9169
-2000-12-31,BG,Bulgaria,
-2000-12-31,BR,Brazil,
-2000-12-31,CA,Canada,49.5278
-2000-12-31,CH,Switzerland,69.5461
-2000-12-31,CL,Chile,
-2000-12-31,CN,China,
-2000-12-31,CO,Colombia,42.747
-2000-12-31,CY,Cyprus,
-2000-12-31,CZ,Czechia,
-2000-12-31,DE,Germany,101.4416
+2000-12-31,BE,Belgium,55.3843
+2000-12-31,BG,Bulgaria,32.4279
+2000-12-31,CA,Canada,49.9118
+2000-12-31,CH,Switzerland,69.5435
+2000-12-31,CO,Colombia,43.017
+2000-12-31,DE,Germany,101.4464
 2000-12-31,DK,Denmark,62.2173
-2000-12-31,EE,Estonia,
 2000-12-31,ES,Spain,46.2547
 2000-12-31,FI,Finland,61.236
 2000-12-31,FR,France,50.7141
-2000-12-31,GB,United Kingdom,55.8846
-2000-12-31,GR,Greece,
+2000-12-31,GB,United Kingdom,55.866
+2000-12-31,GR,Greece,60.1585
 2000-12-31,HK,Hong Kong SAR,55.7734
-2000-12-31,HR,Croatia,
-2000-12-31,HU,Hungary,
-2000-12-31,ID,Indonesia,
-2000-12-31,IE,Ireland,81.589
+2000-12-31,HR,Croatia,49.1715
+2000-12-31,HU,Hungary,54.4693
+2000-12-31,IE,Ireland,81.6033
 2000-12-31,IL,Israel,72.3032
-2000-12-31,IN,India,
-2000-12-31,IS,Iceland,49.3414
+2000-12-31,IS,Iceland,49.3431
 2000-12-31,IT,Italy,63.0457
 2000-12-31,JP,Japan,140.6731
-2000-12-31,KR,Korea,60.0281
+2000-12-31,KR,Korea,60.0497
 2000-12-31,LT,Lithuania,29.6414
-2000-12-31,LU,Luxembourg,
-2000-12-31,LV,Latvia,
-2000-12-31,MA,Morocco,
-2000-12-31,MK,North Macedonia,67.25
-2000-12-31,MT,Malta,
-2000-12-31,MX,Mexico,
+2000-12-31,MK,North Macedonia,67.3117
 2000-12-31,MY,Malaysia,71.79
-2000-12-31,NL,Netherlands,75.279
+2000-12-31,NL,Netherlands,75.2132
 2000-12-31,NO,Norway,52.697
 2000-12-31,NZ,New Zealand,46.8448
 2000-12-31,PE,Peru,65.1266
-2000-12-31,PH,Philippines,
-2000-12-31,PL,Poland,
-2000-12-31,PT,Portugal,
-2000-12-31,RO,Romania,
+2000-12-31,PT,Portugal,97.5051
 2000-12-31,RS,Serbia,29.2998
-2000-12-31,RU,Russia,
 2000-12-31,SE,Sweden,49.752
 2000-12-31,SG,Singapore,71.4205
-2000-12-31,SI,Slovenia,
-2000-12-31,SK,Slovak Republic,
 2000-12-31,TH,Thailand,76.694
-2000-12-31,TR,Türkiye,
-2000-12-31,US,United States,79.565
-2000-12-31,XM,Euro area,68.0263
-2000-12-31,XW,World,
-2000-12-31,ZA,South Africa,29.9356
-2001-03-31,4T,Emerging market economies (aggregate),
-2001-03-31,5R,Advanced economies,
-2001-03-31,AE,United Arab Emirates,
+2000-12-31,US,United States,79.4764
+2000-12-31,XM,Euro area,67.9428
+2000-12-31,ZA,South Africa,29.8984
 2001-03-31,AT,Austria,81.1628
 2001-03-31,AU,Australia,43.4213
-2001-03-31,BE,Belgium,55.7289
-2001-03-31,BG,Bulgaria,
+2001-03-31,BE,Belgium,56.2032
+2001-03-31,BG,Bulgaria,33.1037
 2001-03-31,BR,Brazil,28.55
-2001-03-31,CA,Canada,49.3925
-2001-03-31,CH,Switzerland,71.0014
-2001-03-31,CL,Chile,
-2001-03-31,CN,China,
-2001-03-31,CO,Colombia,45.5614
-2001-03-31,CY,Cyprus,
-2001-03-31,CZ,Czechia,
-2001-03-31,DE,Germany,101.4213
+2001-03-31,CA,Canada,49.7754
+2001-03-31,CH,Switzerland,70.999
+2001-03-31,CO,Colombia,45.9141
+2001-03-31,DE,Germany,101.4345
 2001-03-31,DK,Denmark,63.3924
-2001-03-31,EE,Estonia,
 2001-03-31,ES,Spain,48.1692
 2001-03-31,FI,Finland,61.4063
 2001-03-31,FR,France,51.3155
-2001-03-31,GB,United Kingdom,55.6429
-2001-03-31,GR,Greece,
+2001-03-31,GB,United Kingdom,55.6244
+2001-03-31,GR,Greece,62.789
 2001-03-31,HK,Hong Kong SAR,53.675
-2001-03-31,HR,Croatia,
-2001-03-31,HU,Hungary,
-2001-03-31,ID,Indonesia,
-2001-03-31,IE,Ireland,82.0083
+2001-03-31,HR,Croatia,54.7893
+2001-03-31,HU,Hungary,57.5707
+2001-03-31,IE,Ireland,82.0227
 2001-03-31,IL,Israel,71.7059
-2001-03-31,IN,India,
-2001-03-31,IS,Iceland,49.5247
+2001-03-31,IS,Iceland,49.5355
 2001-03-31,IT,Italy,63.7756
 2001-03-31,JP,Japan,139.1347
-2001-03-31,KR,Korea,59.926
+2001-03-31,KR,Korea,59.9229
 2001-03-31,LT,Lithuania,35.0609
-2001-03-31,LU,Luxembourg,
-2001-03-31,LV,Latvia,
-2001-03-31,MA,Morocco,
-2001-03-31,MK,North Macedonia,68.69
-2001-03-31,MT,Malta,
-2001-03-31,MX,Mexico,
+2001-03-31,MK,North Macedonia,68.7917
 2001-03-31,MY,Malaysia,71.0834
-2001-03-31,NL,Netherlands,77.0671
+2001-03-31,NL,Netherlands,77.3134
 2001-03-31,NO,Norway,54.5276
 2001-03-31,NZ,New Zealand,47.4893
 2001-03-31,PE,Peru,58.4434
-2001-03-31,PH,Philippines,
-2001-03-31,PL,Poland,
-2001-03-31,PT,Portugal,
-2001-03-31,RO,Romania,
+2001-03-31,PT,Portugal,98.4397
 2001-03-31,RS,Serbia,29.7329
 2001-03-31,RU,Russia,12.2882
 2001-03-31,SE,Sweden,51.2207
 2001-03-31,SG,Singapore,68.5607
-2001-03-31,SI,Slovenia,
-2001-03-31,SK,Slovak Republic,
 2001-03-31,TH,Thailand,77.7913
-2001-03-31,TR,Türkiye,
-2001-03-31,US,United States,81.4752
-2001-03-31,XM,Euro area,68.9266
-2001-03-31,XW,World,
-2001-03-31,ZA,South Africa,30.37
-2001-06-30,4T,Emerging market economies (aggregate),
-2001-06-30,5R,Advanced economies,
-2001-06-30,AE,United Arab Emirates,
+2001-03-31,US,United States,81.378
+2001-03-31,XM,Euro area,68.853
+2001-03-31,ZA,South Africa,30.3325
 2001-06-30,AT,Austria,77.6272
 2001-06-30,AU,Australia,44.9723
-2001-06-30,BE,Belgium,56.2359
-2001-06-30,BG,Bulgaria,
+2001-06-30,BE,Belgium,56.7145
+2001-06-30,BG,Bulgaria,32.6084
 2001-06-30,BR,Brazil,28.6128
-2001-06-30,CA,Canada,51.5135
-2001-06-30,CH,Switzerland,70.7453
-2001-06-30,CL,Chile,
-2001-06-30,CN,China,
-2001-06-30,CO,Colombia,45.2773
-2001-06-30,CY,Cyprus,
-2001-06-30,CZ,Czechia,
-2001-06-30,DE,Germany,101.4012
+2001-06-30,CA,Canada,51.9129
+2001-06-30,CH,Switzerland,70.7436
+2001-06-30,CO,Colombia,45.6737
+2001-06-30,DE,Germany,101.4227
 2001-06-30,DK,Denmark,64.2459
-2001-06-30,EE,Estonia,
 2001-06-30,ES,Spain,49.8273
 2001-06-30,FI,Finland,62.0202
 2001-06-30,FR,France,52.9191
-2001-06-30,GB,United Kingdom,57.6366
-2001-06-30,GR,Greece,
+2001-06-30,GB,United Kingdom,57.6175
+2001-06-30,GR,Greece,65.1296
 2001-06-30,HK,Hong Kong SAR,53.8075
-2001-06-30,HR,Croatia,
-2001-06-30,HU,Hungary,
-2001-06-30,ID,Indonesia,
-2001-06-30,IE,Ireland,82.2145
+2001-06-30,HR,Croatia,55.4749
+2001-06-30,HU,Hungary,60.0485
+2001-06-30,IE,Ireland,82.2289
 2001-06-30,IL,Israel,70.7908
-2001-06-30,IN,India,
-2001-06-30,IS,Iceland,50.7158
+2001-06-30,IS,Iceland,50.7267
 2001-06-30,IT,Italy,64.5843
 2001-06-30,JP,Japan,137.5091
-2001-06-30,KR,Korea,61.0481
+2001-06-30,KR,Korea,61.0854
 2001-06-30,LT,Lithuania,32.9595
-2001-06-30,LU,Luxembourg,
-2001-06-30,LV,Latvia,
-2001-06-30,MA,Morocco,
-2001-06-30,MK,North Macedonia,67.45
-2001-06-30,MT,Malta,
-2001-06-30,MX,Mexico,
+2001-06-30,MK,North Macedonia,67.5917
 2001-06-30,MY,Malaysia,71.6486
-2001-06-30,NL,Netherlands,79.1234
+2001-06-30,NL,Netherlands,79.2823
 2001-06-30,NO,Norway,56.8813
 2001-06-30,NZ,New Zealand,47.6695
 2001-06-30,PE,Peru,64.9299
-2001-06-30,PH,Philippines,
-2001-06-30,PL,Poland,
-2001-06-30,PT,Portugal,
-2001-06-30,RO,Romania,
+2001-06-30,PT,Portugal,99.748
 2001-06-30,RS,Serbia,30.3936
 2001-06-30,RU,Russia,13.0001
 2001-06-30,SE,Sweden,51.955
 2001-06-30,SG,Singapore,67.9586
-2001-06-30,SI,Slovenia,
-2001-06-30,SK,Slovak Republic,
 2001-06-30,TH,Thailand,75.1347
-2001-06-30,TR,Türkiye,
-2001-06-30,US,United States,82.9026
-2001-06-30,XM,Euro area,69.8895
-2001-06-30,XW,World,
-2001-06-30,ZA,South Africa,30.9883
-2001-09-30,4T,Emerging market economies (aggregate),
-2001-09-30,5R,Advanced economies,
-2001-09-30,AE,United Arab Emirates,
+2001-06-30,US,United States,82.8126
+2001-06-30,XM,Euro area,69.8162
+2001-06-30,ZA,South Africa,30.9505
 2001-09-30,AT,Austria,80.77
 2001-09-30,AU,Australia,47.3147
-2001-09-30,BE,Belgium,57.2241
-2001-09-30,BG,Bulgaria,
+2001-09-30,BE,Belgium,57.7111
+2001-09-30,BG,Bulgaria,33.1304
 2001-09-30,BR,Brazil,28.6728
-2001-09-30,CA,Canada,51.6579
-2001-09-30,CH,Switzerland,70.6959
-2001-09-30,CL,Chile,
-2001-09-30,CN,China,
-2001-09-30,CO,Colombia,45.0659
-2001-09-30,CY,Cyprus,
-2001-09-30,CZ,Czechia,
-2001-09-30,DE,Germany,101.3078
+2001-09-30,CA,Canada,52.0584
+2001-09-30,CH,Switzerland,70.6944
+2001-09-30,CO,Colombia,45.3363
+2001-09-30,DE,Germany,101.333
 2001-09-30,DK,Denmark,64.9923
-2001-09-30,EE,Estonia,
 2001-09-30,ES,Spain,50.9163
 2001-09-30,FI,Finland,61.743
 2001-09-30,FR,France,54.4225
-2001-09-30,GB,United Kingdom,59.6908
-2001-09-30,GR,Greece,
+2001-09-30,GB,United Kingdom,59.671
+2001-09-30,GR,Greece,66.5684
 2001-09-30,HK,Hong Kong SAR,52.1067
-2001-09-30,HR,Croatia,
-2001-09-30,HU,Hungary,
-2001-09-30,ID,Indonesia,
-2001-09-30,IE,Ireland,81.0578
+2001-09-30,HR,Croatia,50.6864
+2001-09-30,HU,Hungary,63.0341
+2001-09-30,IE,Ireland,81.0721
 2001-09-30,IL,Israel,71.2357
-2001-09-30,IN,India,
-2001-09-30,IS,Iceland,51.1282
+2001-09-30,IS,Iceland,51.1345
 2001-09-30,IT,Italy,65.9695
 2001-09-30,JP,Japan,135.8654
-2001-09-30,KR,Korea,63.4451
+2001-09-30,KR,Korea,63.4739
 2001-09-30,LT,Lithuania,36.4988
-2001-09-30,LU,Luxembourg,
-2001-09-30,LV,Latvia,
-2001-09-30,MA,Morocco,
-2001-09-30,MK,North Macedonia,66.89
-2001-09-30,MT,Malta,
-2001-09-30,MX,Mexico,
+2001-09-30,MK,North Macedonia,66.7417
 2001-09-30,MY,Malaysia,72.3552
-2001-09-30,NL,Netherlands,81.1797
+2001-09-30,NL,Netherlands,81.12
 2001-09-30,NO,Norway,56.8813
 2001-09-30,NZ,New Zealand,48.0854
 2001-09-30,PE,Peru,58.4566
-2001-09-30,PH,Philippines,
-2001-09-30,PL,Poland,
-2001-09-30,PT,Portugal,
-2001-09-30,RO,Romania,
+2001-09-30,PT,Portugal,100.0284
 2001-09-30,RS,Serbia,31.2969
 2001-09-30,RU,Russia,13.9548
 2001-09-30,SE,Sweden,52.8729
 2001-09-30,SG,Singapore,65.9266
-2001-09-30,SI,Slovenia,
-2001-09-30,SK,Slovak Republic,
 2001-09-30,TH,Thailand,73.7487
-2001-09-30,TR,Türkiye,
-2001-09-30,US,United States,84.4832
-2001-09-30,XM,Euro area,70.9782
-2001-09-30,XW,World,
-2001-09-30,ZA,South Africa,31.9778
-2001-12-31,4T,Emerging market economies (aggregate),
-2001-12-31,5R,Advanced economies,
-2001-12-31,AE,United Arab Emirates,
+2001-09-30,US,United States,84.3886
+2001-09-30,XM,Euro area,70.9112
+2001-09-30,ZA,South Africa,31.9382
 2001-12-31,AT,Austria,77.3915
 2001-12-31,AU,Australia,49.0913
-2001-12-31,BE,Belgium,57.1683
-2001-12-31,BG,Bulgaria,
+2001-12-31,BE,Belgium,57.6548
+2001-12-31,BG,Bulgaria,32.6453
 2001-12-31,BR,Brazil,28.7327
-2001-12-31,CA,Canada,52.3348
-2001-12-31,CH,Switzerland,71.6672
-2001-12-31,CL,Chile,
-2001-12-31,CN,China,
-2001-12-31,CO,Colombia,47.1076
-2001-12-31,CY,Cyprus,
-2001-12-31,CZ,Czechia,
-2001-12-31,DE,Germany,100.9669
+2001-12-31,CA,Canada,52.7406
+2001-12-31,CH,Switzerland,71.6661
+2001-12-31,CO,Colombia,47.3509
+2001-12-31,DE,Germany,100.9075
 2001-12-31,DK,Denmark,64.4603
-2001-12-31,EE,Estonia,
 2001-12-31,ES,Spain,51.4327
 2001-12-31,FI,Finland,62.0202
 2001-12-31,FR,France,54.6229
-2001-12-31,GB,United Kingdom,58.4825
-2001-12-31,GR,Greece,
+2001-12-31,GB,United Kingdom,58.463
+2001-12-31,GR,Greece,68.4258
 2001-12-31,HK,Hong Kong SAR,48.9259
-2001-12-31,HR,Croatia,
-2001-12-31,HU,Hungary,
-2001-12-31,ID,Indonesia,
-2001-12-31,IE,Ireland,82.1132
+2001-12-31,HR,Croatia,51.9917
+2001-12-31,HU,Hungary,64.8309
+2001-12-31,IE,Ireland,82.1276
 2001-12-31,IL,Israel,70.9688
-2001-12-31,IN,India,
-2001-12-31,IS,Iceland,51.6779
+2001-12-31,IS,Iceland,51.698
 2001-12-31,IT,Italy,67.7316
 2001-12-31,JP,Japan,134.0385
-2001-12-31,KR,Korea,65.2301
+2001-12-31,KR,Korea,65.2071
 2001-12-31,LT,Lithuania,41.9183
-2001-12-31,LU,Luxembourg,
-2001-12-31,LV,Latvia,
-2001-12-31,MA,Morocco,
-2001-12-31,MK,North Macedonia,67.15
-2001-12-31,MT,Malta,
-2001-12-31,MX,Mexico,
+2001-12-31,MK,North Macedonia,67.1917
 2001-12-31,MY,Malaysia,72.3552
-2001-12-31,NL,Netherlands,81.895
+2001-12-31,NL,Netherlands,81.9076
 2001-12-31,NO,Norway,56.7506
 2001-12-31,NZ,New Zealand,48.9032
 2001-12-31,PE,Peru,60.6535
-2001-12-31,PH,Philippines,
-2001-12-31,PL,Poland,
-2001-12-31,PT,Portugal,
-2001-12-31,RO,Romania,
+2001-12-31,PT,Portugal,100.0284
 2001-12-31,RS,Serbia,31.6729
 2001-12-31,RU,Russia,15.2698
 2001-12-31,SE,Sweden,52.1386
 2001-12-31,SG,Singapore,63.0668
-2001-12-31,SI,Slovenia,
-2001-12-31,SK,Slovak Republic,
 2001-12-31,TH,Thailand,75.7122
-2001-12-31,TR,Türkiye,
-2001-12-31,US,United States,85.8772
-2001-12-31,XM,Euro area,71.3376
-2001-12-31,XW,World,
-2001-12-31,ZA,South Africa,33.1455
-2002-03-31,4T,Emerging market economies (aggregate),
-2002-03-31,5R,Advanced economies,
-2002-03-31,AE,United Arab Emirates,
+2001-12-31,US,United States,85.7876
+2001-12-31,XM,Euro area,71.2716
+2001-12-31,ZA,South Africa,33.1048
 2002-03-31,AT,Austria,79.9057
 2002-03-31,AU,Australia,50.9538
-2002-03-31,BE,Belgium,58.4529
-2002-03-31,BG,Bulgaria,
+2002-03-31,BE,Belgium,58.9503
+2002-03-31,BG,Bulgaria,32.7847
 2002-03-31,BR,Brazil,28.8298
-2002-03-31,CA,Canada,54.6318
-2002-03-31,CH,Switzerland,71.8184
+2002-03-31,CA,Canada,55.0554
+2002-03-31,CH,Switzerland,71.8176
 2002-03-31,CL,Chile,55.9177
-2002-03-31,CN,China,
-2002-03-31,CO,Colombia,44.9696
+2002-03-31,CO,Colombia,45.2344
 2002-03-31,CY,Cyprus,43.9916
-2002-03-31,CZ,Czechia,
-2002-03-31,DE,Germany,100.882
+2002-03-31,DE,Germany,100.8633
 2002-03-31,DK,Denmark,65.4171
-2002-03-31,EE,Estonia,
 2002-03-31,ES,Spain,54.4889
 2002-03-31,FI,Finland,64.3766
 2002-03-31,FR,France,55.124
-2002-03-31,GB,United Kingdom,60.4158
-2002-03-31,GR,Greece,
-2002-03-31,HK,Hong Kong SAR,48.9039
+2002-03-31,GB,United Kingdom,60.3957
+2002-03-31,GR,Greece,71.561
+2002-03-31,HK,Hong Kong SAR,48.8818
 2002-03-31,HR,Croatia,55.0351
-2002-03-31,HU,Hungary,
+2002-03-31,HU,Hungary,66.2293
 2002-03-31,ID,Indonesia,73.9057
-2002-03-31,IE,Ireland,85.1184
+2002-03-31,IE,Ireland,85.1333
 2002-03-31,IL,Israel,74.7688
-2002-03-31,IN,India,
-2002-03-31,IS,Iceland,52.2277
+2002-03-31,IS,Iceland,52.2295
 2002-03-31,IT,Italy,71.6173
 2002-03-31,JP,Japan,132.2116
-2002-03-31,KR,Korea,69.0042
+2002-03-31,KR,Korea,69.0117
 2002-03-31,LT,Lithuania,39.485
-2002-03-31,LU,Luxembourg,
-2002-03-31,LV,Latvia,
-2002-03-31,MA,Morocco,
-2002-03-31,MK,North Macedonia,70.39
-2002-03-31,MT,Malta,
-2002-03-31,MX,Mexico,
+2002-03-31,MK,North Macedonia,70.2018
 2002-03-31,MY,Malaysia,72.3552
-2002-03-31,NL,Netherlands,83.3254
+2002-03-31,NL,Netherlands,83.2202
 2002-03-31,NO,Norway,58.5812
 2002-03-31,NZ,New Zealand,50.8438
 2002-03-31,PE,Peru,57.8199
-2002-03-31,PH,Philippines,
-2002-03-31,PL,Poland,
-2002-03-31,PT,Portugal,
-2002-03-31,RO,Romania,
+2002-03-31,PT,Portugal,100.1219
 2002-03-31,RS,Serbia,31.5183
 2002-03-31,RU,Russia,16.4856
 2002-03-31,SE,Sweden,53.0565
 2002-03-31,SG,Singapore,62.3142
-2002-03-31,SI,Slovenia,
-2002-03-31,SK,Slovak Republic,
 2002-03-31,TH,Thailand,75.6545
-2002-03-31,TR,Türkiye,
-2002-03-31,US,United States,87.4448
-2002-03-31,XM,Euro area,72.8991
-2002-03-31,XW,World,
-2002-03-31,ZA,South Africa,34.2176
-2002-06-30,4T,Emerging market economies (aggregate),
-2002-06-30,5R,Advanced economies,
-2002-06-30,AE,United Arab Emirates,
+2002-03-31,US,United States,87.3426
+2002-03-31,XM,Euro area,72.8384
+2002-03-31,ZA,South Africa,34.175
 2002-06-30,AT,Austria,78.57
 2002-06-30,AU,Australia,53.9858
-2002-06-30,BE,Belgium,59.5313
-2002-06-30,BG,Bulgaria,
+2002-06-30,BE,Belgium,60.0379
+2002-06-30,BG,Bulgaria,33.2544
 2002-06-30,BR,Brazil,29.0211
-2002-06-30,CA,Canada,56.7799
-2002-06-30,CH,Switzerland,70.9933
+2002-06-30,CA,Canada,57.2201
+2002-06-30,CH,Switzerland,70.9928
 2002-06-30,CL,Chile,58.4865
-2002-06-30,CN,China,
-2002-06-30,CO,Colombia,46.451
+2002-06-30,CO,Colombia,46.7416
 2002-06-30,CY,Cyprus,43.7305
-2002-06-30,CZ,Czechia,
-2002-06-30,DE,Germany,100.798
+2002-06-30,DE,Germany,100.8201
 2002-06-30,DK,Denmark,66.6994
-2002-06-30,EE,Estonia,
 2002-06-30,ES,Spain,57.8543
 2002-06-30,FI,Finland,66.5034
 2002-06-30,FR,France,57.0283
-2002-06-30,GB,United Kingdom,65.3699
-2002-06-30,GR,Greece,
-2002-06-30,HK,Hong Kong SAR,47.8215
+2002-06-30,GB,United Kingdom,65.3481
+2002-06-30,GR,Greece,75.233
+2002-06-30,HK,Hong Kong SAR,47.8436
 2002-06-30,HR,Croatia,54.4014
-2002-06-30,HU,Hungary,
+2002-06-30,HU,Hungary,70.0071
 2002-06-30,ID,Indonesia,75.0291
-2002-06-30,IE,Ireland,86.2087
+2002-06-30,IE,Ireland,86.2238
 2002-06-30,IL,Israel,76.2813
-2002-06-30,IN,India,
-2002-06-30,IS,Iceland,52.4109
+2002-06-30,IS,Iceland,52.4311
 2002-06-30,IT,Italy,73.127
 2002-06-30,JP,Japan,130.3948
-2002-06-30,KR,Korea,71.7073
+2002-06-30,KR,Korea,71.7384
 2002-06-30,LT,Lithuania,39.8168
-2002-06-30,LU,Luxembourg,
-2002-06-30,LV,Latvia,
-2002-06-30,MA,Morocco,
-2002-06-30,MK,North Macedonia,74.12
-2002-06-30,MT,Malta,
-2002-06-30,MX,Mexico,
+2002-06-30,MK,North Macedonia,74.2419
 2002-06-30,MY,Malaysia,73.5564
-2002-06-30,NL,Netherlands,84.4877
+2002-06-30,NL,Netherlands,84.5328
 2002-06-30,NO,Norway,60.6734
 2002-06-30,NZ,New Zealand,52.0706
 2002-06-30,PE,Peru,59.1599
-2002-06-30,PH,Philippines,
-2002-06-30,PL,Poland,
-2002-06-30,PT,Portugal,
-2002-06-30,RO,Romania,
+2002-06-30,PT,Portugal,100.3711
 2002-06-30,RS,Serbia,31.203
 2002-06-30,RU,Russia,17.6508
 2002-06-30,SE,Sweden,54.7088
 2002-06-30,SG,Singapore,61.8627
-2002-06-30,SI,Slovenia,
-2002-06-30,SK,Slovak Republic,
 2002-06-30,TH,Thailand,76.3475
-2002-06-30,TR,Türkiye,
-2002-06-30,US,United States,89.7209
-2002-06-30,XM,Euro area,74.3176
-2002-06-30,XW,World,
-2002-06-30,ZA,South Africa,35.2159
-2002-09-30,4T,Emerging market economies (aggregate),
-2002-09-30,5R,Advanced economies,
-2002-09-30,AE,United Arab Emirates,
+2002-06-30,US,United States,89.6184
+2002-06-30,XM,Euro area,74.2578
+2002-06-30,ZA,South Africa,35.1727
 2002-09-30,AT,Austria,81.2414
 2002-09-30,AU,Australia,56.236
-2002-09-30,BE,Belgium,61.0608
-2002-09-30,BG,Bulgaria,
+2002-09-30,BE,Belgium,61.5805
+2002-09-30,BG,Bulgaria,33.838
 2002-09-30,BR,Brazil,29.3466
-2002-09-30,CA,Canada,56.3015
-2002-09-30,CH,Switzerland,71.3116
-2002-09-30,CL,Chile,59.6186
-2002-09-30,CN,China,
-2002-09-30,CO,Colombia,45.7639
+2002-09-30,CA,Canada,56.738
+2002-09-30,CH,Switzerland,71.3118
+2002-09-30,CL,Chile,59.6185
+2002-09-30,CO,Colombia,46.0708
 2002-09-30,CY,Cyprus,46.4913
-2002-09-30,CZ,Czechia,
-2002-09-30,DE,Germany,100.5349
+2002-09-30,DE,Germany,100.5553
 2002-09-30,DK,Denmark,67.1281
-2002-09-30,EE,Estonia,
 2002-09-30,ES,Spain,59.2033
 2002-09-30,FI,Finland,67.2876
 2002-09-30,FR,France,59.3335
-2002-09-30,GB,United Kingdom,69.7802
-2002-09-30,GR,Greece,
+2002-09-30,GB,United Kingdom,69.757
+2002-09-30,GR,Greece,75.4155
 2002-09-30,HK,Hong Kong SAR,45.4801
 2002-09-30,HR,Croatia,57.4791
-2002-09-30,HU,Hungary,
+2002-09-30,HU,Hungary,72.9317
 2002-09-30,ID,Indonesia,76.1377
-2002-09-30,IE,Ireland,90.2763
+2002-09-30,IE,Ireland,90.2921
 2002-09-30,IL,Israel,74.8959
-2002-09-30,IN,India,
-2002-09-30,IS,Iceland,53.9686
+2002-09-30,IS,Iceland,53.9751
 2002-09-30,IT,Italy,74.0059
 2002-09-30,JP,Japan,128.5577
-2002-09-30,KR,Korea,74.2573
+2002-09-30,KR,Korea,74.2325
 2002-09-30,LT,Lithuania,41.4759
-2002-09-30,LU,Luxembourg,
-2002-09-30,LV,Latvia,
-2002-09-30,MA,Morocco,
-2002-09-30,MK,North Macedonia,78.02
-2002-09-30,MT,Malta,
-2002-09-30,MX,Mexico,
+2002-09-30,MK,North Macedonia,78.472
 2002-09-30,MY,Malaysia,74.6163
-2002-09-30,NL,Netherlands,85.9182
+2002-09-30,NL,Netherlands,85.9767
 2002-09-30,NO,Norway,58.712
 2002-09-30,NZ,New Zealand,53.7062
 2002-09-30,PE,Peru,68.8154
-2002-09-30,PH,Philippines,
-2002-09-30,PL,Poland,
-2002-09-30,PT,Portugal,
-2002-09-30,RO,Romania,
+2002-09-30,PT,Portugal,100.0907
 2002-09-30,RS,Serbia,30.7191
 2002-09-30,RU,Russia,18.6021
 2002-09-30,SE,Sweden,56.7283
 2002-09-30,SG,Singapore,62.1637
-2002-09-30,SI,Slovenia,
-2002-09-30,SK,Slovak Republic,
 2002-09-30,TH,Thailand,76.232
-2002-09-30,TR,Türkiye,
-2002-09-30,US,United States,92.0116
-2002-09-30,XM,Euro area,75.7022
-2002-09-30,XW,World,
-2002-09-30,ZA,South Africa,36.3138
-2002-12-31,4T,Emerging market economies (aggregate),
-2002-12-31,5R,Advanced economies,
-2002-12-31,AE,United Arab Emirates,
+2002-09-30,US,United States,91.9052
+2002-09-30,XM,Euro area,75.641
+2002-09-30,ZA,South Africa,36.27
 2002-12-31,AT,Austria,79.0414
 2002-12-31,AU,Australia,58.2892
-2002-12-31,BE,Belgium,61.7998
-2002-12-31,BG,Bulgaria,
+2002-12-31,BE,Belgium,62.3257
+2002-12-31,BG,Bulgaria,34.0339
 2002-12-31,BR,Brazil,29.8662
-2002-12-31,CA,Canada,58.0886
-2002-12-31,CH,Switzerland,71.3188
+2002-12-31,CA,Canada,58.539
+2002-12-31,CH,Switzerland,71.3196
 2002-12-31,CL,Chile,60.0634
-2002-12-31,CN,China,
-2002-12-31,CO,Colombia,45.9801
+2002-12-31,CO,Colombia,46.071
 2002-12-31,CY,Cyprus,46.7523
-2002-12-31,CZ,Czechia,
-2002-12-31,DE,Germany,100.0877
+2002-12-31,DE,Germany,100.0636
 2002-12-31,DK,Denmark,67.1281
-2002-12-31,EE,Estonia,
 2002-12-31,ES,Spain,60.3415
 2002-12-31,FI,Finland,67.4301
 2002-12-31,FR,France,59.9349
-2002-12-31,GB,United Kingdom,73.2239
-2002-12-31,GR,Greece,
+2002-12-31,GB,United Kingdom,73.1996
+2002-12-31,GR,Greece,77.1441
 2002-12-31,HK,Hong Kong SAR,43.1388
 2002-12-31,HR,Croatia,57.8411
-2002-12-31,HU,Hungary,
+2002-12-31,HU,Hungary,73.5246
 2002-12-31,ID,Indonesia,76.8176
-2002-12-31,IE,Ireland,93.7672
+2002-12-31,IE,Ireland,93.7837
 2002-12-31,IL,Israel,73.7521
-2002-12-31,IN,India,
-2002-12-31,IS,Iceland,55.114
+2002-12-31,IS,Iceland,55.1296
 2002-12-31,IT,Italy,74.5555
 2002-12-31,JP,Japan,126.4904
-2002-12-31,KR,Korea,76.2973
+2002-12-31,KR,Korea,76.3039
 2002-12-31,LT,Lithuania,43.1349
-2002-12-31,LU,Luxembourg,
-2002-12-31,LV,Latvia,
-2002-12-31,MA,Morocco,
-2002-12-31,MK,North Macedonia,75.8
-2002-12-31,MT,Malta,
-2002-12-31,MX,Mexico,
+2002-12-31,MK,North Macedonia,75.7919
 2002-12-31,MY,Malaysia,75.8175
-2002-12-31,NL,Netherlands,85.8288
+2002-12-31,NL,Netherlands,85.8454
 2002-12-31,NO,Norway,58.3197
 2002-12-31,NZ,New Zealand,55.73
 2002-12-31,PE,Peru,59.6684
-2002-12-31,PH,Philippines,
-2002-12-31,PL,Poland,
-2002-12-31,PT,Portugal,
-2002-12-31,RO,Romania,
+2002-12-31,PT,Portugal,100.153
 2002-12-31,RS,Serbia,33.7798
 2002-12-31,RU,Russia,19.4509
 2002-12-31,SE,Sweden,56.9118
 2002-12-31,SG,Singapore,61.9379
-2002-12-31,SI,Slovenia,
-2002-12-31,SK,Slovak Republic,
 2002-12-31,TH,Thailand,76.1742
-2002-12-31,TR,Türkiye,
-2002-12-31,US,United States,93.8885
-2002-12-31,XM,Euro area,76.1274
-2002-12-31,XW,World,
-2002-12-31,ZA,South Africa,37.6894
-2003-03-31,4T,Emerging market economies (aggregate),
-2003-03-31,5R,Advanced economies,
-2003-03-31,AE,United Arab Emirates,58.4106
+2002-12-31,US,United States,93.7698
+2002-12-31,XM,Euro area,76.0626
+2002-12-31,ZA,South Africa,37.6436
 2003-03-31,AT,Austria,80.3771
 2003-03-31,AU,Australia,59.8529
-2003-03-31,BE,Belgium,62.7579
-2003-03-31,BG,Bulgaria,
+2003-03-31,BE,Belgium,63.292
+2003-03-31,BG,Bulgaria,34.4841
 2003-03-31,BR,Brazil,30.6399
-2003-03-31,CA,Canada,59.3386
-2003-03-31,CH,Switzerland,71.1083
-2003-03-31,CL,Chile,60.1513
-2003-03-31,CN,China,
-2003-03-31,CO,Colombia,45.1967
+2003-03-31,CA,Canada,59.7987
+2003-03-31,CH,Switzerland,71.1092
+2003-03-31,CL,Chile,60.1512
+2003-03-31,CO,Colombia,45.16
 2003-03-31,CY,Cyprus,46.0195
-2003-03-31,CZ,Czechia,
-2003-03-31,DE,Germany,99.8138
+2003-03-31,DE,Germany,99.829
 2003-03-31,DK,Denmark,66.9608
-2003-03-31,EE,Estonia,
 2003-03-31,ES,Spain,63.7069
 2003-03-31,FI,Finland,68.6341
 2003-03-31,FR,France,61.1376
-2003-03-31,GB,United Kingdom,74.5531
-2003-03-31,GR,Greece,
+2003-03-31,GB,United Kingdom,74.5283
+2003-03-31,GR,Greece,78.7225
 2003-03-31,HK,Hong Kong SAR,41.5705
 2003-03-31,HR,Croatia,63.0007
-2003-03-31,HU,Hungary,
+2003-03-31,HU,Hungary,79.6513
 2003-03-31,ID,Indonesia,78.5544
-2003-03-31,IE,Ireland,95.8604
+2003-03-31,IE,Ireland,95.8772
 2003-03-31,IL,Israel,73.015
-2003-03-31,IN,India,
-2003-03-31,IS,Iceland,57.1298
+2003-03-31,IS,Iceland,57.118
 2003-03-31,IT,Italy,76.2439
 2003-03-31,JP,Japan,124.4231
-2003-03-31,KR,Korea,76.7563
+2003-03-31,KR,Korea,76.7901
 2003-03-31,LT,Lithuania,48.8862
-2003-03-31,LU,Luxembourg,
-2003-03-31,LV,Latvia,
-2003-03-31,MA,Morocco,
-2003-03-31,MK,North Macedonia,78.39
-2003-03-31,MT,Malta,
-2003-03-31,MX,Mexico,
+2003-03-31,MK,North Macedonia,78.442
 2003-03-31,MY,Malaysia,75.7469
-2003-03-31,NL,Netherlands,86.6334
+2003-03-31,NL,Netherlands,86.7643
 2003-03-31,NO,Norway,59.6273
 2003-03-31,NZ,New Zealand,58.7934
 2003-03-31,PE,Peru,50.7241
-2003-03-31,PH,Philippines,
-2003-03-31,PL,Poland,
-2003-03-31,PT,Portugal,
-2003-03-31,RO,Romania,
+2003-03-31,PT,Portugal,100.6514
 2003-03-31,RS,Serbia,40.316
 2003-03-31,RU,Russia,20.9034
 2003-03-31,SE,Sweden,57.279
 2003-03-31,SG,Singapore,61.4111
-2003-03-31,SI,Slovenia,
-2003-03-31,SK,Slovak Republic,
 2003-03-31,TH,Thailand,77.2138
-2003-03-31,TR,Türkiye,
-2003-03-31,US,United States,95.7806
-2003-03-31,XM,Euro area,77.3245
-2003-03-31,XW,World,
-2003-03-31,ZA,South Africa,39.2895
-2003-06-30,4T,Emerging market economies (aggregate),
-2003-06-30,5R,Advanced economies,
-2003-06-30,AE,United Arab Emirates,56.8865
+2003-03-31,US,United States,95.6736
+2003-03-31,XM,Euro area,77.2649
+2003-03-31,ZA,South Africa,39.2413
 2003-06-30,AT,Austria,79.5914
 2003-06-30,AU,Australia,63.082
-2003-06-30,BE,Belgium,63.368
-2003-06-30,BG,Bulgaria,
+2003-06-30,BE,Belgium,63.9073
+2003-06-30,BG,Bulgaria,35.965
 2003-06-30,BR,Brazil,31.6734
-2003-06-30,CA,Canada,61.2927
-2003-06-30,CH,Switzerland,72.8238
-2003-06-30,CL,Chile,61.2414
-2003-06-30,CN,China,
-2003-06-30,CO,Colombia,46.9041
+2003-06-30,CA,Canada,61.7679
+2003-06-30,CH,Switzerland,72.8248
+2003-06-30,CL,Chile,61.2413
+2003-06-30,CO,Colombia,47.002
 2003-06-30,CY,Cyprus,46.5516
-2003-06-30,CZ,Czechia,
-2003-06-30,DE,Germany,99.4571
+2003-06-30,DE,Germany,99.4697
 2003-06-30,DK,Denmark,68.3949
-2003-06-30,EE,Estonia,
 2003-06-30,ES,Spain,67.8521
 2003-06-30,FI,Finland,70.0321
 2003-06-30,FR,France,63.4427
-2003-06-30,GB,United Kingdom,76.8489
-2003-06-30,GR,Greece,
+2003-06-30,GB,United Kingdom,76.8233
+2003-06-30,GR,Greece,78.2393
 2003-06-30,HK,Hong Kong SAR,39.6488
 2003-06-30,HR,Croatia,64.811
-2003-06-30,HU,Hungary,
+2003-06-30,HU,Hungary,83.8379
 2003-06-30,ID,Indonesia,79.6482
-2003-06-30,IE,Ireland,97.4295
+2003-06-30,IE,Ireland,97.4465
 2003-06-30,IL,Israel,69.952
-2003-06-30,IN,India,
-2003-06-30,IS,Iceland,58.5958
+2003-06-30,IS,Iceland,58.5841
 2003-06-30,IT,Italy,77.2642
 2003-06-30,JP,Japan,122.3672
-2003-06-30,KR,Korea,79.0514
+2003-06-30,KR,Korea,79.0306
 2003-06-30,LT,Lithuania,44.2409
-2003-06-30,LU,Luxembourg,
-2003-06-30,LV,Latvia,
-2003-06-30,MA,Morocco,
-2003-06-30,MK,North Macedonia,78.24
-2003-06-30,MT,Malta,
-2003-06-30,MX,Mexico,
+2003-06-30,MK,North Macedonia,78.162
 2003-06-30,MY,Malaysia,75.6762
-2003-06-30,NL,Netherlands,87.5275
+2003-06-30,NL,Netherlands,87.6831
 2003-06-30,NO,Norway,60.0196
 2003-06-30,NZ,New Zealand,60.831
 2003-06-30,PE,Peru,55.061
-2003-06-30,PH,Philippines,
-2003-06-30,PL,Poland,
-2003-06-30,PT,Portugal,
-2003-06-30,RO,Romania,
+2003-06-30,PT,Portugal,101.2433
 2003-06-30,RS,Serbia,43.6315
 2003-06-30,RU,Russia,21.5181
 2003-06-30,SE,Sweden,58.5641
 2003-06-30,SG,Singapore,61.0348
-2003-06-30,SI,Slovenia,
-2003-06-30,SK,Slovak Republic,
 2003-06-30,TH,Thailand,77.3293
-2003-06-30,TR,Türkiye,
-2003-06-30,US,United States,97.8469
-2003-06-30,XM,Euro area,78.7252
-2003-06-30,XW,World,
-2003-06-30,ZA,South Africa,41.2162
-2003-09-30,4T,Emerging market economies (aggregate),
-2003-09-30,5R,Advanced economies,
-2003-09-30,AE,United Arab Emirates,55.8381
+2003-06-30,US,United States,97.7276
+2003-06-30,XM,Euro area,78.6718
+2003-06-30,ZA,South Africa,41.1665
 2003-09-30,AT,Austria,78.8057
 2003-09-30,AU,Australia,66.7942
-2003-09-30,BE,Belgium,65.0909
-2003-09-30,BG,Bulgaria,
+2003-09-30,BE,Belgium,65.6448
+2003-09-30,BG,Bulgaria,38.5832
 2003-09-30,BR,Brazil,32.8753
-2003-09-30,CA,Canada,62.5924
-2003-09-30,CH,Switzerland,73.3941
+2003-09-30,CA,Canada,63.0776
+2003-09-30,CH,Switzerland,73.3959
 2003-09-30,CL,Chile,61.7399
-2003-09-30,CN,China,
-2003-09-30,CO,Colombia,46.3134
+2003-09-30,CO,Colombia,46.6286
 2003-09-30,CY,Cyprus,47.6559
-2003-09-30,CZ,Czechia,
-2003-09-30,DE,Germany,99.0007
+2003-09-30,DE,Germany,98.9997
 2003-09-30,DK,Denmark,69.6084
-2003-09-30,EE,Estonia,
 2003-09-30,ES,Spain,69.6648
 2003-09-30,FI,Finland,71.4618
 2003-09-30,FR,France,66.1488
-2003-09-30,GB,United Kingdom,78.9634
-2003-09-30,GR,Greece,
+2003-09-30,GB,United Kingdom,78.9372
+2003-09-30,GR,Greece,78.8513
 2003-09-30,HK,Hong Kong SAR,39.2954
 2003-09-30,HR,Croatia,65.4447
-2003-09-30,HU,Hungary,
+2003-09-30,HU,Hungary,85.7141
 2003-09-30,ID,Indonesia,80.8455
-2003-09-30,IE,Ireland,102.119
+2003-09-30,IE,Ireland,102.1369
 2003-09-30,IL,Israel,70.2825
-2003-09-30,IN,India,
-2003-09-30,IS,Iceland,61.5279
+2003-09-30,IS,Iceland,61.5117
 2003-09-30,IT,Italy,78.6969
 2003-09-30,JP,Japan,120.2885
-2003-09-30,KR,Korea,80.4284
+2003-09-30,KR,Korea,80.4124
 2003-09-30,LT,Lithuania,45.347
-2003-09-30,LU,Luxembourg,
-2003-09-30,LV,Latvia,
-2003-09-30,MA,Morocco,
-2003-09-30,MK,North Macedonia,76.21
-2003-09-30,MT,Malta,
-2003-09-30,MX,Mexico,
+2003-09-30,MK,North Macedonia,75.9919
 2003-09-30,MY,Malaysia,78.1493
-2003-09-30,NL,Netherlands,88.3321
+2003-09-30,NL,Netherlands,88.4707
 2003-09-30,NO,Norway,59.8889
 2003-09-30,NZ,New Zealand,64.9201
 2003-09-30,PE,Peru,51.9545
-2003-09-30,PH,Philippines,
-2003-09-30,PL,Poland,
-2003-09-30,PT,Portugal,
-2003-09-30,RO,Romania,
+2003-09-30,PT,Portugal,101.5548
 2003-09-30,RS,Serbia,43.7279
 2003-09-30,RU,Russia,22.46
 2003-09-30,SE,Sweden,59.8492
 2003-09-30,SG,Singapore,60.7338
-2003-09-30,SI,Slovenia,
-2003-09-30,SK,Slovak Republic,
 2003-09-30,TH,Thailand,78.542
-2003-09-30,TR,Türkiye,
-2003-09-30,US,United States,100.6836
-2003-09-30,XM,Euro area,80.0847
-2003-09-30,XW,World,
-2003-09-30,ZA,South Africa,43.6841
-2003-12-31,4T,Emerging market economies (aggregate),
-2003-12-31,5R,Advanced economies,
-2003-12-31,AE,United Arab Emirates,57.8269
+2003-09-30,US,United States,100.5691
+2003-09-30,XM,Euro area,80.0241
+2003-09-30,ZA,South Africa,43.6313
 2003-12-31,AT,Austria,80.8486
 2003-12-31,AU,Australia,69.3114
-2003-12-31,BE,Belgium,66.2251
-2003-12-31,BG,Bulgaria,
+2003-12-31,BE,Belgium,66.7887
+2003-12-31,BG,Bulgaria,41.226
 2003-12-31,BR,Brazil,34.0973
-2003-12-31,CA,Canada,64.4291
-2003-12-31,CH,Switzerland,73.621
-2003-12-31,CL,Chile,62.8506
-2003-12-31,CN,China,
-2003-12-31,CO,Colombia,48.646
+2003-12-31,CA,Canada,64.9286
+2003-12-31,CH,Switzerland,73.6229
+2003-12-31,CL,Chile,62.8505
+2003-12-31,CO,Colombia,48.926
 2003-12-31,CY,Cyprus,48.5895
-2003-12-31,CZ,Czechia,
-2003-12-31,DE,Germany,98.4402
+2003-12-31,DE,Germany,98.4138
 2003-12-31,DK,Denmark,69.829
-2003-12-31,EE,Estonia,
 2003-12-31,ES,Spain,71.4774
 2003-12-31,FI,Finland,72.4163
 2003-12-31,FR,France,67.2513
-2003-12-31,GB,United Kingdom,80.5946
-2003-12-31,GR,Greece,
+2003-12-31,GB,United Kingdom,80.5679
+2003-12-31,GR,Greece,79.678
 2003-12-31,HK,Hong Kong SAR,42.6528
 2003-12-31,HR,Croatia,69.9706
-2003-12-31,HU,Hungary,
+2003-12-31,HU,Hungary,89.7342
 2003-12-31,ID,Indonesia,81.4146
-2003-12-31,IE,Ireland,106.8226
+2003-12-31,IE,Ireland,106.8413
 2003-12-31,IL,Israel,69.4691
-2003-12-31,IN,India,
-2003-12-31,IS,Iceland,61.8944
+2003-12-31,IS,Iceland,61.9057
 2003-12-31,IT,Italy,79.1854
 2003-12-31,JP,Japan,118.3654
-2003-12-31,KR,Korea,81.2954
+2003-12-31,KR,Korea,81.3406
 2003-12-31,LT,Lithuania,48.112
-2003-12-31,LU,Luxembourg,
-2003-12-31,LV,Latvia,
-2003-12-31,MA,Morocco,
-2003-12-31,MK,North Macedonia,80.16
-2003-12-31,MT,Malta,
-2003-12-31,MX,Mexico,
+2003-12-31,MK,North Macedonia,80.102
 2003-12-31,MY,Malaysia,78.5733
-2003-12-31,NL,Netherlands,89.3156
+2003-12-31,NL,Netherlands,89.2582
 2003-12-31,NO,Norway,60.6734
 2003-12-31,NZ,New Zealand,69.3073
 2003-12-31,PE,Peru,53.3807
-2003-12-31,PH,Philippines,
-2003-12-31,PL,Poland,
-2003-12-31,PT,Portugal,
-2003-12-31,RO,Romania,
+2003-12-31,PT,Portugal,101.6172
 2003-12-31,RS,Serbia,45.5898
 2003-12-31,RU,Russia,23.5079
 2003-12-31,SE,Sweden,60.4
 2003-12-31,SG,Singapore,60.6585
-2003-12-31,SI,Slovenia,
-2003-12-31,SK,Slovak Republic,
 2003-12-31,TH,Thailand,80.3323
-2003-12-31,TR,Türkiye,
-2003-12-31,US,United States,103.9886
-2003-12-31,XM,Euro area,80.9538
-2003-12-31,XW,World,
-2003-12-31,ZA,South Africa,47.1795
-2004-03-31,4T,Emerging market economies (aggregate),
-2004-03-31,5R,Advanced economies,
-2004-03-31,AE,United Arab Emirates,65.2633
+2003-12-31,US,United States,103.8582
+2003-12-31,XM,Euro area,80.8886
+2003-12-31,ZA,South Africa,47.1221
 2004-03-31,AT,Austria,74.7987
 2004-03-31,AU,Australia,69.0223
-2004-03-31,BE,Belgium,68.0081
-2004-03-31,BG,Bulgaria,
+2004-03-31,BE,Belgium,68.5869
+2004-03-31,BG,Bulgaria,46.3743
 2004-03-31,BR,Brazil,35.2336
-2004-03-31,CA,Canada,65.5212
-2004-03-31,CH,Switzerland,74.7447
-2004-03-31,CL,Chile,63.2028
-2004-03-31,CN,China,
-2004-03-31,CO,Colombia,49.0943
+2004-03-31,CA,Canada,66.0292
+2004-03-31,CH,Switzerland,74.746
+2004-03-31,CL,Chile,63.2027
+2004-03-31,CO,Colombia,49.0182
 2004-03-31,CY,Cyprus,54.8539
-2004-03-31,CZ,Czechia,
-2004-03-31,DE,Germany,97.9675
+2004-03-31,DE,Germany,97.8311
 2004-03-31,DK,Denmark,72.1456
-2004-03-31,EE,Estonia,
 2004-03-31,ES,Spain,75.4154
 2004-03-31,FI,Finland,74.349
 2004-03-31,FR,France,69.4563
-2004-03-31,GB,United Kingdom,81.3196
-2004-03-31,GR,Greece,
+2004-03-31,GB,United Kingdom,81.2926
+2004-03-31,GR,Greece,79.5492
 2004-03-31,HK,Hong Kong SAR,48.7713
 2004-03-31,HR,Croatia,71.3284
-2004-03-31,HU,Hungary,
+2004-03-31,HU,Hungary,87.4988
 2004-03-31,ID,Indonesia,82.0649
-2004-03-31,IE,Ireland,106.6968
+2004-03-31,IE,Ireland,106.7155
 2004-03-31,IL,Israel,69.9774
-2004-03-31,IN,India,
-2004-03-31,IS,Iceland,61.986
+2004-03-31,IS,Iceland,61.979
 2004-03-31,IT,Italy,80.0051
 2004-03-31,JP,Japan,116.4424
-2004-03-31,KR,Korea,80.6324
+2004-03-31,KR,Korea,80.6282
 2004-03-31,LT,Lithuania,52.0937
-2004-03-31,LU,Luxembourg,
-2004-03-31,LV,Latvia,
-2004-03-31,MA,Morocco,
-2004-03-31,MK,North Macedonia,78.54
-2004-03-31,MT,Malta,
-2004-03-31,MX,Mexico,
+2004-03-31,MK,North Macedonia,78.552
 2004-03-31,MY,Malaysia,79.7038
-2004-03-31,NL,Netherlands,90.299
+2004-03-31,NL,Netherlands,90.3083
 2004-03-31,NO,Norway,65.1193
 2004-03-31,NZ,New Zealand,72.3914
 2004-03-31,PE,Peru,59.8422
-2004-03-31,PH,Philippines,
-2004-03-31,PL,Poland,
-2004-03-31,PT,Portugal,
-2004-03-31,RO,Romania,
+2004-03-31,PT,Portugal,101.7418
 2004-03-31,RS,Serbia,49.1969
 2004-03-31,RU,Russia,26.2156
 2004-03-31,SE,Sweden,61.6851
 2004-03-31,SG,Singapore,60.4327
-2004-03-31,SI,Slovenia,
-2004-03-31,SK,Slovak Republic,
 2004-03-31,TH,Thailand,81.0254
-2004-03-31,TR,Türkiye,
-2004-03-31,US,United States,107.523
-2004-03-31,XM,Euro area,81.9474
-2004-03-31,XW,World,
-2004-03-31,ZA,South Africa,51.3188
-2004-06-30,4T,Emerging market economies (aggregate),
-2004-06-30,5R,Advanced economies,
-2004-06-30,AE,United Arab Emirates,67.8358
+2004-03-31,US,United States,107.383
+2004-03-31,XM,Euro area,81.8905
+2004-03-31,ZA,South Africa,51.2569
 2004-06-30,AT,Austria,78.7272
 2004-06-30,AU,Australia,68.3446
-2004-06-30,BE,Belgium,68.3519
-2004-06-30,BG,Bulgaria,
+2004-06-30,BE,Belgium,68.9336
+2004-06-30,BG,Bulgaria,51.983
 2004-06-30,BR,Brazil,36.2385
-2004-06-30,CA,Canada,68.5492
-2004-06-30,CH,Switzerland,75.4148
+2004-06-30,CA,Canada,69.0807
+2004-06-30,CH,Switzerland,75.4163
 2004-06-30,CL,Chile,65.1393
-2004-06-30,CN,China,
-2004-06-30,CO,Colombia,50.5619
+2004-06-30,CO,Colombia,50.7131
 2004-06-30,CY,Cyprus,57.0525
-2004-06-30,CZ,Czechia,
-2004-06-30,DE,Germany,98.1755
+2004-06-30,DE,Germany,98.2637
 2004-06-30,DK,Denmark,75.3447
-2004-06-30,EE,Estonia,
 2004-06-30,ES,Spain,79.7117
 2004-06-30,FI,Finland,76.0837
 2004-06-30,FR,France,72.2626
-2004-06-30,GB,United Kingdom,86.0925
-2004-06-30,GR,Greece,
+2004-06-30,GB,United Kingdom,86.0639
+2004-06-30,GR,Greece,79.9357
 2004-06-30,HK,Hong Kong SAR,51.1569
 2004-06-30,HR,Croatia,73.6818
-2004-06-30,HU,Hungary,
+2004-06-30,HU,Hungary,91.1102
 2004-06-30,ID,Indonesia,83.107
-2004-06-30,IE,Ireland,107.8325
+2004-06-30,IE,Ireland,107.8514
 2004-06-30,IL,Israel,71.2738
-2004-06-30,IN,India,
-2004-06-30,IS,Iceland,65.6511
+2004-06-30,IS,Iceland,65.6351
 2004-06-30,IT,Italy,81.6224
 2004-06-30,JP,Japan,114.7116
-2004-06-30,KR,Korea,80.8364
+2004-06-30,KR,Korea,80.8486
 2004-06-30,LT,Lithuania,50.1029
-2004-06-30,LU,Luxembourg,
-2004-06-30,LV,Latvia,
-2004-06-30,MA,Morocco,
-2004-06-30,MK,North Macedonia,77.21
-2004-06-30,MT,Malta,
-2004-06-30,MX,Mexico,
+2004-06-30,MK,North Macedonia,77.1219
 2004-06-30,MY,Malaysia,79.9158
-2004-06-30,NL,Netherlands,91.2825
+2004-06-30,NL,Netherlands,91.3584
 2004-06-30,NO,Norway,66.1654
 2004-06-30,NZ,New Zealand,73.6806
 2004-06-30,PE,Peru,60.6225
-2004-06-30,PH,Philippines,
-2004-06-30,PL,Poland,
-2004-06-30,PT,Portugal,
-2004-06-30,RO,Romania,
+2004-06-30,PT,Portugal,101.8041
 2004-06-30,RS,Serbia,50.6704
 2004-06-30,RU,Russia,27.6853
 2004-06-30,SE,Sweden,64.2553
 2004-06-30,SG,Singapore,60.508
-2004-06-30,SI,Slovenia,
-2004-06-30,SK,Slovak Republic,
 2004-06-30,TH,Thailand,82.0649
-2004-06-30,TR,Türkiye,
-2004-06-30,US,United States,111.7805
-2004-06-30,XM,Euro area,83.804
-2004-06-30,XW,World,
-2004-06-30,ZA,South Africa,55.1154
-2004-09-30,4T,Emerging market economies (aggregate),
-2004-09-30,5R,Advanced economies,
-2004-09-30,AE,United Arab Emirates,69.6949
+2004-06-30,US,United States,111.6381
+2004-06-30,XM,Euro area,83.7539
+2004-06-30,ZA,South Africa,55.0481
 2004-09-30,AT,Austria,79.12
 2004-09-30,AU,Australia,68.3446
-2004-09-30,BE,Belgium,70.9297
-2004-09-30,BG,Bulgaria,
+2004-09-30,BE,Belgium,71.5333
+2004-09-30,BG,Bulgaria,58.3199
 2004-09-30,BR,Brazil,37.1264
-2004-09-30,CA,Canada,66.9382
-2004-09-30,CH,Switzerland,76.8166
+2004-09-30,CA,Canada,67.4572
+2004-09-30,CH,Switzerland,76.8195
 2004-09-30,CL,Chile,66.6109
-2004-09-30,CN,China,
-2004-09-30,CO,Colombia,51.0524
+2004-09-30,CO,Colombia,51.2212
 2004-09-30,CY,Cyprus,59.3515
-2004-09-30,CZ,Czechia,
-2004-09-30,DE,Germany,97.8513
+2004-09-30,DE,Germany,97.8692
 2004-09-30,DK,Denmark,77.7716
-2004-09-30,EE,Estonia,
 2004-09-30,ES,Spain,81.3698
 2004-09-30,FI,Finland,76.1708
 2004-09-30,FR,France,75.7705
-2004-09-30,GB,United Kingdom,89.8987
-2004-09-30,GR,Greece,
+2004-09-30,GB,United Kingdom,89.8688
+2004-09-30,GR,Greece,80.6658
 2004-09-30,HK,Hong Kong SAR,51.5545
 2004-09-30,HR,Croatia,76.3069
-2004-09-30,HU,Hungary,
+2004-09-30,HU,Hungary,93.5316
 2004-09-30,ID,Indonesia,83.8534
-2004-09-30,IE,Ireland,112.9903
+2004-09-30,IE,Ireland,113.0102
 2004-09-30,IL,Israel,70.5748
-2004-09-30,IN,India,
-2004-09-30,IS,Iceland,67.1172
+2004-09-30,IS,Iceland,67.1195
 2004-09-30,IT,Italy,83.7604
 2004-09-30,JP,Japan,112.9808
-2004-09-30,KR,Korea,80.2244
+2004-09-30,KR,Korea,80.2213
 2004-09-30,LT,Lithuania,55.9648
-2004-09-30,LU,Luxembourg,
-2004-09-30,LV,Latvia,
-2004-09-30,MA,Morocco,
-2004-09-30,MK,North Macedonia,77.39
-2004-09-30,MT,Malta,
-2004-09-30,MX,Mexico,
+2004-09-30,MK,North Macedonia,77.4119
 2004-09-30,MY,Malaysia,80.1278
-2004-09-30,NL,Netherlands,92.6236
+2004-09-30,NL,Netherlands,92.5398
 2004-09-30,NO,Norway,66.2962
 2004-09-30,NZ,New Zealand,75.1915
 2004-09-30,PE,Peru,58.4605
-2004-09-30,PH,Philippines,
-2004-09-30,PL,Poland,
-2004-09-30,PT,Portugal,
-2004-09-30,RO,Romania,
+2004-09-30,PT,Portugal,102.0221
 2004-09-30,RS,Serbia,50.0264
 2004-09-30,RU,Russia,28.9786
 2004-09-30,SE,Sweden,65.724
 2004-09-30,SG,Singapore,60.7338
-2004-09-30,SI,Slovenia,
-2004-09-30,SK,Slovak Republic,
 2004-09-30,TH,Thailand,82.5269
-2004-09-30,TR,Türkiye,
-2004-09-30,US,United States,115.5872
-2004-09-30,XM,Euro area,85.5598
-2004-09-30,XW,World,
-2004-09-30,ZA,South Africa,58.9604
-2004-12-31,4T,Emerging market economies (aggregate),
-2004-12-31,5R,Advanced economies,
-2004-12-31,AE,United Arab Emirates,71.1973
+2004-09-30,US,United States,115.4341
+2004-09-30,XM,Euro area,85.502
+2004-09-30,ZA,South Africa,58.8885
 2004-12-31,AT,Austria,80.8486
 2004-12-31,AU,Australia,69.5063
-2004-12-31,BE,Belgium,72.5151
-2004-12-31,BG,Bulgaria,
+2004-12-31,BE,Belgium,73.1322
+2004-12-31,BG,Bulgaria,64.9275
 2004-12-31,BR,Brazil,37.9287
-2004-12-31,CA,Canada,69.5059
-2004-12-31,CH,Switzerland,77.3865
+2004-12-31,CA,Canada,70.0448
+2004-12-31,CH,Switzerland,77.3904
 2004-12-31,CL,Chile,68.1227
-2004-12-31,CN,China,
-2004-12-31,CO,Colombia,54.3868
+2004-12-31,CO,Colombia,54.4645
 2004-12-31,CY,Cyprus,61.6304
-2004-12-31,CZ,Czechia,
-2004-12-31,DE,Germany,97.5062
+2004-12-31,DE,Germany,97.536
 2004-12-31,DK,Denmark,79.647
-2004-12-31,EE,Estonia,
 2004-12-31,ES,Spain,83.8043
 2004-12-31,FI,Finland,76.5906
 2004-12-31,FR,France,77.5745
-2004-12-31,GB,United Kingdom,90.5028
-2004-12-31,GR,Greece,
+2004-12-31,GB,United Kingdom,90.4728
+2004-12-31,GR,Greece,82.6414
 2004-12-31,HK,Hong Kong SAR,55.2432
 2004-12-31,HR,Croatia,81.0138
-2004-12-31,HU,Hungary,
+2004-12-31,HU,Hungary,92.1729
 2004-12-31,ID,Indonesia,84.2156
-2004-12-31,IE,Ireland,118.875
+2004-12-31,IE,Ireland,118.8959
 2004-12-31,IL,Israel,68.7828
-2004-12-31,IN,India,
-2004-12-31,IS,Iceland,70.2325
+2004-12-31,IS,Iceland,70.2303
 2004-12-31,IT,Italy,85.0432
 2004-12-31,JP,Japan,111.5866
-2004-12-31,KR,Korea,79.4594
+2004-12-31,KR,Korea,79.4628
 2004-12-31,LT,Lithuania,62.8221
-2004-12-31,LU,Luxembourg,
-2004-12-31,LV,Latvia,
-2004-12-31,MA,Morocco,
-2004-12-31,MK,North Macedonia,78.87
-2004-12-31,MT,Malta,
-2004-12-31,MX,Mexico,
+2004-12-31,MK,North Macedonia,78.982
 2004-12-31,MY,Malaysia,80.5517
-2004-12-31,NL,Netherlands,92.8918
+2004-12-31,NL,Netherlands,92.8023
 2004-12-31,NO,Norway,67.0807
 2004-12-31,NZ,New Zealand,77.9083
 2004-12-31,PE,Peru,54.6199
-2004-12-31,PH,Philippines,
-2004-12-31,PL,Poland,
-2004-12-31,PT,Portugal,
-2004-12-31,RO,Romania,
+2004-12-31,PT,Portugal,102.0844
 2004-12-31,RS,Serbia,51.7887
 2004-12-31,RU,Russia,30.1793
 2004-12-31,SE,Sweden,66.4584
 2004-12-31,SG,Singapore,61.1853
-2004-12-31,SI,Slovenia,
-2004-12-31,SK,Slovak Republic,
 2004-12-31,TH,Thailand,84.7792
-2004-12-31,TR,Türkiye,
-2004-12-31,US,United States,119.9486
-2004-12-31,XM,Euro area,86.788
-2004-12-31,XW,World,
-2004-12-31,ZA,South Africa,63.7428
-2005-03-31,4T,Emerging market economies (aggregate),
-2005-03-31,5R,Advanced economies,
-2005-03-31,AE,United Arab Emirates,73.6401
+2004-12-31,US,United States,119.7842
+2004-12-31,XM,Euro area,86.7238
+2004-12-31,ZA,South Africa,63.6654
 2005-03-31,AT,Austria,81.1628
 2005-03-31,AU,Australia,69.4095
-2005-03-31,BE,Belgium,75.8071
+2005-03-31,BE,Belgium,76.4541
 2005-03-31,BG,Bulgaria,71.838
 2005-03-31,BR,Brazil,38.6853
-2005-03-31,CA,Canada,71.9517
-2005-03-31,CH,Switzerland,78.2731
-2005-03-31,CL,Chile,66.6193
-2005-03-31,CN,China,
-2005-03-31,CO,Colombia,53.5532
+2005-03-31,CA,Canada,72.5968
+2005-03-31,CH,Switzerland,78.2761
+2005-03-31,CL,Chile,66.6192
+2005-03-31,CO,Colombia,53.9106
 2005-03-31,CY,Cyprus,61.53
-2005-03-31,CZ,Czechia,
-2005-03-31,DE,Germany,97.4199
+2005-03-31,DE,Germany,97.4609
 2005-03-31,DK,Denmark,83.2874
 2005-03-31,EE,Estonia,79.1802
 2005-03-31,ES,Spain,87.2751
 2005-03-31,FI,Finland,78.3813
 2005-03-31,FR,France,79.98
-2005-03-31,GB,United Kingdom,88.6402
-2005-03-31,GR,Greece,
+2005-03-31,GB,United Kingdom,88.6118
+2005-03-31,GR,Greece,85.637
 2005-03-31,HK,Hong Kong SAR,59.5726
 2005-03-31,HR,Croatia,81.0138
-2005-03-31,HU,Hungary,
+2005-03-31,HU,Hungary,91.5466
 2005-03-31,ID,Indonesia,85.2503
-2005-03-31,IE,Ireland,118.731
+2005-03-31,IE,Ireland,118.7259
 2005-03-31,IL,Israel,68.6684
-2005-03-31,IN,India,
-2005-03-31,IS,Iceland,76.9213
+2005-03-31,IS,Iceland,76.9056
 2005-03-31,IT,Italy,86.6638
 2005-03-31,JP,Japan,110.1924
-2005-03-31,KR,Korea,79.1534
+2005-03-31,KR,Korea,79.1756
 2005-03-31,LT,Lithuania,73.1082
-2005-03-31,LU,Luxembourg,
-2005-03-31,LV,Latvia,
-2005-03-31,MA,Morocco,97.859
-2005-03-31,MK,North Macedonia,76.46
+2005-03-31,MA,Morocco,97.3797
+2005-03-31,MK,North Macedonia,76.4119
 2005-03-31,MT,Malta,62.2735
 2005-03-31,MX,Mexico,72.552
 2005-03-31,MY,Malaysia,81.2583
-2005-03-31,NL,Netherlands,93.7702
+2005-03-31,NL,Netherlands,93.7657
 2005-03-31,NO,Norway,69.8267
 2005-03-31,NZ,New Zealand,81.5123
 2005-03-31,PE,Peru,59.4955
-2005-03-31,PH,Philippines,
-2005-03-31,PL,Poland,
-2005-03-31,PT,Portugal,
-2005-03-31,RO,Romania,
+2005-03-31,PT,Portugal,101.8975
 2005-03-31,RS,Serbia,55.9152
 2005-03-31,RU,Russia,32.9694
 2005-03-31,SE,Sweden,66.8829
 2005-03-31,SG,Singapore,61.6369
-2005-03-31,SI,Slovenia,
-2005-03-31,SK,Slovak Republic,
 2005-03-31,TH,Thailand,87.4358
-2005-03-31,TR,Türkiye,
-2005-03-31,US,United States,124.8865
-2005-03-31,XM,Euro area,88.1885
-2005-03-31,XW,World,
-2005-03-31,ZA,South Africa,68.5349
-2005-06-30,4T,Emerging market economies (aggregate),
-2005-06-30,5R,Advanced economies,
-2005-06-30,AE,United Arab Emirates,74.9264
+2005-03-31,US,United States,124.7175
+2005-03-31,XM,Euro area,88.1302
+2005-03-31,ZA,South Africa,68.4514
 2005-06-30,AT,Austria,81.9485
 2005-06-30,AU,Australia,69.8935
-2005-06-30,BE,Belgium,77.5043
+2005-06-30,BE,Belgium,78.1572
 2005-06-30,BG,Bulgaria,74.9096
 2005-06-30,BR,Brazil,39.4447
-2005-06-30,CA,Canada,73.8002
-2005-06-30,CH,Switzerland,78.6966
+2005-06-30,CA,Canada,74.462
+2005-06-30,CH,Switzerland,78.6987
 2005-06-30,CL,Chile,69.8538
 2005-06-30,CN,China,75.8675
-2005-06-30,CO,Colombia,55.414
+2005-06-30,CO,Colombia,55.4528
 2005-06-30,CY,Cyprus,63.2768
-2005-06-30,CZ,Czechia,
-2005-06-30,DE,Germany,96.9124
+2005-06-30,DE,Germany,96.8822
 2005-06-30,DK,Denmark,87.6999
 2005-06-30,EE,Estonia,89.2777
 2005-06-30,ES,Spain,90.7985
 2005-06-30,FI,Finland,80.6177
 2005-06-30,FR,France,83.3876
-2005-06-30,GB,United Kingdom,91.2143
-2005-06-30,GR,Greece,
+2005-06-30,GB,United Kingdom,91.1056
+2005-06-30,GR,Greece,88.2997
 2005-06-30,HK,Hong Kong SAR,62.6429
 2005-06-30,HR,Croatia,84.4535
-2005-06-30,HU,Hungary,
+2005-06-30,HU,Hungary,93.8172
 2005-06-30,ID,Indonesia,86.1371
-2005-06-30,IE,Ireland,121.2455
+2005-06-30,IE,Ireland,121.2426
 2005-06-30,IL,Israel,70.0537
-2005-06-30,IN,India,
-2005-06-30,IS,Iceland,84.7555
+2005-06-30,IS,Iceland,84.7492
 2005-06-30,IT,Italy,88.2659
 2005-06-30,JP,Japan,108.9493
-2005-06-30,KR,Korea,80.3774
+2005-06-30,KR,Korea,80.4264
 2005-06-30,LT,Lithuania,69.6795
-2005-06-30,LU,Luxembourg,
-2005-06-30,LV,Latvia,
-2005-06-30,MA,Morocco,97.7628
-2005-06-30,MK,North Macedonia,79.09
+2005-06-30,MA,Morocco,97.0939
+2005-06-30,MK,North Macedonia,79.272
 2005-06-30,MT,Malta,62.0538
 2005-06-30,MX,Mexico,75.0652
 2005-06-30,MY,Malaysia,82.6009
-2005-06-30,NL,Netherlands,94.8474
+2005-06-30,NL,Netherlands,94.8511
 2005-06-30,NO,Norway,71.7882
 2005-06-30,NZ,New Zealand,83.7994
 2005-06-30,PE,Peru,53.076
-2005-06-30,PH,Philippines,
-2005-06-30,PL,Poland,
-2005-06-30,PT,Portugal,
-2005-06-30,RO,Romania,
+2005-06-30,PT,Portugal,103.4863
 2005-06-30,RS,Serbia,58.9535
 2005-06-30,RU,Russia,33.9364
 2005-06-30,SE,Sweden,69.1194
 2005-06-30,SG,Singapore,61.9379
-2005-06-30,SI,Slovenia,
-2005-06-30,SK,Slovak Republic,
 2005-06-30,TH,Thailand,88.4175
-2005-06-30,TR,Türkiye,
-2005-06-30,US,United States,129.8272
-2005-06-30,XM,Euro area,89.8648
-2005-06-30,XW,World,
-2005-06-30,ZA,South Africa,72.0974
-2005-09-30,4T,Emerging market economies (aggregate),
-2005-09-30,5R,Advanced economies,
-2005-09-30,AE,United Arab Emirates,75.8667
+2005-06-30,US,United States,129.6565
+2005-06-30,XM,Euro area,89.8075
+2005-06-30,ZA,South Africa,72.0105
 2005-09-30,AT,Austria,82.0271
 2005-09-30,AU,Australia,69.7967
-2005-09-30,BE,Belgium,80.2676
+2005-09-30,BE,Belgium,80.9192
 2005-09-30,BG,Bulgaria,77.0739
 2005-09-30,BR,Brazil,40.2669
-2005-09-30,CA,Canada,75.2222
-2005-09-30,CH,Switzerland,79.9404
+2005-09-30,CA,Canada,75.7532
+2005-09-30,CH,Switzerland,79.9407
 2005-09-30,CL,Chile,71.1752
 2005-09-30,CN,China,77.0645
-2005-09-30,CO,Colombia,56.0687
+2005-09-30,CO,Colombia,56.3619
 2005-09-30,CY,Cyprus,64.0799
-2005-09-30,CZ,Czechia,
-2005-09-30,DE,Germany,96.7614
+2005-09-30,DE,Germany,96.7467
 2005-09-30,DK,Denmark,94.4291
 2005-09-30,EE,Estonia,94.2764
 2005-09-30,ES,Spain,92.2985
 2005-09-30,FI,Finland,82.0021
 2005-09-30,FR,France,87.2964
-2005-09-30,GB,United Kingdom,93.4527
-2005-09-30,GR,Greece,
-2005-09-30,HK,Hong Kong SAR,61.8919
+2005-09-30,GB,United Kingdom,93.4331
+2005-09-30,GR,Greece,90.5115
+2005-09-30,HK,Hong Kong SAR,62.0023
 2005-09-30,HR,Croatia,85.8113
-2005-09-30,HU,Hungary,
+2005-09-30,HU,Hungary,95.5731
 2005-09-30,ID,Indonesia,86.684
-2005-09-30,IE,Ireland,125.9601
+2005-09-30,IE,Ireland,126.0244
 2005-09-30,IL,Israel,70.9433
-2005-09-30,IN,India,
-2005-09-30,IS,Iceland,89.5659
+2005-09-30,IS,Iceland,89.5552
 2005-09-30,IT,Italy,89.9873
 2005-09-30,JP,Japan,107.6924
-2005-09-30,KR,Korea,81.9584
+2005-09-30,KR,Korea,81.9426
 2005-09-30,LT,Lithuania,76.9792
-2005-09-30,LU,Luxembourg,
-2005-09-30,LV,Latvia,
-2005-09-30,MA,Morocco,98.3401
-2005-09-30,MK,North Macedonia,76.47
+2005-09-30,MA,Morocco,97.475
+2005-09-30,MK,North Macedonia,76.5419
 2005-09-30,MT,Malta,67.2158
 2005-09-30,MX,Mexico,76.4861
 2005-09-30,MY,Malaysia,82.2476
-2005-09-30,NL,Netherlands,96.1131
+2005-09-30,NL,Netherlands,96.1173
 2005-09-30,NO,Norway,72.442
 2005-09-30,NZ,New Zealand,86.44
 2005-09-30,PE,Peru,52.8891
-2005-09-30,PH,Philippines,
-2005-09-30,PL,Poland,
-2005-09-30,PT,Portugal,
-2005-09-30,RO,Romania,
+2005-09-30,PT,Portugal,105.698
 2005-09-30,RS,Serbia,60.9361
 2005-09-30,RU,Russia,35.2828
 2005-09-30,SE,Sweden,71.7839
 2005-09-30,SG,Singapore,62.6905
-2005-09-30,SI,Slovenia,
-2005-09-30,SK,Slovak Republic,
 2005-09-30,TH,Thailand,89.9768
-2005-09-30,TR,Türkiye,
-2005-09-30,US,United States,134.3382
-2005-09-30,XM,Euro area,91.6388
-2005-09-30,XW,World,
-2005-09-30,ZA,South Africa,75.3281
-2005-12-31,4T,Emerging market economies (aggregate),
-2005-12-31,5R,Advanced economies,
-2005-12-31,AE,United Arab Emirates,76.2126
+2005-09-30,US,United States,134.1401
+2005-09-30,XM,Euro area,91.5736
+2005-09-30,ZA,South Africa,75.2359
 2005-12-31,AT,Austria,83.9914
 2005-12-31,AU,Australia,71.152
-2005-12-31,BE,Belgium,81.856
+2005-12-31,BE,Belgium,82.5896
 2005-12-31,BG,Bulgaria,78.9358
 2005-12-31,BR,Brazil,41.2062
-2005-12-31,CA,Canada,76.2887
-2005-12-31,CH,Switzerland,80.6502
-2005-12-31,CL,Chile,73.1334
+2005-12-31,CA,Canada,76.7575
+2005-12-31,CH,Switzerland,80.6491
+2005-12-31,CL,Chile,73.1333
 2005-12-31,CN,China,77.9195
-2005-12-31,CO,Colombia,57.0104
+2005-12-31,CO,Colombia,57.3915
 2005-12-31,CY,Cyprus,65.646
-2005-12-31,CZ,Czechia,
-2005-12-31,DE,Germany,96.8125
+2005-12-31,DE,Germany,96.817
 2005-12-31,DK,Denmark,100.6067
 2005-12-31,EE,Estonia,106.5734
 2005-12-31,ES,Spain,94.473
 2005-12-31,FI,Finland,83.8126
 2005-12-31,FR,France,89.0003
-2005-12-31,GB,United Kingdom,93.5646
-2005-12-31,GR,Greece,
+2005-12-31,GB,United Kingdom,93.5993
+2005-12-31,GR,Greece,93.5178
 2005-12-31,HK,Hong Kong SAR,59.7272
 2005-12-31,HR,Croatia,90.2467
-2005-12-31,HU,Hungary,
+2005-12-31,HU,Hungary,94.66
 2005-12-31,ID,Indonesia,88.3469
-2005-12-31,IE,Ireland,131.4999
+2005-12-31,IE,Ireland,131.5297
 2005-12-31,IL,Israel,71.5534
-2005-12-31,IN,India,
-2005-12-31,IS,Iceland,92.5896
+2005-12-31,IS,Iceland,92.602
 2005-12-31,IT,Italy,90.7968
 2005-12-31,JP,Japan,106.827
-2005-12-31,KR,Korea,82.2134
+2005-12-31,KR,Korea,82.1968
 2005-12-31,LT,Lithuania,97.7725
-2005-12-31,LU,Luxembourg,
-2005-12-31,LV,Latvia,
-2005-12-31,MA,Morocco,97.6666
-2005-12-31,MK,North Macedonia,77.92
+2005-12-31,MA,Morocco,96.808
+2005-12-31,MK,North Macedonia,78.022
 2005-12-31,MT,Malta,65.2389
 2005-12-31,MX,Mexico,76.3238
 2005-12-31,MY,Malaysia,82.6009
-2005-12-31,NL,Netherlands,96.5799
+2005-12-31,NL,Netherlands,96.5825
 2005-12-31,NO,Norway,72.442
 2005-12-31,NZ,New Zealand,89.7806
 2005-12-31,PE,Peru,57.6166
-2005-12-31,PH,Philippines,
-2005-12-31,PL,Poland,
-2005-12-31,PT,Portugal,
-2005-12-31,RO,Romania,
+2005-12-31,PT,Portugal,105.8226
 2005-12-31,RS,Serbia,61.4507
 2005-12-31,RU,Russia,37.3069
 2005-12-31,SE,Sweden,73.6559
 2005-12-31,SG,Singapore,63.5936
-2005-12-31,SI,Slovenia,
-2005-12-31,SK,Slovak Republic,
 2005-12-31,TH,Thailand,90.9009
-2005-12-31,TR,Türkiye,
-2005-12-31,US,United States,138.0519
-2005-12-31,XM,Euro area,92.8734
-2005-12-31,XW,World,
-2005-12-31,ZA,South Africa,78.7004
-2006-03-31,4T,Emerging market economies (aggregate),
-2006-03-31,5R,Advanced economies,
-2006-03-31,AE,United Arab Emirates,81.6818
+2005-12-31,US,United States,137.8701
+2005-12-31,XM,Euro area,92.8024
+2005-12-31,ZA,South Africa,78.6051
 2006-03-31,AT,Austria,84.9342
 2006-03-31,AU,Australia,71.9264
-2006-03-31,BE,Belgium,83.4444
+2006-03-31,BE,Belgium,84.1726
 2006-03-31,BG,Bulgaria,82.669
 2006-03-31,BR,Brazil,42.3111
-2006-03-31,CA,Canada,79.3459
-2006-03-31,CH,Switzerland,82.2796
+2006-03-31,CA,Canada,79.627
+2006-03-31,CH,Switzerland,82.2776
 2006-03-31,CL,Chile,71.6821
 2006-03-31,CN,China,78.005
-2006-03-31,CO,Colombia,58.9764
+2006-03-31,CO,Colombia,58.6162
 2006-03-31,CY,Cyprus,68.3164
-2006-03-31,CZ,Czechia,
 2006-03-31,DE,Germany,95.8
 2006-03-31,DK,Denmark,107.7772
 2006-03-31,EE,Estonia,120.5699
 2006-03-31,ES,Spain,95.3531
 2006-03-31,FI,Finland,84.771
 2006-03-31,FR,France,91.0048
-2006-03-31,GB,United Kingdom,94.2362
+2006-03-31,GB,United Kingdom,94.2643
 2006-03-31,GR,Greece,97.1531
 2006-03-31,HK,Hong Kong SAR,60.6328
 2006-03-31,HR,Croatia,93.7769
-2006-03-31,HU,Hungary,
+2006-03-31,HU,Hungary,95.7866
 2006-03-31,ID,Indonesia,90.5197
-2006-03-31,IE,Ireland,133.8965
+2006-03-31,IE,Ireland,133.8891
 2006-03-31,IL,Israel,72.1253
-2006-03-31,IN,India,
-2006-03-31,IS,Iceland,95.8424
+2006-03-31,IS,Iceland,95.8457
 2006-03-31,IT,Italy,91.7756
 2006-03-31,JP,Japan,105.9616
-2006-03-31,KR,Korea,83.0295
+2006-03-31,KR,Korea,83
 2006-03-31,LT,Lithuania,102.8473
-2006-03-31,LU,Luxembourg,
 2006-03-31,LV,Latvia,111.95
-2006-03-31,MA,Morocco,96.2232
-2006-03-31,MK,North Macedonia,78.21
+2006-03-31,MA,Morocco,95.2835
+2006-03-31,MK,North Macedonia,78.362
 2006-03-31,MT,Malta,68.4239
 2006-03-31,MX,Mexico,77.9707
 2006-03-31,MY,Malaysia,83.1661
-2006-03-31,NL,Netherlands,97.6481
+2006-03-31,NL,Netherlands,97.6549
 2006-03-31,NO,Norway,77.0186
 2006-03-31,NZ,New Zealand,91.4995
 2006-03-31,PE,Peru,57.9886
-2006-03-31,PH,Philippines,
-2006-03-31,PL,Poland,
-2006-03-31,PT,Portugal,
-2006-03-31,RO,Romania,
+2006-03-31,PT,Portugal,105.8849
 2006-03-31,RS,Serbia,60.497
 2006-03-31,RU,Russia,43.2703
 2006-03-31,SE,Sweden,76.2414
 2006-03-31,SG,Singapore,64.572
-2006-03-31,SI,Slovenia,
-2006-03-31,SK,Slovak Republic,74.1275
+2006-03-31,SK,Slovakia,73.9123
 2006-03-31,TH,Thailand,91.7671
-2006-03-31,TR,Türkiye,
-2006-03-31,US,United States,140.62
-2006-03-31,XM,Euro area,93.7815
-2006-03-31,XW,World,
-2006-03-31,ZA,South Africa,81.6749
-2006-06-30,4T,Emerging market economies (aggregate),
-2006-06-30,5R,Advanced economies,
-2006-06-30,AE,United Arab Emirates,85.0434
+2006-03-31,US,United States,140.4419
+2006-03-31,XM,Euro area,93.7083
+2006-03-31,ZA,South Africa,81.5754
 2006-06-30,AT,Austria,85.6413
 2006-06-30,AU,Australia,74.5402
-2006-06-30,BE,Belgium,85.7182
+2006-06-30,BE,Belgium,86.4434
 2006-06-30,BG,Bulgaria,84.03
 2006-06-30,BR,Brazil,43.613
-2006-06-30,CA,Canada,83.3274
-2006-06-30,CH,Switzerland,83.6242
+2006-06-30,CA,Canada,83.429
+2006-06-30,CH,Switzerland,83.6222
 2006-06-30,CL,Chile,74.3088
 2006-06-30,CN,China,79.544
-2006-06-30,CO,Colombia,61.9058
+2006-06-30,CO,Colombia,62.2062
 2006-06-30,CY,Cyprus,72.4425
-2006-06-30,CZ,Czechia,
 2006-06-30,DE,Germany,97.3
 2006-06-30,DK,Denmark,114.2857
 2006-06-30,EE,Estonia,132.6668
 2006-06-30,ES,Spain,99.4333
 2006-06-30,FI,Finland,86.688
 2006-06-30,FR,France,93.8111
-2006-06-30,GB,United Kingdom,97.8176
+2006-06-30,GB,United Kingdom,97.7556
 2006-06-30,GR,Greece,99.9384
 2006-06-30,HK,Hong Kong SAR,61.7814
 2006-06-30,HR,Croatia,95.1346
-2006-06-30,HU,Hungary,
+2006-06-30,HU,Hungary,97.0607
 2006-06-30,ID,Indonesia,90.8301
-2006-06-30,IE,Ireland,139.2005
+2006-06-30,IE,Ireland,139.2057
 2006-06-30,IL,Israel,70.9179
-2006-06-30,IN,India,
-2006-06-30,IS,Iceland,99.2784
+2006-06-30,IS,Iceland,99.2773
 2006-06-30,IT,Italy,93.5538
 2006-06-30,JP,Japan,105.3878
-2006-06-30,KR,Korea,84.9165
+2006-06-30,KR,Korea,84.9264
 2006-06-30,LT,Lithuania,103.7974
-2006-06-30,LU,Luxembourg,
 2006-06-30,LV,Latvia,123.48
-2006-06-30,MA,Morocco,93.4328
-2006-06-30,MK,North Macedonia,75.68
+2006-06-30,MA,Morocco,94.9023
+2006-06-30,MK,North Macedonia,75.7519
 2006-06-30,MT,Malta,76.112
 2006-06-30,MX,Mexico,80.0124
 2006-06-30,MY,Malaysia,83.7314
-2006-06-30,NL,Netherlands,98.9408
+2006-06-30,NL,Netherlands,98.934
 2006-06-30,NO,Norway,80.8107
 2006-06-30,NZ,New Zealand,92.3104
 2006-06-30,PE,Peru,55.6081
-2006-06-30,PH,Philippines,
-2006-06-30,PL,Poland,
-2006-06-30,PT,Portugal,
-2006-06-30,RO,Romania,
+2006-06-30,PT,Portugal,106.5391
 2006-06-30,RS,Serbia,60.5789
 2006-06-30,RU,Russia,47.4496
 2006-06-30,SE,Sweden,78.4102
 2006-06-30,SG,Singapore,65.7008
-2006-06-30,SI,Slovenia,
-2006-06-30,SK,Slovak Republic,77.1025
+2006-06-30,SK,Slovakia,76.8786
 2006-06-30,TH,Thailand,92.8067
-2006-06-30,TR,Türkiye,
-2006-06-30,US,United States,139.6325
-2006-06-30,XM,Euro area,96.027
-2006-06-30,XW,World,
-2006-06-30,ZA,South Africa,84.6001
-2006-09-30,4T,Emerging market economies (aggregate),
-2006-09-30,5R,Advanced economies,
-2006-09-30,AE,United Arab Emirates,94.1227
+2006-06-30,US,United States,139.4454
+2006-06-30,XM,Euro area,95.9507
+2006-06-30,ZA,South Africa,84.4964
 2006-09-30,AT,Austria,86.1913
 2006-09-30,AU,Australia,75.8955
-2006-09-30,BE,Belgium,88.1987
+2006-09-30,BE,Belgium,89.0199
 2006-09-30,BG,Bulgaria,87.8577
 2006-09-30,BR,Brazil,45.1233
-2006-09-30,CA,Canada,85.6026
-2006-09-30,CH,Switzerland,84.3458
-2006-09-30,CL,Chile,75.6276
+2006-09-30,CA,Canada,85.5811
+2006-09-30,CH,Switzerland,84.3436
+2006-09-30,CL,Chile,75.6275
 2006-09-30,CN,China,80.855
-2006-09-30,CO,Colombia,64.2945
+2006-09-30,CO,Colombia,64.4263
 2006-09-30,CY,Cyprus,73.7075
-2006-09-30,CZ,Czechia,
 2006-09-30,DE,Germany,98.1
 2006-09-30,DK,Denmark,116.6023
 2006-09-30,EE,Estonia,141.9645
 2006-09-30,ES,Spain,102.6811
 2006-09-30,FI,Finland,87.3269
 2006-09-30,FR,France,96.7176
-2006-09-30,GB,United Kingdom,100.8394
+2006-09-30,GB,United Kingdom,100.7481
 2006-09-30,GR,Greece,101.5453
 2006-09-30,HK,Hong Kong SAR,61.4501
 2006-09-30,HR,Croatia,97.3976
-2006-09-30,HU,Hungary,
+2006-09-30,HU,Hungary,99.7279
 2006-09-30,ID,Indonesia,91.377
-2006-09-30,IE,Ireland,147.569
+2006-09-30,IE,Ireland,147.6052
 2006-09-30,IL,Israel,70.6765
-2006-09-30,IN,India,
-2006-09-30,IS,Iceland,99.874
+2006-09-30,IS,Iceland,99.8683
 2006-09-30,IT,Italy,95.2532
 2006-09-30,JP,Japan,104.8077
-2006-09-30,KR,Korea,85.9365
+2006-09-30,KR,Korea,85.9437
 2006-09-30,LT,Lithuania,114.2603
-2006-09-30,LU,Luxembourg,
 2006-09-30,LV,Latvia,136.32
-2006-09-30,MA,Morocco,92.1819
-2006-09-30,MK,North Macedonia,77.36
+2006-09-30,MA,Morocco,94.5212
+2006-09-30,MK,North Macedonia,77.2719
 2006-09-30,MT,Malta,78.6381
 2006-09-30,MX,Mexico,81.2138
 2006-09-30,MY,Malaysia,83.9434
-2006-09-30,NL,Netherlands,100.0718
+2006-09-30,NL,Netherlands,100.0711
 2006-09-30,NO,Norway,83.426
 2006-09-30,NZ,New Zealand,94.4589
 2006-09-30,PE,Peru,50.7966
-2006-09-30,PH,Philippines,
-2006-09-30,PL,Poland,
-2006-09-30,PT,Portugal,
-2006-09-30,RO,Romania,
+2006-09-30,PT,Portugal,106.508
 2006-09-30,RS,Serbia,61.7149
 2006-09-30,RU,Russia,54.3493
 2006-09-30,SE,Sweden,80.5003
 2006-09-30,SG,Singapore,67.4318
-2006-09-30,SI,Slovenia,
-2006-09-30,SK,Slovak Republic,79.1065
+2006-09-30,SK,Slovakia,78.8768
 2006-09-30,TH,Thailand,92.2291
-2006-09-30,TR,Türkiye,
-2006-09-30,US,United States,138.5682
-2006-09-30,XM,Euro area,98.0453
-2006-09-30,XW,World,
-2006-09-30,ZA,South Africa,87.5103
-2006-12-31,4T,Emerging market economies (aggregate),
-2006-12-31,5R,Advanced economies,
-2006-12-31,AE,United Arab Emirates,91.788
+2006-09-30,US,United States,138.4039
+2006-09-30,XM,Euro area,97.9605
+2006-09-30,ZA,South Africa,87.4033
 2006-12-31,AT,Austria,85.877
 2006-12-31,AU,Australia,77.2507
-2006-12-31,BE,Belgium,88.8732
+2006-12-31,BE,Belgium,89.6968
 2006-12-31,BG,Bulgaria,92.7061
 2006-12-31,BR,Brazil,46.8334
-2006-12-31,CA,Canada,86.1713
-2006-12-31,CH,Switzerland,88.0302
-2006-12-31,CL,Chile,76.4848
+2006-12-31,CA,Canada,86.0832
+2006-12-31,CH,Switzerland,88.0273
+2006-12-31,CL,Chile,76.4847
 2006-12-31,CN,China,81.824
-2006-12-31,CO,Colombia,65.4328
+2006-12-31,CO,Colombia,65.6214
 2006-12-31,CY,Cyprus,78.5162
-2006-12-31,CZ,Czechia,
 2006-12-31,DE,Germany,97.1
 2006-12-31,DK,Denmark,115.3889
 2006-12-31,EE,Estonia,156.8608
 2006-12-31,ES,Spain,105.3418
 2006-12-31,FI,Finland,88.6049
 2006-12-31,FR,France,97.5194
-2006-12-31,GB,United Kingdom,102.742
+2006-12-31,GB,United Kingdom,102.7431
 2006-12-31,GR,Greece,105.8089
 2006-12-31,HK,Hong Kong SAR,61.8256
 2006-12-31,HR,Croatia,104.0054
-2006-12-31,HU,Hungary,
+2006-12-31,HU,Hungary,100.1948
 2006-12-31,ID,Indonesia,91.9313
-2006-12-31,IE,Ireland,150.7907
+2006-12-31,IE,Ireland,150.814
 2006-12-31,IL,Israel,68.7828
-2006-12-31,IN,India,
-2006-12-31,IS,Iceland,99.8282
+2006-12-31,IS,Iceland,99.827
 2006-12-31,IT,Italy,95.8933
 2006-12-31,JP,Japan,104.5674
-2006-12-31,KR,Korea,89.8126
+2006-12-31,KR,Korea,89.8204
 2006-12-31,LT,Lithuania,126.8133
-2006-12-31,LU,Luxembourg,
 2006-12-31,LV,Latvia,148.34
-2006-12-31,MA,Morocco,92.9516
-2006-12-31,MK,North Macedonia,74.09
+2006-12-31,MA,Morocco,94.8071
+2006-12-31,MK,North Macedonia,74.0119
 2006-12-31,MT,Malta,84.4591
 2006-12-31,MX,Mexico,81.6445
 2006-12-31,MY,Malaysia,86.4871
-2006-12-31,NL,Netherlands,100.9425
+2006-12-31,NL,Netherlands,100.9368
 2006-12-31,NO,Norway,84.472
 2006-12-31,NZ,New Zealand,97.7926
 2006-12-31,PE,Peru,53.9737
-2006-12-31,PH,Philippines,
-2006-12-31,PL,Poland,
-2006-12-31,PT,Portugal,
-2006-12-31,RO,Romania,
+2006-12-31,PT,Portugal,106.7572
 2006-12-31,RS,Serbia,61.6793
 2006-12-31,RU,Russia,61.6269
 2006-12-31,SE,Sweden,80.9821
 2006-12-31,SG,Singapore,70.0659
-2006-12-31,SI,Slovenia,
-2006-12-31,SK,Slovak Republic,83.631
+2006-12-31,SK,Slovakia,83.3882
 2006-12-31,TH,Thailand,93.2687
-2006-12-31,TR,Türkiye,
-2006-12-31,US,United States,138.5653
-2006-12-31,XM,Euro area,98.7417
-2006-12-31,XW,World,
-2006-12-31,ZA,South Africa,90.1867
-2007-03-31,4T,Emerging market economies (aggregate),
-2007-03-31,5R,Advanced economies,
-2007-03-31,AE,United Arab Emirates,101.343
+2006-12-31,US,United States,138.3886
+2006-12-31,XM,Euro area,98.6576
+2006-12-31,ZA,South Africa,90.0771
 2007-03-31,AT,Austria,88.3913
 2007-03-31,AU,Australia,77.9284
-2007-03-31,BE,Belgium,90.9729
+2007-03-31,BE,Belgium,91.7601
 2007-03-31,BG,Bulgaria,101.3444
 2007-03-31,BR,Brazil,48.7463
-2007-03-31,CA,Canada,88.9442
-2007-03-31,CH,Switzerland,89.2439
+2007-03-31,CA,Canada,88.7374
+2007-03-31,CH,Switzerland,89.2407
 2007-03-31,CL,Chile,77.241
 2007-03-31,CN,China,82.1375
-2007-03-31,CO,Colombia,69.7187
+2007-03-31,CO,Colombia,69.745
 2007-03-31,CY,Cyprus,83.0639
-2007-03-31,CZ,Czechia,
 2007-03-31,DE,Germany,96.6
 2007-03-31,DK,Denmark,115.8301
 2007-03-31,EE,Estonia,161.9595
 2007-03-31,ES,Spain,107.8687
 2007-03-31,FI,Finland,90.6283
 2007-03-31,FR,France,98.221
-2007-03-31,GB,United Kingdom,104.197
+2007-03-31,GB,United Kingdom,104.2394
 2007-03-31,GR,Greece,105.584
 2007-03-31,HK,Hong Kong SAR,63.9903
 2007-03-31,HR,Croatia,107.0831
 2007-03-31,HU,Hungary,101.4145
 2007-03-31,ID,Indonesia,92.1604
-2007-03-31,IE,Ireland,153.423
+2007-03-31,IE,Ireland,153.3936
 2007-03-31,IL,Israel,68.3634
-2007-03-31,IN,India,
-2007-03-31,IS,Iceland,101.7066
+2007-03-31,IS,Iceland,101.6917
 2007-03-31,IT,Italy,97.1558
 2007-03-31,JP,Japan,104.327
-2007-03-31,KR,Korea,92.9236
+2007-03-31,KR,Korea,92.9299
 2007-03-31,LT,Lithuania,132.1338
 2007-03-31,LU,Luxembourg,90.6741
 2007-03-31,LV,Latvia,167.51
-2007-03-31,MA,Morocco,94.1063
-2007-03-31,MK,North Macedonia,77.73
+2007-03-31,MA,Morocco,95.9505
+2007-03-31,MK,North Macedonia,77.7719
 2007-03-31,MT,Malta,88.8523
 2007-03-31,MX,Mexico,83.7828
 2007-03-31,MY,Malaysia,87.1937
-2007-03-31,NL,Netherlands,102.289
+2007-03-31,NL,Netherlands,102.2805
 2007-03-31,NO,Norway,89.7025
 2007-03-31,NZ,New Zealand,101.8609
 2007-03-31,PE,Peru,52.1185
-2007-03-31,PH,Philippines,
-2007-03-31,PL,Poland,
-2007-03-31,PT,Portugal,
-2007-03-31,RO,Romania,
+2007-03-31,PT,Portugal,107.3179
 2007-03-31,RS,Serbia,60.4789
 2007-03-31,RU,Russia,70.5233
 2007-03-31,SE,Sweden,84.083
 2007-03-31,SG,Singapore,73.4525
 2007-03-31,SI,Slovenia,98.6818
-2007-03-31,SK,Slovak Republic,90.3351
+2007-03-31,SK,Slovakia,90.0728
 2007-03-31,TH,Thailand,92.1136
-2007-03-31,TR,Türkiye,
-2007-03-31,US,United States,137.2163
-2007-03-31,XM,Euro area,99.7342
-2007-03-31,XW,World,
-2007-03-31,ZA,South Africa,93.6009
-2007-06-30,4T,Emerging market economies (aggregate),
-2007-06-30,5R,Advanced economies,
-2007-06-30,AE,United Arab Emirates,108.1957
+2007-03-31,US,United States,137.044
+2007-03-31,XM,Euro area,99.6509
+2007-03-31,ZA,South Africa,93.4865
 2007-06-30,AT,Austria,90.1984
 2007-06-30,AU,Australia,81.4134
-2007-06-30,BE,Belgium,92.7789
+2007-06-30,BE,Belgium,93.6161
 2007-06-30,BG,Bulgaria,106.7694
 2007-06-30,BR,Brazil,50.8818
-2007-06-30,CA,Canada,92.8546
-2007-06-30,CH,Switzerland,90.7704
-2007-06-30,CL,Chile,80.5974
+2007-06-30,CA,Canada,92.6112
+2007-06-30,CH,Switzerland,90.766
+2007-06-30,CL,Chile,80.5973
 2007-06-30,CN,China,84.218
-2007-06-30,CO,Colombia,72.9135
+2007-06-30,CO,Colombia,72.6167
 2007-06-30,CY,Cyprus,89.8705
-2007-06-30,CZ,Czechia,
 2007-06-30,DE,Germany,96.5
 2007-06-30,DK,Denmark,117.3745
 2007-06-30,EE,Estonia,172.3569
 2007-06-30,ES,Spain,110.953
 2007-06-30,FI,Finland,92.2258
 2007-06-30,FR,France,99.9248
-2007-06-30,GB,United Kingdom,108.2261
+2007-06-30,GB,United Kingdom,108.2294
 2007-06-30,GR,Greece,106.7302
 2007-06-30,HK,Hong Kong SAR,66.4421
 2007-06-30,HR,Croatia,111.3374
 2007-06-30,HU,Hungary,103.8698
 2007-06-30,ID,Indonesia,92.7813
-2007-06-30,IE,Ireland,153.9731
+2007-06-30,IE,Ireland,153.9599
 2007-06-30,IL,Israel,68.8717
-2007-06-30,IN,India,
-2007-06-30,IS,Iceland,106.8973
+2007-06-30,IS,Iceland,106.9009
 2007-06-30,IT,Italy,98.2676
 2007-06-30,JP,Japan,104.1835
-2007-06-30,KR,Korea,93.3826
+2007-06-30,KR,Korea,93.3399
 2007-06-30,LT,Lithuania,137.6087
 2007-06-30,LU,Luxembourg,91.29
 2007-06-30,LV,Latvia,172.47
-2007-06-30,MA,Morocco,95.0686
-2007-06-30,MK,North Macedonia,78.07
+2007-06-30,MA,Morocco,97.0939
+2007-06-30,MK,North Macedonia,77.9619
 2007-06-30,MT,Malta,93.1356
 2007-06-30,MX,Mexico,86.1737
 2007-06-30,MY,Malaysia,87.4057
-2007-06-30,NL,Netherlands,103.1867
+2007-06-30,NL,Netherlands,103.185
 2007-06-30,NO,Norway,93.1023
 2007-06-30,NZ,New Zealand,104.7164
 2007-06-30,PE,Peru,55.565
-2007-06-30,PH,Philippines,
-2007-06-30,PL,Poland,
-2007-06-30,PT,Portugal,
-2007-06-30,RO,Romania,
+2007-06-30,PT,Portugal,106.913
 2007-06-30,RS,Serbia,60.8184
 2007-06-30,RU,Russia,72.9128
 2007-06-30,SE,Sweden,89.2076
 2007-06-30,SG,Singapore,79.4732
 2007-06-30,SI,Slovenia,100.7807
-2007-06-30,SK,Slovak Republic,96.7087
+2007-06-30,SK,Slovakia,96.4279
 2007-06-30,TH,Thailand,92.9799
-2007-06-30,TR,Türkiye,
-2007-06-30,US,United States,133.1177
-2007-06-30,XM,Euro area,100.9455
-2007-06-30,XW,World,
-2007-06-30,ZA,South Africa,97.971
-2007-09-30,4T,Emerging market economies (aggregate),
-2007-09-30,5R,Advanced economies,
-2007-09-30,AE,United Arab Emirates,118.5614
+2007-06-30,US,United States,132.9688
+2007-06-30,XM,Euro area,100.8702
+2007-06-30,ZA,South Africa,97.8514
 2007-09-30,AT,Austria,90.7484
 2007-09-30,AU,Australia,84.3175
-2007-09-30,BE,Belgium,94.5413
+2007-09-30,BE,Belgium,95.3083
 2007-09-30,BG,Bulgaria,114.7556
 2007-09-30,BR,Brazil,53.2686
-2007-09-30,CA,Canada,94.9165
-2007-09-30,CH,Switzerland,90.3142
-2007-09-30,CL,Chile,82.982
+2007-09-30,CA,Canada,94.5481
+2007-09-30,CH,Switzerland,90.3116
+2007-09-30,CL,Chile,82.9819
 2007-09-30,CN,China,86.498
-2007-09-30,CO,Colombia,73.524
+2007-09-30,CO,Colombia,73.519
 2007-09-30,CY,Cyprus,92.3903
-2007-09-30,CZ,Czechia,
 2007-09-30,DE,Germany,97.1
 2007-09-30,DK,Denmark,117.5951
 2007-09-30,EE,Estonia,167.3582
 2007-09-30,ES,Spain,112.1495
 2007-09-30,FI,Finland,92.4388
 2007-09-30,FR,France,102.23
-2007-09-30,GB,United Kingdom,111.2479
+2007-09-30,GB,United Kingdom,111.2219
 2007-09-30,GR,Greece,107.8229
 2007-09-30,HK,Hong Kong SAR,68.9381
 2007-09-30,HR,Croatia,113.2383
 2007-09-30,HU,Hungary,108.0331
 2007-09-30,ID,Indonesia,93.0843
-2007-09-30,IE,Ireland,153.7766
+2007-09-30,IE,Ireland,153.8026
 2007-09-30,IL,Israel,70.8925
-2007-09-30,IN,India,
-2007-09-30,IS,Iceland,112.427
+2007-09-30,IS,Iceland,112.4446
 2007-09-30,IT,Italy,99.6198
 2007-09-30,JP,Japan,104.0385
-2007-09-30,KR,Korea,93.8416
+2007-09-30,KR,Korea,93.878
 2007-09-30,LT,Lithuania,146.5752
 2007-09-30,LU,Luxembourg,95.0003
 2007-09-30,LV,Latvia,186.09
-2007-09-30,MA,Morocco,96.0308
-2007-09-30,MK,North Macedonia,76.61
+2007-09-30,MA,Morocco,97.9514
+2007-09-30,MK,North Macedonia,76.5319
 2007-09-30,MT,Malta,94.6733
 2007-09-30,MX,Mexico,87.8281
 2007-09-30,MY,Malaysia,88.4656
-2007-09-30,NL,Netherlands,105.1975
+2007-09-30,NL,Netherlands,105.2006
 2007-09-30,NO,Norway,92.9716
 2007-09-30,NZ,New Zealand,105.1253
 2007-09-30,PE,Peru,56.9205
-2007-09-30,PH,Philippines,
-2007-09-30,PL,Poland,
-2007-09-30,PT,Portugal,
-2007-09-30,RO,Romania,
+2007-09-30,PT,Portugal,107.6606
 2007-09-30,RS,Serbia,62.7289
 2007-09-30,RU,Russia,75.7276
 2007-09-30,SE,Sweden,92.4254
 2007-09-30,SG,Singapore,86.096
 2007-09-30,SI,Slovenia,104.1594
-2007-09-30,SK,Slovak Republic,104.9106
+2007-09-30,SK,Slovakia,104.606
 2007-09-30,TH,Thailand,94.597
-2007-09-30,TR,Türkiye,
-2007-09-30,US,United States,129.388
-2007-09-30,XM,Euro area,102.3392
-2007-09-30,XW,World,
-2007-09-30,ZA,South Africa,100.865
-2007-12-31,4T,Emerging market economies (aggregate),84.9201
-2007-12-31,5R,Advanced economies,110.4639
-2007-12-31,AE,United Arab Emirates,130.7753
+2007-09-30,US,United States,129.3047
+2007-09-30,XM,Euro area,102.273
+2007-09-30,ZA,South Africa,100.7423
+2007-12-31,4T,Emerging market economies (aggregate),84.0641
+2007-12-31,5R,Advanced economies,108.7669
 2007-12-31,AT,Austria,89.3341
 2007-12-31,AU,Australia,87.5121
-2007-12-31,BE,Belgium,94.9112
+2007-12-31,BE,Belgium,95.745
 2007-12-31,BG,Bulgaria,124.8116
 2007-12-31,BR,Brazil,55.9323
-2007-12-31,CA,Canada,95.2009
-2007-12-31,CH,Switzerland,91.122
+2007-12-31,CA,Canada,94.835
+2007-12-31,CH,Switzerland,91.119
 2007-12-31,CL,Chile,83.4961
 2007-12-31,CN,China,89.1486
-2007-12-31,CO,Colombia,76.0237
+2007-12-31,CO,Colombia,75.6759
 2007-12-31,CY,Cyprus,95.8338
-2007-12-31,CZ,Czechia,
 2007-12-31,DE,Germany,97.3
 2007-12-31,DK,Denmark,115.3889
 2007-12-31,EE,Estonia,164.9588
 2007-12-31,ES,Spain,111.3469
 2007-12-31,FI,Finland,92.6518
 2007-12-31,FR,France,102.8314
-2007-12-31,GB,United Kingdom,111.136
+2007-12-31,GB,United Kingdom,111.2219
 2007-12-31,GR,Greece,108.3693
 2007-12-31,HK,Hong Kong SAR,75.0345
 2007-12-31,HR,Croatia,112.6952
 2007-12-31,HU,Hungary,108.8871
 2007-12-31,ID,Indonesia,93.5351
-2007-12-31,IE,Ireland,152.9123
+2007-12-31,IE,Ireland,152.9217
 2007-12-31,IL,Israel,69.9902
-2007-12-31,IN,India,
-2007-12-31,IS,Iceland,114.9009
+2007-12-31,IS,Iceland,114.9278
 2007-12-31,IT,Italy,100.1448
 2007-12-31,JP,Japan,103.7981
-2007-12-31,KR,Korea,94.5557
+2007-12-31,KR,Korea,94.558
 2007-12-31,LT,Lithuania,149.2474
 2007-12-31,LU,Luxembourg,94.4805
 2007-12-31,LV,Latvia,182.67
-2007-12-31,MA,Morocco,100.842
-2007-12-31,MK,North Macedonia,82.2
+2007-12-31,MA,Morocco,102.4297
+2007-12-31,MK,North Macedonia,82.2121
 2007-12-31,MT,Malta,95.6617
 2007-12-31,MX,Mexico,87.7284
 2007-12-31,MY,Malaysia,88.9602
-2007-12-31,NL,Netherlands,106.1849
+2007-12-31,NL,Netherlands,106.1826
 2007-12-31,NO,Norway,90.8794
 2007-12-31,NZ,New Zealand,105.2777
 2007-12-31,PE,Peru,62.9638
-2007-12-31,PH,Philippines,
-2007-12-31,PL,Poland,
-2007-12-31,PT,Portugal,
-2007-12-31,RO,Romania,
+2007-12-31,PT,Portugal,105.7292
 2007-12-31,RS,Serbia,65.3656
 2007-12-31,RU,Russia,79.4521
 2007-12-31,SE,Sweden,89.789
 2007-12-31,SG,Singapore,91.8909
 2007-12-31,SI,Slovenia,108.8008
-2007-12-31,SK,Slovak Republic,112.9886
+2007-12-31,SK,Slovakia,112.6606
 2007-12-31,TH,Thailand,94.4237
-2007-12-31,TR,Türkiye,
-2007-12-31,US,United States,125.2371
-2007-12-31,XM,Euro area,102.5911
-2007-12-31,XW,World,97.3201
-2007-12-31,ZA,South Africa,101.3112
-2008-03-31,4T,Emerging market economies (aggregate),86.8551
-2008-03-31,5R,Advanced economies,108.9352
-2008-03-31,AE,United Arab Emirates,142.2974
+2007-12-31,US,United States,125.1802
+2007-12-31,XM,Euro area,102.5209
+2007-12-31,XW,World,97.539
+2007-12-31,ZA,South Africa,101.1885
+2008-03-31,4T,Emerging market economies (aggregate),85.8754
+2008-03-31,5R,Advanced economies,107.5864
 2008-03-31,AT,Austria,89.9627
 2008-03-31,AU,Australia,87.8993
-2008-03-31,BE,Belgium,95.8359
+2008-03-31,BE,Belgium,96.6293
 2008-03-31,BG,Bulgaria,133.3365
 2008-03-31,BR,Brazil,58.8844
-2008-03-31,CA,Canada,96.6228
-2008-03-31,CH,Switzerland,92.3484
+2008-03-31,CA,Canada,96.2697
+2008-03-31,CH,Switzerland,92.3454
 2008-03-31,CL,Chile,85.2449
 2008-03-31,CN,China,89.8611
-2008-03-31,CO,Colombia,80.6684
+2008-03-31,CO,Colombia,80.8864
 2008-03-31,CY,Cyprus,103.9755
 2008-03-31,CZ,Czechia,102.074
 2008-03-31,DE,Germany,99.4
@@ -20108,60 +4719,55 @@ date,country_code,country,price
 2008-03-31,ES,Spain,110.9381
 2008-03-31,FI,Finland,93.6102
 2008-03-31,FR,France,102.23
-2008-03-31,GB,United Kingdom,108.1142
+2008-03-31,GB,United Kingdom,108.0632
 2008-03-31,GR,Greece,108.6371
 2008-03-31,HK,Hong Kong SAR,82.8538
 2008-03-31,HR,Croatia,111.5184
 2008-03-31,HU,Hungary,107.3926
 2008-03-31,ID,Indonesia,94.2298
-2008-03-31,IE,Ireland,149.6906
+2008-03-31,IE,Ireland,149.7129
 2008-03-31,IL,Israel,71.4898
-2008-03-31,IN,India,
-2008-03-31,IS,Iceland,115.863
+2008-03-31,IS,Iceland,115.8899
 2008-03-31,IT,Italy,100.7849
 2008-03-31,JP,Japan,103.5577
-2008-03-31,KR,Korea,95.4227
+2008-03-31,KR,Korea,95.4294
 2008-03-31,LT,Lithuania,154.271
 2008-03-31,LU,Luxembourg,94.0542
 2008-03-31,LV,Latvia,195.45
-2008-03-31,MA,Morocco,97.0892
-2008-03-31,MK,North Macedonia,86.82
+2008-03-31,MA,Morocco,98.5231
+2008-03-31,MK,North Macedonia,86.6722
 2008-03-31,MT,Malta,103.6793
 2008-03-31,MX,Mexico,89.0422
 2008-03-31,MY,Malaysia,90.9387
-2008-03-31,NL,Netherlands,106.2478
+2008-03-31,NL,Netherlands,106.2472
 2008-03-31,NO,Norway,92.9716
 2008-03-31,NZ,New Zealand,104.6471
 2008-03-31,PE,Peru,61.1675
 2008-03-31,PH,Philippines,95.8009
-2008-03-31,PL,Poland,
 2008-03-31,PT,Portugal,101.7442
-2008-03-31,RO,Romania,
 2008-03-31,RS,Serbia,68.6998
 2008-03-31,RU,Russia,87.9696
 2008-03-31,SE,Sweden,90.0528
 2008-03-31,SG,Singapore,95.3528
 2008-03-31,SI,Slovenia,110.3366
-2008-03-31,SK,Slovak Republic,120.4468
+2008-03-31,SK,Slovakia,120.0971
 2008-03-31,TH,Thailand,87.1094
-2008-03-31,TR,Türkiye,
-2008-03-31,US,United States,120.3378
-2008-03-31,XM,Euro area,103.3993
-2008-03-31,XW,World,97.6422
-2008-03-31,ZA,South Africa,100.2703
-2008-06-30,4T,Emerging market economies (aggregate),89.0086
-2008-06-30,5R,Advanced economies,107.0703
-2008-06-30,AE,United Arab Emirates,151.366
+2008-03-31,US,United States,120.2955
+2008-03-31,XM,Euro area,103.3393
+2008-03-31,XW,World,97.7762
+2008-03-31,ZA,South Africa,100.1485
+2008-06-30,4T,Emerging market economies (aggregate),87.9858
+2008-06-30,5R,Advanced economies,106.0678
 2008-06-30,AT,Austria,89.3341
 2008-06-30,AU,Australia,87.1249
-2008-06-30,BE,Belgium,97.1959
+2008-06-30,BE,Belgium,97.9175
 2008-06-30,BG,Bulgaria,141.162
 2008-06-30,BR,Brazil,62.0934
-2008-06-30,CA,Canada,97.1916
-2008-06-30,CH,Switzerland,93.6788
+2008-06-30,CA,Canada,96.9871
+2008-06-30,CH,Switzerland,93.6784
 2008-06-30,CL,Chile,88.605
 2008-06-30,CN,China,90.8301
-2008-06-30,CO,Colombia,84.6683
+2008-06-30,CO,Colombia,83.9184
 2008-06-30,CY,Cyprus,107.3687
 2008-06-30,CZ,Czechia,106.2746
 2008-06-30,DE,Germany,100.3
@@ -20170,60 +4776,55 @@ date,country_code,country,price
 2008-06-30,ES,Spain,110.6483
 2008-06-30,FI,Finland,94.4622
 2008-06-30,FR,France,102.6309
-2008-06-30,GB,United Kingdom,107.4426
+2008-06-30,GB,United Kingdom,107.3982
 2008-06-30,GR,Greece,108.5835
 2008-06-30,HK,Hong Kong SAR,83.4281
 2008-06-30,HR,Croatia,112.2426
 2008-06-30,HU,Hungary,108.7804
 2008-06-30,ID,Indonesia,95.0206
-2008-06-30,IE,Ireland,145.6046
+2008-06-30,IE,Ireland,145.5918
 2008-06-30,IL,Israel,73.32
-2008-06-30,IN,India,
-2008-06-30,IS,Iceland,114.5802
+2008-06-30,IS,Iceland,114.5888
 2008-06-30,IT,Italy,101.79
 2008-06-30,JP,Japan,102.8847
-2008-06-30,KR,Korea,97.4627
+2008-06-30,KR,Korea,97.4392
 2008-06-30,LT,Lithuania,159.7221
 2008-06-30,LU,Luxembourg,96.772
 2008-06-30,LV,Latvia,191.9
-2008-06-30,MA,Morocco,96.7044
-2008-06-30,MK,North Macedonia,93.37
+2008-06-30,MA,Morocco,98.7137
+2008-06-30,MK,North Macedonia,93.3223
 2008-06-30,MT,Malta,99.3959
 2008-06-30,MX,Mexico,91.573
 2008-06-30,MY,Malaysia,91.08
-2008-06-30,NL,Netherlands,106.4093
+2008-06-30,NL,Netherlands,106.4151
 2008-06-30,NO,Norway,94.1484
 2008-06-30,NZ,New Zealand,100.052
 2008-06-30,PE,Peru,70.1174
 2008-06-30,PH,Philippines,100.8353
-2008-06-30,PL,Poland,
 2008-06-30,PT,Portugal,102.0795
-2008-06-30,RO,Romania,
 2008-06-30,RS,Serbia,73.1325
 2008-06-30,RU,Russia,92.2605
 2008-06-30,SE,Sweden,91.7944
 2008-06-30,SG,Singapore,95.5033
 2008-06-30,SI,Slovenia,110.1318
-2008-06-30,SK,Slovak Republic,124.3619
+2008-06-30,SK,Slovakia,124.0008
 2008-06-30,TH,Thailand,90.5273
-2008-06-30,TR,Türkiye,
-2008-06-30,US,United States,114.8539
-2008-06-30,XM,Euro area,103.9096
-2008-06-30,XW,World,97.8869
-2008-06-30,ZA,South Africa,97.8429
-2008-09-30,4T,Emerging market economies (aggregate),90.3425
-2008-09-30,5R,Advanced economies,104.618
-2008-09-30,AE,United Arab Emirates,148.5773
+2008-06-30,US,United States,114.8612
+2008-06-30,XM,Euro area,103.8558
+2008-06-30,XW,World,97.9473
+2008-06-30,ZA,South Africa,97.7228
+2008-09-30,4T,Emerging market economies (aggregate),89.4391
+2008-09-30,5R,Advanced economies,103.8861
 2008-09-30,AT,Austria,90.9841
 2008-09-30,AU,Australia,85.1888
-2008-09-30,BE,Belgium,98.5884
+2008-09-30,BE,Belgium,99.4241
 2008-09-30,BG,Bulgaria,145.4717
 2008-09-30,BR,Brazil,65.528
-2008-09-30,CA,Canada,95.2009
-2008-09-30,CH,Switzerland,94.6841
-2008-09-30,CL,Chile,90.8435
+2008-09-30,CA,Canada,95.0502
+2008-09-30,CH,Switzerland,94.6825
+2008-09-30,CL,Chile,90.8434
 2008-09-30,CN,China,91.2576
-2008-09-30,CO,Colombia,85.9383
+2008-09-30,CO,Colombia,85.4668
 2008-09-30,CY,Cyprus,108.1317
 2008-09-30,CZ,Czechia,107.8498
 2008-09-30,DE,Germany,99.9
@@ -20232,60 +4833,55 @@ date,country_code,country,price
 2008-09-30,ES,Spain,108.8869
 2008-09-30,FI,Finland,93.1842
 2008-09-30,FR,France,102.8314
-2008-09-30,GB,United Kingdom,103.1897
+2008-09-30,GB,United Kingdom,103.2419
 2008-09-30,GR,Greece,109.5048
 2008-09-30,HK,Hong Kong SAR,81.6611
 2008-09-30,HR,Croatia,114.3245
 2008-09-30,HU,Hungary,109.2074
 2008-09-30,ID,Indonesia,95.4714
-2008-09-30,IE,Ireland,141.715
+2008-09-30,IE,Ireland,141.6909
 2008-09-30,IL,Israel,76.8405
-2008-09-30,IN,India,
-2008-09-30,IS,Iceland,113.664
+2008-09-30,IS,Iceland,113.6541
 2008-09-30,IT,Italy,102.2252
 2008-09-30,JP,Japan,102.2116
-2008-09-30,KR,Korea,98.5847
+2008-09-30,KR,Korea,98.6174
 2008-09-30,LT,Lithuania,156.8718
 2008-09-30,LU,Luxembourg,96.4156
 2008-09-30,LV,Latvia,179
-2008-09-30,MA,Morocco,99.1099
-2008-09-30,MK,North Macedonia,95.22
+2008-09-30,MA,Morocco,99.7618
+2008-09-30,MK,North Macedonia,94.9724
 2008-09-30,MT,Malta,105.8759
 2008-09-30,MX,Mexico,93.8626
 2008-09-30,MY,Malaysia,92.8465
-2008-09-30,NL,Netherlands,107.7738
+2008-09-30,NL,Netherlands,107.7718
 2008-09-30,NO,Norway,91.0101
 2008-09-30,NZ,New Zealand,98.1183
 2008-09-30,PE,Peru,79.048
 2008-09-30,PH,Philippines,101.118
-2008-09-30,PL,Poland,
 2008-09-30,PT,Portugal,99.2572
-2008-09-30,RO,Romania,
 2008-09-30,RS,Serbia,78.7123
 2008-09-30,RU,Russia,96.1357
 2008-09-30,SE,Sweden,91.1452
 2008-09-30,SG,Singapore,93.2455
 2008-09-30,SI,Slovenia,112.2136
-2008-09-30,SK,Slovak Republic,118.5565
+2008-09-30,SK,Slovakia,118.2122
 2008-09-30,TH,Thailand,94.8242
-2008-09-30,TR,Türkiye,
-2008-09-30,US,United States,109.7686
-2008-09-30,XM,Euro area,103.716
-2008-09-30,XW,World,97.3815
-2008-09-30,ZA,South Africa,95.8434
-2008-12-31,4T,Emerging market economies (aggregate),89.907
-2008-12-31,5R,Advanced economies,101.0982
-2008-12-31,AE,United Arab Emirates,134.1476
+2008-09-30,US,United States,109.7669
+2008-09-30,XM,Euro area,103.6678
+2008-09-30,XW,World,97.4221
+2008-09-30,ZA,South Africa,95.7262
+2008-12-31,4T,Emerging market economies (aggregate),89.3198
+2008-12-31,5R,Advanced economies,100.4958
 2008-12-31,AT,Austria,92.2412
 2008-12-31,AU,Australia,84.0271
-2008-12-31,BE,Belgium,98.0444
+2008-12-31,BE,Belgium,98.8237
 2008-12-31,BG,Bulgaria,139.4325
 2008-12-31,BR,Brazil,69.2024
-2008-12-31,CA,Canada,91.3615
-2008-12-31,CH,Switzerland,95.8471
+2008-12-31,CA,Canada,91.3199
+2008-12-31,CH,Switzerland,95.8448
 2008-12-31,CL,Chile,92.2381
 2008-12-31,CN,China,90.7446
-2008-12-31,CO,Colombia,87.3952
+2008-12-31,CO,Colombia,87.2559
 2008-12-31,CY,Cyprus,105.1601
 2008-12-31,CZ,Czechia,107.2197
 2008-12-31,DE,Germany,100.6
@@ -20294,60 +4890,55 @@ date,country_code,country,price
 2008-12-31,ES,Spain,105.5276
 2008-12-31,FI,Finland,89.6699
 2008-12-31,FR,France,99.4237
-2008-12-31,GB,United Kingdom,96.3626
+2008-12-31,GB,United Kingdom,96.4256
 2008-12-31,GR,Greece,109.012
 2008-12-31,HK,Hong Kong SAR,71.5666
 2008-12-31,HR,Croatia,111.3374
 2008-12-31,HU,Hungary,107.0723
 2008-12-31,ID,Indonesia,95.9296
-2008-12-31,IE,Ireland,134.4465
+2008-12-31,IE,Ireland,134.4554
 2008-12-31,IL,Israel,77.5268
-2008-12-31,IN,India,
-2008-12-31,IS,Iceland,111.7856
+2008-12-31,IS,Iceland,111.8032
 2008-12-31,IT,Italy,100.6689
 2008-12-31,JP,Japan,101.1539
-2008-12-31,KR,Korea,98.2787
+2008-12-31,KR,Korea,98.2808
 2008-12-31,LT,Lithuania,145.5301
 2008-12-31,LU,Luxembourg,96.6108
 2008-12-31,LV,Latvia,150.23
-2008-12-31,MA,Morocco,100.1684
-2008-12-31,MK,North Macedonia,102.46
+2008-12-31,MA,Morocco,99.9524
+2008-12-31,MK,North Macedonia,102.2526
 2008-12-31,MT,Malta,104.5579
 2008-12-31,MX,Mexico,94.841
 2008-12-31,MY,Malaysia,91.1506
-2008-12-31,NL,Netherlands,105.5655
+2008-12-31,NL,Netherlands,105.5624
 2008-12-31,NO,Norway,84.6028
 2008-12-31,NZ,New Zealand,95.8797
 2008-12-31,PE,Peru,80.7951
 2008-12-31,PH,Philippines,100.9196
-2008-12-31,PL,Poland,
 2008-12-31,PT,Portugal,97.5619
-2008-12-31,RO,Romania,
 2008-12-31,RS,Serbia,83.9474
 2008-12-31,RU,Russia,95.0864
 2008-12-31,SE,Sweden,86.4797
 2008-12-31,SG,Singapore,87.6011
 2008-12-31,SI,Slovenia,108.6216
-2008-12-31,SK,Slovak Republic,114.0836
+2008-12-31,SK,Slovakia,113.7524
 2008-12-31,TH,Thailand,97.4609
-2008-12-31,TR,Türkiye,
-2008-12-31,US,United States,104.1156
-2008-12-31,XM,Euro area,102.1795
-2008-12-31,XW,World,95.4194
-2008-12-31,ZA,South Africa,95.619
-2009-03-31,4T,Emerging market economies (aggregate),89.2863
-2009-03-31,5R,Advanced economies,98.7565
-2009-03-31,AE,United Arab Emirates,122.5066
+2008-12-31,US,United States,104.1273
+2008-12-31,XM,Euro area,102.1383
+2008-12-31,XW,World,95.4931
+2008-12-31,ZA,South Africa,95.5022
+2009-03-31,4T,Emerging market economies (aggregate),88.9646
+2009-03-31,5R,Advanced economies,98.1556
 2009-03-31,AT,Austria,94.0483
 2009-03-31,AU,Australia,83.8335
-2009-03-31,BE,Belgium,96.7716
+2009-03-31,BE,Belgium,97.5682
 2009-03-31,BG,Bulgaria,123.5924
 2009-03-31,BR,Brazil,73.1794
-2009-03-31,CA,Canada,88.4465
-2009-03-31,CH,Switzerland,96.1821
-2009-03-31,CL,Chile,87.4298
+2009-03-31,CA,Canada,88.4505
+2009-03-31,CH,Switzerland,96.1839
+2009-03-31,CL,Chile,87.4297
 2009-03-31,CN,China,89.6901
-2009-03-31,CO,Colombia,90.1741
+2009-03-31,CO,Colombia,90.2046
 2009-03-31,CY,Cyprus,99.6988
 2009-03-31,CZ,Czechia,104.9094
 2009-03-31,DE,Germany,100.3
@@ -20356,33 +4947,32 @@ date,country_code,country,price
 2009-03-31,ES,Spain,102.7108
 2009-03-31,FI,Finland,91.7998
 2009-03-31,FR,France,95.7154
-2009-03-31,GB,United Kingdom,91.4382
+2009-03-31,GB,United Kingdom,91.4381
 2009-03-31,GR,Greece,105.0591
 2009-03-31,HK,Hong Kong SAR,71.5887
 2009-03-31,HR,Croatia,110.9753
 2009-03-31,HU,Hungary,106.4318
 2009-03-31,ID,Indonesia,96.3805
-2009-03-31,IE,Ireland,125.0172
+2009-03-31,IE,Ireland,125.0177
 2009-03-31,IL,Israel,78.9629
 2009-03-31,IN,India,78.5736
-2009-03-31,IS,Iceland,103.0352
+2009-03-31,IS,Iceland,103.0433
 2009-03-31,IT,Italy,101.0246
 2009-03-31,JP,Japan,99.2083
-2009-03-31,KR,Korea,96.9017
+2009-03-31,KR,Korea,96.9146
 2009-03-31,LT,Lithuania,116.3505
 2009-03-31,LU,Luxembourg,94.312
 2009-03-31,LV,Latvia,123.18
-2009-03-31,MA,Morocco,103.3438
-2009-03-31,MK,North Macedonia,98.76
+2009-03-31,MA,Morocco,100.4288
+2009-03-31,MK,North Macedonia,98.6925
 2009-03-31,MT,Malta,100.7139
 2009-03-31,MX,Mexico,96.1445
 2009-03-31,MY,Malaysia,91.5078
-2009-03-31,NL,Netherlands,104.4704
+2009-03-31,NL,Netherlands,104.477
 2009-03-31,NO,Norway,88.1334
 2009-03-31,NZ,New Zealand,95.2282
 2009-03-31,PE,Peru,78.6196
 2009-03-31,PH,Philippines,100.1905
-2009-03-31,PL,Poland,
 2009-03-31,PT,Portugal,98.4281
 2009-03-31,RO,Romania,111.2971
 2009-03-31,RS,Serbia,88.7545
@@ -20390,26 +4980,24 @@ date,country_code,country,price
 2009-03-31,SE,Sweden,88.8526
 2009-03-31,SG,Singapore,75.2587
 2009-03-31,SI,Slovenia,101.8472
-2009-03-31,SK,Slovak Republic,106.801
+2009-03-31,SK,Slovakia,106.4909
 2009-03-31,TH,Thailand,95.5078
-2009-03-31,TR,Türkiye,
-2009-03-31,US,United States,101.096
-2009-03-31,XM,Euro area,100.5116
-2009-03-31,XW,World,93.9605
-2009-03-31,ZA,South Africa,95.5667
-2009-06-30,4T,Emerging market economies (aggregate),90.1784
-2009-06-30,5R,Advanced economies,98.5139
-2009-06-30,AE,United Arab Emirates,115.2863
+2009-03-31,US,United States,101.1044
+2009-03-31,XM,Euro area,100.4848
+2009-03-31,XW,World,94.0534
+2009-03-31,ZA,South Africa,95.4509
+2009-06-30,4T,Emerging market economies (aggregate),89.9595
+2009-06-30,5R,Advanced economies,97.9409
 2009-06-30,AT,Austria,94.4412
 2009-06-30,AU,Australia,87.3185
-2009-06-30,BE,Belgium,95.8359
+2009-06-30,BE,Belgium,96.6839
 2009-06-30,BG,Bulgaria,111.684
 2009-06-30,BR,Brazil,77.5104
-2009-06-30,CA,Canada,90.4373
-2009-06-30,CH,Switzerland,95.6529
+2009-06-30,CA,Canada,90.4591
+2009-06-30,CH,Switzerland,95.6544
 2009-06-30,CL,Chile,89.8014
 2009-06-30,CN,China,90.4026
-2009-06-30,CO,Colombia,92.3829
+2009-06-30,CO,Colombia,92.6077
 2009-06-30,CY,Cyprus,100.5321
 2009-06-30,CZ,Czechia,101.549
 2009-06-30,DE,Germany,99
@@ -20418,33 +5006,32 @@ date,country_code,country,price
 2009-06-30,ES,Spain,102.2501
 2009-06-30,FI,Finland,93.1842
 2009-06-30,FR,France,94.4124
-2009-06-30,GB,United Kingdom,92.6693
+2009-06-30,GB,United Kingdom,92.6018
 2009-06-30,GR,Greece,105.8946
 2009-06-30,HK,Hong Kong SAR,77.5747
 2009-06-30,HR,Croatia,107.2641
 2009-06-30,HU,Hungary,103.1225
 2009-06-30,ID,Indonesia,97.0456
-2009-06-30,IE,Ireland,116.4129
+2009-06-30,IE,Ireland,116.4294
 2009-06-30,IL,Israel,82.4326
 2009-06-30,IN,India,82.5022
-2009-06-30,IS,Iceland,102.5312
+2009-06-30,IS,Iceland,102.5347
 2009-06-30,IT,Italy,100.9179
 2009-06-30,JP,Japan,97.7081
-2009-06-30,KR,Korea,96.8507
+2009-06-30,KR,Korea,96.9103
 2009-06-30,LT,Lithuania,110.1986
 2009-06-30,LU,Luxembourg,94.8983
 2009-06-30,LV,Latvia,110.82
-2009-06-30,MA,Morocco,102.0929
-2009-06-30,MK,North Macedonia,100.28
+2009-06-30,MA,Morocco,100.0476
+2009-06-30,MK,North Macedonia,100.0625
 2009-06-30,MT,Malta,98.6271
 2009-06-30,MX,Mexico,97.3531
 2009-06-30,MY,Malaysia,93.3895
-2009-06-30,NL,Netherlands,101.4632
+2009-06-30,NL,Netherlands,101.4665
 2009-06-30,NO,Norway,92.71
 2009-06-30,NZ,New Zealand,96.9539
 2009-06-30,PE,Peru,78.5831
 2009-06-30,PH,Philippines,100.1924
-2009-06-30,PL,Poland,
 2009-06-30,PT,Portugal,99.341
 2009-06-30,RO,Romania,106.2762
 2009-06-30,RS,Serbia,91.2392
@@ -20452,26 +5039,24 @@ date,country_code,country,price
 2009-06-30,SE,Sweden,91.467
 2009-06-30,SG,Singapore,71.7215
 2009-06-30,SI,Slovenia,99.7654
-2009-06-30,SK,Slovak Republic,101.8427
+2009-06-30,SK,Slovakia,101.547
 2009-06-30,TH,Thailand,96.1914
-2009-06-30,TR,Türkiye,
-2009-06-30,US,United States,101.0873
-2009-06-30,XM,Euro area,99.2468
-2009-06-30,XW,World,94.296
-2009-06-30,ZA,South Africa,95.1805
-2009-09-30,4T,Emerging market economies (aggregate),92.0405
-2009-09-30,5R,Advanced economies,99.3127
-2009-09-30,AE,United Arab Emirates,112.2707
+2009-06-30,US,United States,101.1008
+2009-06-30,XM,Euro area,99.2337
+2009-06-30,XW,World,94.3824
+2009-06-30,ZA,South Africa,95.0651
+2009-09-30,4T,Emerging market economies (aggregate),91.7101
+2009-09-30,5R,Advanced economies,98.9
 2009-09-30,AT,Austria,93.8912
 2009-09-30,AU,Australia,90.9971
-2009-09-30,BE,Belgium,98.0771
+2009-09-30,BE,Belgium,98.9219
 2009-09-30,BG,Bulgaria,106.4386
 2009-09-30,BR,Brazil,82.2041
-2009-09-30,CA,Canada,93.6367
-2009-09-30,CH,Switzerland,95.7398
+2009-09-30,CA,Canada,93.6155
+2009-09-30,CH,Switzerland,95.7411
 2009-09-30,CL,Chile,94.17
 2009-09-30,CN,China,92.3406
-2009-09-30,CO,Colombia,93.8918
+2009-09-30,CO,Colombia,93.8283
 2009-09-30,CY,Cyprus,101.1043
 2009-09-30,CZ,Czechia,100.7088
 2009-09-30,DE,Germany,99
@@ -20480,33 +5065,32 @@ date,country_code,country,price
 2009-09-30,ES,Spain,101.321
 2009-09-30,FI,Finland,94.6752
 2009-09-30,FR,France,95.9158
-2009-09-30,GB,United Kingdom,96.2507
+2009-09-30,GB,United Kingdom,96.2594
 2009-09-30,GR,Greece,103.9128
 2009-09-30,HK,Hong Kong SAR,84.2454
 2009-09-30,HR,Croatia,105.3632
 2009-09-30,HU,Hungary,101.5212
 2009-09-30,ID,Indonesia,97.4743
-2009-09-30,IE,Ireland,111.5804
+2009-09-30,IE,Ireland,111.5847
 2009-09-30,IL,Israel,87.0969
 2009-09-30,IN,India,86.0381
-2009-09-30,IS,Iceland,100.7903
+2009-09-30,IS,Iceland,100.78
 2009-09-30,IT,Italy,101.0694
 2009-09-30,JP,Japan,99.1416
-2009-09-30,KR,Korea,97.7687
+2009-09-30,KR,Korea,97.7728
 2009-09-30,LT,Lithuania,105.1275
 2009-09-30,LU,Luxembourg,94.0384
 2009-09-30,LV,Latvia,109.02
-2009-09-30,MA,Morocco,100.0722
-2009-09-30,MK,North Macedonia,97.46
+2009-09-30,MA,Morocco,99.8571
+2009-09-30,MK,North Macedonia,97.3724
 2009-09-30,MT,Malta,99.8353
 2009-09-30,MX,Mexico,97.5974
 2009-09-30,MY,Malaysia,94.6769
-2009-09-30,NL,Netherlands,100.5745
+2009-09-30,NL,Netherlands,100.575
 2009-09-30,NO,Norway,94.4099
 2009-09-30,NZ,New Zealand,99.151
 2009-09-30,PE,Peru,85.452
 2009-09-30,PH,Philippines,98.9068
-2009-09-30,PL,Poland,
 2009-09-30,PT,Portugal,99.3876
 2009-09-30,RO,Romania,106.2762
 2009-09-30,RS,Serbia,91.4043
@@ -20514,26 +5098,24 @@ date,country_code,country,price
 2009-09-30,SE,Sweden,93.9709
 2009-09-30,SG,Singapore,83.0103
 2009-09-30,SI,Slovenia,98.076
-2009-09-30,SK,Slovak Republic,106.5944
+2009-09-30,SK,Slovakia,106.2849
 2009-09-30,TH,Thailand,97.7539
-2009-09-30,TR,Türkiye,
-2009-09-30,US,United States,101.4031
-2009-09-30,XM,Euro area,99.2272
-2009-09-30,XW,World,95.6332
-2009-09-30,ZA,South Africa,95.6178
-2009-12-31,4T,Emerging market economies (aggregate),94.0057
-2009-12-31,5R,Advanced economies,99.8403
-2009-12-31,AE,United Arab Emirates,110.7574
+2009-09-30,US,United States,101.3843
+2009-09-30,XM,Euro area,99.2179
+2009-09-30,XW,World,95.6947
+2009-09-30,ZA,South Africa,95.5012
+2009-12-31,4T,Emerging market economies (aggregate),93.6607
+2009-12-31,5R,Advanced economies,99.5412
 2009-12-31,AT,Austria,94.284
 2009-12-31,AU,Australia,96.031
-2009-12-31,BE,Belgium,97.1523
+2009-12-31,BE,Belgium,98.0049
 2009-12-31,BG,Bulgaria,103.5654
 2009-12-31,BR,Brazil,87.1917
-2009-12-31,CA,Canada,96.3384
-2009-12-31,CH,Switzerland,96.1567
+2009-12-31,CA,Canada,96.2697
+2009-12-31,CH,Switzerland,96.1575
 2009-12-31,CL,Chile,99.0376
 2009-12-31,CN,China,94.7631
-2009-12-31,CO,Colombia,95.0567
+2009-12-31,CO,Colombia,95.1586
 2009-12-31,CY,Cyprus,103.2025
 2009-12-31,CZ,Czechia,99.9737
 2009-12-31,DE,Germany,99.4
@@ -20542,33 +5124,32 @@ date,country_code,country,price
 2009-12-31,ES,Spain,100.9123
 2009-12-31,FI,Finland,96.5921
 2009-12-31,FR,France,96.2165
-2009-12-31,GB,United Kingdom,98.1533
+2009-12-31,GB,United Kingdom,98.0881
 2009-12-31,GR,Greece,104.652
 2009-12-31,HK,Hong Kong SAR,88.0667
 2009-12-31,HR,Croatia,103.4623
 2009-12-31,HU,Hungary,98.6389
 2009-12-31,ID,Indonesia,98.1394
-2009-12-31,IE,Ireland,108.9873
+2009-12-31,IE,Ireland,109.0051
 2009-12-31,IL,Israel,91.6468
 2009-12-31,IN,India,89.4167
-2009-12-31,IS,Iceland,102.4854
+2009-12-31,IS,Iceland,102.4706
 2009-12-31,IT,Italy,100.4115
 2009-12-31,JP,Japan,98.2749
-2009-12-31,KR,Korea,98.9417
+2009-12-31,KR,Korea,98.9283
 2009-12-31,LT,Lithuania,100.2464
 2009-12-31,LU,Luxembourg,96.1925
 2009-12-31,LV,Latvia,106.21
-2009-12-31,MA,Morocco,99.5911
-2009-12-31,MK,North Macedonia,94.38
+2009-12-31,MA,Morocco,100.6193
+2009-12-31,MK,North Macedonia,94.0524
 2009-12-31,MT,Malta,96.5404
 2009-12-31,MX,Mexico,97.5239
 2009-12-31,MY,Malaysia,95.7663
-2009-12-31,NL,Netherlands,100.4937
+2009-12-31,NL,Netherlands,100.4974
 2009-12-31,NO,Norway,94.4099
 2009-12-31,NZ,New Zealand,101.05
 2009-12-31,PE,Peru,86.5187
 2009-12-31,PH,Philippines,98.396
-2009-12-31,PL,Poland,
 2009-12-31,PT,Portugal,99.7881
 2009-12-31,RO,Romania,109.6234
 2009-12-31,RS,Serbia,92.7646
@@ -20576,26 +5157,24 @@ date,country_code,country,price
 2009-12-31,SE,Sweden,96.5073
 2009-12-31,SG,Singapore,89.1063
 2009-12-31,SI,Slovenia,99.7995
-2009-12-31,SK,Slovak Republic,101.3262
+2009-12-31,SK,Slovakia,101.032
 2009-12-31,TH,Thailand,99.9023
-2009-12-31,TR,Türkiye,
-2009-12-31,US,United States,101.9868
-2009-12-31,XM,Euro area,99.2586
-2009-12-31,XW,World,96.884
-2009-12-31,ZA,South Africa,97.1917
-2010-03-31,4T,Emerging market economies (aggregate),97.0781
-2010-03-31,5R,Advanced economies,99.807
-2010-03-31,AE,United Arab Emirates,104.3586
+2009-12-31,US,United States,101.9776
+2009-12-31,XM,Euro area,99.2488
+2009-12-31,XW,World,96.9167
+2009-12-31,ZA,South Africa,97.0727
+2010-03-31,4T,Emerging market economies (aggregate),96.9296
+2010-03-31,5R,Advanced economies,99.6416
 2010-03-31,AT,Austria,99.3125
 2010-03-31,AU,Australia,99.0319
-2010-03-31,BE,Belgium,98.2185
+2010-03-31,BE,Belgium,98.376
 2010-03-31,BG,Bulgaria,101.2972
 2010-03-31,BR,Brazil,92.3279
-2010-03-31,CA,Canada,99.3957
-2010-03-31,CH,Switzerland,98.1403
-2010-03-31,CL,Chile,96.0126
+2010-03-31,CA,Canada,99.3544
+2010-03-31,CH,Switzerland,98.1407
+2010-03-31,CL,Chile,96.0095
 2010-03-31,CN,China,97.7556
-2010-03-31,CO,Colombia,97.2871
+2010-03-31,CO,Colombia,97.1341
 2010-03-31,CY,Cyprus,100.3915
 2010-03-31,CZ,Czechia,99.9737
 2010-03-31,DE,Germany,98.6
@@ -20604,28 +5183,28 @@ date,country_code,country,price
 2010-03-31,ES,Spain,99.6488
 2010-03-31,FI,Finland,98.8285
 2010-03-31,FR,France,96.9181
-2010-03-31,GB,United Kingdom,98.4891
+2010-03-31,GB,United Kingdom,98.4206
 2010-03-31,GR,Greece,103.1951
 2010-03-31,HK,Hong Kong SAR,93.3017
 2010-03-31,HR,Croatia,101.4709
 2010-03-31,HU,Hungary,101.0942
 2010-03-31,ID,Indonesia,98.8267
-2010-03-31,IE,Ireland,105.2549
+2010-03-31,IE,Ireland,105.2615
 2010-03-31,IL,Israel,95.1546
 2010-03-31,IN,India,93.1097
-2010-03-31,IS,Iceland,98.408
+2010-03-31,IS,Iceland,98.4159
 2010-03-31,IT,Italy,98.8992
 2010-03-31,JP,Japan,99.6083
-2010-03-31,KR,Korea,99.5027
+2010-03-31,KR,Korea,99.5077
 2010-03-31,LT,Lithuania,98.275
 2010-03-31,LU,Luxembourg,99.9417
 2010-03-31,LV,Latvia,97.72
-2010-03-31,MA,Morocco,98.6288
-2010-03-31,MK,North Macedonia,100.1
+2010-03-31,MA,Morocco,99.8571
+2010-03-31,MK,North Macedonia,100.0325
 2010-03-31,MT,Malta,100.4942
 2010-03-31,MX,Mexico,98.2774
 2010-03-31,MY,Malaysia,96.2615
-2010-03-31,NL,Netherlands,100.1885
+2010-03-31,NL,Netherlands,100.1874
 2010-03-31,NO,Norway,97.5482
 2010-03-31,NZ,New Zealand,101.1332
 2010-03-31,PE,Peru,94.9953
@@ -20638,26 +5217,25 @@ date,country_code,country,price
 2010-03-31,SE,Sweden,97.937
 2010-03-31,SG,Singapore,94.1486
 2010-03-31,SI,Slovenia,100.1749
-2010-03-31,SK,Slovak Republic,100.7748
+2010-03-31,SK,Slovakia,100.7748
 2010-03-31,TH,Thailand,98.0469
-2010-03-31,TR,Türkiye,98.081
-2010-03-31,US,United States,101.043
-2010-03-31,XM,Euro area,98.9257
-2010-03-31,XW,World,98.4408
-2010-03-31,ZA,South Africa,99.135
-2010-06-30,4T,Emerging market economies (aggregate),99.4802
-2010-06-30,5R,Advanced economies,100.5374
-2010-06-30,AE,United Arab Emirates,101.2133
+2010-03-31,TR,Türkiye,97.3913
+2010-03-31,US,United States,101.0456
+2010-03-31,XM,Euro area,98.9182
+2010-03-31,XW,World,98.4478
+2010-03-31,ZA,South Africa,99.015
+2010-06-30,4T,Emerging market economies (aggregate),99.4335
+2010-06-30,5R,Advanced economies,100.4499
 2010-06-30,AT,Austria,99.7054
 2010-06-30,AU,Australia,100.9681
-2010-06-30,BE,Belgium,99.1324
+2010-06-30,BE,Belgium,99.1621
 2010-06-30,BG,Bulgaria,100.6734
 2010-06-30,BR,Brazil,97.4869
-2010-06-30,CA,Canada,101.102
-2010-06-30,CH,Switzerland,98.9517
-2010-06-30,CL,Chile,100.2511
+2010-06-30,CA,Canada,101.076
+2010-06-30,CH,Switzerland,98.9518
+2010-06-30,CL,Chile,100.2541
 2010-06-30,CN,China,100.0071
-2010-06-30,CO,Colombia,99.437
+2010-06-30,CO,Colombia,99.1818
 2010-06-30,CY,Cyprus,100.0301
 2010-06-30,CZ,Czechia,100.1838
 2010-06-30,DE,Germany,99.8
@@ -20666,28 +5244,28 @@ date,country_code,country,price
 2010-06-30,ES,Spain,101.269
 2010-06-30,FI,Finland,99.6805
 2010-06-30,FR,France,98.8224
-2010-06-30,GB,United Kingdom,100.2798
+2010-06-30,GB,United Kingdom,100.2494
 2010-06-30,GR,Greece,100.9347
 2010-06-30,HK,Hong Kong SAR,97.0346
 2010-06-30,HR,Croatia,100.0226
 2010-06-30,HU,Hungary,100.5604
 2010-06-30,ID,Indonesia,99.854
-2010-06-30,IE,Ireland,101.6796
+2010-06-30,IE,Ireland,101.6752
 2010-06-30,IL,Israel,98.4209
 2010-06-30,IN,India,98.5312
-2010-06-30,IS,Iceland,100.7903
+2010-06-30,IS,Iceland,100.7754
 2010-06-30,IT,Italy,99.8307
 2010-06-30,JP,Japan,99.775
-2010-06-30,KR,Korea,100.0128
+2010-06-30,KR,Korea,99.9959
 2010-06-30,LT,Lithuania,100.4364
 2010-06-30,LU,Luxembourg,98.5575
 2010-06-30,LV,Latvia,98.07
-2010-06-30,MA,Morocco,101.4193
-2010-06-30,MK,North Macedonia,100.35
+2010-06-30,MA,Morocco,99.9524
+2010-06-30,MK,North Macedonia,100.2525
 2010-06-30,MT,Malta,100.1647
 2010-06-30,MX,Mexico,99.3245
 2010-06-30,MY,Malaysia,99.4306
-2010-06-30,NL,Netherlands,100.0718
+2010-06-30,NL,Netherlands,100.0711
 2010-06-30,NO,Norway,101.2095
 2010-06-30,NZ,New Zealand,100.0243
 2010-06-30,PE,Peru,99.1784
@@ -20700,26 +5278,25 @@ date,country_code,country,price
 2010-06-30,SE,Sweden,99.1428
 2010-06-30,SG,Singapore,99.1157
 2010-06-30,SI,Slovenia,100.7466
-2010-06-30,SK,Slovak Republic,100.175
+2010-06-30,SK,Slovakia,100.175
 2010-06-30,TH,Thailand,98.8281
-2010-06-30,TR,Türkiye,99.3603
-2010-06-30,US,United States,101.3682
-2010-06-30,XM,Euro area,99.8543
-2010-06-30,XW,World,100.0134
-2010-06-30,ZA,South Africa,100.1154
-2010-09-30,4T,Emerging market economies (aggregate),101.0929
-2010-09-30,5R,Advanced economies,100.0177
-2010-09-30,AE,United Arab Emirates,98.3165
+2010-06-30,TR,Türkiye,99.3079
+2010-06-30,US,United States,101.3735
+2010-06-30,XM,Euro area,99.8561
+2010-06-30,XW,World,100.0076
+2010-06-30,ZA,South Africa,99.7415
+2010-09-30,4T,Emerging market economies (aggregate),101.185
+2010-09-30,5R,Advanced economies,100.0704
 2010-09-30,AT,Austria,99.7839
 2010-09-30,AU,Australia,99.7096
-2010-09-30,BE,Belgium,101.0254
+2010-09-30,BE,Belgium,101.3128
 2010-09-30,BG,Bulgaria,99.596
 2010-09-30,BR,Brazil,102.5916
-2010-09-30,CA,Canada,99.9645
-2010-09-30,CH,Switzerland,100.63
-2010-09-30,CL,Chile,101.343
+2010-09-30,CA,Canada,100
+2010-09-30,CH,Switzerland,100.6296
+2010-09-30,CL,Chile,101.3438
 2010-09-30,CN,China,100.3776
-2010-09-30,CO,Colombia,99.6365
+2010-09-30,CO,Colombia,99.9188
 2010-09-30,CY,Cyprus,100.0602
 2010-09-30,CZ,Czechia,99.8687
 2010-09-30,DE,Germany,100.6
@@ -20728,28 +5305,28 @@ date,country_code,country,price
 2010-09-30,ES,Spain,99.5968
 2010-09-30,FI,Finland,100.7455
 2010-09-30,FR,France,101.5284
-2010-09-30,GB,United Kingdom,101.7348
+2010-09-30,GB,United Kingdom,101.7456
 2010-09-30,GR,Greece,98.5136
 2010-09-30,HK,Hong Kong SAR,102.115
 2010-09-30,HR,Croatia,99.1174
 2010-09-30,HU,Hungary,100.1334
 2010-09-30,ID,Indonesia,100.327
-2010-09-30,IE,Ireland,98.6936
+2010-09-30,IE,Ireland,98.6866
 2010-09-30,IL,Israel,101.5474
 2010-09-30,IN,India,104.3887
-2010-09-30,IS,Iceland,99.7366
+2010-09-30,IS,Iceland,99.7492
 2010-09-30,IT,Italy,100.5927
 2010-09-30,JP,Japan,100.375
-2010-09-30,KR,Korea,99.9107
+2010-09-30,KR,Korea,99.9233
 2010-09-30,LT,Lithuania,99.6883
 2010-09-30,LU,Luxembourg,100.0765
 2010-09-30,LV,Latvia,100.6
-2010-09-30,MA,Morocco,100.3608
-2010-09-30,MK,North Macedonia,98.47
+2010-09-30,MA,Morocco,100.1429
+2010-09-30,MK,North Macedonia,98.3825
 2010-09-30,MT,Malta,103.24
 2010-09-30,MX,Mexico,100.5778
 2010-09-30,MY,Malaysia,101.0151
-2010-09-30,NL,Netherlands,100.1616
+2010-09-30,NL,Netherlands,100.1615
 2010-09-30,NO,Norway,100.6865
 2010-09-30,NZ,New Zealand,99.4213
 2010-09-30,PE,Peru,101.9988
@@ -20762,26 +5339,25 @@ date,country_code,country,price
 2010-09-30,SE,Sweden,100.6451
 2010-09-30,SG,Singapore,101.9755
 2010-09-30,SI,Slovenia,99.4241
-2010-09-30,SK,Slovak Republic,99.4751
+2010-09-30,SK,Slovakia,99.4751
 2010-09-30,TH,Thailand,101.4648
-2010-09-30,TR,Türkiye,100
-2010-09-30,US,United States,99.2148
-2010-09-30,XM,Euro area,100.4893
-2010-09-30,XW,World,100.5587
-2010-09-30,ZA,South Africa,100.1989
-2010-12-31,4T,Emerging market economies (aggregate),102.3488
-2010-12-31,5R,Advanced economies,99.6378
-2010-12-31,AE,United Arab Emirates,96.1115
+2010-09-30,TR,Türkiye,100.7276
+2010-09-30,US,United States,99.2129
+2010-09-30,XM,Euro area,100.4898
+2010-09-30,XW,World,100.5634
+2010-09-30,ZA,South Africa,99.9505
+2010-12-31,4T,Emerging market economies (aggregate),102.452
+2010-12-31,5R,Advanced economies,99.838
 2010-12-31,AT,Austria,101.1982
 2010-12-31,AU,Australia,100.2904
-2010-12-31,BE,Belgium,101.6237
+2010-12-31,BE,Belgium,101.149
 2010-12-31,BG,Bulgaria,98.4335
 2010-12-31,BR,Brazil,107.5936
-2010-12-31,CA,Canada,99.5379
-2010-12-31,CH,Switzerland,102.2781
-2010-12-31,CL,Chile,102.3934
+2010-12-31,CA,Canada,99.5696
+2010-12-31,CH,Switzerland,102.278
+2010-12-31,CL,Chile,102.3926
 2010-12-31,CN,China,101.8596
-2010-12-31,CO,Colombia,103.6393
+2010-12-31,CO,Colombia,103.7653
 2010-12-31,CY,Cyprus,99.5181
 2010-12-31,CZ,Czechia,99.9737
 2010-12-31,DE,Germany,101
@@ -20790,28 +5366,28 @@ date,country_code,country,price
 2010-12-31,ES,Spain,99.4853
 2010-12-31,FI,Finland,100.7455
 2010-12-31,FR,France,102.7311
-2010-12-31,GB,United Kingdom,99.4964
+2010-12-31,GB,United Kingdom,99.5844
 2010-12-31,GR,Greece,97.3567
 2010-12-31,HK,Hong Kong SAR,107.5487
 2010-12-31,HR,Croatia,99.389
 2010-12-31,HU,Hungary,98.2119
 2010-12-31,ID,Indonesia,100.9922
-2010-12-31,IE,Ireland,94.3719
+2010-12-31,IE,Ireland,94.3767
 2010-12-31,IL,Israel,104.8772
 2010-12-31,IN,India,103.9703
-2010-12-31,IS,Iceland,101.0652
+2010-12-31,IS,Iceland,101.0595
 2010-12-31,IT,Italy,100.6774
 2010-12-31,JP,Japan,100.2417
-2010-12-31,KR,Korea,100.5738
+2010-12-31,KR,Korea,100.5731
 2010-12-31,LT,Lithuania,101.6003
 2010-12-31,LU,Luxembourg,101.4243
 2010-12-31,LV,Latvia,103.61
-2010-12-31,MA,Morocco,99.5911
-2010-12-31,MK,North Macedonia,101.08
+2010-12-31,MA,Morocco,100.0476
+2010-12-31,MK,North Macedonia,101.3325
 2010-12-31,MT,Malta,96.101
 2010-12-31,MX,Mexico,101.8204
 2010-12-31,MY,Malaysia,103.2929
-2010-12-31,NL,Netherlands,99.5781
+2010-12-31,NL,Netherlands,99.5801
 2010-12-31,NO,Norway,100.5557
 2010-12-31,NZ,New Zealand,99.4213
 2010-12-31,PE,Peru,103.8274
@@ -20824,26 +5400,25 @@ date,country_code,country,price
 2010-12-31,SE,Sweden,102.2751
 2010-12-31,SG,Singapore,104.7601
 2010-12-31,SI,Slovenia,99.6545
-2010-12-31,SK,Slovak Republic,99.5751
+2010-12-31,SK,Slovakia,99.5751
 2010-12-31,TH,Thailand,101.6602
-2010-12-31,TR,Türkiye,102.5586
-2010-12-31,US,United States,98.374
-2010-12-31,XM,Euro area,100.7307
-2010-12-31,XW,World,100.9871
-2010-12-31,ZA,South Africa,100.5508
-2011-03-31,4T,Emerging market economies (aggregate),103.0358
-2011-03-31,5R,Advanced economies,98.9466
-2011-03-31,AE,United Arab Emirates,97.4951
+2010-12-31,TR,Türkiye,102.5732
+2010-12-31,US,United States,98.368
+2010-12-31,XM,Euro area,100.7359
+2010-12-31,XW,World,100.9812
+2010-12-31,ZA,South Africa,101.293
+2011-03-31,4T,Emerging market economies (aggregate),102.7641
+2011-03-31,5R,Advanced economies,99.3697
 2011-03-31,AT,Austria,103.8696
 2011-03-31,AU,Australia,99.4192
-2011-03-31,BE,Belgium,102.3418
+2011-03-31,BE,Belgium,102.0879
 2011-03-31,BG,Bulgaria,96.4298
 2011-03-31,BR,Brazil,112.4642
-2011-03-31,CA,Canada,102.4529
-2011-03-31,CH,Switzerland,105.2026
-2011-03-31,CL,Chile,105.3439
+2011-03-31,CA,Canada,102.2956
+2011-03-31,CH,Switzerland,105.2029
+2011-03-31,CL,Chile,105.3408
 2011-03-31,CN,China,103.5126
-2011-03-31,CO,Colombia,103.14
+2011-03-31,CO,Colombia,103.3087
 2011-03-31,CY,Cyprus,98.4941
 2011-03-31,CZ,Czechia,100.1838
 2011-03-31,DE,Germany,101.5
@@ -20852,28 +5427,28 @@ date,country_code,country,price
 2011-03-31,ES,Spain,96.1038
 2011-03-31,FI,Finland,102.0234
 2011-03-31,FR,France,103.3325
-2011-03-31,GB,United Kingdom,97.7057
+2011-03-31,GB,United Kingdom,97.7556
 2011-03-31,GR,Greece,97.6138
 2011-03-31,HK,Hong Kong SAR,116.0528
 2011-03-31,HR,Croatia,98.4838
 2011-03-31,HU,Hungary,97.8916
 2011-03-31,ID,Indonesia,103.2537
-2011-03-31,IE,Ireland,90.0501
+2011-03-31,IE,Ireland,90.0983
 2011-03-31,IL,Israel,108.6646
 2011-03-31,IN,India,111.5014
-2011-03-31,IS,Iceland,101.7982
+2011-03-31,IS,Iceland,101.7925
 2011-03-31,IT,Italy,100.1693
 2011-03-31,JP,Japan,100.4417
-2011-03-31,KR,Korea,102.3078
+2011-03-31,KR,Korea,102.323
 2011-03-31,LT,Lithuania,105.9351
 2011-03-31,LU,Luxembourg,100.9871
 2011-03-31,LV,Latvia,108.25
-2011-03-31,MA,Morocco,100.1684
-2011-03-31,MK,North Macedonia,96.69
+2011-03-31,MA,Morocco,100.2382
+2011-03-31,MK,North Macedonia,96.5324
 2011-03-31,MT,Malta,97.419
 2011-03-31,MX,Mexico,103.7879
 2011-03-31,MY,Malaysia,105.3726
-2011-03-31,NL,Netherlands,99.7038
+2011-03-31,NL,Netherlands,99.6964
 2011-03-31,NO,Norway,105.7862
 2011-03-31,NZ,New Zealand,99.6639
 2011-03-31,PE,Peru,112.5811
@@ -20886,26 +5461,25 @@ date,country_code,country,price
 2011-03-31,SE,Sweden,103.1907
 2011-03-31,SG,Singapore,107.0931
 2011-03-31,SI,Slovenia,104.2959
-2011-03-31,SK,Slovak Republic,99.6751
-2011-03-31,TH,Thailand,104.1667
-2011-03-31,TR,Türkiye,104.4776
-2011-03-31,US,United States,96.67
-2011-03-31,XM,Euro area,100.4677
-2011-03-31,XW,World,100.9882
-2011-03-31,ZA,South Africa,101.4402
-2011-06-30,4T,Emerging market economies (aggregate),105.607
-2011-06-30,5R,Advanced economies,99.453
-2011-06-30,AE,United Arab Emirates,97.387
+2011-03-31,SK,Slovakia,99.6751
+2011-03-31,TH,Thailand,102.6525
+2011-03-31,TR,Türkiye,105.4126
+2011-03-31,US,United States,96.6832
+2011-03-31,XM,Euro area,100.478
+2011-03-31,XW,World,100.8573
+2011-03-31,ZA,South Africa,102.2124
+2011-06-30,4T,Emerging market economies (aggregate),105.3874
+2011-06-30,5R,Advanced economies,100.0109
 2011-06-30,AT,Austria,101.0411
 2011-06-30,AU,Australia,98.7415
-2011-06-30,BE,Belgium,103.2774
+2011-06-30,BE,Belgium,102.7976
 2011-06-30,BG,Bulgaria,94.7286
 2011-06-30,BR,Brazil,117.1293
-2011-06-30,CA,Canada,105.9367
-2011-06-30,CH,Switzerland,106.7923
-2011-06-30,CL,Chile,111.5089
+2011-06-30,CA,Canada,105.7389
+2011-06-30,CH,Switzerland,106.7929
+2011-06-30,CL,Chile,111.5077
 2011-06-30,CN,China,104.2822
-2011-06-30,CO,Colombia,107.1693
+2011-06-30,CO,Colombia,107.513
 2011-06-30,CY,Cyprus,97.3798
 2011-06-30,CZ,Czechia,100.7088
 2011-06-30,DE,Germany,101.9
@@ -20914,28 +5488,28 @@ date,country_code,country,price
 2011-06-30,ES,Spain,94.9518
 2011-06-30,FI,Finland,103.9404
 2011-06-30,FR,France,105.337
-2011-06-30,GB,United Kingdom,98.4891
+2011-06-30,GB,United Kingdom,98.4206
 2011-06-30,GR,Greece,95.7712
 2011-06-30,HK,Hong Kong SAR,123.099
 2011-06-30,HR,Croatia,100.0226
 2011-06-30,HU,Hungary,97.1444
 2011-06-30,ID,Indonesia,104.3771
-2011-06-30,IE,Ireland,85.414
+2011-06-30,IE,Ireland,85.4109
 2011-06-30,IL,Israel,111.2573
 2011-06-30,IN,India,121.3336
-2011-06-30,IS,Iceland,104.5928
+2011-06-30,IS,Iceland,104.5918
 2011-06-30,IT,Italy,102.2015
 2011-06-30,JP,Japan,99.975
-2011-06-30,KR,Korea,104.7048
+2011-06-30,KR,Korea,104.7629
 2011-06-30,LT,Lithuania,106.7427
 2011-06-30,LU,Luxembourg,103.4136
 2011-06-30,LV,Latvia,110.15
-2011-06-30,MA,Morocco,100.3608
-2011-06-30,MK,North Macedonia,98.74
+2011-06-30,MA,Morocco,100.8099
+2011-06-30,MK,North Macedonia,98.7025
 2011-06-30,MT,Malta,99.7254
 2011-06-30,MX,Mexico,105.413
 2011-06-30,MY,Malaysia,108.1456
-2011-06-30,NL,Netherlands,98.3393
+2011-06-30,NL,Netherlands,98.3397
 2011-06-30,NO,Norway,108.663
 2011-06-30,NZ,New Zealand,100.149
 2011-06-30,PE,Peru,118.5388
@@ -20948,26 +5522,25 @@ date,country_code,country,price
 2011-06-30,SE,Sweden,103.2119
 2011-06-30,SG,Singapore,109.2004
 2011-06-30,SI,Slovenia,103.9973
-2011-06-30,SK,Slovak Republic,98.1755
-2011-06-30,TH,Thailand,105.3125
-2011-06-30,TR,Türkiye,106.1834
-2011-06-30,US,United States,97.2152
-2011-06-30,XM,Euro area,100.8761
-2011-06-30,XW,World,102.525
-2011-06-30,ZA,South Africa,102.7064
-2011-09-30,4T,Emerging market economies (aggregate),106.7859
-2011-09-30,5R,Advanced economies,99.8678
-2011-09-30,AE,United Arab Emirates,99.365
+2011-06-30,SK,Slovakia,98.1755
+2011-06-30,TH,Thailand,104.936
+2011-06-30,TR,Türkiye,108.394
+2011-06-30,US,United States,97.2126
+2011-06-30,XM,Euro area,100.8945
+2011-06-30,XW,World,102.3695
+2011-06-30,ZA,South Africa,102.8866
+2011-09-30,4T,Emerging market economies (aggregate),106.4975
+2011-09-30,5R,Advanced economies,100.4684
 2011-09-30,AT,Austria,105.7553
 2011-09-30,AU,Australia,96.999
-2011-09-30,BE,Belgium,105.3118
+2011-09-30,BE,Belgium,104.8609
 2011-09-30,BG,Bulgaria,94.0765
 2011-09-30,BR,Brazil,121.389
-2011-09-30,CA,Canada,107.2876
-2011-09-30,CH,Switzerland,108.9513
+2011-09-30,CA,Canada,107.1736
+2011-09-30,CH,Switzerland,108.9531
 2011-09-30,CL,Chile,114.3935
 2011-09-30,CN,China,104.4817
-2011-09-30,CO,Colombia,109.904
+2011-09-30,CO,Colombia,109.9566
 2011-09-30,CY,Cyprus,96.2654
 2011-09-30,CZ,Czechia,100.0788
 2011-09-30,DE,Germany,103.1
@@ -20976,28 +5549,28 @@ date,country_code,country,price
 2011-09-30,ES,Spain,91.5628
 2011-09-30,FI,Finland,103.6209
 2011-09-30,FR,France,107.542
-2011-09-30,GB,United Kingdom,99.6083
+2011-09-30,GB,United Kingdom,99.7506
 2011-09-30,GR,Greece,93.8429
 2011-09-30,HK,Hong Kong SAR,122.7235
 2011-09-30,HR,Croatia,100.7468
 2011-09-30,HU,Hungary,95.8634
 2011-09-30,ID,Indonesia,104.8796
-2011-09-30,IE,Ireland,80.3065
+2011-09-30,IE,Ireland,80.346
 2011-09-30,IL,Israel,111.6513
 2011-09-30,IN,India,124.8899
-2011-09-30,IS,Iceland,106.3796
+2011-09-30,IS,Iceland,106.4015
 2011-09-30,IT,Italy,101.8628
 2011-09-30,JP,Japan,100.6084
-2011-09-30,KR,Korea,106.2859
+2011-09-30,KR,Korea,106.3191
 2011-09-30,LT,Lithuania,106.4933
 2011-09-30,LU,Luxembourg,103.4063
 2011-09-30,LV,Latvia,113.7
-2011-09-30,MA,Morocco,101.2268
-2011-09-30,MK,North Macedonia,99.12
+2011-09-30,MA,Morocco,100.8099
+2011-09-30,MK,North Macedonia,99.1825
 2011-09-30,MT,Malta,99.9451
 2011-09-30,MX,Mexico,106.5574
 2011-09-30,MY,Malaysia,110.9185
-2011-09-30,NL,Netherlands,97.8725
+2011-09-30,NL,Netherlands,97.8745
 2011-09-30,NO,Norway,109.0552
 2011-09-30,NZ,New Zealand,101.5005
 2011-09-30,PE,Peru,125.5256
@@ -21010,26 +5583,25 @@ date,country_code,country,price
 2011-09-30,SE,Sweden,102.974
 2011-09-30,SG,Singapore,110.6303
 2011-09-30,SI,Slovenia,101.54
-2011-09-30,SK,Slovak Republic,98.7753
-2011-09-30,TH,Thailand,103.9583
-2011-09-30,TR,Türkiye,107.8891
-2011-09-30,US,United States,97.6124
-2011-09-30,XM,Euro area,101.1892
-2011-09-30,XW,World,103.3176
-2011-09-30,ZA,South Africa,103.8238
-2011-12-31,4T,Emerging market economies (aggregate),108.2195
-2011-12-31,5R,Advanced economies,99.184
-2011-12-31,AE,United Arab Emirates,102.1645
+2011-09-30,SK,Slovakia,98.6753
+2011-09-30,TH,Thailand,103.8981
+2011-09-30,TR,Türkiye,109.4587
+2011-09-30,US,United States,97.5832
+2011-09-30,XM,Euro area,101.2083
+2011-09-30,XW,World,103.1109
+2011-09-30,ZA,South Africa,103.9969
+2011-12-31,4T,Emerging market economies (aggregate),108.0466
+2011-12-31,5R,Advanced economies,99.8331
 2011-12-31,AT,Austria,106.2267
 2011-12-31,AU,Australia,96.2246
-2011-12-31,BE,Belgium,105.1378
+2011-12-31,BE,Belgium,104.5771
 2011-12-31,BG,Bulgaria,92.7155
 2011-12-31,BR,Brazil,125.1062
-2011-12-31,CA,Canada,107.572
-2011-12-31,CH,Switzerland,109.0961
-2011-12-31,CL,Chile,117.677
+2011-12-31,CA,Canada,107.3888
+2011-12-31,CH,Switzerland,109.0988
+2011-12-31,CL,Chile,117.6754
 2011-12-31,CN,China,104.1967
-2011-12-31,CO,Colombia,111.354
+2011-12-31,CO,Colombia,111.5488
 2011-12-31,CY,Cyprus,94.5889
 2011-12-31,CZ,Czechia,99.1336
 2011-12-31,DE,Germany,103.2
@@ -21038,28 +5610,28 @@ date,country_code,country,price
 2011-12-31,ES,Spain,86.8063
 2011-12-31,FI,Finland,103.0884
 2011-12-31,FR,France,106.5397
-2011-12-31,GB,United Kingdom,98.2652
+2011-12-31,GB,United Kingdom,98.2544
 2011-12-31,GR,Greece,90.9076
 2011-12-31,HK,Hong Kong SAR,120.6693
 2011-12-31,HR,Croatia,101.3804
 2011-12-31,HU,Hungary,95.3296
 2011-12-31,ID,Indonesia,106.0917
-2011-12-31,IE,Ireland,75.8275
+2011-12-31,IE,Ireland,75.8474
 2011-12-31,IL,Israel,110.5074
 2011-12-31,IN,India,131.2704
-2011-12-31,IS,Iceland,109.22
+2011-12-31,IS,Iceland,109.2421
 2011-12-31,IT,Italy,101.1854
 2011-12-31,JP,Japan,99.2416
-2011-12-31,KR,Korea,107.6119
+2011-12-31,KR,Korea,107.6472
 2011-12-31,LT,Lithuania,107.2533
 2011-12-31,LU,Luxembourg,106.8981
 2011-12-31,LV,Latvia,109.58
-2011-12-31,MA,Morocco,100.5533
-2011-12-31,MK,North Macedonia,99.3
+2011-12-31,MA,Morocco,100.5241
+2011-12-31,MK,North Macedonia,99.4225
 2011-12-31,MT,Malta,97.419
 2011-12-31,MX,Mexico,107.416
 2011-12-31,MY,Malaysia,114.8799
-2011-12-31,NL,Netherlands,96.149
+2011-12-31,NL,Netherlands,96.1561
 2011-12-31,NO,Norway,108.5322
 2011-12-31,NZ,New Zealand,101.6876
 2011-12-31,PE,Peru,125.0811
@@ -21072,26 +5644,25 @@ date,country_code,country,price
 2011-12-31,SE,Sweden,100.9526
 2011-12-31,SG,Singapore,110.9313
 2011-12-31,SI,Slovenia,101.0196
-2011-12-31,SK,Slovak Republic,97.2757
-2011-12-31,TH,Thailand,104.5833
-2011-12-31,TR,Türkiye,109.1684
-2011-12-31,US,United States,97.518
-2011-12-31,XM,Euro area,100.0897
-2011-12-31,XW,World,103.6764
-2011-12-31,ZA,South Africa,104.9096
-2012-03-31,4T,Emerging market economies (aggregate),110.5055
-2012-03-31,5R,Advanced economies,99.5113
-2012-03-31,AE,United Arab Emirates,104.2505
+2011-12-31,SK,Slovakia,97.2757
+2011-12-31,TH,Thailand,105.5588
+2011-12-31,TR,Türkiye,111.9432
+2011-12-31,US,United States,97.481
+2011-12-31,XM,Euro area,100.1101
+2011-12-31,XW,World,103.4224
+2011-12-31,ZA,South Africa,105.262
+2012-03-31,4T,Emerging market economies (aggregate),110.4757
+2012-03-31,5R,Advanced economies,100.1745
 2012-03-31,AT,Austria,115.0265
 2012-03-31,AU,Australia,96.8054
-2012-03-31,BE,Belgium,105.8884
+2012-03-31,BE,Belgium,105.3631
 2012-03-31,BG,Bulgaria,92.8384
 2012-03-31,BR,Brazil,128.398
-2012-03-31,CA,Canada,109.9893
-2012-03-31,CH,Switzerland,111.8117
-2012-03-31,CL,Chile,118.697
+2012-03-31,CA,Canada,109.8278
+2012-03-31,CH,Switzerland,111.8124
+2012-03-31,CL,Chile,118.6938
 2012-03-31,CN,China,103.6551
-2012-03-31,CO,Colombia,114.5881
+2012-03-31,CO,Colombia,114.9166
 2012-03-31,CY,Cyprus,93.5549
 2012-03-31,CZ,Czechia,98.6086
 2012-03-31,DE,Germany,104.1
@@ -21100,28 +5671,28 @@ date,country_code,country,price
 2012-03-31,ES,Spain,82.4734
 2012-03-31,FI,Finland,104.7923
 2012-03-31,FR,France,105.1366
-2012-03-31,GB,United Kingdom,97.258
+2012-03-31,GB,United Kingdom,97.2569
 2012-03-31,GR,Greece,87.3189
 2012-03-31,HK,Hong Kong SAR,122.7677
 2012-03-31,HR,Croatia,100.8373
 2012-03-31,HU,Hungary,96.2904
 2012-03-31,ID,Indonesia,106.9638
-2012-03-31,IE,Ireland,72.4487
+2012-03-31,IE,Ireland,72.4184
 2012-03-31,IL,Israel,111.0793
 2012-03-31,IN,India,140.2658
-2012-03-31,IS,Iceland,109.2658
+2012-03-31,IS,Iceland,109.2696
 2012-03-31,IT,Italy,100.7621
 2012-03-31,JP,Japan,99.9417
-2012-03-31,KR,Korea,108.2239
+2012-03-31,KR,Korea,108.2519
 2012-03-31,LT,Lithuania,106.8733
 2012-03-31,LU,Luxembourg,105.5618
 2012-03-31,LV,Latvia,111.05
-2012-03-31,MA,Morocco,100.6495
-2012-03-31,MK,North Macedonia,98.87
+2012-03-31,MA,Morocco,101.0005
+2012-03-31,MK,North Macedonia,98.9425
 2012-03-31,MT,Malta,99.3959
 2012-03-31,MX,Mexico,108.0055
 2012-03-31,MY,Malaysia,118.7423
-2012-03-31,NL,Netherlands,94.3178
+2012-03-31,NL,Netherlands,94.3213
 2012-03-31,NO,Norway,112.4551
 2012-03-31,NZ,New Zealand,102.7619
 2012-03-31,PE,Peru,134.4645
@@ -21134,26 +5705,25 @@ date,country_code,country,price
 2012-03-31,SE,Sweden,102.1384
 2012-03-31,SG,Singapore,110.7808
 2012-03-31,SI,Slovenia,96.9242
-2012-03-31,SK,Slovak Republic,96.6758
-2012-03-31,TH,Thailand,106.4583
-2012-03-31,TR,Türkiye,113.0064
-2012-03-31,US,United States,98.337
-2012-03-31,XM,Euro area,99.4536
-2012-03-31,XW,World,104.9788
-2012-03-31,ZA,South Africa,106.2351
-2012-06-30,4T,Emerging market economies (aggregate),112.3134
-2012-06-30,5R,Advanced economies,100.6091
-2012-06-30,AE,United Arab Emirates,110.1738
+2012-03-31,SK,Slovakia,96.5759
+2012-03-31,TH,Thailand,106.7005
+2012-03-31,TR,Türkiye,115.9184
+2012-03-31,US,United States,98.3586
+2012-03-31,XM,Euro area,99.4764
+2012-03-31,XW,World,104.68
+2012-03-31,ZA,South Africa,106.9973
+2012-06-30,4T,Emerging market economies (aggregate),112.2005
+2012-06-30,5R,Advanced economies,101.2582
 2012-06-30,AT,Austria,116.7551
 2012-06-30,AU,Australia,97.1926
-2012-06-30,BE,Belgium,105.9863
+2012-06-30,BE,Belgium,105.5924
 2012-06-30,BG,Bulgaria,93.2543
 2012-06-30,BR,Brazil,131.5156
-2012-06-30,CA,Canada,112.1223
-2012-06-30,CH,Switzerland,113.1483
-2012-06-30,CL,Chile,122.2154
+2012-06-30,CA,Canada,111.9799
+2012-06-30,CH,Switzerland,113.1497
+2012-06-30,CL,Chile,122.214
 2012-06-30,CN,China,103.1136
-2012-06-30,CO,Colombia,118.2989
+2012-06-30,CO,Colombia,118.2274
 2012-06-30,CY,Cyprus,91.6976
 2012-06-30,CZ,Czechia,98.7136
 2012-06-30,DE,Germany,105.4
@@ -21162,28 +5732,28 @@ date,country_code,country,price
 2012-06-30,ES,Spain,79.7978
 2012-06-30,FI,Finland,105.8573
 2012-06-30,FR,France,105.1366
-2012-06-30,GB,United Kingdom,99.0487
+2012-06-30,GB,United Kingdom,99.0856
 2012-06-30,GR,Greece,85.4013
 2012-06-30,HK,Hong Kong SAR,134.0328
 2012-06-30,HR,Croatia,99.4795
 2012-06-30,HU,Hungary,92.9811
 2012-06-30,ID,Indonesia,108.2202
-2012-06-30,IE,Ireland,70.7593
+2012-06-30,IE,Ireland,70.7825
 2012-06-30,IL,Israel,112.5028
 2012-06-30,IN,India,149.1566
-2012-06-30,IS,Iceland,112.6102
+2012-06-30,IS,Iceland,112.6187
 2012-06-30,IT,Italy,100
 2012-06-30,JP,Japan,98.8749
-2012-06-30,KR,Korea,108.5299
+2012-06-30,KR,Korea,108.5599
 2012-06-30,LT,Lithuania,105.757
 2012-06-30,LU,Luxembourg,107.629
 2012-06-30,LV,Latvia,112.36
-2012-06-30,MA,Morocco,101.3231
-2012-06-30,MK,North Macedonia,97.27
+2012-06-30,MA,Morocco,101.9533
+2012-06-30,MK,North Macedonia,97.2724
 2012-06-30,MT,Malta,98.2976
 2012-06-30,MX,Mexico,108.6432
 2012-06-30,MY,Malaysia,122.7036
-2012-06-30,NL,Netherlands,92.7558
+2012-06-30,NL,Netherlands,92.7579
 2012-06-30,NO,Norway,116.1164
 2012-06-30,NZ,New Zealand,103.9748
 2012-06-30,PE,Peru,142.3037
@@ -21196,26 +5766,25 @@ date,country_code,country,price
 2012-06-30,SE,Sweden,103.6418
 2012-06-30,SG,Singapore,111.3076
 2012-06-30,SI,Slovenia,98.0419
-2012-06-30,SK,Slovak Republic,95.7761
-2012-06-30,TH,Thailand,105.5208
-2012-06-30,TR,Türkiye,116.6311
-2012-06-30,US,United States,100.9137
-2012-06-30,XM,Euro area,99.1803
-2012-06-30,XW,World,106.4276
-2012-06-30,ZA,South Africa,107.6355
-2012-09-30,4T,Emerging market economies (aggregate),113.6862
-2012-09-30,5R,Advanced economies,101.3201
-2012-09-30,AE,United Arab Emirates,114.5945
+2012-06-30,SK,Slovakia,95.6761
+2012-06-30,TH,Thailand,106.1815
+2012-06-30,TR,Türkiye,119.6096
+2012-06-30,US,United States,100.8716
+2012-06-30,XM,Euro area,99.1919
+2012-06-30,XW,World,106.0425
+2012-06-30,ZA,South Africa,107.7208
+2012-09-30,4T,Emerging market economies (aggregate),113.5742
+2012-09-30,5R,Advanced economies,101.9413
 2012-09-30,AT,Austria,118.3265
 2012-09-30,AU,Australia,96.999
-2012-09-30,BE,Belgium,107.1831
+2012-09-30,BE,Belgium,106.7387
 2012-09-30,BG,Bulgaria,93.1597
 2012-09-30,BR,Brazil,134.6076
-2012-09-30,CA,Canada,110.9847
-2012-09-30,CH,Switzerland,114.7981
-2012-09-30,CL,Chile,125.2405
+2012-09-30,CA,Canada,110.9039
+2012-09-30,CH,Switzerland,114.799
+2012-09-30,CL,Chile,125.2342
 2012-09-30,CN,China,103.2561
-2012-09-30,CO,Colombia,119.7233
+2012-09-30,CO,Colombia,119.7931
 2012-09-30,CY,Cyprus,90.8041
 2012-09-30,CZ,Czechia,98.5035
 2012-09-30,DE,Germany,105.8
@@ -21224,28 +5793,28 @@ date,country_code,country,price
 2012-09-30,ES,Spain,76.8176
 2012-09-30,FI,Finland,105.8573
 2012-09-30,FR,France,105.8381
-2012-09-30,GB,United Kingdom,100.1679
+2012-09-30,GB,United Kingdom,100.0831
 2012-09-30,GR,Greece,82.0268
 2012-09-30,HK,Hong Kong SAR,140.1955
 2012-09-30,HR,Croatia,98.7554
 2012-09-30,HU,Hungary,92.2338
 2012-09-30,ID,Indonesia,109.3361
-2012-09-30,IE,Ireland,71.5843
+2012-09-30,IE,Ireland,71.6005
 2012-09-30,IL,Israel,114.549
 2012-09-30,IN,India,153.8636
-2012-09-30,IS,Iceland,113.3891
+2012-09-30,IS,Iceland,113.4021
 2012-09-30,IT,Italy,98.1372
 2012-09-30,JP,Japan,99.1416
-2012-09-30,KR,Korea,108.3259
+2012-09-30,KR,Korea,108.3017
 2012-09-30,LT,Lithuania,106.8139
 2012-09-30,LU,Luxembourg,107.9178
 2012-09-30,LV,Latvia,115.18
-2012-09-30,MA,Morocco,101.9966
-2012-09-30,MK,North Macedonia,96.1
+2012-09-30,MA,Morocco,101.191
+2012-09-30,MK,North Macedonia,96.2124
 2012-09-30,MT,Malta,105.4366
 2012-09-30,MX,Mexico,109.6152
 2012-09-30,MY,Malaysia,125.5756
-2012-09-30,NL,Netherlands,89.1472
+2012-09-30,NL,Netherlands,89.153
 2012-09-30,NO,Norway,116.7702
 2012-09-30,NZ,New Zealand,106.0332
 2012-09-30,PE,Peru,146.1383
@@ -21258,26 +5827,25 @@ date,country_code,country,price
 2012-09-30,SE,Sweden,104.8591
 2012-09-30,SG,Singapore,111.9849
 2012-09-30,SI,Slovenia,95.4737
-2012-09-30,SK,Slovak Republic,96.3759
-2012-09-30,TH,Thailand,106.875
-2012-09-30,TR,Türkiye,118.3369
-2012-09-30,US,United States,102.9176
-2012-09-30,XM,Euro area,98.5706
-2012-09-30,XW,World,107.4649
-2012-09-30,ZA,South Africa,109.2331
-2012-12-31,4T,Emerging market economies (aggregate),116.142
-2012-12-31,5R,Advanced economies,101.9489
-2012-12-31,AE,United Arab Emirates,120.0746
+2012-09-30,SK,Slovakia,96.2759
+2012-09-30,TH,Thailand,106.8043
+2012-09-30,TR,Türkiye,122.8039
+2012-09-30,US,United States,102.8987
+2012-09-30,XM,Euro area,98.5656
+2012-09-30,XW,World,107.0251
+2012-09-30,ZA,South Africa,108.6
+2012-12-31,4T,Emerging market economies (aggregate),115.9995
+2012-12-31,5R,Advanced economies,102.5958
 2012-12-31,AT,Austria,118.405
 2012-12-31,AU,Australia,99.1288
-2012-12-31,BE,Belgium,106.3127
+2012-12-31,BE,Belgium,106.3675
 2012-12-31,BG,Bulgaria,91.5058
 2012-12-31,BR,Brazil,137.7139
-2012-12-31,CA,Canada,109.4916
-2012-12-31,CH,Switzerland,115.127
-2012-12-31,CL,Chile,129.9761
+2012-12-31,CA,Canada,109.4692
+2012-12-31,CH,Switzerland,115.1272
+2012-12-31,CL,Chile,129.9702
 2012-12-31,CN,China,103.6551
-2012-12-31,CO,Colombia,123.094
+2012-12-31,CO,Colombia,122.9131
 2012-12-31,CY,Cyprus,90.1315
 2012-12-31,CZ,Czechia,98.3985
 2012-12-31,DE,Germany,106.6
@@ -21286,28 +5854,28 @@ date,country_code,country,price
 2012-12-31,ES,Spain,75.74
 2012-12-31,FI,Finland,106.0703
 2012-12-31,FR,France,104.3348
-2012-12-31,GB,United Kingdom,99.2725
+2012-12-31,GB,United Kingdom,99.2519
 2012-12-31,GR,Greece,79.2951
-2012-12-31,HK,Hong Kong SAR,149.6714
+2012-12-31,HK,Hong Kong SAR,149.5831
 2012-12-31,HR,Croatia,95.4062
 2012-12-31,HU,Hungary,90.419
 2012-12-31,ID,Indonesia,113.2679
-2012-12-31,IE,Ireland,72.1737
+2012-12-31,IE,Ireland,72.1982
 2012-12-31,IL,Israel,118.2601
 2012-12-31,IN,India,164.2187
-2012-12-31,IS,Iceland,114.2137
+2012-12-31,IS,Iceland,114.2131
 2012-12-31,IT,Italy,96.1897
 2012-12-31,JP,Japan,98.8082
-2012-12-31,KR,Korea,107.9179
+2012-12-31,KR,Korea,107.9549
 2012-12-31,LT,Lithuania,105.9945
 2012-12-31,LU,Luxembourg,111.0054
 2012-12-31,LV,Latvia,116.26
-2012-12-31,MA,Morocco,102.8626
-2012-12-31,MK,North Macedonia,94.92
+2012-12-31,MA,Morocco,101.5722
+2012-12-31,MK,North Macedonia,94.8524
 2012-12-31,MT,Malta,103.3498
 2012-12-31,MX,Mexico,110.4012
 2012-12-31,MY,Malaysia,131.3196
-2012-12-31,NL,Netherlands,89.5242
+2012-12-31,NL,Netherlands,89.5277
 2012-12-31,NO,Norway,115.9856
 2012-12-31,NZ,New Zealand,108.2372
 2012-12-31,PE,Peru,149.6073
@@ -21320,26 +5888,25 @@ date,country_code,country,price
 2012-12-31,SE,Sweden,104.8152
 2012-12-31,SG,Singapore,114.0169
 2012-12-31,SI,Slovenia,92.1036
-2012-12-31,SK,Slovak Republic,94.4764
-2012-12-31,TH,Thailand,110.5208
-2012-12-31,TR,Türkiye,120.2559
-2012-12-31,US,United States,105.1677
-2012-12-31,XM,Euro area,98.0357
-2012-12-31,XW,World,108.9917
-2012-12-31,ZA,South Africa,110.9266
-2013-03-31,4T,Emerging market economies (aggregate),118.1606
-2013-03-31,5R,Advanced economies,102.7166
-2013-03-31,AE,United Arab Emirates,120.9717
+2012-12-31,SK,Slovakia,94.3764
+2012-12-31,TH,Thailand,110.8523
+2012-12-31,TR,Türkiye,124.3656
+2012-12-31,US,United States,105.1644
+2012-12-31,XM,Euro area,98.0224
+2012-12-31,XW,World,108.4451
+2012-12-31,ZA,South Africa,110.3052
+2013-03-31,4T,Emerging market economies (aggregate),118.0497
+2013-03-31,5R,Advanced economies,103.3522
 2013-03-31,AT,Austria,120.605
 2013-03-31,AU,Australia,99.8064
-2013-03-31,BE,Belgium,106.9872
+2013-03-31,BE,Belgium,106.8479
 2013-03-31,BG,Bulgaria,90.7308
 2013-03-31,BR,Brazil,140.823
-2013-03-31,CA,Canada,110.7003
-2013-03-31,CH,Switzerland,117.2732
-2013-03-31,CL,Chile,132.2431
+2013-03-31,CA,Canada,110.7604
+2013-03-31,CH,Switzerland,117.2725
+2013-03-31,CL,Chile,131.9421
 2013-03-31,CN,China,105.5932
-2013-03-31,CO,Colombia,126.3261
+2013-03-31,CO,Colombia,125.2538
 2013-03-31,CY,Cyprus,88.6959
 2013-03-31,CZ,Czechia,98.2935
 2013-03-31,DE,Germany,107.4
@@ -21348,28 +5915,28 @@ date,country_code,country,price
 2013-03-31,ES,Spain,71.905
 2013-03-31,FI,Finland,106.8158
 2013-03-31,FR,France,103.0318
-2013-03-31,GB,United Kingdom,98.601
+2013-03-31,GB,United Kingdom,98.5869
 2013-03-31,GR,Greece,77.2918
 2013-03-31,HK,Hong Kong SAR,157.3582
 2013-03-31,HR,Croatia,95.3157
 2013-03-31,HU,Hungary,90.6325
 2013-03-31,ID,Indonesia,118.7296
-2013-03-31,IE,Ireland,70.0913
+2013-03-31,IE,Ireland,70.1534
 2013-03-31,IL,Israel,121.8441
 2013-03-31,IN,India,168.1935
-2013-03-31,IS,Iceland,114.2595
+2013-03-31,IS,Iceland,114.268
 2013-03-31,IT,Italy,93.5648
 2013-03-31,JP,Japan,99.475
-2013-03-31,KR,Korea,107.7649
+2013-03-31,KR,Korea,107.7603
 2013-03-31,LT,Lithuania,106.7189
 2013-03-31,LU,Luxembourg,111.2545
 2013-03-31,LV,Latvia,116.39
-2013-03-31,MA,Morocco,102.4777
-2013-03-31,MK,North Macedonia,93.55
+2013-03-31,MA,Morocco,101.191
+2013-03-31,MK,North Macedonia,93.5323
 2013-03-31,MT,Malta,100.3844
 2013-03-31,MX,Mexico,112.0894
 2013-03-31,MY,Malaysia,131.8148
-2013-03-31,NL,Netherlands,87.0916
+2013-03-31,NL,Netherlands,87.0857
 2013-03-31,NO,Norway,119.5162
 2013-03-31,NZ,New Zealand,110.7184
 2013-03-31,PE,Peru,160.0459
@@ -21382,26 +5949,25 @@ date,country_code,country,price
 2013-03-31,SE,Sweden,106.3913
 2013-03-31,SG,Singapore,114.6943
 2013-03-31,SI,Slovenia,92.7605
-2013-03-31,SK,Slovak Republic,96.6758
-2013-03-31,TH,Thailand,112.1875
-2013-03-31,TR,Türkiye,124.5203
-2013-03-31,US,United States,107.7974
-2013-03-31,XM,Euro area,96.7098
-2013-03-31,XW,World,110.375
-2013-03-31,ZA,South Africa,112.6667
-2013-06-30,4T,Emerging market economies (aggregate),120.5974
-2013-06-30,5R,Advanced economies,104.3177
-2013-06-30,AE,United Arab Emirates,128.4081
+2013-03-31,SK,Slovakia,96.5759
+2013-03-31,TH,Thailand,112.6168
+2013-03-31,TR,Türkiye,128.4827
+2013-03-31,US,United States,107.8189
+2013-03-31,XM,Euro area,96.6856
+2013-03-31,XW,World,109.7675
+2013-03-31,ZA,South Africa,112.3389
+2013-06-30,4T,Emerging market economies (aggregate),120.5102
+2013-06-30,5R,Advanced economies,104.8545
 2013-06-30,AT,Austria,122.5692
 2013-06-30,AU,Australia,102.3233
-2013-06-30,BE,Belgium,107.2701
+2013-06-30,BE,Belgium,107.361
 2013-06-30,BG,Bulgaria,91.1845
 2013-06-30,BR,Brazil,143.8892
-2013-06-30,CA,Canada,112.9044
-2013-06-30,CH,Switzerland,118.0954
-2013-06-30,CL,Chile,136.471
+2013-06-30,CA,Canada,112.9842
+2013-06-30,CH,Switzerland,118.0943
+2013-06-30,CL,Chile,135.7049
 2013-06-30,CN,China,108.5572
-2013-06-30,CO,Colombia,129.9171
+2013-06-30,CO,Colombia,129.512
 2013-06-30,CY,Cyprus,86.658
 2013-06-30,CZ,Czechia,98.8186
 2013-06-30,DE,Germany,108.6
@@ -21410,28 +5976,28 @@ date,country_code,country,price
 2013-06-30,ES,Spain,71.3328
 2013-06-30,FI,Finland,107.2417
 2013-06-30,FR,France,102.9316
-2013-06-30,GB,United Kingdom,100.6156
+2013-06-30,GB,United Kingdom,100.5819
 2013-06-30,GR,Greece,75.1814
 2013-06-30,HK,Hong Kong SAR,159.81
 2013-06-30,HR,Croatia,94.6821
 2013-06-30,HU,Hungary,90.846
 2013-06-30,ID,Indonesia,121.3237
-2013-06-30,IE,Ireland,70.1306
+2013-06-30,IE,Ireland,70.1534
 2013-06-30,IL,Israel,123.0769
 2013-06-30,IN,India,169.7624
-2013-06-30,IS,Iceland,118.1079
+2013-06-30,IS,Iceland,118.1028
 2013-06-30,IT,Italy,93.3108
 2013-06-30,JP,Japan,100.575
-2013-06-30,KR,Korea,107.7139
+2013-06-30,KR,Korea,107.6851
 2013-06-30,LT,Lithuania,108.3103
 2013-06-30,LU,Luxembourg,112.6398
 2013-06-30,LV,Latvia,121.19
-2013-06-30,MA,Morocco,102.3815
-2013-06-30,MK,North Macedonia,93.36
+2013-06-30,MA,Morocco,101.6675
+2013-06-30,MK,North Macedonia,93.4223
 2013-06-30,MT,Malta,98.9566
 2013-06-30,MX,Mexico,114.1783
 2013-06-30,MY,Malaysia,136.7665
-2013-06-30,NL,Netherlands,85.2962
+2013-06-30,NL,Netherlands,85.3027
 2013-06-30,NO,Norway,122.7852
 2013-06-30,NZ,New Zealand,113.0817
 2013-06-30,PE,Peru,162.9718
@@ -21444,26 +6010,25 @@ date,country_code,country,price
 2013-06-30,SE,Sweden,108.3409
 2013-06-30,SG,Singapore,115.8984
 2013-06-30,SI,Slovenia,93.5114
-2013-06-30,SK,Slovak Republic,96.8758
-2013-06-30,TH,Thailand,114.6875
-2013-06-30,TR,Türkiye,129.2111
-2013-06-30,US,United States,110.6029
-2013-06-30,XM,Euro area,96.8285
-2013-06-30,XW,World,112.3867
-2013-06-30,ZA,South Africa,114.3433
-2013-09-30,4T,Emerging market economies (aggregate),123.2345
-2013-09-30,5R,Advanced economies,105.9421
-2013-09-30,AE,United Arab Emirates,139.3466
+2013-06-30,SK,Slovakia,96.7758
+2013-06-30,TH,Thailand,114.2775
+2013-06-30,TR,Türkiye,132.8838
+2013-06-30,US,United States,110.6111
+2013-06-30,XM,Euro area,96.7984
+2013-06-30,XW,World,111.6871
+2013-06-30,ZA,South Africa,114.3205
+2013-09-30,4T,Emerging market economies (aggregate),123.1997
+2013-09-30,5R,Advanced economies,106.389
 2013-09-30,AT,Austria,123.9049
 2013-09-30,AU,Australia,104.8403
-2013-09-30,BE,Belgium,108.5974
+2013-09-30,BE,Belgium,108.5837
 2013-09-30,BG,Bulgaria,90.2772
 2013-09-30,BR,Brazil,146.8527
-2013-09-30,CA,Canada,113.5443
-2013-09-30,CH,Switzerland,118.2852
-2013-09-30,CL,Chile,136.9887
+2013-09-30,CA,Canada,113.6298
+2013-09-30,CH,Switzerland,118.2837
+2013-09-30,CL,Chile,136.6716
 2013-09-30,CN,China,111.0082
-2013-09-30,CO,Colombia,132.4257
+2013-09-30,CO,Colombia,132.0485
 2013-09-30,CY,Cyprus,84.4995
 2013-09-30,CZ,Czechia,98.7136
 2013-09-30,DE,Germany,109.6
@@ -21472,28 +6037,28 @@ date,country_code,country,price
 2013-09-30,ES,Spain,71.8827
 2013-09-30,FI,Finland,107.0288
 2013-09-30,FR,France,103.8336
-2013-09-30,GB,United Kingdom,103.0778
+2013-09-30,GB,United Kingdom,103.0756
 2013-09-30,GR,Greece,73.671
 2013-09-30,HK,Hong Kong SAR,162.7699
 2013-09-30,HR,Croatia,95.0441
 2013-09-30,HU,Hungary,91.0595
 2013-09-30,ID,Indonesia,124.1025
-2013-09-30,IE,Ireland,74.0988
+2013-09-30,IE,Ireland,74.1172
 2013-09-30,IL,Israel,125.4281
 2013-09-30,IN,India,176.9797
-2013-09-30,IS,Iceland,120.2153
+2013-09-30,IS,Iceland,120.2332
 2013-09-30,IT,Italy,91.956
 2013-09-30,JP,Japan,101.6085
-2013-09-30,KR,Korea,107.6629
+2013-09-30,KR,Korea,107.6388
 2013-09-30,LT,Lithuania,106.4101
 2013-09-30,LU,Luxembourg,114.0535
 2013-09-30,LV,Latvia,122.61
-2013-09-30,MA,Morocco,102.4777
-2013-09-30,MK,North Macedonia,94.18
+2013-09-30,MA,Morocco,101.4769
+2013-09-30,MK,North Macedonia,94.1124
 2013-09-30,MT,Malta,103.5695
 2013-09-30,MX,Mexico,115.8688
 2013-09-30,MY,Malaysia,142.2134
-2013-09-30,NL,Netherlands,85.8438
+2013-09-30,NL,Netherlands,85.8453
 2013-09-30,NO,Norway,120.4315
 2013-09-30,NZ,New Zealand,116.6164
 2013-09-30,PE,Peru,164.5198
@@ -21506,26 +6071,25 @@ date,country_code,country,price
 2013-09-30,SE,Sweden,110.2446
 2013-09-30,SG,Singapore,116.35
 2013-09-30,SI,Slovenia,88.1362
-2013-09-30,SK,Slovak Republic,96.6758
-2013-09-30,TH,Thailand,116.7708
-2013-09-30,TR,Türkiye,132.1962
-2013-09-30,US,United States,113.3749
-2013-09-30,XM,Euro area,97.379
-2013-09-30,XW,World,114.5075
-2013-09-30,ZA,South Africa,116.2086
-2013-12-31,4T,Emerging market economies (aggregate),125.2757
-2013-12-31,5R,Advanced economies,106.7046
-2013-12-31,AE,United Arab Emirates,150.2418
+2013-09-30,SK,Slovakia,96.3759
+2013-09-30,TH,Thailand,116.9761
+2013-09-30,TR,Türkiye,136.7169
+2013-09-30,US,United States,113.3809
+2013-09-30,XM,Euro area,97.3335
+2013-09-30,XW,World,113.7231
+2013-09-30,ZA,South Africa,116.3653
+2013-12-31,4T,Emerging market economies (aggregate),125.241
+2013-12-31,5R,Advanced economies,107.0903
 2013-12-31,AT,Austria,123.2764
 2013-12-31,AU,Australia,109.0029
-2013-12-31,BE,Belgium,107.5203
+2013-12-31,BE,Belgium,107.5684
 2013-12-31,BG,Bulgaria,90.4095
 2013-12-31,BR,Brazil,149.7106
-2013-12-31,CA,Canada,113.8998
-2013-12-31,CH,Switzerland,119.5518
-2013-12-31,CL,Chile,142.0469
+2013-12-31,CA,Canada,113.9885
+2013-12-31,CH,Switzerland,119.5504
+2013-12-31,CL,Chile,141.7577
 2013-12-31,CN,China,113.0602
-2013-12-31,CO,Colombia,133.3094
+2013-12-31,CO,Colombia,133.7639
 2013-12-31,CY,Cyprus,82.4716
 2013-12-31,CZ,Czechia,98.5035
 2013-12-31,DE,Germany,109.1
@@ -21534,28 +6098,28 @@ date,country_code,country,price
 2013-12-31,ES,Spain,70.976
 2013-12-31,FI,Finland,106.3898
 2013-12-31,FR,France,102.7311
-2013-12-31,GB,United Kingdom,103.6374
+2013-12-31,GB,United Kingdom,103.5744
 2013-12-31,GR,Greece,71.657
 2013-12-31,HK,Hong Kong SAR,162.4607
 2013-12-31,HR,Croatia,93.7769
 2013-12-31,HU,Hungary,89.7785
 2013-12-31,ID,Indonesia,126.3049
-2013-12-31,IE,Ireland,76.2204
+2013-12-31,IE,Ireland,76.2249
 2013-12-31,IL,Israel,127.4616
 2013-12-31,IN,India,180.7452
-2013-12-31,IS,Iceland,124.1095
+2013-12-31,IS,Iceland,124.1367
 2013-12-31,IT,Italy,90.6859
 2013-12-31,JP,Japan,101.5751
-2013-12-31,KR,Korea,108.0709
+2013-12-31,KR,Korea,108.076
 2013-12-31,LT,Lithuania,109.1654
 2013-12-31,LU,Luxembourg,115.7228
 2013-12-31,LV,Latvia,125.8
-2013-12-31,MA,Morocco,103.6324
-2013-12-31,MK,North Macedonia,92.41
+2013-12-31,MA,Morocco,102.2392
+2013-12-31,MK,North Macedonia,92.6323
 2013-12-31,MT,Malta,101.922
 2013-12-31,MX,Mexico,116.8736
 2013-12-31,MY,Malaysia,143.5999
-2013-12-31,NL,Netherlands,85.5655
+2013-12-31,NL,Netherlands,85.5611
 2013-12-31,NO,Norway,117.1625
 2013-12-31,NZ,New Zealand,117.9402
 2013-12-31,PE,Peru,163.8529
@@ -21568,26 +6132,25 @@ date,country_code,country,price
 2013-12-31,SE,Sweden,111.915
 2013-12-31,SG,Singapore,115.2963
 2013-12-31,SI,Slovenia,88.0679
-2013-12-31,SK,Slovak Republic,96.5759
-2013-12-31,TH,Thailand,119.4792
-2013-12-31,TR,Türkiye,135.6077
-2013-12-31,US,United States,115.577
-2013-12-31,XM,Euro area,96.7459
-2013-12-31,XW,World,115.8936
-2013-12-31,ZA,South Africa,118.8397
-2014-03-31,4T,Emerging market economies (aggregate),127.4783
-2014-03-31,5R,Advanced economies,107.6237
-2014-03-31,AE,United Arab Emirates,166.8657
+2013-12-31,SK,Slovakia,96.3759
+2013-12-31,TH,Thailand,120.09
+2013-12-31,TR,Türkiye,139.7693
+2013-12-31,US,United States,115.569
+2013-12-31,XM,Euro area,96.692
+2013-12-31,XW,World,115.0038
+2013-12-31,ZA,South Africa,118.597
+2014-03-31,4T,Emerging market economies (aggregate),127.3301
+2014-03-31,5R,Advanced economies,107.9886
 2014-03-31,AT,Austria,125.5549
 2014-03-31,AU,Australia,110.5518
-2014-03-31,BE,Belgium,105.5294
+2014-03-31,BE,Belgium,106.3675
 2014-03-31,BG,Bulgaria,91.3546
 2014-03-31,BR,Brazil,152.7426
-2014-03-31,CA,Canada,116.3171
-2014-03-31,CH,Switzerland,120.027
-2014-03-31,CL,Chile,144.8358
+2014-03-31,CA,Canada,116.4275
+2014-03-31,CH,Switzerland,120.0257
+2014-03-31,CL,Chile,144.8363
 2014-03-31,CN,China,114.2857
-2014-03-31,CO,Colombia,137.9797
+2014-03-31,CO,Colombia,137.3328
 2014-03-31,CY,Cyprus,80.3132
 2014-03-31,CZ,Czechia,99.7637
 2014-03-31,DE,Germany,109.9
@@ -21596,28 +6159,28 @@ date,country_code,country,price
 2014-03-31,ES,Spain,70.7531
 2014-03-31,FI,Finland,106.6028
 2014-03-31,FR,France,101.5284
-2014-03-31,GB,United Kingdom,104.9804
+2014-03-31,GB,United Kingdom,105.0707
 2014-03-31,GR,Greece,70.2643
 2014-03-31,HK,Hong Kong SAR,161.8422
 2014-03-31,HR,Croatia,93.1432
 2014-03-31,HU,Hungary,91.4865
 2014-03-31,ID,Indonesia,128.1378
-2014-03-31,IE,Ireland,77.4384
+2014-03-31,IE,Ireland,77.4204
 2014-03-31,IL,Israel,131.1219
 2014-03-31,IN,India,188.7993
-2014-03-31,IS,Iceland,125.3923
+2014-03-31,IS,Iceland,125.4058
 2014-03-31,IT,Italy,89.5004
 2014-03-31,JP,Japan,102.5419
-2014-03-31,KR,Korea,108.6319
+2014-03-31,KR,Korea,108.619
 2014-03-31,LT,Lithuania,110.8399
 2014-03-31,LU,Luxembourg,113.9953
 2014-03-31,LV,Latvia,128.67
-2014-03-31,MA,Morocco,103.44
-2014-03-31,MK,North Macedonia,91.43
+2014-03-31,MA,Morocco,101.858
+2014-03-31,MK,North Macedonia,91.6023
 2014-03-31,MT,Malta,101.922
 2014-03-31,MX,Mexico,118.4747
 2014-03-31,MY,Malaysia,145.2835
-2014-03-31,NL,Netherlands,85.9964
+2014-03-31,NL,Netherlands,86.0004
 2014-03-31,NO,Norway,119.9085
 2014-03-31,NZ,New Zealand,119.1669
 2014-03-31,PE,Peru,171.0863
@@ -21630,27 +6193,26 @@ date,country_code,country,price
 2014-03-31,SE,Sweden,115.1595
 2014-03-31,SG,Singapore,113.8664
 2014-03-31,SI,Slovenia,86.6089
-2014-03-31,SK,Slovak Republic,96.4759
-2014-03-31,TH,Thailand,121.6667
-2014-03-31,TR,Türkiye,140.0853
-2014-03-31,US,United States,117.056
-2014-03-31,XM,Euro area,96.6552
-2014-03-31,XW,World,117.4395
-2014-03-31,ZA,South Africa,121.6877
-2014-06-30,4T,Emerging market economies (aggregate),129.3322
-2014-06-30,5R,Advanced economies,108.686
-2014-06-30,AE,United Arab Emirates,173.7725
+2014-03-31,SK,Slovakia,96.176
+2014-03-31,TH,Thailand,122.1658
+2014-03-31,TR,Türkiye,143.6735
+2014-03-31,US,United States,117.087
+2014-03-31,XM,Euro area,96.5972
+2014-03-31,XW,World,116.4219
+2014-03-31,ZA,South Africa,121.31
+2014-06-30,4T,Emerging market economies (aggregate),129.2237
+2014-06-30,5R,Advanced economies,109.0088
 2014-06-30,AT,Austria,128.462
 2014-06-30,AU,Australia,112.6815
-2014-06-30,BE,Belgium,106.2583
+2014-06-30,BE,Belgium,106.3566
 2014-06-30,BG,Bulgaria,91.6476
 2014-06-30,BR,Brazil,154.9895
-2014-06-30,CA,Canada,118.9477
-2014-06-30,CH,Switzerland,121.5077
-2014-06-30,CL,Chile,150.4379
+2014-06-30,CA,Canada,119.2253
+2014-06-30,CH,Switzerland,121.5056
+2014-06-30,CL,Chile,150.4404
 2014-06-30,CN,China,114.3427
-2014-06-30,CO,Colombia,139.6547
-2014-06-30,CY,Cyprus,78.7572
+2014-06-30,CO,Colombia,139.4368
+2014-06-30,CY,Cyprus,78.7371
 2014-06-30,CZ,Czechia,100.6038
 2014-06-30,DE,Germany,112.1
 2014-06-30,DK,Denmark,104.4677
@@ -21658,28 +6220,28 @@ date,country_code,country,price
 2014-06-30,ES,Spain,71.9273
 2014-06-30,FI,Finland,107.0288
 2014-06-30,FR,France,101.7289
-2014-06-30,GB,United Kingdom,108.7857
+2014-06-30,GB,United Kingdom,108.7282
 2014-06-30,GR,Greece,69.011
 2014-06-30,HK,Hong Kong SAR,164.051
 2014-06-30,HR,Croatia,93.9579
 2014-06-30,HU,Hungary,93.4081
 2014-06-30,ID,Indonesia,130.3032
-2014-06-30,IE,Ireland,81.7601
+2014-06-30,IE,Ireland,81.7302
 2014-06-30,IL,Israel,132.6216
 2014-06-30,IN,India,196.6441
-2014-06-30,IS,Iceland,128.0495
+2014-06-30,IS,Iceland,128.0585
 2014-06-30,IT,Italy,88.6537
 2014-06-30,JP,Japan,102.0752
-2014-06-30,KR,Korea,109.1929
+2014-06-30,KR,Korea,109.1799
 2014-06-30,LT,Lithuania,115.3291
 2014-06-30,LU,Luxembourg,118.1957
 2014-06-30,LV,Latvia,130.56
-2014-06-30,MA,Morocco,103.5362
-2014-06-30,MK,North Macedonia,93.26
+2014-06-30,MA,Morocco,102.2392
+2014-06-30,MK,North Macedonia,93.5523
 2014-06-30,MT,Malta,101.8122
 2014-06-30,MX,Mexico,118.9788
 2014-06-30,MY,Malaysia,150.5323
-2014-06-30,NL,Netherlands,86.3824
+2014-06-30,NL,Netherlands,86.3751
 2014-06-30,NO,Norway,124.4851
 2014-06-30,NZ,New Zealand,120.3452
 2014-06-30,PE,Peru,178.2897
@@ -21692,26 +6254,25 @@ date,country_code,country,price
 2014-06-30,SE,Sweden,117.7231
 2014-06-30,SG,Singapore,112.6623
 2014-06-30,SI,Slovenia,84.3309
-2014-06-30,SK,Slovak Republic,97.9755
-2014-06-30,TH,Thailand,125.2083
-2014-06-30,TR,Türkiye,145.4158
-2014-06-30,US,United States,117.838
-2014-06-30,XM,Euro area,97.6282
-2014-06-30,XW,World,118.8878
-2014-06-30,ZA,South Africa,123.661
-2014-09-30,4T,Emerging market economies (aggregate),129.541
-2014-09-30,5R,Advanced economies,109.8685
-2014-09-30,AE,United Arab Emirates,172.7673
+2014-06-30,SK,Slovakia,97.7756
+2014-06-30,TH,Thailand,126.4214
+2014-06-30,TR,Türkiye,148.5714
+2014-06-30,US,United States,117.8485
+2014-06-30,XM,Euro area,97.5578
+2014-06-30,XW,World,117.8221
+2014-06-30,ZA,South Africa,123.4724
+2014-09-30,4T,Emerging market economies (aggregate),129.3481
+2014-09-30,5R,Advanced economies,110.1513
 2014-09-30,AT,Austria,126.8906
 2014-09-30,AU,Australia,114.0368
-2014-09-30,BE,Belgium,107.6618
+2014-09-30,BE,Belgium,107.8741
 2014-09-30,BG,Bulgaria,91.8744
 2014-09-30,BR,Brazil,156.4712
-2014-09-30,CA,Canada,119.6587
-2014-09-30,CH,Switzerland,121.3478
-2014-09-30,CL,Chile,160.4883
+2014-09-30,CA,Canada,119.8709
+2014-09-30,CH,Switzerland,121.3459
+2014-09-30,CL,Chile,160.4849
 2014-09-30,CN,China,111.7207
-2014-09-30,CO,Colombia,142.7905
+2014-09-30,CO,Colombia,142.334
 2014-09-30,CY,Cyprus,77.4119
 2014-09-30,CZ,Czechia,101.4439
 2014-09-30,DE,Germany,112.7
@@ -21720,28 +6281,28 @@ date,country_code,country,price
 2014-09-30,ES,Spain,72.0834
 2014-09-30,FI,Finland,106.4963
 2014-09-30,FR,France,102.5307
-2014-09-30,GB,United Kingdom,112.2552
+2014-09-30,GB,United Kingdom,112.2195
 2014-09-30,GR,Greece,68.6039
 2014-09-30,HK,Hong Kong SAR,173.1515
 2014-09-30,HR,Croatia,93.2338
 2014-09-30,HU,Hungary,95.2228
 2014-09-30,ID,Indonesia,132.2026
-2014-09-30,IE,Ireland,88.3607
+2014-09-30,IE,Ireland,88.3681
 2014-09-30,IL,Israel,131.9861
 2014-09-30,IN,India,201.874
-2014-09-30,IS,Iceland,130.615
+2014-09-30,IS,Iceland,130.6104
 2014-09-30,IT,Italy,87.6376
 2014-09-30,JP,Japan,102.7086
-2014-09-30,KR,Korea,109.6009
+2014-09-30,KR,Korea,109.5532
 2014-09-30,LT,Lithuania,117.1937
 2014-09-30,LU,Luxembourg,119.769
 2014-09-30,LV,Latvia,135.71
-2014-09-30,MA,Morocco,104.5947
-2014-09-30,MK,North Macedonia,96.39
+2014-09-30,MA,Morocco,101.6675
+2014-09-30,MK,North Macedonia,96.4324
 2014-09-30,MT,Malta,103.899
 2014-09-30,MX,Mexico,119.7511
 2014-09-30,MY,Malaysia,154.7908
-2014-09-30,NL,Netherlands,86.939
+2014-09-30,NL,Netherlands,86.9307
 2014-09-30,NO,Norway,124.6159
 2014-09-30,NZ,New Zealand,122.2303
 2014-09-30,PE,Peru,169.7076
@@ -21754,26 +6315,25 @@ date,country_code,country,price
 2014-09-30,SE,Sweden,121.641
 2014-09-30,SG,Singapore,111.8344
 2014-09-30,SI,Slovenia,83.4179
-2014-09-30,SK,Slovak Republic,97.8755
-2014-09-30,TH,Thailand,126.4583
-2014-09-30,TR,Türkiye,151.1727
-2014-09-30,US,United States,119.4033
-2014-09-30,XM,Euro area,98.2232
-2014-09-30,XW,World,119.6009
-2014-09-30,ZA,South Africa,125.1763
-2014-12-31,4T,Emerging market economies (aggregate),130.1292
-2014-12-31,5R,Advanced economies,110.414
-2014-12-31,AE,United Arab Emirates,169.5463
+2014-09-30,SK,Slovakia,97.6756
+2014-09-30,TH,Thailand,127.3556
+2014-09-30,TR,Türkiye,154.1792
+2014-09-30,US,United States,119.3904
+2014-09-30,XM,Euro area,98.1304
+2014-09-30,XW,World,118.5237
+2014-09-30,ZA,South Africa,124.849
+2014-12-31,4T,Emerging market economies (aggregate),130.0248
+2014-12-31,5R,Advanced economies,110.7209
 2014-12-31,AT,Austria,126.262
 2014-12-31,AU,Australia,116.3601
-2014-12-31,BE,Belgium,108.5539
+2014-12-31,BE,Belgium,108.2999
 2014-12-31,BG,Bulgaria,92.9235
 2014-12-31,BR,Brazil,157.2306
-2014-12-31,CA,Canada,120.2275
-2014-12-31,CH,Switzerland,122.9659
-2014-12-31,CL,Chile,163.1275
+2014-12-31,CA,Canada,120.3013
+2014-12-31,CH,Switzerland,122.9638
+2014-12-31,CL,Chile,163.1218
 2014-12-31,CN,China,109.1557
-2014-12-31,CO,Colombia,143.1061
+2014-12-31,CO,Colombia,143.4913
 2014-12-31,CY,Cyprus,75.8558
 2014-12-31,CZ,Czechia,102.179
 2014-12-31,DE,Germany,112.7
@@ -21782,28 +6342,28 @@ date,country_code,country,price
 2014-12-31,ES,Spain,72.2246
 2014-12-31,FI,Finland,105.8573
 2014-12-31,FR,France,100.5262
-2014-12-31,GB,United Kingdom,112.479
+2014-12-31,GB,United Kingdom,112.3857
 2014-12-31,GR,Greece,67.6826
 2014-12-31,HK,Hong Kong SAR,181.7881
 2014-12-31,HR,Croatia,92.4191
 2014-12-31,HU,Hungary,97.3579
 2014-12-31,ID,Indonesia,134.2424
-2014-12-31,IE,Ireland,91.1109
+2014-12-31,IE,Ireland,91.1365
 2014-12-31,IL,Israel,133.7146
 2014-12-31,IN,India,211.2878
-2014-12-31,IS,Iceland,131.6688
+2014-12-31,IS,Iceland,131.6962
 2014-12-31,IT,Italy,86.2828
 2014-12-31,JP,Japan,102.1752
-2014-12-31,KR,Korea,110.3149
+2014-12-31,KR,Korea,110.3424
 2014-12-31,LT,Lithuania,114.9135
 2014-12-31,LU,Luxembourg,121.5935
 2014-12-31,LV,Latvia,120.18
-2014-12-31,MA,Morocco,102.3815
-2014-12-31,MK,North Macedonia,91.22
+2014-12-31,MA,Morocco,102.0486
+2014-12-31,MK,North Macedonia,91.2723
 2014-12-31,MT,Malta,107.5233
 2014-12-31,MX,Mexico,121.3634
 2014-12-31,MY,Malaysia,156.0782
-2014-12-31,NL,Netherlands,87.298
+2014-12-31,NL,Netherlands,87.3054
 2014-12-31,NO,Norway,123.9621
 2014-12-31,NZ,New Zealand,126.3818
 2014-12-31,PE,Peru,170.337
@@ -21816,26 +6376,25 @@ date,country_code,country,price
 2014-12-31,SE,Sweden,123.5648
 2014-12-31,SG,Singapore,110.6303
 2014-12-31,SI,Slovenia,84.2029
-2014-12-31,SK,Slovak Republic,99.875
-2014-12-31,TH,Thailand,128.5417
-2014-12-31,TR,Türkiye,155.8635
-2014-12-31,US,United States,121.2279
-2014-12-31,XM,Euro area,97.6506
-2014-12-31,XW,World,120.1679
-2014-12-31,ZA,South Africa,126.898
-2015-03-31,4T,Emerging market economies (aggregate),131.3776
-2015-03-31,5R,Advanced economies,111.6283
-2015-03-31,AE,United Arab Emirates,161.3208
+2014-12-31,SK,Slovakia,99.5751
+2014-12-31,TH,Thailand,132.3377
+2014-12-31,TR,Türkiye,158.5803
+2014-12-31,US,United States,121.2224
+2014-12-31,XM,Euro area,97.5526
+2014-12-31,XW,World,119.14
+2014-12-31,ZA,South Africa,126.322
+2015-03-31,4T,Emerging market economies (aggregate),131.3373
+2015-03-31,5R,Advanced economies,111.9304
 2015-03-31,AT,Austria,130.0334
 2015-03-31,AU,Australia,118.1994
-2015-03-31,BE,Belgium,105.9646
+2015-03-31,BE,Belgium,106.9243
 2015-03-31,BG,Bulgaria,93.4244
 2015-03-31,BR,Brazil,157.2906
-2015-03-31,CA,Canada,123.3558
-2015-03-31,CH,Switzerland,124.1876
-2015-03-31,CL,Chile,164.2812
+2015-03-31,CA,Canada,123.6011
+2015-03-31,CH,Switzerland,124.1854
+2015-03-31,CL,Chile,164.2798
 2015-03-31,CN,China,107.8162
-2015-03-31,CO,Colombia,147.9002
+2015-03-31,CO,Colombia,148.0564
 2015-03-31,CY,Cyprus,75.0929
 2015-03-31,CZ,Czechia,103.2292
 2015-03-31,DE,Germany,114.6
@@ -21844,28 +6403,28 @@ date,country_code,country,price
 2015-03-31,ES,Spain,71.8456
 2015-03-31,FI,Finland,105.9638
 2015-03-31,FR,France,99.6242
-2015-03-31,GB,United Kingdom,112.1433
+2015-03-31,GB,United Kingdom,112.0532
 2015-03-31,GR,Greece,67.3719
 2015-03-31,HK,Hong Kong SAR,191.6395
 2015-03-31,HR,Croatia,91.5139
 2015-03-31,HU,Hungary,99.9199
 2015-03-31,ID,Indonesia,136.1713
-2015-03-31,IE,Ireland,90.993
+2015-03-31,IE,Ireland,90.9792
 2015-03-31,IL,Israel,136.4598
 2015-03-31,IN,India,221.8522
-2015-03-31,IS,Iceland,137.1664
+2015-03-31,IS,Iceland,137.1895
 2015-03-31,IT,Italy,84.42
 2015-03-31,JP,Japan,104.9754
-2015-03-31,KR,Korea,110.9779
+2015-03-31,KR,Korea,111.0199
 2015-03-31,LT,Lithuania,115.7804
 2015-03-31,LU,Luxembourg,122.032
 2015-03-31,LV,Latvia,120.26
-2015-03-31,MA,Morocco,107.0965
-2015-03-31,MK,North Macedonia,92.8
+2015-03-31,MA,Morocco,101.4769
+2015-03-31,MK,North Macedonia,92.9623
 2015-03-31,MT,Malta,104.6678
 2015-03-31,MX,Mexico,123.5909
 2015-03-31,MY,Malaysia,158.6531
-2015-03-31,NL,Netherlands,88.2136
+2015-03-31,NL,Netherlands,88.1194
 2015-03-31,NO,Norway,128.5387
 2015-03-31,NZ,New Zealand,130.367
 2015-03-31,PE,Peru,170.3163
@@ -21878,26 +6437,25 @@ date,country_code,country,price
 2015-03-31,SE,Sweden,128.7305
 2015-03-31,SG,Singapore,109.5014
 2015-03-31,SI,Slovenia,85.4144
-2015-03-31,SK,Slovak Republic,101.4746
-2015-03-31,TH,Thailand,129.4792
-2015-03-31,TR,Türkiye,163.3262
-2015-03-31,US,United States,122.749
-2015-03-31,XM,Euro area,97.7574
-2015-03-31,XW,World,121.4009
-2015-03-31,ZA,South Africa,129.2028
-2015-06-30,4T,Emerging market economies (aggregate),132.3706
-2015-06-30,5R,Advanced economies,113.0913
-2015-06-30,AE,United Arab Emirates,155.8948
+2015-03-31,SK,Slovakia,101.1747
+2015-03-31,TH,Thailand,134.7249
+2015-03-31,TR,Türkiye,165.6788
+2015-03-31,US,United States,122.7658
+2015-03-31,XM,Euro area,97.6567
+2015-03-31,XW,World,120.394
+2015-03-31,ZA,South Africa,128.8492
+2015-06-30,4T,Emerging market economies (aggregate),132.36
+2015-06-30,5R,Advanced economies,113.4052
 2015-06-30,AT,Austria,130.3477
 2015-06-30,AU,Australia,123.7173
-2015-06-30,BE,Belgium,108.3145
+2015-06-30,BE,Belgium,108.2235
 2015-06-30,BG,Bulgaria,94.2372
-2015-06-30,BR,Brazil,156.7596
-2015-06-30,CA,Canada,127.6929
-2015-06-30,CH,Switzerland,123.6848
-2015-06-30,CL,Chile,170.7733
+2015-06-30,BR,Brazil,156.7567
+2015-06-30,CA,Canada,127.8336
+2015-06-30,CH,Switzerland,123.6844
+2015-06-30,CL,Chile,170.7721
 2015-06-30,CN,China,107.5882
-2015-06-30,CO,Colombia,153.6311
+2015-06-30,CO,Colombia,153.4489
 2015-06-30,CY,Cyprus,74.7716
 2015-06-30,CZ,Czechia,104.3844
 2015-06-30,DE,Germany,117
@@ -21906,28 +6464,28 @@ date,country_code,country,price
 2015-06-30,ES,Spain,74.8184
 2015-06-30,FI,Finland,106.9223
 2015-06-30,FR,France,99.7244
-2015-06-30,GB,United Kingdom,114.4936
+2015-06-30,GB,United Kingdom,114.547
 2015-06-30,GR,Greece,65.5829
 2015-06-30,HK,Hong Kong SAR,198.244
 2015-06-30,HR,Croatia,89.7036
 2015-06-30,HU,Hungary,105.3643
 2015-06-30,ID,Indonesia,138.0559
-2015-06-30,IE,Ireland,93.036
+2015-06-30,IE,Ireland,93.024
 2015-06-30,IL,Israel,139.0779
 2015-06-30,IN,India,225.1993
-2015-06-30,IS,Iceland,138.0827
+2015-06-30,IS,Iceland,138.1058
 2015-06-30,IT,Italy,84.5047
 2015-06-30,JP,Japan,104.6421
-2015-06-30,KR,Korea,112.406
+2015-06-30,KR,Korea,112.4098
 2015-06-30,LT,Lithuania,119.3433
 2015-06-30,LU,Luxembourg,124.6216
 2015-06-30,LV,Latvia,124.53
-2015-06-30,MA,Morocco,102.6702
-2015-06-30,MK,North Macedonia,93.64
+2015-06-30,MA,Morocco,101.9533
+2015-06-30,MK,North Macedonia,93.5623
 2015-06-30,MT,Malta,105.5464
 2015-06-30,MX,Mexico,128.0902
 2015-06-30,MY,Malaysia,161.228
-2015-06-30,NL,Netherlands,88.9946
+2015-06-30,NL,Netherlands,89.0238
 2015-06-30,NO,Norway,132.7231
 2015-06-30,NZ,New Zealand,134.8581
 2015-06-30,PE,Peru,168.2133
@@ -21940,26 +6498,25 @@ date,country_code,country,price
 2015-06-30,SE,Sweden,133.0013
 2015-06-30,SG,Singapore,108.523
 2015-06-30,SI,Slovenia,87.3512
-2015-06-30,SK,Slovak Republic,103.4741
-2015-06-30,TH,Thailand,131.0417
-2015-06-30,TR,Türkiye,170.3625
-2015-06-30,US,United States,124.1931
-2015-06-30,XM,Euro area,99.0318
-2015-06-30,XW,World,122.6381
-2015-06-30,ZA,South Africa,131.3948
-2015-09-30,4T,Emerging market economies (aggregate),133.3888
-2015-09-30,5R,Advanced economies,114.6447
-2015-09-30,AE,United Arab Emirates,154.0141
+2015-06-30,SK,Slovakia,103.1742
+2015-06-30,TH,Thailand,135.0363
+2015-06-30,TR,Türkiye,173.2032
+2015-06-30,US,United States,124.1902
+2015-06-30,XM,Euro area,98.9322
+2015-06-30,XW,World,121.6682
+2015-06-30,ZA,South Africa,131.0427
+2015-09-30,4T,Emerging market economies (aggregate),133.3615
+2015-09-30,5R,Advanced economies,114.9154
 2015-09-30,AT,Austria,131.9976
 2015-09-30,AU,Australia,126.2343
-2015-09-30,BE,Belgium,110.6971
+2015-09-30,BE,Belgium,110.8
 2015-09-30,BG,Bulgaria,93.7646
 2015-09-30,BR,Brazil,155.846
-2015-09-30,CA,Canada,130.2524
-2015-09-30,CH,Switzerland,123.9743
-2015-09-30,CL,Chile,179.6382
+2015-09-30,CA,Canada,130.2009
+2015-09-30,CH,Switzerland,123.9741
+2015-09-30,CL,Chile,179.6415
 2015-09-30,CN,China,108.2437
-2015-09-30,CO,Colombia,155.9038
+2015-09-30,CO,Colombia,155.3471
 2015-09-30,CY,Cyprus,74.5106
 2015-09-30,CZ,Czechia,105.6445
 2015-09-30,DE,Germany,117.6
@@ -21968,28 +6525,28 @@ date,country_code,country,price
 2015-09-30,ES,Spain,75.3163
 2015-09-30,FI,Finland,106.8158
 2015-09-30,FR,France,101.1275
-2015-09-30,GB,United Kingdom,118.2988
+2015-09-30,GB,United Kingdom,118.2045
 2015-09-30,GR,Greece,64.6295
-2015-09-30,HK,Hong Kong SAR,202.1315
+2015-09-30,HK,Hong Kong SAR,202.2199
 2015-09-30,HR,Croatia,90.4277
 2015-09-30,HU,Hungary,110.0614
 2015-09-30,ID,Indonesia,139.4232
-2015-09-30,IE,Ireland,96.022
+2015-09-30,IE,Ireland,96.0126
 2015-09-30,IL,Israel,141.0098
 2015-09-30,IN,India,228.2327
-2015-09-30,IS,Iceland,140.0985
+2015-09-30,IS,Iceland,140.085
 2015-09-30,IT,Italy,85.2667
 2015-09-30,JP,Japan,105.6421
-2015-09-30,KR,Korea,113.834
+2015-09-30,KR,Korea,113.8459
 2015-09-30,LT,Lithuania,121.2197
 2015-09-30,LU,Luxembourg,126.3589
 2015-09-30,LV,Latvia,124.96
-2015-09-30,MA,Morocco,102.4777
-2015-09-30,MK,North Macedonia,93.08
+2015-09-30,MA,Morocco,101.6675
+2015-09-30,MK,North Macedonia,93.1823
 2015-09-30,MT,Malta,112.7952
 2015-09-30,MX,Mexico,132.1108
 2015-09-30,MY,Malaysia,165.4865
-2015-09-30,NL,Netherlands,90.7899
+2015-09-30,NL,Netherlands,90.5743
 2015-09-30,NO,Norway,132.2001
 2015-09-30,NZ,New Zealand,141.1443
 2015-09-30,PE,Peru,167.5195
@@ -22002,26 +6559,25 @@ date,country_code,country,price
 2015-09-30,SE,Sweden,138.0609
 2015-09-30,SG,Singapore,107.0931
 2015-09-30,SI,Slovenia,84.2711
-2015-09-30,SK,Slovak Republic,103.5741
-2015-09-30,TH,Thailand,131.4583
-2015-09-30,TR,Türkiye,174.2004
-2015-09-30,US,United States,125.9567
-2015-09-30,XM,Euro area,99.9727
-2015-09-30,XW,World,123.9331
-2015-09-30,ZA,South Africa,132.9657
-2015-12-31,4T,Emerging market economies (aggregate),134.2252
-2015-12-31,5R,Advanced economies,115.4416
-2015-12-31,AE,United Arab Emirates,151.6146
+2015-09-30,SK,Slovakia,103.2742
+2015-09-30,TH,Thailand,134.1022
+2015-09-30,TR,Türkiye,178.0302
+2015-09-30,US,United States,125.9533
+2015-09-30,XM,Euro area,99.8656
+2015-09-30,XW,World,122.9519
+2015-09-30,ZA,South Africa,132.4997
+2015-12-31,4T,Emerging market economies (aggregate),134.3345
+2015-12-31,5R,Advanced economies,115.6972
 2015-12-31,AT,Austria,135.8476
 2015-12-31,AU,Australia,126.4279
-2015-12-31,BE,Belgium,110.1966
+2015-12-31,BE,Belgium,110.7345
 2015-12-31,BG,Bulgaria,96.6189
 2015-12-31,BR,Brazil,154.7554
-2015-12-31,CA,Canada,132.101
-2015-12-31,CH,Switzerland,124.4482
-2015-12-31,CL,Chile,185.0517
+2015-12-31,CA,Canada,131.7073
+2015-12-31,CH,Switzerland,124.4481
+2015-12-31,CL,Chile,185.055
 2015-12-31,CN,China,108.8422
-2015-12-31,CO,Colombia,155.6492
+2015-12-31,CO,Colombia,155.031
 2015-12-31,CY,Cyprus,74.4805
 2015-12-31,CZ,Czechia,106.7997
 2015-12-31,DE,Germany,119.3
@@ -22030,28 +6586,28 @@ date,country_code,country,price
 2015-12-31,ES,Spain,75.294
 2015-12-31,FI,Finland,106.2833
 2015-12-31,FR,France,100.426
-2015-12-31,GB,United Kingdom,119.7538
+2015-12-31,GB,United Kingdom,119.7007
 2015-12-31,GR,Greece,64.2224
 2015-12-31,HK,Hong Kong SAR,194.5331
 2015-12-31,HR,Croatia,90.5182
 2015-12-31,HU,Hungary,111.6627
 2015-12-31,ID,Indonesia,140.4357
-2015-12-31,IE,Ireland,97.4364
+2015-12-31,IE,Ireland,97.4282
 2015-12-31,IL,Israel,143.9075
 2015-12-31,IN,India,231.8936
-2015-12-31,IS,Iceland,143.5803
+2015-12-31,IS,Iceland,143.5807
 2015-12-31,IT,Italy,84.5047
 2015-12-31,JP,Japan,104.1753
-2015-12-31,KR,Korea,115.109
+2015-12-31,KR,Korea,115.1342
 2015-12-31,LT,Lithuania,118.7019
 2015-12-31,LU,Luxembourg,126.1068
 2015-12-31,LV,Latvia,128.08
-2015-12-31,MA,Morocco,103.1513
-2015-12-31,MK,North Macedonia,92.25
+2015-12-31,MA,Morocco,102.4297
+2015-12-31,MK,North Macedonia,92.2723
 2015-12-31,MT,Malta,116.3097
 2015-12-31,MX,Mexico,133.7682
 2015-12-31,MY,Malaysia,166.1797
-2015-12-31,NL,Netherlands,91.0682
+2015-12-31,NL,Netherlands,91.0912
 2015-12-31,NO,Norway,129.5848
 2015-12-31,NZ,New Zealand,142.3363
 2015-12-31,PE,Peru,163.8173
@@ -22064,26 +6620,25 @@ date,country_code,country,price
 2015-12-31,SE,Sweden,141.0069
 2015-12-31,SG,Singapore,106.5663
 2015-12-31,SI,Slovenia,84.2456
-2015-12-31,SK,Slovak Republic,104.6738
-2015-12-31,TH,Thailand,133.2292
-2015-12-31,TR,Türkiye,180.1706
-2015-12-31,US,United States,127.8059
-2015-12-31,XM,Euro area,100.3323
-2015-12-31,XW,World,124.7502
-2015-12-31,ZA,South Africa,134.787
-2016-03-31,4T,Emerging market economies (aggregate),135.5889
-2016-03-31,5R,Advanced economies,117.0353
-2016-03-31,AE,United Arab Emirates,151.8902
+2015-12-31,SK,Slovakia,104.3739
+2015-12-31,TH,Thailand,140.1223
+2015-12-31,TR,Türkiye,183.425
+2015-12-31,US,United States,127.8238
+2015-12-31,XM,Euro area,100.2202
+2015-12-31,XW,World,123.8175
+2015-12-31,ZA,South Africa,134.7977
+2016-03-31,4T,Emerging market economies (aggregate),135.8598
+2016-03-31,5R,Advanced economies,117.1484
 2016-03-31,AT,Austria,140.5618
 2016-03-31,AU,Australia,126.2343
-2016-03-31,BE,Belgium,109.4025
+2016-03-31,BE,Belgium,109.5772
 2016-03-31,BG,Bulgaria,97.7057
-2016-03-31,BR,Brazil,153.5991
-2016-03-31,CA,Canada,139.2108
-2016-03-31,CH,Switzerland,125.9267
-2016-03-31,CL,Chile,184.476
+2016-03-31,BR,Brazil,153.5962
+2016-03-31,CA,Canada,138.6657
+2016-03-31,CH,Switzerland,125.9269
+2016-03-31,CL,Chile,184.469
 2016-03-31,CN,China,111.5332
-2016-03-31,CO,Colombia,163.4621
+2016-03-31,CO,Colombia,163.0845
 2016-03-31,CY,Cyprus,73.8781
 2016-03-31,CZ,Czechia,108.1649
 2016-03-31,DE,Germany,121.7
@@ -22092,28 +6647,28 @@ date,country_code,country,price
 2016-03-31,ES,Spain,76.3568
 2016-03-31,FI,Finland,107.0288
 2016-03-31,FR,France,99.9248
-2016-03-31,GB,United Kingdom,121.0968
+2016-03-31,GB,United Kingdom,121.0308
 2016-03-31,GR,Greece,64.4366
-2016-03-31,HK,Hong Kong SAR,181.9869
+2016-03-31,HK,Hong Kong SAR,182.031
 2016-03-31,HR,Croatia,91.6044
 2016-03-31,HU,Hungary,116.778
 2016-03-31,ID,Indonesia,141.8251
-2016-03-31,IE,Ireland,97.79
+2016-03-31,IE,Ireland,97.8687
 2016-03-31,IL,Israel,146.7289
 2016-03-31,IN,India,229.1741
-2016-03-31,IS,Iceland,146.375
+2016-03-31,IS,Iceland,146.3617
 2016-03-31,IT,Italy,84.5047
 2016-03-31,JP,Japan,106.6756
-2016-03-31,KR,Korea,115.619
+2016-03-31,KR,Korea,115.6019
 2016-03-31,LT,Lithuania,119.6877
 2016-03-31,LU,Luxembourg,128.074
 2016-03-31,LV,Latvia,128.81
-2016-03-31,MA,Morocco,102.9589
-2016-03-31,MK,North Macedonia,95.04
+2016-03-31,MA,Morocco,102.0486
+2016-03-31,MK,North Macedonia,95.1524
 2016-03-31,MT,Malta,110.1593
 2016-03-31,MX,Mexico,135.407
 2016-03-31,MY,Malaysia,170.1411
-2016-03-31,NL,Netherlands,92.289
+2016-03-31,NL,Netherlands,91.9956
 2016-03-31,NO,Norway,134.423
 2016-03-31,NZ,New Zealand,147.5275
 2016-03-31,PE,Peru,160.6317
@@ -22126,26 +6681,25 @@ date,country_code,country,price
 2016-03-31,SE,Sweden,142.8586
 2016-03-31,SG,Singapore,105.8137
 2016-03-31,SI,Slovenia,86.1226
-2016-03-31,SK,Slovak Republic,106.5734
-2016-03-31,TH,Thailand,133.2292
-2016-03-31,TR,Türkiye,186.5672
-2016-03-31,US,United States,129.3531
-2016-03-31,XM,Euro area,101.2067
-2016-03-31,XW,World,126.2327
-2016-03-31,ZA,South Africa,137.2602
-2016-06-30,4T,Emerging market economies (aggregate),138.2633
-2016-06-30,5R,Advanced economies,118.8431
-2016-06-30,AE,United Arab Emirates,152.3171
+2016-03-31,SK,Slovakia,106.2734
+2016-03-31,TH,Thailand,141.3678
+2016-03-31,TR,Türkiye,189.3878
+2016-03-31,US,United States,129.3758
+2016-03-31,XM,Euro area,101.0987
+2016-03-31,XW,World,125.2987
+2016-03-31,ZA,South Africa,136.4134
+2016-06-30,4T,Emerging market economies (aggregate),138.6867
+2016-06-30,5R,Advanced economies,118.8577
 2016-06-30,AT,Austria,142.7617
 2016-06-30,AU,Australia,128.7512
-2016-06-30,BE,Belgium,110.6971
+2016-06-30,BE,Belgium,110.7235
 2016-06-30,BG,Bulgaria,100.4088
 2016-06-30,BR,Brazil,152.4485
-2016-06-30,CA,Canada,148.3114
-2016-06-30,CH,Switzerland,124.6696
-2016-06-30,CL,Chile,183.5188
+2016-06-30,CA,Canada,147.4175
+2016-06-30,CH,Switzerland,124.6694
+2016-06-30,CL,Chile,183.5259
 2016-06-30,CN,China,113.8325
-2016-06-30,CO,Colombia,168.2101
+2016-06-30,CO,Colombia,166.2493
 2016-06-30,CY,Cyprus,73.5167
 2016-06-30,CZ,Czechia,110.3702
 2016-06-30,DE,Germany,125.2
@@ -22154,28 +6708,28 @@ date,country_code,country,price
 2016-06-30,ES,Spain,77.702
 2016-06-30,FI,Finland,108.2002
 2016-06-30,FR,France,100.426
-2016-06-30,GB,United Kingdom,123.671
+2016-06-30,GB,United Kingdom,123.6908
 2016-06-30,GR,Greece,63.9224
-2016-06-30,HK,Hong Kong SAR,182.2961
+2016-06-30,HK,Hong Kong SAR,182.3403
 2016-06-30,HR,Croatia,90.7898
 2016-06-30,HU,Hungary,119.5334
 2016-06-30,ID,Indonesia,142.7341
-2016-06-30,IE,Ireland,98.8901
+2016-06-30,IE,Ireland,98.9068
 2016-06-30,IL,Israel,149.2962
 2016-06-30,IN,India,241.7106
-2016-06-30,IS,Iceland,149.2154
+2016-06-30,IS,Iceland,149.2389
 2016-06-30,IT,Italy,85.0974
 2016-06-30,JP,Japan,107.7423
-2016-06-30,KR,Korea,115.772
+2016-06-30,KR,Korea,115.7891
 2016-06-30,LT,Lithuania,123.4049
 2016-06-30,LU,Luxembourg,131.5658
 2016-06-30,LV,Latvia,136.31
-2016-06-30,MA,Morocco,103.2475
-2016-06-30,MK,North Macedonia,94.33
+2016-06-30,MA,Morocco,102.8109
+2016-06-30,MK,North Macedonia,94.4124
 2016-06-30,MT,Malta,112.905
 2016-06-30,MX,Mexico,138.069
 2016-06-30,MY,Malaysia,172.716
-2016-06-30,NL,Netherlands,92.9803
+2016-06-30,NL,Netherlands,93.2877
 2016-06-30,NO,Norway,140.0458
 2016-06-30,NZ,New Zealand,155.3245
 2016-06-30,PE,Peru,163.6111
@@ -22188,26 +6742,25 @@ date,country_code,country,price
 2016-06-30,SE,Sweden,144.5232
 2016-06-30,SG,Singapore,105.3622
 2016-06-30,SI,Slovenia,87.7437
-2016-06-30,SK,Slovak Republic,109.5726
-2016-06-30,TH,Thailand,134.6875
-2016-06-30,TR,Türkiye,192.9638
-2016-06-30,US,United States,130.8118
-2016-06-30,XM,Euro area,102.766
-2016-06-30,XW,World,128.4672
-2016-06-30,ZA,South Africa,139.2815
-2016-09-30,4T,Emerging market economies (aggregate),140.1174
-2016-09-30,5R,Advanced economies,120.462
-2016-09-30,AE,United Arab Emirates,151.3768
-2016-09-30,AT,Austria,141.426
+2016-06-30,SK,Slovakia,109.2727
+2016-06-30,TH,Thailand,142.8209
+2016-06-30,TR,Türkiye,195.3505
+2016-06-30,US,United States,130.8314
+2016-06-30,XM,Euro area,102.6576
+2016-06-30,XW,World,127.5071
+2016-06-30,ZA,South Africa,137.5378
+2016-09-30,4T,Emerging market economies (aggregate),140.6916
+2016-09-30,5R,Advanced economies,120.4357
+2016-09-30,AT,Austria,141.6618
 2016-09-30,AU,Australia,130.6873
-2016-09-30,BE,Belgium,113.4822
+2016-09-30,BE,Belgium,113.1363
 2016-09-30,BG,Bulgaria,102.0155
 2016-09-30,BR,Brazil,151.3493
-2016-09-30,CA,Canada,152.6484
-2016-09-30,CH,Switzerland,123.89
-2016-09-30,CL,Chile,186.0372
+2016-09-30,CA,Canada,151.7217
+2016-09-30,CH,Switzerland,123.8902
+2016-09-30,CL,Chile,186.0343
 2016-09-30,CN,China,116.4238
-2016-09-30,CO,Colombia,170.8268
+2016-09-30,CO,Colombia,169.0136
 2016-09-30,CY,Cyprus,73.577
 2016-09-30,CZ,Czechia,113.1006
 2016-09-30,DE,Germany,127.5
@@ -22216,28 +6769,28 @@ date,country_code,country,price
 2016-09-30,ES,Spain,78.3412
 2016-09-30,FI,Finland,108.5197
 2016-09-30,FR,France,102.6309
-2016-09-30,GB,United Kingdom,126.2451
+2016-09-30,GB,United Kingdom,126.1845
 2016-09-30,GR,Greece,63.4939
 2016-09-30,HK,Hong Kong SAR,191.1315
 2016-09-30,HR,Croatia,91.695
 2016-09-30,HU,Hungary,122.9756
 2016-09-30,ID,Indonesia,143.2515
-2016-09-30,IE,Ireland,103.1726
+2016-09-30,IE,Ireland,103.1852
 2016-09-30,IL,Israel,152.5371
 2016-09-30,IN,India,245.7005
-2016-09-30,IS,Iceland,158.1033
+2016-09-30,IS,Iceland,158.1087
 2016-09-30,IT,Italy,85.2667
 2016-09-30,JP,Japan,107.509
-2016-09-30,KR,Korea,116.129
+2016-09-30,KR,Korea,116.1854
 2016-09-30,LT,Lithuania,127.6447
 2016-09-30,LU,Luxembourg,133.545
 2016-09-30,LV,Latvia,136.96
-2016-09-30,MA,Morocco,104.9796
-2016-09-30,MK,North Macedonia,93.45
+2016-09-30,MA,Morocco,105.4788
+2016-09-30,MK,North Macedonia,93.4623
 2016-09-30,MT,Malta,118.1768
 2016-09-30,MX,Mexico,140.1558
 2016-09-30,MY,Malaysia,176.7764
-2016-09-30,NL,Netherlands,95.2962
+2016-09-30,NL,Netherlands,95.6134
 2016-09-30,NO,Norway,142.661
 2016-09-30,NZ,New Zealand,161.0008
 2016-09-30,PE,Peru,165.1165
@@ -22250,26 +6803,25 @@ date,country_code,country,price
 2016-09-30,SE,Sweden,147.8363
 2016-09-30,SG,Singapore,103.7817
 2016-09-30,SI,Slovenia,88.4689
-2016-09-30,SK,Slovak Republic,111.3722
-2016-09-30,TH,Thailand,131.6667
-2016-09-30,TR,Türkiye,197.8678
-2016-09-30,US,United States,132.632
-2016-09-30,XM,Euro area,104.3593
-2016-09-30,XW,World,130.2028
-2016-09-30,ZA,South Africa,140.1763
-2016-12-31,4T,Emerging market economies (aggregate),142.3244
-2016-12-31,5R,Advanced economies,121.4744
-2016-12-31,AE,United Arab Emirates,150.8688
+2016-09-30,SK,Slovakia,110.9723
+2016-09-30,TH,Thailand,140.4336
+2016-09-30,TR,Türkiye,200.3194
+2016-09-30,US,United States,132.6453
+2016-09-30,XM,Euro area,104.2365
+2016-09-30,XW,World,129.2734
+2016-09-30,ZA,South Africa,138.9195
+2016-12-31,4T,Emerging market economies (aggregate),143.0452
+2016-12-31,5R,Advanced economies,121.5204
 2016-12-31,AT,Austria,142.0546
 2016-12-31,AU,Australia,136.1084
-2016-12-31,BE,Belgium,113.0797
+2016-12-31,BE,Belgium,113.431
 2016-12-31,BG,Bulgaria,104.4538
 2016-12-31,BR,Brazil,150.3786
-2016-12-31,CA,Canada,153.3594
-2016-12-31,CH,Switzerland,122.7878
-2016-12-31,CL,Chile,191.7115
+2016-12-31,CA,Canada,152.7977
+2016-12-31,CH,Switzerland,122.7876
+2016-12-31,CL,Chile,191.7035
 2016-12-31,CN,China,119.1975
-2016-12-31,CO,Colombia,171.3006
+2016-12-31,CO,Colombia,170.0382
 2016-12-31,CY,Cyprus,73.7777
 2016-12-31,CZ,Czechia,118.4563
 2016-12-31,DE,Germany,129.3
@@ -22278,28 +6830,28 @@ date,country_code,country,price
 2016-12-31,ES,Spain,78.6162
 2016-12-31,FI,Finland,107.6677
 2016-12-31,FR,France,102.0296
-2016-12-31,GB,United Kingdom,126.1332
+2016-12-31,GB,United Kingdom,126.1845
 2016-12-31,GR,Greece,63.5582
 2016-12-31,HK,Hong Kong SAR,202.8605
 2016-12-31,HR,Croatia,91.2424
 2016-12-31,HU,Hungary,124.8447
 2016-12-31,ID,Indonesia,143.7762
-2016-12-31,IE,Ireland,105.7656
+2016-12-31,IE,Ireland,105.7334
 2016-12-31,IL,Israel,153.6936
 2016-12-31,IN,India,251.2442
-2016-12-31,IS,Iceland,164.6547
+2016-12-31,IS,Iceland,164.6649
 2016-12-31,IT,Italy,84.674
 2016-12-31,JP,Japan,106.8089
-2016-12-31,KR,Korea,116.843
+2016-12-31,KR,Korea,116.8458
 2016-12-31,LT,Lithuania,129.9249
 2016-12-31,LU,Luxembourg,135.9115
 2016-12-31,LV,Latvia,138.02
-2016-12-31,MA,Morocco,108.3474
-2016-12-31,MK,North Macedonia,93.61
+2016-12-31,MA,Morocco,107.0033
+2016-12-31,MK,North Macedonia,93.7823
 2016-12-31,MT,Malta,122.0209
 2016-12-31,MX,Mexico,141.6184
 2016-12-31,MY,Malaysia,177.7668
-2016-12-31,NL,Netherlands,96.5171
+2016-12-31,NL,Netherlands,96.9055
 2016-12-31,NO,Norway,142.661
 2016-12-31,NZ,New Zealand,162.6503
 2016-12-31,PE,Peru,167.377
@@ -22312,26 +6864,25 @@ date,country_code,country,price
 2016-12-31,SE,Sweden,150.1527
 2016-12-31,SG,Singapore,103.2549
 2016-12-31,SI,Slovenia,90.0474
-2016-12-31,SK,Slovak Republic,113.3717
-2016-12-31,TH,Thailand,132.5
-2016-12-31,TR,Türkiye,202.1322
-2016-12-31,US,United States,134.7092
-2016-12-31,XM,Euro area,104.891
-2016-12-31,XW,World,131.8013
-2016-12-31,ZA,South Africa,141.3062
-2017-03-31,4T,Emerging market economies (aggregate),143.6402
-2017-03-31,5R,Advanced economies,123.3972
-2017-03-31,AE,United Arab Emirates,149.7555
+2016-12-31,SK,Slovakia,112.9718
+2016-12-31,TH,Thailand,145.0006
+2016-12-31,TR,Türkiye,204.7915
+2016-12-31,US,United States,134.713
+2016-12-31,XM,Euro area,104.7661
+2016-12-31,XW,World,130.9249
+2016-12-31,ZA,South Africa,140.0348
+2017-03-31,4T,Emerging market economies (aggregate),144.3798
+2017-03-31,5R,Advanced economies,123.3582
 2017-03-31,AT,Austria,143.7831
 2017-03-31,AU,Australia,139.1094
-2017-03-31,BE,Belgium,114.2438
+2017-03-31,BE,Belgium,113.9332
 2017-03-31,BG,Bulgaria,106.4764
 2017-03-31,BR,Brazil,149.5935
-2017-03-31,CA,Canada,163.6687
-2017-03-31,CH,Switzerland,123.0351
-2017-03-31,CL,Chile,195.6225
+2017-03-31,CA,Canada,163.056
+2017-03-31,CH,Switzerland,123.0354
+2017-03-31,CL,Chile,195.6226
 2017-03-31,CN,China,120.6209
-2017-03-31,CO,Colombia,173.1782
+2017-03-31,CO,Colombia,172.4255
 2017-03-31,CY,Cyprus,73.9384
 2017-03-31,CZ,Czechia,122.0268
 2017-03-31,DE,Germany,129.9
@@ -22340,28 +6891,28 @@ date,country_code,country,price
 2017-03-31,ES,Spain,80.4147
 2017-03-31,FI,Finland,108.3067
 2017-03-31,FR,France,102.7311
-2017-03-31,GB,United Kingdom,126.4689
+2017-03-31,GB,United Kingdom,126.3508
 2017-03-31,GR,Greece,63.2261
 2017-03-31,HK,Hong Kong SAR,208.7139
 2017-03-31,HR,Croatia,91.3329
 2017-03-31,HU,Hungary,130.4985
 2017-03-31,ID,Indonesia,145.55
-2017-03-31,IE,Ireland,106.9836
+2017-03-31,IE,Ireland,106.9917
 2017-03-31,IL,Israel,154.3545
 2017-03-31,IN,India,253.1299
-2017-03-31,IS,Iceland,172.4888
+2017-03-31,IS,Iceland,172.4948
 2017-03-31,IT,Italy,83.9119
 2017-03-31,JP,Japan,110.8426
-2017-03-31,KR,Korea,117.047
+2017-03-31,KR,Korea,117.0466
 2017-03-31,LT,Lithuania,131.9438
 2017-03-31,LU,Luxembourg,137.0083
 2017-03-31,LV,Latvia,140.77
-2017-03-31,MA,Morocco,110.4643
-2017-03-31,MK,North Macedonia,91.42
+2017-03-31,MA,Morocco,107.3845
+2017-03-31,MK,North Macedonia,91.4123
 2017-03-31,MT,Malta,115.9802
 2017-03-31,MX,Mexico,145.3789
 2017-03-31,MY,Malaysia,181.5301
-2017-03-31,NL,Netherlands,98.447
+2017-03-31,NL,Netherlands,98.8436
 2017-03-31,NO,Norway,148.0222
 2017-03-31,NZ,New Zealand,165.381
 2017-03-31,PE,Peru,168.8773
@@ -22369,31 +6920,30 @@ date,country_code,country,price
 2017-03-31,PL,Poland,97.8411
 2017-03-31,PT,Portugal,104.2219
 2017-03-31,RO,Romania,91.2134
-2017-03-31,RS,Serbia,112.6901
+2017-03-31,RS,Serbia,112.0003
 2017-03-31,RU,Russia,89.2515
 2017-03-31,SE,Sweden,154.1598
 2017-03-31,SG,Singapore,102.8786
 2017-03-31,SI,Slovenia,91.8732
-2017-03-31,SK,Slovak Republic,110.5724
-2017-03-31,TH,Thailand,131.6667
-2017-03-31,TR,Türkiye,208.742
-2017-03-31,US,United States,136.5098
-2017-03-31,XM,Euro area,105.667
-2017-03-31,XW,World,133.4274
-2017-03-31,ZA,South Africa,143.4771
-2017-06-30,4T,Emerging market economies (aggregate),146.3149
-2017-06-30,5R,Advanced economies,125.1554
-2017-06-30,AE,United Arab Emirates,150.7956
+2017-03-31,SK,Slovakia,110.0725
+2017-03-31,TH,Thailand,143.4437
+2017-03-31,TR,Türkiye,211.961
+2017-03-31,US,United States,136.5255
+2017-03-31,XM,Euro area,105.5435
+2017-03-31,XW,World,132.5296
+2017-03-31,ZA,South Africa,141.5039
+2017-06-30,4T,Emerging market economies (aggregate),147.1484
+2017-06-30,5R,Advanced economies,125.0872
 2017-06-30,AT,Austria,147.9474
 2017-06-30,AU,Australia,141.8199
-2017-06-30,BE,Belgium,113.8739
+2017-06-30,BE,Belgium,114.0642
 2017-06-30,BG,Bulgaria,109.0376
-2017-06-30,BR,Brazil,149.0368
-2017-06-30,CA,Canada,172.9329
-2017-06-30,CH,Switzerland,124.7017
-2017-06-30,CL,Chile,198.4296
+2017-06-30,BR,Brazil,149.0396
+2017-06-30,CA,Canada,172.2855
+2017-06-30,CH,Switzerland,124.702
+2017-06-30,CL,Chile,198.4239
 2017-06-30,CN,China,122.9931
-2017-06-30,CO,Colombia,179.4173
+2017-06-30,CO,Colombia,177.3825
 2017-06-30,CY,Cyprus,74.4805
 2017-06-30,CZ,Czechia,125.0722
 2017-06-30,DE,Germany,132.5
@@ -22402,28 +6952,28 @@ date,country_code,country,price
 2017-06-30,ES,Spain,82.0423
 2017-06-30,FI,Finland,109.9042
 2017-06-30,FR,France,103.7334
-2017-06-30,GB,United Kingdom,129.2669
+2017-06-30,GB,United Kingdom,129.1771
 2017-06-30,GR,Greece,63.2475
-2017-06-30,HK,Hong Kong SAR,220.9067
+2017-06-30,HK,Hong Kong SAR,220.8184
 2017-06-30,HR,Croatia,94.6821
 2017-06-30,HU,Hungary,133.9561
 2017-06-30,ID,Indonesia,147.2646
-2017-06-30,IE,Ireland,109.3409
+2017-06-30,IE,Ireland,109.3512
 2017-06-30,IL,Israel,156.3245
 2017-06-30,IN,India,262.75
-2017-06-30,IS,Iceland,183.759
+2017-06-30,IS,Iceland,183.7745
 2017-06-30,IT,Italy,84.3353
 2017-06-30,JP,Japan,109.9092
-2017-06-30,KR,Korea,117.2001
+2017-06-30,KR,Korea,117.2244
 2017-06-30,LT,Lithuania,136.0055
 2017-06-30,LU,Luxembourg,140.003
 2017-06-30,LV,Latvia,148.76
-2017-06-30,MA,Morocco,109.8869
-2017-06-30,MK,North Macedonia,92.22
+2017-06-30,MA,Morocco,107.1939
+2017-06-30,MK,North Macedonia,92.1823
 2017-06-30,MT,Malta,119.6046
 2017-06-30,MX,Mexico,148.3989
 2017-06-30,MY,Malaysia,184.5011
-2017-06-30,NL,Netherlands,99.991
+2017-06-30,NL,Netherlands,100.5233
 2017-06-30,NO,Norway,149.7221
 2017-06-30,NZ,New Zealand,165.6998
 2017-06-30,PE,Peru,166.2024
@@ -22431,31 +6981,30 @@ date,country_code,country,price
 2017-06-30,PL,Poland,99.839
 2017-06-30,PT,Portugal,107.5938
 2017-06-30,RO,Romania,95.3975
-2017-06-30,RS,Serbia,114.4501
+2017-06-30,RS,Serbia,114.2358
 2017-06-30,RU,Russia,88.7969
 2017-06-30,SE,Sweden,156.7952
 2017-06-30,SG,Singapore,102.8034
 2017-06-30,SI,Slovenia,94.9874
-2017-06-30,SK,Slovak Republic,116.8708
-2017-06-30,TH,Thailand,134.2708
-2017-06-30,TR,Türkiye,213.8593
-2017-06-30,US,United States,138.4549
-2017-06-30,XM,Euro area,107.2216
-2017-06-30,XW,World,135.6379
-2017-06-30,ZA,South Africa,145.2139
-2017-09-30,4T,Emerging market economies (aggregate),147.4498
-2017-09-30,5R,Advanced economies,126.8628
-2017-09-30,AE,United Arab Emirates,147.6112
+2017-06-30,SK,Slovakia,116.3709
+2017-06-30,TH,Thailand,143.9626
+2017-06-30,TR,Türkiye,218.2786
+2017-06-30,US,United States,138.4728
+2017-06-30,XM,Euro area,107.1025
+2017-06-30,XW,World,134.7255
+2017-06-30,ZA,South Africa,143.4663
+2017-09-30,4T,Emerging market economies (aggregate),148.3546
+2017-09-30,5R,Advanced economies,126.7519
 2017-09-30,AT,Austria,147.8688
 2017-09-30,AU,Australia,141.5295
-2017-09-30,BE,Belgium,117.6925
+2017-09-30,BE,Belgium,117.6997
 2017-09-30,BG,Bulgaria,111.1641
-2017-09-30,BR,Brazil,148.737
-2017-09-30,CA,Canada,175.1632
-2017-09-30,CH,Switzerland,127.1119
-2017-09-30,CL,Chile,202.3192
+2017-09-30,BR,Brazil,148.7427
+2017-09-30,CA,Canada,174.5075
+2017-09-30,CH,Switzerland,127.1122
+2017-09-30,CL,Chile,202.3087
 2017-09-30,CN,China,124.38
-2017-09-30,CO,Colombia,182.4194
+2017-09-30,CO,Colombia,180.2878
 2017-09-30,CY,Cyprus,74.7616
 2017-09-30,CZ,Czechia,127.2775
 2017-09-30,DE,Germany,134.7
@@ -22464,28 +7013,28 @@ date,country_code,country,price
 2017-09-30,ES,Spain,83.5585
 2017-09-30,FI,Finland,109.1587
 2017-09-30,FR,France,105.9384
-2017-09-30,GB,United Kingdom,132.1768
+2017-09-30,GB,United Kingdom,132.1696
 2017-09-30,GR,Greece,63.0761
 2017-09-30,HK,Hong Kong SAR,224.8606
 2017-09-30,HR,Croatia,95.1346
 2017-09-30,HU,Hungary,138.008
 2017-09-30,ID,Indonesia,148.0036
-2017-09-30,IE,Ireland,115.3128
+2017-09-30,IE,Ireland,115.2969
 2017-09-30,IL,Israel,158.2054
 2017-09-30,IN,India,264.0052
-2017-09-30,IS,Iceland,190.3562
+2017-09-30,IS,Iceland,190.3398
 2017-09-30,IT,Italy,83.9966
 2017-09-30,JP,Japan,110.1425
-2017-09-30,KR,Korea,117.8631
+2017-09-30,KR,Korea,117.8753
 2017-09-30,LT,Lithuania,138.547
 2017-09-30,LU,Luxembourg,140.1278
 2017-09-30,LV,Latvia,149
-2017-09-30,MA,Morocco,110.7529
-2017-09-30,MK,North Macedonia,92.62
+2017-09-30,MA,Morocco,107.3845
+2017-09-30,MK,North Macedonia,92.5923
 2017-09-30,MT,Malta,124.1076
 2017-09-30,MX,Mexico,151.2265
 2017-09-30,MY,Malaysia,188.2644
-2017-09-30,NL,Netherlands,102.3519
+2017-09-30,NL,Netherlands,103.3659
 2017-09-30,NO,Norway,146.1916
 2017-09-30,NZ,New Zealand,166.8781
 2017-09-30,PE,Peru,169.207
@@ -22493,31 +7042,30 @@ date,country_code,country,price
 2017-09-30,PL,Poland,100.8427
 2017-09-30,PT,Portugal,111.4035
 2017-09-30,RO,Romania,93.7238
-2017-09-30,RS,Serbia,116.184
+2017-09-30,RS,Serbia,116.4184
 2017-09-30,RU,Russia,88.0088
 2017-09-30,SE,Sweden,158.9762
 2017-09-30,SG,Singapore,103.556
 2017-09-30,SI,Slovenia,95.7041
-2017-09-30,SK,Slovak Republic,119.4701
-2017-09-30,TH,Thailand,136.1458
-2017-09-30,TR,Türkiye,216.2047
-2017-09-30,US,United States,140.575
-2017-09-30,XM,Euro area,108.9173
-2017-09-30,XW,World,137.0649
-2017-09-30,ZA,South Africa,146.0046
-2017-12-31,4T,Emerging market economies (aggregate),148.8373
-2017-12-31,5R,Advanced economies,127.7844
-2017-12-31,AE,United Arab Emirates,145.0987
+2017-09-30,SK,Slovakia,119.0702
+2017-09-30,TH,Thailand,146.5575
+2017-09-30,TR,Türkiye,220.4082
+2017-09-30,US,United States,140.5971
+2017-09-30,XM,Euro area,108.7833
+2017-09-30,XW,World,136.1777
+2017-09-30,ZA,South Africa,144.7605
+2017-12-31,4T,Emerging market economies (aggregate),149.8869
+2017-12-31,5R,Advanced economies,127.6645
 2017-12-31,AT,Austria,148.7331
 2017-12-31,AU,Australia,142.8848
-2017-12-31,BE,Belgium,117.0941
+2017-12-31,BE,Belgium,116.9683
 2017-12-31,BG,Bulgaria,112.9693
-2017-12-31,BR,Brazil,148.7056
-2017-12-31,CA,Canada,174.6486
-2017-12-31,CH,Switzerland,126.8487
-2017-12-31,CL,Chile,210.2585
+2017-12-31,BR,Brazil,148.717
+2017-12-31,CA,Canada,173.9947
+2017-12-31,CH,Switzerland,126.849
+2017-12-31,CL,Chile,210.2554
 2017-12-31,CN,China,125.1464
-2017-12-31,CO,Colombia,183.8153
+2017-12-31,CO,Colombia,181.7758
 2017-12-31,CY,Cyprus,75.0929
 2017-12-31,CZ,Czechia,128.4327
 2017-12-31,DE,Germany,137.4
@@ -22526,28 +7074,28 @@ date,country_code,country,price
 2017-12-31,ES,Spain,84.2719
 2017-12-31,FI,Finland,108.7327
 2017-12-31,FR,France,105.4372
-2017-12-31,GB,United Kingdom,132.0649
+2017-12-31,GB,United Kingdom,132.0033
 2017-12-31,GR,Greece,63.2904
 2017-12-31,HK,Hong Kong SAR,230.6257
 2017-12-31,HR,Croatia,98.2123
 2017-12-31,HU,Hungary,140.8666
 2017-12-31,ID,Indonesia,148.8166
-2017-12-31,IE,Ireland,118.1023
+2017-12-31,IE,Ireland,118.1282
 2017-12-31,IL,Israel,156.8583
 2017-12-31,IN,India,269.3397
-2017-12-31,IS,Iceland,189.3483
+2017-12-31,IS,Iceland,189.3686
 2017-12-31,IT,Italy,83.6579
 2017-12-31,JP,Japan,108.7424
-2017-12-31,KR,Korea,118.2711
+2017-12-31,KR,Korea,118.3167
 2017-12-31,LT,Lithuania,138.8795
 2017-12-31,LU,Luxembourg,141.6251
 2017-12-31,LV,Latvia,148.96
-2017-12-31,MA,Morocco,110.0794
-2017-12-31,MK,North Macedonia,93.32
+2017-12-31,MA,Morocco,107.0986
+2017-12-31,MK,North Macedonia,93.2623
 2017-12-31,MT,Malta,128.0615
 2017-12-31,MX,Mexico,153.7489
 2017-12-31,MY,Malaysia,188.6606
-2017-12-31,NL,Netherlands,104.7127
+2017-12-31,NL,Netherlands,105.5624
 2017-12-31,NO,Norway,143.7071
 2017-12-31,NZ,New Zealand,169.2484
 2017-12-31,PE,Peru,167.7279
@@ -22555,31 +7103,30 @@ date,country_code,country,price
 2017-12-31,PL,Poland,102.1305
 2017-12-31,PT,Portugal,112.7634
 2017-12-31,RO,Romania,95.3975
-2017-12-31,RS,Serbia,117.8918
+2017-12-31,RS,Serbia,118.5613
 2017-12-31,RU,Russia,88.1102
 2017-12-31,SE,Sweden,154.3072
 2017-12-31,SG,Singapore,104.3838
 2017-12-31,SI,Slovenia,98.9378
-2017-12-31,SK,Slovak Republic,119.97
-2017-12-31,TH,Thailand,139.375
-2017-12-31,TR,Türkiye,220.4691
-2017-12-31,US,United States,142.8119
-2017-12-31,XM,Euro area,109.8163
-2017-12-31,XW,World,138.2167
-2017-12-31,ZA,South Africa,146.8287
-2018-03-31,4T,Emerging market economies (aggregate),150.2044
-2018-03-31,5R,Advanced economies,129.5138
-2018-03-31,AE,United Arab Emirates,141.6458
+2017-12-31,SK,Slovakia,119.6701
+2017-12-31,TH,Thailand,151.9548
+2017-12-31,TR,Türkiye,224.5963
+2017-12-31,US,United States,142.8389
+2017-12-31,XM,Euro area,109.6786
+2017-12-31,XW,World,137.369
+2017-12-31,ZA,South Africa,146.0165
+2018-03-31,4T,Emerging market economies (aggregate),151.1969
+2018-03-31,5R,Advanced economies,129.4007
 2018-03-31,AT,Austria,154.3115
 2018-03-31,AU,Australia,141.9167
-2018-03-31,BE,Belgium,117.1377
+2018-03-31,BE,Belgium,117.2194
 2018-03-31,BG,Bulgaria,114.0278
-2018-03-31,BR,Brazil,148.9283
-2018-03-31,CA,Canada,175.8495
-2018-03-31,CH,Switzerland,126.7614
-2018-03-31,CL,Chile,212.5109
+2018-03-31,BR,Brazil,148.9426
+2018-03-31,CA,Canada,175.1911
+2018-03-31,CH,Switzerland,126.7617
+2018-03-31,CL,Chile,212.1857
 2018-03-31,CN,China,125.8764
-2018-03-31,CO,Colombia,185.2996
+2018-03-31,CO,Colombia,183.4695
 2018-03-31,CY,Cyprus,75.5045
 2018-03-31,CZ,Czechia,131.268
 2018-03-31,DE,Germany,138.6
@@ -22588,28 +7135,28 @@ date,country_code,country,price
 2018-03-31,ES,Spain,85.4388
 2018-03-31,FI,Finland,109.3717
 2018-03-31,FR,France,105.7379
-2018-03-31,GB,United Kingdom,131.8411
+2018-03-31,GB,United Kingdom,131.8371
 2018-03-31,GR,Greece,63.5261
 2018-03-31,HK,Hong Kong SAR,241.4048
 2018-03-31,HR,Croatia,99.0269
 2018-03-31,HU,Hungary,147.9584
 2018-03-31,ID,Indonesia,150.9229
-2018-03-31,IE,Ireland,120.1454
+2018-03-31,IE,Ireland,120.2045
 2018-03-31,IL,Israel,154.8883
 2018-03-31,IN,India,270.1032
-2018-03-31,IS,Iceland,195.2229
+2018-03-31,IS,Iceland,195.2283
 2018-03-31,IT,Italy,83.4886
 2018-03-31,JP,Japan,112.5427
-2018-03-31,KR,Korea,118.9341
+2018-03-31,KR,Korea,118.9426
 2018-03-31,LT,Lithuania,142.2523
 2018-03-31,LU,Luxembourg,145.7429
 2018-03-31,LV,Latvia,156.84
-2018-03-31,MA,Morocco,110.3681
-2018-03-31,MK,North Macedonia,95.21
+2018-03-31,MA,Morocco,107.0986
+2018-03-31,MK,North Macedonia,95.3124
 2018-03-31,MT,Malta,122.2405
 2018-03-31,MX,Mexico,157.6318
 2018-03-31,MY,Malaysia,189.3538
-2018-03-31,NL,Netherlands,107.6302
+2018-03-31,NL,Netherlands,107.8881
 2018-03-31,NO,Norway,146.4531
 2018-03-31,NZ,New Zealand,171.3068
 2018-03-31,PE,Peru,167.6095
@@ -22617,31 +7164,30 @@ date,country_code,country,price
 2018-03-31,PL,Poland,103.6644
 2018-03-31,PT,Portugal,116.9737
 2018-03-31,RO,Romania,97.0711
-2018-03-31,RS,Serbia,119.6257
+2018-03-31,RS,Serbia,120.6646
 2018-03-31,RU,Russia,89.4809
 2018-03-31,SE,Sweden,153.1039
 2018-03-31,SG,Singapore,108.4478
 2018-03-31,SI,Slovenia,100.7124
-2018-03-31,SK,Slovak Republic,123.4691
-2018-03-31,TH,Thailand,140.8333
-2018-03-31,TR,Türkiye,225.3731
-2018-03-31,US,United States,145.0409
-2018-03-31,XM,Euro area,110.9085
-2018-03-31,XW,World,139.7644
-2018-03-31,ZA,South Africa,148.4967
-2018-06-30,4T,Emerging market economies (aggregate),152.614
-2018-06-30,5R,Advanced economies,130.8789
-2018-06-30,AE,United Arab Emirates,140.1511
+2018-03-31,SK,Slovakia,123.1692
+2018-03-31,TH,Thailand,152.4738
+2018-03-31,TR,Türkiye,229.2103
+2018-03-31,US,United States,145.0466
+2018-03-31,XM,Euro area,110.7706
+2018-03-31,XW,World,138.9012
+2018-03-31,ZA,South Africa,147.0666
+2018-06-30,4T,Emerging market economies (aggregate),153.6228
+2018-06-30,5R,Advanced economies,130.8438
 2018-06-30,AT,Austria,155.2544
 2018-06-30,AU,Australia,140.9487
-2018-06-30,BE,Belgium,118.2909
+2018-06-30,BE,Belgium,118.4639
 2018-06-30,BG,Bulgaria,117.2223
-2018-06-30,BR,Brazil,149.3566
-2018-06-30,CA,Canada,178.0798
-2018-06-30,CH,Switzerland,128.7734
-2018-06-30,CL,Chile,217.931
+2018-06-30,BR,Brazil,149.3765
+2018-06-30,CA,Canada,177.4131
+2018-06-30,CH,Switzerland,128.7736
+2018-06-30,CL,Chile,217.6942
 2018-06-30,CN,China,127.7012
-2018-06-30,CO,Colombia,192.1679
+2018-06-30,CO,Colombia,190.1251
 2018-06-30,CY,Cyprus,75.7755
 2018-06-30,CZ,Czechia,135.1536
 2018-06-30,DE,Germany,141.3
@@ -22650,28 +7196,28 @@ date,country_code,country,price
 2018-06-30,ES,Spain,87.6238
 2018-06-30,FI,Finland,110.7561
 2018-06-30,FR,France,106.6399
-2018-06-30,GB,United Kingdom,133.296
+2018-06-30,GB,United Kingdom,133.3333
 2018-06-30,GR,Greece,64.051
 2018-06-30,HK,Hong Kong SAR,254.3487
 2018-06-30,HR,Croatia,98.9364
 2018-06-30,HU,Hungary,152.1217
 2018-06-30,ID,Indonesia,151.8042
-2018-06-30,IE,Ireland,123.0527
+2018-06-30,IE,Ireland,123.1302
 2018-06-30,IL,Israel,155.8034
 2018-06-30,IN,India,276.7452
-2018-06-30,IS,Iceland,196.4494
+2018-06-30,IS,Iceland,196.4424
 2018-06-30,IT,Italy,83.9966
 2018-06-30,JP,Japan,112.0093
-2018-06-30,KR,Korea,119.4951
+2018-06-30,KR,Korea,119.5458
 2018-06-30,LT,Lithuania,146.0764
 2018-06-30,LU,Luxembourg,147.1154
 2018-06-30,LV,Latvia,161.68
-2018-06-30,MA,Morocco,110.0794
-2018-06-30,MK,North Macedonia,94.47
+2018-06-30,MA,Morocco,107.1939
+2018-06-30,MK,North Macedonia,94.4824
 2018-06-30,MT,Malta,126.8534
 2018-06-30,MX,Mexico,161.2641
 2018-06-30,MY,Malaysia,191.2355
-2018-06-30,NL,Netherlands,109.2101
+2018-06-30,NL,Netherlands,109.9554
 2018-06-30,NO,Norway,152.2066
 2018-06-30,NZ,New Zealand,171.688
 2018-06-30,PE,Peru,165.842
@@ -22679,31 +7225,30 @@ date,country_code,country,price
 2018-06-30,PL,Poland,106.0032
 2018-06-30,PT,Portugal,119.6842
 2018-06-30,RO,Romania,100.4184
-2018-06-30,RS,Serbia,121.6855
+2018-06-30,RS,Serbia,122.8869
 2018-06-30,RU,Russia,90.1704
 2018-06-30,SE,Sweden,154.1805
 2018-06-30,SG,Singapore,112.1355
 2018-06-30,SI,Slovenia,102.325
-2018-06-30,SK,Slovak Republic,124.9688
-2018-06-30,TH,Thailand,141.7708
-2018-06-30,TR,Türkiye,232.6226
-2018-06-30,US,United States,146.697
-2018-06-30,XM,Euro area,112.5322
-2018-06-30,XW,World,141.6506
-2018-06-30,ZA,South Africa,150.5029
-2018-09-30,4T,Emerging market economies (aggregate),155.0725
-2018-09-30,5R,Advanced economies,132.2329
-2018-09-30,AE,United Arab Emirates,135.843
+2018-06-30,SK,Slovakia,124.6688
+2018-06-30,TH,Thailand,152.6814
+2018-06-30,TR,Türkiye,236.5927
+2018-06-30,US,United States,146.7292
+2018-06-30,XM,Euro area,112.3882
+2018-06-30,XW,World,140.7923
+2018-06-30,ZA,South Africa,148.409
+2018-09-30,4T,Emerging market economies (aggregate),156.4214
+2018-09-30,5R,Advanced economies,132.1953
 2018-09-30,AT,Austria,159.6543
 2018-09-30,AU,Australia,138.819
-2018-09-30,BE,Belgium,120.6843
+2018-09-30,BE,Belgium,120.7893
 2018-09-30,BG,Bulgaria,118.1296
-2018-09-30,BR,Brazil,149.9932
-2018-09-30,CA,Canada,178.4229
-2018-09-30,CH,Switzerland,129.5867
-2018-09-30,CL,Chile,226.0829
+2018-09-30,BR,Brazil,150.0161
+2018-09-30,CA,Canada,177.7549
+2018-09-30,CH,Switzerland,129.587
+2018-09-30,CL,Chile,226.1814
 2018-09-30,CN,China,131.5698
-2018-09-30,CO,Colombia,190.8949
+2018-09-30,CO,Colombia,189.0436
 2018-09-30,CY,Cyprus,76.2976
 2018-09-30,CZ,Czechia,138.514
 2018-09-30,DE,Germany,144.2
@@ -22712,28 +7257,28 @@ date,country_code,country,price
 2018-09-30,ES,Spain,89.5413
 2018-09-30,FI,Finland,110.2236
 2018-09-30,FR,France,108.8449
-2018-09-30,GB,United Kingdom,135.8702
+2018-09-30,GB,United Kingdom,135.8271
 2018-09-30,GR,Greece,64.5116
 2018-09-30,HK,Hong Kong SAR,260.3788
 2018-09-30,HR,Croatia,101.652
 2018-09-30,HU,Hungary,158.5268
 2018-09-30,ID,Indonesia,152.2753
-2018-09-30,IE,Ireland,125.803
+2018-09-30,IE,Ireland,125.8042
 2018-09-30,IL,Israel,155.3204
 2018-09-30,IN,India,279.0045
-2018-09-30,IS,Iceland,199.8801
+2018-09-30,IS,Iceland,199.8878
 2018-09-30,IT,Italy,83.3192
 2018-09-30,JP,Japan,112.1093
-2018-09-30,KR,Korea,120.3621
+2018-09-30,KR,Korea,120.3656
 2018-09-30,LT,Lithuania,147.6797
 2018-09-30,LU,Luxembourg,150.7341
 2018-09-30,LV,Latvia,159.73
-2018-09-30,MA,Morocco,110.2718
-2018-09-30,MK,North Macedonia,95.39
+2018-09-30,MA,Morocco,107.0986
+2018-09-30,MK,North Macedonia,95.6124
 2018-09-30,MT,Malta,131.0269
 2018-09-30,MX,Mexico,164.9095
 2018-09-30,MY,Malaysia,193.4142
-2018-09-30,NL,Netherlands,112.7379
+2018-09-30,NL,Netherlands,113.444
 2018-09-30,NO,Norway,150.5067
 2018-09-30,NZ,New Zealand,173.3236
 2018-09-30,PE,Peru,169.9126
@@ -22741,31 +7286,30 @@ date,country_code,country,price
 2018-09-30,PL,Poland,107.4046
 2018-09-30,PT,Portugal,120.8299
 2018-09-30,RO,Romania,99.5816
-2018-09-30,RS,Serbia,124.2407
+2018-09-30,RS,Serbia,125.4795
 2018-09-30,RU,Russia,90.8011
 2018-09-30,SE,Sweden,155.6895
 2018-09-30,SG,Singapore,112.6623
 2018-09-30,SI,Slovenia,104.6628
-2018-09-30,SK,Slovak Republic,124.6688
-2018-09-30,TH,Thailand,143.4375
-2018-09-30,TR,Türkiye,229.8507
-2018-09-30,US,United States,148.136
-2018-09-30,XM,Euro area,114.3443
-2018-09-30,XW,World,143.5545
-2018-09-30,ZA,South Africa,151.8577
-2018-12-31,4T,Emerging market economies (aggregate),157.2316
-2018-12-31,5R,Advanced economies,132.7493
-2018-12-31,AE,United Arab Emirates,132.1814
+2018-09-30,SK,Slovakia,124.2689
+2018-09-30,TH,Thailand,154.861
+2018-09-30,TR,Türkiye,238.0124
+2018-09-30,US,United States,148.1949
+2018-09-30,XM,Euro area,114.203
+2018-09-30,XW,World,142.8055
+2018-09-30,ZA,South Africa,149.5686
+2018-12-31,4T,Emerging market economies (aggregate),158.8743
+2018-12-31,5R,Advanced economies,132.6934
 2018-12-31,AT,Austria,159.7329
 2018-12-31,AU,Australia,135.5276
-2018-12-31,BE,Belgium,120.0424
+2018-12-31,BE,Belgium,120.1561
 2018-12-31,BG,Bulgaria,119.226
-2018-12-31,BR,Brazil,150.884
-2018-12-31,CA,Canada,177.7366
-2018-12-31,CH,Switzerland,131.4891
-2018-12-31,CL,Chile,230.7888
+2018-12-31,BR,Brazil,150.9125
+2018-12-31,CA,Canada,177.0712
+2018-12-31,CH,Switzerland,131.4893
+2018-12-31,CL,Chile,231.2859
 2018-12-31,CN,China,134.1611
-2018-12-31,CO,Colombia,190.368
+2018-12-31,CO,Colombia,187.2961
 2018-12-31,CY,Cyprus,76.9802
 2018-12-31,CZ,Czechia,141.1394
 2018-12-31,DE,Germany,146
@@ -22774,28 +7318,28 @@ date,country_code,country,price
 2018-12-31,ES,Spain,89.9054
 2018-12-31,FI,Finland,109.9042
 2018-12-31,FR,France,108.8449
-2018-12-31,GB,United Kingdom,135.1987
+2018-12-31,GB,United Kingdom,135.1621
 2018-12-31,GR,Greece,65.3151
 2018-12-31,HK,Hong Kong SAR,244.0554
 2018-12-31,HR,Croatia,102.7382
 2018-12-31,HU,Hungary,162.5834
 2018-12-31,ID,Indonesia,152.8224
-2018-12-31,IE,Ireland,126.6673
+2018-12-31,IE,Ireland,126.685
 2018-12-31,IL,Israel,154.5452
 2018-12-31,IN,India,283.1675
-2018-12-31,IS,Iceland,202.4061
+2018-12-31,IS,Iceland,202.4122
 2018-12-31,IT,Italy,83.2345
 2018-12-31,JP,Japan,111.476
-2018-12-31,KR,Korea,122.0961
+2018-12-31,KR,Korea,122.0746
 2018-12-31,LT,Lithuania,149.1523
 2018-12-31,LU,Luxembourg,154.6022
 2018-12-31,LV,Latvia,165.44
-2018-12-31,MA,Morocco,111.1378
-2018-12-31,MK,North Macedonia,95.25
+2018-12-31,MA,Morocco,107.9562
+2018-12-31,MK,North Macedonia,95.4124
 2018-12-31,MT,Malta,135.9692
 2018-12-31,MX,Mexico,168.0721
 2018-12-31,MY,Malaysia,193.4142
-2018-12-31,NL,Netherlands,114.2639
+2018-12-31,NL,Netherlands,114.9945
 2018-12-31,NO,Norway,146.9761
 2018-12-31,NZ,New Zealand,174.8623
 2018-12-31,PE,Peru,170.2999
@@ -22803,31 +7347,30 @@ date,country_code,country,price
 2018-12-31,PL,Poland,109.9422
 2018-12-31,PT,Portugal,123.2704
 2018-12-31,RO,Romania,100.4184
-2018-12-31,RS,Serbia,127.2261
+2018-12-31,RS,Serbia,128.7468
 2018-12-31,RU,Russia,92.4425
 2018-12-31,SE,Sweden,155.4238
 2018-12-31,SG,Singapore,112.587
 2018-12-31,SI,Slovenia,107.12
-2018-12-31,SK,Slovak Republic,128.168
-2018-12-31,TH,Thailand,143.9583
-2018-12-31,TR,Türkiye,230.2772
-2018-12-31,US,United States,149.4262
-2018-12-31,XM,Euro area,115.1044
-2018-12-31,XW,World,144.8877
-2018-12-31,ZA,South Africa,152.7605
-2019-03-31,4T,Emerging market economies (aggregate),158.6422
-2019-03-31,5R,Advanced economies,133.6128
-2019-03-31,AE,United Arab Emirates,131.2655
+2018-12-31,SK,Slovakia,127.7681
+2018-12-31,TH,Thailand,155.5876
+2018-12-31,TR,Türkiye,240
+2018-12-31,US,United States,149.4569
+2018-12-31,XM,Euro area,114.962
+2018-12-31,XW,World,144.1999
+2018-12-31,ZA,South Africa,150.7944
+2019-03-31,4T,Emerging market economies (aggregate),160.2906
+2019-03-31,5R,Advanced economies,133.5208
 2019-03-31,AT,Austria,161.9328
 2019-03-31,AU,Australia,131.4618
-2019-03-31,BE,Belgium,121.3479
+2019-03-31,BE,Belgium,121.1823
 2019-03-31,BG,Bulgaria,122.3448
-2019-03-31,BR,Brazil,152.1088
-2019-03-31,CA,Canada,176.8788
-2019-03-31,CH,Switzerland,132.7894
-2019-03-31,CL,Chile,232.6754
+2019-03-31,BR,Brazil,152.1373
+2019-03-31,CA,Canada,176.2167
+2019-03-31,CH,Switzerland,132.7897
+2019-03-31,CL,Chile,233.3696
 2019-03-31,CN,China,135.4384
-2019-03-31,CO,Colombia,195.7392
+2019-03-31,CO,Colombia,193.5608
 2019-03-31,CY,Cyprus,77.5123
 2019-03-31,CZ,Czechia,144.0798
 2019-03-31,DE,Germany,146
@@ -22836,60 +7379,59 @@ date,country_code,country,price
 2019-03-31,ES,Spain,91.3249
 2019-03-31,FI,Finland,109.7977
 2019-03-31,FR,France,108.8449
-2019-03-31,GB,United Kingdom,133.6318
+2019-03-31,GB,United Kingdom,133.6658
 2019-03-31,GR,Greece,67.0184
 2019-03-31,HK,Hong Kong SAR,244.453
 2019-03-31,HR,Croatia,106.4494
 2019-03-31,HU,Hungary,176.1409
 2019-03-31,ID,Indonesia,153.3846
-2019-03-31,IE,Ireland,125.4887
+2019-03-31,IE,Ireland,125.521
 2019-03-31,IL,Israel,156.1592
 2019-03-31,IN,India,279.9041
-2019-03-31,IS,Iceland,203.7671
+2019-03-31,IS,Iceland,203.7729
 2019-03-31,IT,Italy,82.7265
 2019-03-31,JP,Japan,115.1429
-2019-03-31,KR,Korea,122.0961
+2019-03-31,KR,Korea,122.1278
 2019-03-31,LT,Lithuania,153.4396
 2019-03-31,LU,Luxembourg,155.9748
 2019-03-31,LV,Latvia,166.83
-2019-03-31,MA,Morocco,110.3681
-2019-03-31,MK,North Macedonia,96.87
+2019-03-31,MA,Morocco,106.5269
+2019-03-31,MK,North Macedonia,96.8824
 2019-03-31,MT,Malta,130.1483
 2019-03-31,MX,Mexico,171.8704
 2019-03-31,MY,Malaysia,194.1075
-2019-03-31,NL,Netherlands,116.3914
+2019-03-31,NL,Netherlands,116.9326
 2019-03-31,NO,Norway,150.899
 2019-03-31,NZ,New Zealand,175.7425
 2019-03-31,PE,Peru,171.9173
-2019-03-31,PH,Philippines,188.3855
+2019-03-31,PH,Philippines,188.1044
 2019-03-31,PL,Poland,112.0538
 2019-03-31,PT,Portugal,127.7414
 2019-03-31,RO,Romania,100.4184
-2019-03-31,RS,Serbia,130.368
+2019-03-31,RS,Serbia,132.2786
 2019-03-31,RU,Russia,95.948
 2019-03-31,SE,Sweden,155.4349
 2019-03-31,SG,Singapore,111.8344
 2019-03-31,SI,Slovenia,108.3401
-2019-03-31,SK,Slovak Republic,130.5674
-2019-03-31,TH,Thailand,143.8542
-2019-03-31,TR,Türkiye,232.4094
-2019-03-31,US,United States,150.5465
-2019-03-31,XM,Euro area,115.541
-2019-03-31,XW,World,146.024
-2019-03-31,ZA,South Africa,153.8906
-2019-06-30,4T,Emerging market economies (aggregate),160.7549
-2019-06-30,5R,Advanced economies,134.8903
-2019-06-30,AE,United Arab Emirates,127.1786
+2019-03-31,SK,Slovakia,130.1675
+2019-03-31,TH,Thailand,153.9269
+2019-03-31,TR,Türkiye,238.5803
+2019-03-31,US,United States,150.5919
+2019-03-31,XM,Euro area,115.4088
+2019-03-31,XW,World,145.2956
+2019-03-31,ZA,South Africa,151.8626
+2019-06-30,4T,Emerging market economies (aggregate),162.5522
+2019-06-30,5R,Advanced economies,134.843
 2019-06-30,AT,Austria,163.8971
 2019-06-30,AU,Australia,130.4937
-2019-06-30,BE,Belgium,121.8593
+2019-06-30,BE,Belgium,122.0994
 2019-06-30,BG,Bulgaria,123.1104
-2019-06-30,BR,Brazil,153.7561
-2019-06-30,CA,Canada,178.4229
-2019-06-30,CH,Switzerland,133.4809
-2019-06-30,CL,Chile,234.0195
+2019-06-30,BR,Brazil,153.779
+2019-06-30,CA,Canada,177.7549
+2019-06-30,CH,Switzerland,133.4812
+2019-06-30,CL,Chile,234.7169
 2019-06-30,CN,China,137.1538
-2019-06-30,CO,Colombia,198.6508
+2019-06-30,CO,Colombia,196.1345
 2019-06-30,CY,Cyprus,77.9239
 2019-06-30,CZ,Czechia,147.6503
 2019-06-30,DE,Germany,149.7
@@ -22898,60 +7440,59 @@ date,country_code,country,price
 2019-06-30,ES,Spain,92.358
 2019-06-30,FI,Finland,111.5016
 2019-06-30,FR,France,110.0476
-2019-06-30,GB,United Kingdom,134.6391
+2019-06-30,GB,United Kingdom,134.6633
 2019-06-30,GR,Greece,68.9145
-2019-06-30,HK,Hong Kong SAR,261.3728
+2019-06-30,HK,Hong Kong SAR,261.2844
 2019-06-30,HR,Croatia,109.165
 2019-06-30,HU,Hungary,182.0123
 2019-06-30,ID,Indonesia,153.7189
-2019-06-30,IE,Ireland,126.1566
+2019-06-30,IE,Ireland,126.1817
 2019-06-30,IL,Israel,157.6844
 2019-06-30,IN,India,286.2845
-2019-06-30,IS,Iceland,204.6363
+2019-06-30,IS,Iceland,204.6434
 2019-06-30,IT,Italy,83.9119
 2019-06-30,JP,Japan,114.1762
-2019-06-30,KR,Korea,121.7391
+2019-06-30,KR,Korea,121.7576
 2019-06-30,LT,Lithuania,155.708
 2019-06-30,LU,Luxembourg,163.8359
 2019-06-30,LV,Latvia,174.48
-2019-06-30,MA,Morocco,109.7907
-2019-06-30,MK,North Macedonia,99.68
+2019-06-30,MA,Morocco,106.5269
+2019-06-30,MK,North Macedonia,99.7625
 2019-06-30,MT,Malta,134.871
 2019-06-30,MX,Mexico,176.0633
 2019-06-30,MY,Malaysia,195.692
-2019-06-30,NL,Netherlands,118.3034
+2019-06-30,NL,Netherlands,118.4831
 2019-06-30,NO,Norway,155.2141
 2019-06-30,NZ,New Zealand,175.1256
 2019-06-30,PE,Peru,173.6966
-2019-06-30,PH,Philippines,185.466
+2019-06-30,PH,Philippines,195.1776
 2019-06-30,PL,Poland,114.6672
 2019-06-30,PT,Portugal,131.0109
 2019-06-30,RO,Romania,102.0921
-2019-06-30,RS,Serbia,133.562
+2019-06-30,RS,Serbia,136.2205
 2019-06-30,RU,Russia,96.4025
 2019-06-30,SE,Sweden,157.5278
 2019-06-30,SG,Singapore,113.4901
 2019-06-30,SI,Slovenia,109.9185
-2019-06-30,SK,Slovak Republic,135.3662
-2019-06-30,TH,Thailand,142.9167
-2019-06-30,TR,Türkiye,236.6738
-2019-06-30,US,United States,152.0182
-2019-06-30,XM,Euro area,117.441
-2019-06-30,XW,World,147.7177
-2019-06-30,ZA,South Africa,155.7393
-2019-09-30,4T,Emerging market economies (aggregate),162.5876
-2019-09-30,5R,Advanced economies,136.3097
-2019-09-30,AE,United Arab Emirates,125.6921
+2019-06-30,SK,Slovakia,134.9663
+2019-06-30,TH,Thailand,155.1724
+2019-06-30,TR,Türkiye,242.5555
+2019-06-30,US,United States,152.1012
+2019-06-30,XM,Euro area,117.3079
+2019-06-30,XW,World,147.0454
+2019-06-30,ZA,South Africa,152.3529
+2019-09-30,4T,Emerging market economies (aggregate),164.395
+2019-09-30,5R,Advanced economies,136.1803
 2019-09-30,AT,Austria,163.2685
 2019-09-30,AU,Australia,133.6883
-2019-09-30,BE,Belgium,126.1566
+2019-09-30,BE,Belgium,125.9532
 2019-09-30,BG,Bulgaria,124.7265
-2019-09-30,BR,Brazil,155.8688
-2019-09-30,CA,Canada,178.766
-2019-09-30,CH,Switzerland,133.6661
-2019-09-30,CL,Chile,243.4635
+2019-09-30,BR,Brazil,155.8745
+2019-09-30,CA,Canada,178.0968
+2019-09-30,CH,Switzerland,133.6664
+2019-09-30,CL,Chile,244.1798
 2019-09-30,CN,China,138.5041
-2019-09-30,CO,Colombia,203.1274
+2019-09-30,CO,Colombia,199.9576
 2019-09-30,CY,Cyprus,78.4359
 2019-09-30,CZ,Czechia,150.5907
 2019-09-30,DE,Germany,151.8
@@ -22960,60 +7501,59 @@ date,country_code,country,price
 2019-09-30,ES,Spain,93.837
 2019-09-30,FI,Finland,110.7561
 2019-09-30,FR,France,112.5532
-2019-09-30,GB,United Kingdom,136.8774
+2019-09-30,GB,United Kingdom,136.8246
 2019-09-30,GR,Greece,69.8573
 2019-09-30,HK,Hong Kong SAR,256.9109
 2019-09-30,HR,Croatia,109.8891
 2019-09-30,HU,Hungary,184.8946
 2019-09-30,ID,Indonesia,154.1748
-2019-09-30,IE,Ireland,127.9639
+2019-09-30,IE,Ireland,128.0063
 2019-09-30,IL,Israel,158.358
 2019-09-30,IN,India,288.0732
-2019-09-30,IS,Iceland,206.5283
+2019-09-30,IS,Iceland,206.5356
 2019-09-30,IT,Italy,83.6579
 2019-09-30,JP,Japan,113.5095
-2019-09-30,KR,Korea,121.6881
+2019-09-30,KR,Korea,121.718
 2019-09-30,LT,Lithuania,157.1925
 2019-09-30,LU,Luxembourg,167.7041
 2019-09-30,LV,Latvia,179.94
-2019-09-30,MA,Morocco,110.6567
-2019-09-30,MK,North Macedonia,97.24
+2019-09-30,MA,Morocco,107.1939
+2019-09-30,MK,North Macedonia,97.2224
 2019-09-30,MT,Malta,138.8248
 2019-09-30,MX,Mexico,178.8326
 2019-09-30,MY,Malaysia,197.5737
-2019-09-30,NL,Netherlands,119.7846
+2019-09-30,NL,Netherlands,120.6796
 2019-09-30,NO,Norway,154.0373
 2019-09-30,NZ,New Zealand,178.688
 2019-09-30,PE,Peru,173.2663
-2019-09-30,PH,Philippines,202.3684
+2019-09-30,PH,Philippines,196.1196
 2019-09-30,PL,Poland,117.0249
 2019-09-30,PT,Portugal,133.8239
 2019-09-30,RO,Romania,103.7657
-2019-09-30,RS,Serbia,136.8343
+2019-09-30,RS,Serbia,140.2815
 2019-09-30,RU,Russia,98.1507
 2019-09-30,SE,Sweden,160.2648
 2019-09-30,SG,Singapore,114.9953
 2019-09-30,SI,Slovenia,112.0515
-2019-09-30,SK,Slovak Republic,138.9653
-2019-09-30,TH,Thailand,142.8125
-2019-09-30,TR,Türkiye,245.629
-2019-09-30,US,United States,153.8232
-2019-09-30,XM,Euro area,119.0076
-2019-09-30,XW,World,149.3424
-2019-09-30,ZA,South Africa,157.458
-2019-12-31,4T,Emerging market economies (aggregate),164.2259
-2019-12-31,5R,Advanced economies,137.5639
-2019-12-31,AE,United Arab Emirates,124.1812
+2019-09-30,SK,Slovakia,138.6653
+2019-09-30,TH,Thailand,152.4738
+2019-09-30,TR,Türkiye,249.37
+2019-09-30,US,United States,153.8897
+2019-09-30,XM,Euro area,118.8726
+2019-09-30,XW,World,148.6099
+2019-09-30,ZA,South Africa,152.7378
+2019-12-31,4T,Emerging market economies (aggregate),166.2633
+2019-12-31,5R,Advanced economies,137.3827
 2019-12-31,AT,Austria,164.6042
 2019-12-31,AU,Australia,138.9158
-2019-12-31,BE,Belgium,125.7758
+2019-12-31,BE,Belgium,125.2436
 2019-12-31,BG,Bulgaria,126.6356
-2019-12-31,BR,Brazil,158.4355
-2019-12-31,CA,Canada,180.6532
-2019-12-31,CH,Switzerland,136.0164
-2019-12-31,CL,Chile,249.132
+2019-12-31,BR,Brazil,158.4155
+2019-12-31,CA,Canada,179.9769
+2019-12-31,CH,Switzerland,136.0167
+2019-12-31,CL,Chile,249.8645
 2019-12-31,CN,China,139.2341
-2019-12-31,CO,Colombia,202.6291
+2019-12-31,CO,Colombia,199.5204
 2019-12-31,CY,Cyprus,78.6367
 2019-12-31,CZ,Czechia,153.7411
 2019-12-31,DE,Germany,155.5
@@ -23022,60 +7562,59 @@ date,country_code,country,price
 2019-12-31,ES,Spain,93.2276
 2019-12-31,FI,Finland,110.0106
 2019-12-31,FR,France,112.9541
-2019-12-31,GB,United Kingdom,136.3179
+2019-12-31,GB,United Kingdom,136.3259
 2019-12-31,GR,Greece,70.2001
 2019-12-31,HK,Hong Kong SAR,252.4049
 2019-12-31,HR,Croatia,113.0573
 2019-12-31,HU,Hungary,183.5068
 2019-12-31,ID,Indonesia,154.7218
-2019-12-31,IE,Ireland,127.7281
+2019-12-31,IE,Ireland,127.6917
 2019-12-31,IL,Israel,160.061
 2019-12-31,IN,India,291.5876
-2019-12-31,IS,Iceland,211.0794
+2019-12-31,IS,Iceland,211.085
 2019-12-31,IT,Italy,83.4039
 2019-12-31,JP,Japan,112.5427
-2019-12-31,KR,Korea,122.1981
+2019-12-31,KR,Korea,122.1546
 2019-12-31,LT,Lithuania,158.867
 2019-12-31,LU,Luxembourg,171.1979
 2019-12-31,LV,Latvia,180.08
-2019-12-31,MA,Morocco,110.3681
-2019-12-31,MK,North Macedonia,98.46
+2019-12-31,MA,Morocco,106.9081
+2019-12-31,MK,North Macedonia,98.5225
 2019-12-31,MT,Malta,143.7672
 2019-12-31,MX,Mexico,180.9432
 2019-12-31,MY,Malaysia,196.8804
-2019-12-31,NL,Netherlands,121.7056
+2019-12-31,NL,Netherlands,122.4885
 2019-12-31,NO,Norway,150.7682
 2019-12-31,NZ,New Zealand,183.2138
 2019-12-31,PE,Peru,169.2388
-2019-12-31,PH,Philippines,204.827
+2019-12-31,PH,Philippines,201.7839
 2019-12-31,PL,Poland,120.3106
 2019-12-31,PT,Portugal,136.0594
 2019-12-31,RO,Romania,104.6025
-2019-12-31,RS,Serbia,139.924
+2019-12-31,RS,Serbia,144.1573
 2019-12-31,RU,Russia,98.5077
 2019-12-31,SE,Sweden,160.521
 2019-12-31,SG,Singapore,115.5974
 2019-12-31,SI,Slovenia,112.299
-2019-12-31,SK,Slovak Republic,142.0645
-2019-12-31,TH,Thailand,146.0417
-2019-12-31,TR,Türkiye,253.3049
-2019-12-31,US,United States,156.1023
-2019-12-31,XM,Euro area,120.0652
-2019-12-31,XW,World,150.7875
-2019-12-31,ZA,South Africa,157.8091
-2020-03-31,4T,Emerging market economies (aggregate),165.9845
-2020-03-31,5R,Advanced economies,139.3429
-2020-03-31,AE,United Arab Emirates,121.2304
+2019-12-31,SK,Slovakia,141.7646
+2019-12-31,TH,Thailand,158.8052
+2019-12-31,TR,Türkiye,258.669
+2019-12-31,US,United States,156.1576
+2019-12-31,XM,Euro area,119.9251
+2019-12-31,XW,World,150.1138
+2019-12-31,ZA,South Africa,153.7968
+2020-03-31,4T,Emerging market economies (aggregate),168.1432
+2020-03-31,5R,Advanced economies,139.1213
 2020-03-31,AT,Austria,167.4327
 2020-03-31,AU,Australia,141.1423
-2020-03-31,BE,Belgium,125.6453
+2020-03-31,BE,Belgium,125.8113
 2020-03-31,BG,Bulgaria,128.1006
-2020-03-31,BR,Brazil,161.4989
-2020-03-31,CA,Canada,184.4275
-2020-03-31,CH,Switzerland,134.9885
-2020-03-31,CL,Chile,253.8062
+2020-03-31,BR,Brazil,161.4332
+2020-03-31,CA,Canada,183.7371
+2020-03-31,CH,Switzerland,134.9888
+2020-03-31,CL,Chile,254.2973
 2020-03-31,CN,China,139.4895
-2020-03-31,CO,Colombia,206.8589
+2020-03-31,CO,Colombia,203.3567
 2020-03-31,CY,Cyprus,78.9278
 2020-03-31,CZ,Czechia,156.4715
 2020-03-31,DE,Germany,156.8
@@ -23084,60 +7623,59 @@ date,country_code,country,price
 2020-03-31,ES,Spain,94.3275
 2020-03-31,FI,Finland,111.0756
 2020-03-31,FR,France,114.1569
-2020-03-31,GB,United Kingdom,135.9821
+2020-03-31,GB,United Kingdom,135.9934
 2020-03-31,GR,Greece,71.5284
 2020-03-31,HK,Hong Kong SAR,249.931
 2020-03-31,HR,Croatia,116.1349
 2020-03-31,HU,Hungary,190.7659
 2020-03-31,ID,Indonesia,155.3904
-2020-03-31,IE,Ireland,126.7459
+2020-03-31,IE,Ireland,126.7479
 2020-03-31,IL,Israel,161.5988
 2020-03-31,IN,India,290.8659
-2020-03-31,IS,Iceland,214.9973
+2020-03-31,IS,Iceland,215.0068
 2020-03-31,IT,Italy,84.166
 2020-03-31,JP,Japan,114.6429
-2020-03-31,KR,Korea,123.4222
+2020-03-31,KR,Korea,123.4607
 2020-03-31,LT,Lithuania,163.0118
 2020-03-31,LU,Luxembourg,178.0608
 2020-03-31,LV,Latvia,181.43
-2020-03-31,MA,Morocco,109.502
-2020-03-31,MK,North Macedonia,99.01
+2020-03-31,MA,Morocco,105.8599
+2020-03-31,MK,North Macedonia,99.1225
 2020-03-31,MT,Malta,137.397
 2020-03-31,MX,Mexico,183.9652
 2020-03-31,MY,Malaysia,197.7717
-2020-03-31,NL,Netherlands,123.7343
+2020-03-31,NL,Netherlands,124.9435
 2020-03-31,NO,Norway,153.7757
 2020-03-31,NZ,New Zealand,189.0217
 2020-03-31,PE,Peru,171.3878
-2020-03-31,PH,Philippines,212.0489
+2020-03-31,PH,Philippines,202.6184
 2020-03-31,PL,Poland,124.6662
 2020-03-31,PT,Portugal,141.2756
 2020-03-31,RO,Romania,108.7866
-2020-03-31,RS,Serbia,142.8573
+2020-03-31,RS,Serbia,147.9537
 2020-03-31,RU,Russia,102.7828
 2020-03-31,SE,Sweden,162.5093
 2020-03-31,SG,Singapore,114.4685
 2020-03-31,SI,Slovenia,113.4679
-2020-03-31,SK,Slovak Republic,147.7631
-2020-03-31,TH,Thailand,149.375
-2020-03-31,TR,Türkiye,267.3774
-2020-03-31,US,United States,158.316
-2020-03-31,XM,Euro area,121.4303
-2020-03-31,XW,World,152.5532
-2020-03-31,ZA,South Africa,156.8467
-2020-06-30,4T,Emerging market economies (aggregate),167.8203
-2020-06-30,5R,Advanced economies,140.4962
-2020-06-30,AE,United Arab Emirates,118.1609
+2020-03-31,SK,Slovakia,147.2632
+2020-03-31,TH,Thailand,160.3621
+2020-03-31,TR,Türkiye,274.2147
+2020-03-31,US,United States,158.4799
+2020-03-31,XM,Euro area,121.301
+2020-03-31,XW,World,151.9091
+2020-03-31,ZA,South Africa,153.7577
+2020-06-30,4T,Emerging market economies (aggregate),169.6415
+2020-06-30,5R,Advanced economies,140.3296
 2020-06-30,AT,Austria,172.4612
 2020-06-30,AU,Australia,138.6254
-2020-06-30,BE,Belgium,127.3316
+2020-06-30,BE,Belgium,127.307
 2020-06-30,BG,Bulgaria,126.7112
-2020-06-30,BR,Brazil,165.0248
-2020-06-30,CA,Canada,188.5449
-2020-06-30,CH,Switzerland,136.8283
-2020-06-30,CL,Chile,256.1381
+2020-06-30,BR,Brazil,164.8963
+2020-06-30,CA,Canada,187.8391
+2020-06-30,CH,Switzerland,136.8285
+2020-06-30,CL,Chile,256.9437
 2020-06-30,CN,China,140.256
-2020-06-30,CO,Colombia,200.9167
+2020-06-30,CO,Colombia,198.2056
 2020-06-30,CY,Cyprus,79.6607
 2020-06-30,CZ,Czechia,159.0969
 2020-06-30,DE,Germany,159.6
@@ -23146,60 +7684,59 @@ date,country_code,country,price
 2020-06-30,ES,Spain,94.3721
 2020-06-30,FI,Finland,112.2471
 2020-06-30,FR,France,115.7605
-2020-06-30,GB,United Kingdom,136.3179
+2020-06-30,GB,United Kingdom,136.3259
 2020-06-30,GR,Greece,71.8712
 2020-06-30,HK,Hong Kong SAR,254.0836
 2020-06-30,HR,Croatia,118.2168
 2020-06-30,HU,Hungary,186.7094
 2020-06-30,ID,Indonesia,155.8159
-2020-06-30,IE,Ireland,126.5887
+2020-06-30,IE,Ireland,126.6221
 2020-06-30,IL,Israel,161.2684
 2020-06-30,IN,India,294.37
-2020-06-30,IS,Iceland,218.3209
+2020-06-30,IS,Iceland,218.3284
 2020-06-30,IT,Italy,86.7062
 2020-06-30,JP,Japan,113.3761
-2020-06-30,KR,Korea,124.6972
+2020-06-30,KR,Korea,124.6709
 2020-06-30,LT,Lithuania,166.5628
 2020-06-30,LU,Luxembourg,185.5476
 2020-06-30,LV,Latvia,177.1
-2020-06-30,MA,Morocco,108.8285
-2020-06-30,MK,North Macedonia,101.11
+2020-06-30,MA,Morocco,100.7146
+2020-06-30,MK,North Macedonia,101.2025
 2020-06-30,MT,Malta,140.1428
 2020-06-30,MX,Mexico,186.2172
 2020-06-30,MY,Malaysia,198.465
-2020-06-30,NL,Netherlands,126.6697
+2020-06-30,NL,Netherlands,127.9152
 2020-06-30,NO,Norway,159.3985
 2020-06-30,NZ,New Zealand,187.0465
 2020-06-30,PE,Peru,173.4013
-2020-06-30,PH,Philippines,234.7904
+2020-06-30,PH,Philippines,212.0423
 2020-06-30,PL,Poland,127.1755
 2020-06-30,PT,Portugal,143.7627
 2020-06-30,RO,Romania,108.7866
-2020-06-30,RS,Serbia,145.8427
+2020-06-30,RS,Serbia,151.922
 2020-06-30,RU,Russia,104.1895
 2020-06-30,SE,Sweden,162.6473
 2020-06-30,SG,Singapore,114.8448
 2020-06-30,SI,Slovenia,115.6606
-2020-06-30,SK,Slovak Republic,148.4629
-2020-06-30,TH,Thailand,150.3125
-2020-06-30,TR,Türkiye,297.4414
-2020-06-30,US,United States,159.5488
-2020-06-30,XM,Euro area,123.4209
-2020-06-30,XW,World,154.0492
-2020-06-30,ZA,South Africa,158.0144
-2020-09-30,4T,Emerging market economies (aggregate),169.3881
-2020-09-30,5R,Advanced economies,143.5256
-2020-09-30,AE,United Arab Emirates,116.0976
+2020-06-30,SK,Slovakia,148.063
+2020-06-30,TH,Thailand,161.8153
+2020-06-30,TR,Türkiye,290.1154
+2020-06-30,US,United States,159.8064
+2020-06-30,XM,Euro area,123.2946
+2020-06-30,XW,World,153.2462
+2020-06-30,ZA,South Africa,154.2289
+2020-09-30,4T,Emerging market economies (aggregate),171.5071
+2020-09-30,5R,Advanced economies,143.2416
 2020-09-30,AT,Austria,178.7468
 2020-09-30,AU,Australia,139.6902
-2020-09-30,BE,Belgium,130.1384
+2020-09-30,BE,Belgium,129.9708
 2020-09-30,BG,Bulgaria,131.1911
-2020-09-30,BR,Brazil,168.919
-2020-09-30,CA,Canada,191.1184
-2020-09-30,CH,Switzerland,137.1253
-2020-09-30,CL,Chile,252.7101
+2020-09-30,BR,Brazil,168.7106
+2020-09-30,CA,Canada,190.4029
+2020-09-30,CH,Switzerland,137.1256
+2020-09-30,CL,Chile,253.6588
 2020-09-30,CN,China,141.5698
-2020-09-30,CO,Colombia,205.8238
+2020-09-30,CO,Colombia,202.4235
 2020-09-30,CY,Cyprus,79.3695
 2020-09-30,CZ,Czechia,163.1924
 2020-09-30,DE,Germany,164.4
@@ -23208,60 +7745,59 @@ date,country_code,country,price
 2020-09-30,ES,Spain,95.5463
 2020-09-30,FI,Finland,112.6731
 2020-09-30,FR,France,118.0656
-2020-09-30,GB,United Kingdom,140.347
+2020-09-30,GB,United Kingdom,140.3159
 2020-09-30,GR,Greece,72.5676
 2020-09-30,HK,Hong Kong SAR,254.1278
 2020-09-30,HR,Croatia,117.4926
 2020-09-30,HU,Hungary,193.8618
 2020-09-30,ID,Indonesia,156.1198
-2020-09-30,IE,Ireland,126.9423
+2020-09-30,IE,Ireland,126.9996
 2020-09-30,IL,Israel,162.7681
 2020-09-30,IN,India,291.2529
-2020-09-30,IS,Iceland,222.5331
+2020-09-30,IS,Iceland,222.5389
 2020-09-30,IT,Italy,84.5047
 2020-09-30,JP,Japan,113.3761
-2020-09-30,KR,Korea,127.1962
+2020-09-30,KR,Korea,127.2227
 2020-09-30,LT,Lithuania,167.2753
 2020-09-30,LU,Luxembourg,190.9132
 2020-09-30,LV,Latvia,183.05
-2020-09-30,MA,Morocco,109.6945
-2020-09-30,MK,North Macedonia,100.05
+2020-09-30,MA,Morocco,105.8599
+2020-09-30,MK,North Macedonia,100.1625
 2020-09-30,MT,Malta,142.559
 2020-09-30,MX,Mexico,187.8402
 2020-09-30,MY,Malaysia,197.9698
-2020-09-30,NL,Netherlands,129.7935
+2020-09-30,NL,Netherlands,130.887
 2020-09-30,NO,Norway,161.6214
 2020-09-30,NZ,New Zealand,196.5346
 2020-09-30,PE,Peru,174.1416
-2020-09-30,PH,Philippines,201.6001
+2020-09-30,PH,Philippines,208.5135
 2020-09-30,PL,Poland,129.7794
 2020-09-30,PT,Portugal,143.0827
 2020-09-30,RO,Romania,105.4393
-2020-09-30,RS,Serbia,148.6847
+2020-09-30,RS,Serbia,155.8904
 2020-09-30,RU,Russia,107.5779
 2020-09-30,SE,Sweden,166.2237
 2020-09-30,SG,Singapore,115.7479
 2020-09-30,SI,Slovenia,115.7374
-2020-09-30,SK,Slovak Republic,150.7623
-2020-09-30,TH,Thailand,150.5208
-2020-09-30,TR,Türkiye,312.7932
-2020-09-30,US,United States,164.7902
-2020-09-30,XM,Euro area,125.207
-2020-09-30,XW,World,156.3363
-2020-09-30,ZA,South Africa,161.8039
-2020-12-31,4T,Emerging market economies (aggregate),171.8676
-2020-12-31,5R,Advanced economies,147.2265
-2020-12-31,AE,United Arab Emirates,116.1886
+2020-09-30,SK,Slovakia,150.2624
+2020-09-30,TH,Thailand,159.6356
+2020-09-30,TR,Türkiye,320.4259
+2020-09-30,US,United States,164.9151
+2020-09-30,XM,Euro area,125.072
+2020-09-30,XW,World,155.6557
+2020-09-30,ZA,South Africa,157.0434
+2020-12-31,4T,Emerging market economies (aggregate),173.9891
+2020-12-31,5R,Advanced economies,146.8721
 2020-12-31,AT,Austria,181.0253
 2020-12-31,AU,Australia,143.9497
-2020-12-31,BE,Belgium,132.9779
+2020-12-31,BE,Belgium,132.591
 2020-12-31,BG,Bulgaria,133.4783
-2020-12-31,BR,Brazil,172.8903
-2020-12-31,CA,Canada,195.7505
-2020-12-31,CH,Switzerland,140.2726
-2020-12-31,CL,Chile,260.5337
+2020-12-31,BR,Brazil,172.5848
+2020-12-31,CA,Canada,195.0177
+2020-12-31,CH,Switzerland,140.2729
+2020-12-31,CL,Chile,261.1373
 2020-12-31,CN,China,142.4458
-2020-12-31,CO,Colombia,206.5434
+2020-12-31,CO,Colombia,203.0192
 2020-12-31,CY,Cyprus,79.239
 2020-12-31,CZ,Czechia,167.498
 2020-12-31,DE,Germany,169.1
@@ -23270,60 +7806,59 @@ date,country_code,country,price
 2020-12-31,ES,Spain,94.7957
 2020-12-31,FI,Finland,113.951
 2020-12-31,FR,France,119.569
-2020-12-31,GB,United Kingdom,144.376
+2020-12-31,GB,United Kingdom,144.3059
 2020-12-31,GR,Greece,72.4283
 2020-12-31,HK,Hong Kong SAR,252.2061
 2020-12-31,HR,Croatia,120.3892
 2020-12-31,HU,Hungary,191.193
 2020-12-31,ID,Indonesia,156.4997
-2020-12-31,IE,Ireland,128.6318
+2020-12-31,IE,Ireland,128.604
 2020-12-31,IL,Israel,165.9581
 2020-12-31,IN,India,297.9786
-2020-12-31,IS,Iceland,227.4654
+2020-12-31,IS,Iceland,227.4732
 2020-12-31,IT,Italy,84.674
 2020-12-31,JP,Japan,114.3095
-2020-12-31,KR,Korea,130.9193
+2020-12-31,KR,Korea,130.9111
 2020-12-31,LT,Lithuania,173.8072
 2020-12-31,LU,Luxembourg,199.7725
 2020-12-31,LV,Latvia,184.1
-2020-12-31,MA,Morocco,111.7152
-2020-12-31,MK,North Macedonia,100.26
+2020-12-31,MA,Morocco,108.5279
+2020-12-31,MK,North Macedonia,100.3725
 2020-12-31,MT,Malta,146.0736
 2020-12-31,MX,Mexico,190.6729
 2020-12-31,MY,Malaysia,199.2572
-2020-12-31,NL,Netherlands,132.3519
+2020-12-31,NL,Netherlands,133.0835
 2020-12-31,NO,Norway,162.1445
 2020-12-31,NZ,New Zealand,212.6486
 2020-12-31,PE,Peru,175.7486
-2020-12-31,PH,Philippines,206.5172
+2020-12-31,PH,Philippines,209.6731
 2020-12-31,PL,Poland,131.0671
 2020-12-31,PT,Portugal,146.8831
 2020-12-31,RO,Romania,107.113
-2020-12-31,RS,Serbia,151.7093
+2020-12-31,RS,Serbia,159.9381
 2020-12-31,RU,Russia,112.2823
 2020-12-31,SE,Sweden,168.988
 2020-12-31,SG,Singapore,118.1562
 2020-12-31,SI,Slovenia,118.1093
-2020-12-31,SK,Slovak Republic,152.3619
-2020-12-31,TH,Thailand,151.7708
-2020-12-31,TR,Türkiye,330.2772
-2020-12-31,US,United States,170.9616
-2020-12-31,XM,Euro area,127.1906
-2020-12-31,XW,World,159.4099
-2020-12-31,ZA,South Africa,163.8478
-2021-03-31,4T,Emerging market economies (aggregate),174.2506
-2021-03-31,5R,Advanced economies,151.1071
-2021-03-31,AE,United Arab Emirates,117.016
+2020-12-31,SK,Slovakia,151.862
+2020-12-31,TH,Thailand,160.5697
+2020-12-31,TR,Türkiye,339.7338
+2020-12-31,US,United States,171.0508
+2020-12-31,XM,Euro area,127.0503
+2020-12-31,XW,World,158.7285
+2020-12-31,ZA,South Africa,160.1996
+2021-03-31,4T,Emerging market economies (aggregate),176.1607
+2021-03-31,5R,Advanced economies,150.7624
 2021-03-31,AT,Austria,188.0966
 2021-03-31,AU,Australia,151.6941
-2021-03-31,BE,Belgium,134.3487
+2021-03-31,BE,Belgium,133.639
 2021-03-31,BG,Bulgaria,137.7218
-2021-03-31,BR,Brazil,176.5761
-2021-03-31,CA,Canada,200.5542
-2021-03-31,CH,Switzerland,140.1987
-2021-03-31,CL,Chile,273.8311
+2021-03-31,BR,Brazil,176.1565
+2021-03-31,CA,Canada,199.8034
+2021-03-31,CH,Switzerland,140.199
+2021-03-31,CL,Chile,275.0971
 2021-03-31,CN,China,143.7231
-2021-03-31,CO,Colombia,211.3178
+2021-03-31,CO,Colombia,207.8692
 2021-03-31,CY,Cyprus,79.6406
 2021-03-31,CZ,Czechia,177.3694
 2021-03-31,DE,Germany,171.4
@@ -23332,60 +7867,59 @@ date,country_code,country,price
 2021-03-31,ES,Spain,95.2193
 2021-03-31,FI,Finland,115.655
 2021-03-31,FR,France,120.4711
-2021-03-31,GB,United Kingdom,147.286
+2021-03-31,GB,United Kingdom,146.4672
 2021-03-31,GR,Greece,74.7744
 2021-03-31,HK,Hong Kong SAR,255.431
 2021-03-31,HR,Croatia,121.4754
 2021-03-31,HU,Hungary,209.2341
 2021-03-31,ID,Indonesia,156.8796
-2021-03-31,IE,Ireland,130.5569
+2021-03-31,IE,Ireland,130.5859
 2021-03-31,IL,Israel,169.0846
 2021-03-31,IN,India,298.5957
-2021-03-31,IS,Iceland,233.3753
+2021-03-31,IS,Iceland,233.3833
 2021-03-31,IT,Italy,85.6054
 2021-03-31,JP,Japan,118.4765
-2021-03-31,KR,Korea,136.1214
+2021-03-31,KR,Korea,136.1153
 2021-03-31,LT,Lithuania,182.5243
 2021-03-31,LU,Luxembourg,208.6319
 2021-03-31,LV,Latvia,186.65
-2021-03-31,MA,Morocco,109.3096
-2021-03-31,MK,North Macedonia,102.06
+2021-03-31,MA,Morocco,106.4316
+2021-03-31,MK,North Macedonia,102.0526
 2021-03-31,MT,Malta,143.6573
 2021-03-31,MX,Mexico,196.0467
 2021-03-31,MY,Malaysia,199.1582
-2021-03-31,NL,Netherlands,137.675
+2021-03-31,NL,Netherlands,137.8642
 2021-03-31,NO,Norway,170.9055
 2021-03-31,NZ,New Zealand,232.0061
 2021-03-31,PE,Peru,175.0434
-2021-03-31,PH,Philippines,203.1367
+2021-03-31,PH,Philippines,210.9456
 2021-03-31,PL,Poland,133.6616
 2021-03-31,PT,Portugal,150.6183
 2021-03-31,RO,Romania,109.6234
-2021-03-31,RS,Serbia,155.2422
+2021-03-31,RS,Serbia,164.4753
 2021-03-31,RU,Russia,114.1583
 2021-03-31,SE,Sweden,174.2737
 2021-03-31,SG,Singapore,122.0696
 2021-03-31,SI,Slovenia,121.7098
-2021-03-31,SK,Slovak Republic,150.6623
-2021-03-31,TH,Thailand,149.8958
-2021-03-31,TR,Türkiye,352.8785
-2021-03-31,US,United States,176.3954
-2021-03-31,XM,Euro area,128.984
-2021-03-31,XW,World,162.5086
-2021-03-31,ZA,South Africa,164.143
-2021-06-30,4T,Emerging market economies (aggregate),177.329
-2021-06-30,5R,Advanced economies,156.6111
-2021-06-30,AE,United Arab Emirates,120.6848
+2021-03-31,SK,Slovakia,150.1625
+2021-03-31,TH,Thailand,161.919
+2021-03-31,TR,Türkiye,360.5324
+2021-03-31,US,United States,176.446
+2021-03-31,XM,Euro area,128.8007
+2021-03-31,XW,World,161.7712
+2021-03-31,ZA,South Africa,163.4582
+2021-06-30,4T,Emerging market economies (aggregate),179.035
+2021-06-30,5R,Advanced economies,156.1204
 2021-06-30,AT,Austria,192.7323
 2021-06-30,AU,Australia,161.8587
-2021-06-30,BE,Belgium,136.7639
+2021-06-30,BE,Belgium,136.2264
 2021-06-30,BG,Bulgaria,138.2038
-2021-06-30,BR,Brazil,179.7252
-2021-06-30,CA,Canada,213.9359
-2021-06-30,CH,Switzerland,143.2769
-2021-06-30,CL,Chile,282.1627
+2021-06-30,BR,Brazil,179.1942
+2021-06-30,CA,Canada,213.135
+2021-06-30,CH,Switzerland,143.2772
+2021-06-30,CL,Chile,283.543
 2021-06-30,CN,China,145.402
-2021-06-30,CO,Colombia,216.8836
+2021-06-30,CO,Colombia,212.725
 2021-06-30,CY,Cyprus,79.8514
 2021-06-30,CZ,Czechia,186.5056
 2021-06-30,DE,Germany,177.9
@@ -23394,60 +7928,59 @@ date,country_code,country,price
 2021-06-30,ES,Spain,97.4712
 2021-06-30,FI,Finland,118.4239
 2021-06-30,FR,France,122.7762
-2021-06-30,GB,United Kingdom,150.0839
+2021-06-30,GB,United Kingdom,149.1272
 2021-06-30,GR,Greece,76.8098
 2021-06-30,HK,Hong Kong SAR,260.4009
 2021-06-30,HR,Croatia,125.8203
 2021-06-30,HU,Hungary,218.2012
 2021-06-30,ID,Indonesia,157.3051
-2021-06-30,IE,Ireland,133.7
+2021-06-30,IE,Ireland,133.6689
 2021-06-30,IL,Israel,173.66
 2021-06-30,IN,India,300.1751
-2021-06-30,IS,Iceland,245.8825
+2021-06-30,IS,Iceland,245.8909
 2021-06-30,IT,Italy,87.0449
 2021-06-30,JP,Japan,119.5766
-2021-06-30,KR,Korea,140.9155
+2021-06-30,KR,Korea,140.8894
 2021-06-30,LT,Lithuania,188.6761
 2021-06-30,LU,Luxembourg,210.5036
 2021-06-30,LV,Latvia,198.53
-2021-06-30,MA,Morocco,104.0173
-2021-06-30,MK,North Macedonia,105.24
+2021-06-30,MA,Morocco,103.0014
+2021-06-30,MK,North Macedonia,105.4026
 2021-06-30,MT,Malta,147.6112
 2021-06-30,MX,Mexico,200.6422
 2021-06-30,MY,Malaysia,200.5447
-2021-06-30,NL,Netherlands,143.1508
+2021-06-30,NL,Netherlands,143.9369
 2021-06-30,NO,Norway,179.1435
 2021-06-30,NZ,New Zealand,240.3853
 2021-06-30,PE,Peru,175.8926
-2021-06-30,PH,Philippines,212.8172
+2021-06-30,PH,Philippines,217.1014
 2021-06-30,PL,Poland,137.771
 2021-06-30,PT,Portugal,154.9962
 2021-06-30,RO,Romania,112.1339
-2021-06-30,RS,Serbia,159.3619
+2021-06-30,RS,Serbia,169.7135
 2021-06-30,RU,Russia,119.1462
 2021-06-30,SE,Sweden,180.4166
 2021-06-30,SG,Singapore,123.048
 2021-06-30,SI,Slovenia,127.3069
-2021-06-30,SK,Slovak Republic,155.5611
-2021-06-30,TH,Thailand,151.0417
-2021-06-30,TR,Türkiye,384.435
-2021-06-30,US,United States,184.8982
-2021-06-30,XM,Euro area,132.5209
-2021-06-30,XW,World,166.7395
-2021-06-30,ZA,South Africa,165.5866
-2021-09-30,4T,Emerging market economies (aggregate),179.537
-2021-09-30,5R,Advanced economies,162.1391
-2021-09-30,AE,United Arab Emirates,125.1569
+2021-06-30,SK,Slovakia,155.0612
+2021-06-30,TH,Thailand,163.1646
+2021-06-30,TR,Türkiye,389.6362
+2021-06-30,US,United States,184.7496
+2021-06-30,XM,Euro area,132.3602
+2021-06-30,XW,World,165.8956
+2021-06-30,ZA,South Africa,166.12
+2021-09-30,4T,Emerging market economies (aggregate),180.8108
+2021-09-30,5R,Advanced economies,161.4671
 2021-09-30,AT,Austria,197.3679
 2021-09-30,AU,Australia,169.9903
-2021-09-30,BE,Belgium,140.8002
+2021-09-30,BE,Belgium,139.7855
 2021-09-30,BG,Bulgaria,142.6175
-2021-09-30,BR,Brazil,182.1919
-2021-09-30,CA,Canada,218.568
-2021-09-30,CH,Switzerland,146.6494
-2021-09-30,CL,Chile,286.428
+2021-09-30,BR,Brazil,181.5724
+2021-09-30,CA,Canada,217.7498
+2021-09-30,CH,Switzerland,146.6498
+2021-09-30,CL,Chile,287.4578
 2021-09-30,CN,China,145.9129
-2021-09-30,CO,Colombia,219.9771
+2021-09-30,CO,Colombia,215.3215
 2021-09-30,CY,Cyprus,80.3032
 2021-09-30,CZ,Czechia,199.3174
 2021-09-30,DE,Germany,185.4
@@ -23456,60 +7989,59 @@ date,country_code,country,price
 2021-09-30,ES,Spain,99.5299
 2021-09-30,FI,Finland,118.1044
 2021-09-30,FR,France,126.4846
-2021-09-30,GB,United Kingdom,153.1058
+2021-09-30,GB,United Kingdom,151.9534
 2021-09-30,GR,Greece,78.9523
 2021-09-30,HK,Hong Kong SAR,263.6479
 2021-09-30,HR,Croatia,127.9928
 2021-09-30,HU,Hungary,226.2076
 2021-09-30,ID,Indonesia,157.7153
-2021-09-30,IE,Ireland,140.4577
+2021-09-30,IE,Ireland,140.4326
 2021-09-30,IL,Israel,178.4005
 2021-09-30,IN,India,298.1878
-2021-09-30,IS,Iceland,255.1369
+2021-09-30,IS,Iceland,255.1456
 2021-09-30,IT,Italy,87.9763
 2021-09-30,JP,Japan,122.6102
-2021-09-30,KR,Korea,146.4236
+2021-09-30,KR,Korea,146.4089
 2021-09-30,LT,Lithuania,198.854
 2021-09-30,LU,Luxembourg,216.1187
 2021-09-30,LV,Latvia,205.74
-2021-09-30,MA,Morocco,103.0551
-2021-09-30,MK,North Macedonia,105.84
+2021-09-30,MA,Morocco,100.0476
+2021-09-30,MK,North Macedonia,105.8326
 2021-09-30,MT,Malta,151.0159
 2021-09-30,MX,Mexico,204.1149
 2021-09-30,MY,Malaysia,200.0495
-2021-09-30,NL,Netherlands,151.544
+2021-09-30,NL,Netherlands,152.077
 2021-09-30,NO,Norway,178.4897
 2021-09-30,NZ,New Zealand,252.8815
 2021-09-30,PE,Peru,172.9691
-2021-09-30,PH,Philippines,214.3538
+2021-09-30,PH,Philippines,218.9644
 2021-09-30,PL,Poland,141.3503
 2021-09-30,PT,Portugal,159.5603
 2021-09-30,RO,Romania,112.1339
-2021-09-30,RS,Serbia,163.9899
+2021-09-30,RS,Serbia,175.7719
 2021-09-30,RU,Russia,123.2451
 2021-09-30,SE,Sweden,185.0698
 2021-09-30,SG,Singapore,124.4026
 2021-09-30,SI,Slovenia,130.6685
-2021-09-30,SK,Slovak Republic,162.8593
-2021-09-30,TH,Thailand,153.5417
-2021-09-30,TR,Türkiye,424.0938
-2021-09-30,US,United States,193.0023
-2021-09-30,XM,Euro area,136.8151
-2021-09-30,XW,World,170.5151
-2021-09-30,ZA,South Africa,167.8754
-2021-12-31,4T,Emerging market economies (aggregate),183.3092
-2021-12-31,5R,Advanced economies,166.3348
-2021-12-31,AE,United Arab Emirates,127.5702
+2021-09-30,SK,Slovakia,162.3594
+2021-09-30,TH,Thailand,166.3822
+2021-09-30,TR,Türkiye,427.1162
+2021-09-30,US,United States,192.5142
+2021-09-30,XM,Euro area,136.5962
+2021-09-30,XW,World,169.4683
+2021-09-30,ZA,South Africa,167.9497
+2021-12-31,4T,Emerging market economies (aggregate),183.779
+2021-12-31,5R,Advanced economies,165.6621
 2021-12-31,AT,Austria,203.7321
 2021-12-31,AU,Australia,178.0252
-2021-12-31,BE,Belgium,141.0069
+2021-12-31,BE,Belgium,140.4187
 2021-12-31,BG,Bulgaria,146.001
-2021-12-31,BR,Brazil,183.8935
-2021-12-31,CA,Canada,223.0286
-2021-12-31,CH,Switzerland,150.5322
-2021-12-31,CL,Chile,301.9545
+2021-12-31,BR,Brazil,183.2397
+2021-12-31,CA,Canada,222.1936
+2021-12-31,CH,Switzerland,150.5325
+2021-12-31,CL,Chile,301.4479
 2021-12-31,CN,China,144.745
-2021-12-31,CO,Colombia,221.1912
+2021-12-31,CO,Colombia,216.3598
 2021-12-31,CY,Cyprus,81.3171
 2021-12-31,CZ,Czechia,210.659
 2021-12-31,DE,Germany,190.4
@@ -23518,478 +8050,1013 @@ date,country_code,country,price
 2021-12-31,ES,Spain,100.7636
 2021-12-31,FI,Finland,118.3174
 2021-12-31,FR,France,127.7875
-2021-12-31,GB,United Kingdom,156.2395
+2021-12-31,GB,United Kingdom,154.7797
 2021-12-31,GR,Greece,79.7022
 2021-12-31,HK,Hong Kong SAR,261.417
 2021-12-31,HR,Croatia,131.2514
 2021-12-31,HU,Hungary,234.7478
 2021-12-31,ID,Indonesia,158.3536
-2021-12-31,IE,Ireland,146.3903
+2021-12-31,IE,Ireland,146.3783
 2021-12-31,IL,Israel,185.4542
 2021-12-31,IN,India,307.2983
-2021-12-31,IS,Iceland,263.5208
+2021-12-31,IS,Iceland,263.5298
 2021-12-31,IT,Italy,88.061
 2021-12-31,JP,Japan,122.1102
-2021-12-31,KR,Korea,151.4727
+2021-12-31,KR,Korea,151.529
 2021-12-31,LT,Lithuania,208.2598
 2021-12-31,LU,Luxembourg,223.9798
 2021-12-31,LV,Latvia,213.8
-2021-12-31,MA,Morocco,103.44
-2021-12-31,MK,North Macedonia,111.59
+2021-12-31,MA,Morocco,100.8099
+2021-12-31,MK,North Macedonia,111.7928
 2021-12-31,MT,Malta,152.6634
 2021-12-31,MX,Mexico,206.974
 2021-12-31,MY,Malaysia,203.0205
-2021-12-31,NL,Netherlands,157.1275
+2021-12-31,NL,Netherlands,157.7621
 2021-12-31,NO,Norway,175.0899
 2021-12-31,NZ,New Zealand,267.7825
 2021-12-31,PE,Peru,170.4981
-2021-12-31,PH,Philippines,216.6587
+2021-12-31,PH,Philippines,223.0055
 2021-12-31,PL,Poland,146.9084
 2021-12-31,PT,Portugal,163.901
 2021-12-31,RO,Romania,115.4812
-2021-12-31,RS,Serbia,169.6479
-2021-12-31,RU,Russia,129.0703
+2021-12-31,RS,Serbia,182.7562
+2021-12-31,RU,Russia,129.0708
 2021-12-31,SE,Sweden,187.4124
 2021-12-31,SG,Singapore,130.6491
 2021-12-31,SI,Slovenia,136.7348
-2021-12-31,SK,Slovak Republic,168.6578
-2021-12-31,TH,Thailand,155.4167
-2021-12-31,TR,Türkiye,527.5053
-2021-12-31,US,United States,200.7094
-2021-12-31,XM,Euro area,139.3956
-2021-12-31,XW,World,174.4679
-2021-12-31,ZA,South Africa,169.5413
-2022-03-31,4T,Emerging market economies (aggregate),188.4394
-2022-03-31,5R,Advanced economies,172.7058
-2022-03-31,AE,United Arab Emirates,131.0243
+2021-12-31,SK,Slovakia,168.158
+2021-12-31,TH,Thailand,165.448
+2021-12-31,TR,Türkiye,506.9033
+2021-12-31,US,United States,199.9837
+2021-12-31,XM,Euro area,139.1617
+2021-12-31,XW,World,173.0242
+2021-12-31,ZA,South Africa,169.7484
+2022-03-31,4T,Emerging market economies (aggregate),188.6729
+2022-03-31,5R,Advanced economies,171.4005
 2022-03-31,AT,Austria,211.3534
-2022-03-31,AU,Australia,182.9249
-2022-03-31,BE,Belgium,143.0304
+2022-03-31,AU,Australia,182.9175
+2022-03-31,BE,Belgium,141.9471
 2022-03-31,BG,Bulgaria,153.5997
-2022-03-31,BR,Brazil,184.8185
-2022-03-31,CA,Canada,251.7973
-2022-03-31,CH,Switzerland,149.9765
-2022-03-31,CL,Chile,295.5795
+2022-03-31,BR,Brazil,184.239
+2022-03-31,CA,Canada,250.6746
+2022-03-31,CH,Switzerland,149.9769
+2022-03-31,CL,Chile,295.4363
 2022-03-31,CN,China,143.5042
-2022-03-31,CO,Colombia,229.3452
+2022-03-31,CO,Colombia,224.5133
 2022-03-31,CY,Cyprus,82.1805
 2022-03-31,CZ,Czechia,220.8454
-2022-03-31,DE,Germany,191.3
+2022-03-31,DE,Germany,192.3
 2022-03-31,DK,Denmark,155.102
 2022-03-31,EE,Estonia,274.3314
 2022-03-31,ES,Spain,103.3426
-2022-03-31,FI,Finland,119.4888
+2022-03-31,FI,Finland,119.1693
 2022-03-31,FR,France,128.89
-2022-03-31,GB,United Kingdom,160.2686
+2022-03-31,GB,United Kingdom,158.4372
 2022-03-31,GR,Greece,82.2732
 2022-03-31,HK,Hong Kong SAR,255.2985
 2022-03-31,HR,Croatia,137.8592
 2022-03-31,HU,Hungary,257.6995
 2022-03-31,ID,Indonesia,159.3565
-2022-03-31,IE,Ireland,150.0835
+2022-03-31,IE,Ireland,150.0904
 2022-03-31,IL,Israel,194.7955
 2022-03-31,IN,India,303.9616
-2022-03-31,IS,Iceland,277.9063
+2022-03-31,IS,Iceland,277.9159
 2022-03-31,IT,Italy,89.5004
 2022-03-31,JP,Japan,129.2108
-2022-03-31,KR,Korea,153.2577
+2022-03-31,KR,Korea,153.2779
 2022-03-31,LT,Lithuania,217.4757
 2022-03-31,LU,Luxembourg,229.9693
 2022-03-31,LV,Latvia,219.12
-2022-03-31,MA,Morocco,103.3438
-2022-03-31,MK,North Macedonia,114.7
+2022-03-31,MA,Morocco,100.8099
+2022-03-31,MK,North Macedonia,114.7629
 2022-03-31,MT,Malta,153.4322
 2022-03-31,MX,Mexico,211.2251
 2022-03-31,MY,Malaysia,203.9119
-2022-03-31,NL,Netherlands,164.2549
+2022-03-31,NL,Netherlands,164.0933
 2022-03-31,NO,Norway,183.1971
 2022-03-31,NZ,New Zealand,263.5409
 2022-03-31,PE,Peru,171.3539
-2022-03-31,PH,Philippines,214.8148
+2022-03-31,PH,Philippines,230.1263
 2022-03-31,PL,Poland,151.7849
 2022-03-31,PT,Portugal,170.1232
 2022-03-31,RO,Romania,117.1548
-2022-03-31,RS,Serbia,176.0881
-2022-03-31,RU,Russia,151.2563
-2022-03-31,SE,Sweden,192.2484
+2022-03-31,RS,Serbia,190.349
+2022-03-31,RU,Russia,151.2562
+2022-03-31,SE,Sweden,192.2476
 2022-03-31,SG,Singapore,131.5522
 2022-03-31,SI,Slovenia,142.4257
-2022-03-31,SK,Slovak Republic,171.957
-2022-03-31,TH,Thailand,156.1458
-2022-03-31,TR,Türkiye,741.3646
-2022-03-31,US,United States,210.1778
-2022-03-31,XM,Euro area,141.6871
-2022-03-31,XW,World,180.1487
-2022-03-31,ZA,South Africa,170.7125
-2022-06-30,4T,Emerging market economies (aggregate),192.4372
-2022-06-30,5R,Advanced economies,176.4894
-2022-06-30,AE,United Arab Emirates,134.0226
+2022-03-31,SK,Slovakia,171.4571
+2022-03-31,TH,Thailand,166.486
+2022-03-31,TR,Türkiye,693.0967
+2022-03-31,US,United States,208.3989
+2022-03-31,XM,Euro area,141.6675
+2022-03-31,XW,World,178.2903
+2022-03-31,ZA,South Africa,171.8685
+2022-06-30,4T,Emerging market economies (aggregate),192.4473
+2022-06-30,5R,Advanced economies,174.9503
 2022-06-30,AT,Austria,218.0318
-2022-06-30,AU,Australia,183.4476
-2022-06-30,BE,Belgium,144.8799
+2022-06-30,AU,Australia,183.4788
+2022-06-30,BE,Belgium,144.3052
 2022-06-30,BG,Bulgaria,158.382
-2022-06-30,BR,Brazil,185.2182
-2022-06-30,CA,Canada,246.6702
-2022-06-30,CH,Switzerland,153.9964
-2022-06-30,CL,Chile,306.6084
+2022-06-30,BR,Brazil,184.8813
+2022-06-30,CA,Canada,244.1727
+2022-06-30,CH,Switzerland,153.9967
+2022-06-30,CL,Chile,303.8703
 2022-06-30,CN,China,142.2268
-2022-06-30,CO,Colombia,232.943
+2022-06-30,CO,Colombia,227.5304
 2022-06-30,CY,Cyprus,83.5759
 2022-06-30,CZ,Czechia,228.0914
-2022-06-30,DE,Germany,195
+2022-06-30,DE,Germany,196.1
 2022-06-30,DK,Denmark,157.198
 2022-06-30,EE,Estonia,296.2259
 2022-06-30,ES,Spain,105.3195
-2022-06-30,FI,Finland,121.1928
+2022-06-30,FI,Finland,120.8733
 2022-06-30,FR,France,131.095
-2022-06-30,GB,United Kingdom,164.4096
+2022-06-30,GB,United Kingdom,162.4273
 2022-06-30,GR,Greece,85.1656
 2022-06-30,HK,Hong Kong SAR,254.5254
 2022-06-30,HR,Croatia,142.9283
 2022-06-30,HU,Hungary,272.4313
 2022-06-30,ID,Indonesia,159.9035
-2022-06-30,IE,Ireland,152.7551
+2022-06-30,IE,Ireland,152.7645
 2022-06-30,IL,Israel,204.0352
 2022-06-30,IN,India,310.2479
-2022-06-30,IS,Iceland,302.1418
+2022-06-30,IS,Iceland,302.1522
 2022-06-30,IT,Italy,91.5326
 2022-06-30,JP,Japan,130.5775
-2022-06-30,KR,Korea,154.1247
+2022-06-30,KR,Korea,154.1145
 2022-06-30,LT,Lithuania,230.2901
 2022-06-30,LU,Luxembourg,235.0852
 2022-06-30,LV,Latvia,230.94
-2022-06-30,MA,Morocco,103.6324
-2022-06-30,MK,North Macedonia,122.6
+2022-06-30,MA,Morocco,101.0005
+2022-06-30,MK,North Macedonia,122.8031
 2022-06-30,MT,Malta,158.8138
 2022-06-30,MX,Mexico,216.6289
 2022-06-30,MY,Malaysia,205.7935
-2022-06-30,NL,Netherlands,169.1562
+2022-06-30,NL,Netherlands,169.1324
 2022-06-30,NO,Norway,190.5198
 2022-06-30,NZ,New Zealand,252.6666
 2022-06-30,PE,Peru,172.9568
-2022-06-30,PH,Philippines,218.3489
+2022-06-30,PH,Philippines,238.0161
 2022-06-30,PL,Poland,154.8149
 2022-06-30,PT,Portugal,175.4046
 2022-06-30,RO,Romania,121.3389
-2022-06-30,RS,Serbia,182.802
-2022-06-30,RU,Russia,154.2343
-2022-06-30,SE,Sweden,193.1445
+2022-06-30,RS,Serbia,197.6904
+2022-06-30,RU,Russia,154.235
+2022-06-30,SE,Sweden,193.1446
 2022-06-30,SG,Singapore,136.143
 2022-06-30,SI,Slovenia,147.1183
-2022-06-30,SK,Slovak Republic,181.4546
-2022-06-30,TH,Thailand,158.9583
-2022-06-30,TR,Türkiye,1002.1322
-2022-06-30,US,United States,216.4828
-2022-06-30,XM,Euro area,144.7557
-2022-06-30,XW,World,184.0259
-2022-06-30,ZA,South Africa,171.8637
-2022-09-30,4T,Emerging market economies (aggregate),194.7554
-2022-09-30,5R,Advanced economies,176.1578
-2022-09-30,AE,United Arab Emirates,136.4185
+2022-06-30,SK,Slovakia,180.8548
+2022-06-30,TH,Thailand,168.9771
+2022-06-30,TR,Türkiye,947.8616
+2022-06-30,US,United States,214.2358
+2022-06-30,XM,Euro area,144.8396
+2022-06-30,XW,World,181.9168
+2022-06-30,ZA,South Africa,173.6169
+2022-09-30,4T,Emerging market economies (aggregate),195.5478
+2022-09-30,5R,Advanced economies,174.9125
 2022-09-30,AT,Austria,218.6604
-2022-09-30,AU,Australia,177.0779
-2022-09-30,BE,Belgium,148.3287
+2022-09-30,AU,Australia,177.1329
+2022-09-30,BE,Belgium,147.3403
 2022-09-30,BG,Bulgaria,164.856
-2022-09-30,BR,Brazil,185.3952
-2022-09-30,CA,Canada,224.7376
-2022-09-30,CH,Switzerland,155.9094
-2022-09-30,CL,Chile,308.9892
+2022-09-30,BR,Brazil,185.5608
+2022-09-30,CA,Canada,222.0523
+2022-09-30,CH,Switzerland,155.9098
+2022-09-30,CL,Chile,310.7883
 2022-09-30,CN,China,141.1319
-2022-09-30,CO,Colombia,236.3796
+2022-09-30,CO,Colombia,230.0607
 2022-09-30,CY,Cyprus,85.3428
 2022-09-30,CZ,Czechia,230.4017
-2022-09-30,DE,Germany,193.6
+2022-09-30,DE,Germany,194.8
 2022-09-30,DK,Denmark,151.6823
 2022-09-30,EE,Estonia,298.7253
 2022-09-30,ES,Spain,107.1329
-2022-09-30,FI,Finland,119.7018
+2022-09-30,FI,Finland,119.4888
 2022-09-30,FR,France,134.6029
-2022-09-30,GB,United Kingdom,170.3414
+2022-09-30,GB,United Kingdom,168.5786
 2022-09-30,GR,Greece,88.9151
 2022-09-30,HK,Hong Kong SAR,244.0775
 2022-09-30,HR,Croatia,147.0016
 2022-09-30,HU,Hungary,280.7579
 2022-09-30,ID,Indonesia,160.7697
-2022-09-30,IE,Ireland,157.1162
+2022-09-30,IE,Ireland,157.1058
 2022-09-30,IL,Israel,213.3384
-2022-09-30,IN,India,311.7332
-2022-09-30,IS,Iceland,312.8622
+2022-09-30,IN,India,318.0057
+2022-09-30,IS,Iceland,312.873
 2022-09-30,IT,Italy,90.5165
 2022-09-30,JP,Japan,132.2444
-2022-09-30,KR,Korea,154.1247
+2022-09-30,KR,Korea,154.12
 2022-09-30,LT,Lithuania,237.1664
 2022-09-30,LU,Luxembourg,239.9516
 2022-09-30,LV,Latvia,233.72
-2022-09-30,MA,Morocco,104.2098
-2022-09-30,MK,North Macedonia,128.35
+2022-09-30,MA,Morocco,101.5722
+2022-09-30,MK,North Macedonia,128.4532
 2022-09-30,MT,Malta,160.5711
 2022-09-30,MX,Mexico,223.3499
 2022-09-30,MY,Malaysia,210.3491
-2022-09-30,NL,Netherlands,169.9551
+2022-09-30,NL,Netherlands,170.4244
 2022-09-30,NO,Norway,187.12
 2022-09-30,NZ,New Zealand,243.6636
 2022-09-30,PE,Peru,173.1625
-2022-09-30,PH,Philippines,228.3367
+2022-09-30,PH,Philippines,249.4314
 2022-09-30,PL,Poland,158.4888
 2022-09-30,PT,Portugal,180.537
 2022-09-30,RO,Romania,119.6653
-2022-09-30,RS,Serbia,189.2031
-2022-09-30,RU,Russia,156.3466
-2022-09-30,SE,Sweden,187.1992
+2022-09-30,RS,Serbia,204.7409
+2022-09-30,RU,Russia,156.3471
+2022-09-30,SE,Sweden,187.1993
 2022-09-30,SG,Singapore,141.3358
 2022-09-30,SI,Slovenia,150.5055
-2022-09-30,SK,Slovak Republic,186.5534
-2022-09-30,TH,Thailand,159.0625
-2022-09-30,TR,Türkiye,1226.0128
-2022-09-30,US,United States,214.7504
-2022-09-30,XM,Euro area,146.051
-2022-09-30,XW,World,185.1065
-2022-09-30,ZA,South Africa,173.4
-2022-12-31,4T,Emerging market economies (aggregate),195.9948
-2022-12-31,5R,Advanced economies,174.4734
-2022-12-31,AE,United Arab Emirates,139.7707
+2022-09-30,SK,Slovakia,186.0535
+2022-09-30,TH,Thailand,168.6657
+2022-09-30,TR,Türkiye,1198.0834
+2022-09-30,US,United States,213.0232
+2022-09-30,XM,Euro area,146.1322
+2022-09-30,XW,World,183.4363
+2022-09-30,ZA,South Africa,174.8941
+2022-12-31,4T,Emerging market economies (aggregate),196.768
+2022-12-31,5R,Advanced economies,173.3356
 2022-12-31,AT,Austria,214.4176
-2022-12-31,AU,Australia,172.5048
-2022-12-31,BE,Belgium,147.7303
+2022-12-31,AU,Australia,172.5522
+2022-12-31,BE,Belgium,146.8927
 2022-12-31,BG,Bulgaria,165.527
-2022-12-31,BR,Brazil,185.5494
-2022-12-31,CA,Canada,214.4834
-2022-12-31,CH,Switzerland,157.7692
-2022-12-31,CL,Chile,316.0603
+2022-12-31,BR,Brazil,186.5572
+2022-12-31,CA,Canada,211.8048
+2022-12-31,CH,Switzerland,157.7695
+2022-12-31,CL,Chile,316.2108
 2022-12-31,CN,China,139.3801
-2022-12-31,CO,Colombia,234.334
+2022-12-31,CO,Colombia,228.1647
 2022-12-31,CY,Cyprus,86.6881
 2022-12-31,CZ,Czechia,225.256
-2022-12-31,DE,Germany,183.6
+2022-12-31,DE,Germany,185.7
 2022-12-31,DK,Denmark,141.9746
 2022-12-31,EE,Estonia,299.4251
 2022-12-31,ES,Spain,106.2708
 2022-12-31,FI,Finland,115.5485
 2022-12-31,FR,France,133.8011
-2022-12-31,GB,United Kingdom,170.4533
-2022-12-31,GR,Greece,90.8434
+2022-12-31,GB,United Kingdom,168.7448
+2022-12-31,GR,Greece,91.0576
 2022-12-31,HK,Hong Kong SAR,225.9871
 2022-12-31,HR,Croatia,153.9715
-2022-12-31,HU,Hungary,275.1001
+2022-12-31,HU,Hungary,275.8473
 2022-12-31,ID,Indonesia,161.5294
-2022-12-31,IE,Ireland,158.9235
+2022-12-31,IE,Ireland,158.9619
 2022-12-31,IL,Israel,216.4776
-2022-12-31,IN,India,315.9276
-2022-12-31,IS,Iceland,316.9396
+2022-12-31,IN,India,321.1405
+2022-12-31,IS,Iceland,316.9505
 2022-12-31,IT,Italy,90.4318
 2022-12-31,JP,Japan,131.3109
-2022-12-31,KR,Korea,151.3706
+2022-12-31,KR,Korea,151.3923
 2022-12-31,LT,Lithuania,241.6318
 2022-12-31,LU,Luxembourg,236.333
 2022-12-31,LV,Latvia,232.25
-2022-12-31,MA,Morocco,103.5362
-2022-12-31,MK,North Macedonia,134.53
+2022-12-31,MA,Morocco,101.858
+2022-12-31,MK,North Macedonia,134.6734
 2022-12-31,MT,Malta,161.6694
 2022-12-31,MX,Mexico,228.5141
 2022-12-31,MY,Malaysia,210.9433
-2022-12-31,NL,Netherlands,165.5386
+2022-12-31,NL,Netherlands,166.6774
 2022-12-31,NO,Norway,179.6666
 2022-12-31,NZ,New Zealand,238.8952
 2022-12-31,PE,Peru,173.1242
-2022-12-31,PH,Philippines,233.4075
+2022-12-31,PH,Philippines,251.8549
 2022-12-31,PL,Poland,160.6287
 2022-12-31,PT,Portugal,182.4838
 2022-12-31,RO,Romania,123.0126
-2022-12-31,RS,Serbia,195.1348
-2022-12-31,RU,Russia,158.8224
-2022-12-31,SE,Sweden,180.484
+2022-12-31,RS,Serbia,211.0109
+2022-12-31,RU,Russia,158.8221
+2022-12-31,SE,Sweden,180.4842
 2022-12-31,SG,Singapore,141.9379
 2022-12-31,SI,Slovenia,152.5788
-2022-12-31,SK,Slovak Republic,185.0537
-2022-12-31,TH,Thailand,162.8125
-2022-12-31,TR,Türkiye,1413.0064
-2022-12-31,US,United States,214.8339
-2022-12-31,XM,Euro area,143.4805
-2022-12-31,XW,World,184.9774
-2022-12-31,ZA,South Africa,174.8837
-2023-03-31,4T,Emerging market economies (aggregate),197.8407
-2023-03-31,5R,Advanced economies,175.1168
-2023-03-31,AE,United Arab Emirates,149.322
+2022-12-31,SK,Slovakia,184.4539
+2022-12-31,TH,Thailand,172.5061
+2022-12-31,TR,Türkiye,1371.0027
+2022-12-31,US,United States,213.7818
+2022-12-31,XM,Euro area,143.6264
+2022-12-31,XW,World,183.2512
+2022-12-31,ZA,South Africa,175.7451
+2023-03-31,4T,Emerging market economies (aggregate),197.8653
+2023-03-31,5R,Advanced economies,173.6465
 2023-03-31,AT,Austria,213.5533
-2023-03-31,AU,Australia,171.6555
-2023-03-31,BE,Belgium,149.2643
+2023-03-31,AU,Australia,171.7021
+2023-03-31,BE,Belgium,147.4276
 2023-03-31,BG,Bulgaria,168.1639
-2023-03-31,BR,Brazil,185.7407
-2023-03-31,CA,Canada,214.7683
-2023-03-31,CH,Switzerland,155.8616
-2023-03-31,CL,Chile,319.4951
+2023-03-31,BR,Brazil,188.0276
+2023-03-31,CA,Canada,211.9462
+2023-03-31,CH,Switzerland,155.8619
+2023-03-31,CL,Chile,320.0674
 2023-03-31,CN,China,138.6866
-2023-03-31,CO,Colombia,249.718
+2023-03-31,CO,Colombia,242.1456
 2023-03-31,CY,Cyprus,88.4851
 2023-03-31,CZ,Czechia,222.4206
-2023-03-31,DE,Germany,178.3
-2023-03-31,DK,Denmark,142.8571
+2023-03-31,DE,Germany,180.1
+2023-03-31,DK,Denmark,149.0347
 2023-03-31,EE,Estonia,299.5251
 2023-03-31,ES,Spain,107.0066
-2023-03-31,FI,Finland,113.4185
+2023-03-31,FI,Finland,112.6731
 2023-03-31,FR,France,132.5983
-2023-03-31,GB,United Kingdom,166.3123
-2023-03-31,GR,Greece,94.9142
+2023-03-31,GB,United Kingdom,164.7548
+2023-03-31,GR,Greece,95.1284
 2023-03-31,HK,Hong Kong SAR,229.1457
 2023-03-31,HR,Croatia,157.1396
-2023-03-31,HU,Hungary,284.4943
+2023-03-31,HU,Hungary,286.9496
 2023-03-31,ID,Indonesia,162.2132
-2023-03-31,IE,Ireland,157.7448
+2023-03-31,IE,Ireland,157.7664
 2023-03-31,IL,Israel,216.6937
-2023-03-31,IN,India,317.8836
-2023-03-31,IS,Iceland,315.0155
+2023-03-31,IN,India,317.1603
+2023-03-31,IS,Iceland,315.0263
 2023-03-31,IT,Italy,90.4318
 2023-03-31,JP,Japan,135.3446
-2023-03-31,KR,Korea,146.6276
+2023-03-31,KR,Korea,146.6481
 2023-03-31,LT,Lithuania,246.0497
 2023-03-31,LU,Luxembourg,226.1011
 2023-03-31,LV,Latvia,231.98
-2023-03-31,MA,Morocco,103.7287
-2023-03-31,MK,North Macedonia,136.3
-2023-03-31,MT,Malta,163.5365
+2023-03-31,MA,Morocco,101.4769
+2023-03-31,MK,North Macedonia,136.6034
+2023-03-31,MT,Malta,164.6348
 2023-03-31,MX,Mexico,235.8938
 2023-03-31,MY,Malaysia,213.7163
-2023-03-31,NL,Netherlands,164.0126
+2023-03-31,NL,Netherlands,164.2225
 2023-03-31,NO,Norway,183.0664
 2023-03-31,NZ,New Zealand,232.7754
 2023-03-31,PE,Peru,172.5929
-2023-03-31,PH,Philippines,236.788
+2023-03-31,PH,Philippines,253.4098
 2023-03-31,PL,Poland,160.5151
 2023-03-31,PT,Portugal,184.9428
 2023-03-31,RO,Romania,122.1757
-2023-03-31,RS,Serbia,199.5413
-2023-03-31,RU,Russia,152.9804
-2023-03-31,SE,Sweden,178.9593
+2023-03-31,RS,Serbia,216.2359
+2023-03-31,RU,Russia,152.9796
+2023-03-31,SE,Sweden,179.3281
 2023-03-31,SG,Singapore,146.604
-2023-03-31,SI,Slovenia,154.9934
-2023-03-31,SK,Slovak Republic,185.0537
-2023-03-31,TH,Thailand,163.6458
-2023-03-31,TR,Türkiye,1726.226
-2023-03-31,US,United States,217.3875
-2023-03-31,XM,Euro area,142.2949
-2023-03-31,XW,World,186.2566
-2023-03-31,ZA,South Africa,175.2089
-2023-06-30,4T,Emerging market economies (aggregate),200.3271
-2023-06-30,5R,Advanced economies,176.5412
-2023-06-30,AE,United Arab Emirates,155.5417
+2023-03-31,SI,Slovenia,155.2493
+2023-03-31,SK,Slovakia,184.154
+2023-03-31,TH,Thailand,174.3744
+2023-03-31,TR,Türkiye,1682.0586
+2023-03-31,US,United States,216.0548
+2023-03-31,XM,Euro area,142.3437
+2023-03-31,XW,World,183.9496
+2023-03-31,ZA,South Africa,176.3078
+2023-06-30,4T,Emerging market economies (aggregate),200.3033
+2023-06-30,5R,Advanced economies,174.8676
 2023-06-30,AT,Austria,213.0819
-2023-06-30,AU,Australia,176.3592
-2023-06-30,BE,Belgium,147.393
+2023-06-30,AU,Australia,176.5027
+2023-06-30,BE,Belgium,146.8927
 2023-06-30,BG,Bulgaria,175.3184
-2023-06-30,BR,Brazil,185.9548
-2023-06-30,CA,Canada,225.4497
-2023-06-30,CH,Switzerland,157.6819
-2023-06-30,CL,Chile,330.6801
-2023-06-30,CN,China,138.4233
-2023-06-30,CO,Colombia,249.5302
+2023-06-30,BR,Brazil,190.0203
+2023-06-30,CA,Canada,222.6177
+2023-06-30,CH,Switzerland,157.6822
+2023-06-30,CL,Chile,328.2919
+2023-06-30,CN,China,138.4311
+2023-06-30,CO,Colombia,241.1591
 2023-06-30,CY,Cyprus,89.7801
 2023-06-30,CZ,Czechia,221.8955
-2023-06-30,DE,Germany,176.2
-2023-06-30,DK,Denmark,146.8285
+2023-06-30,DE,Germany,177.6
+2023-06-30,DK,Denmark,149.6966
 2023-06-30,EE,Estonia,311.0222
 2023-06-30,ES,Spain,109.2287
-2023-06-30,FI,Finland,114.4835
+2023-06-30,FI,Finland,113.525
 2023-06-30,FR,France,131.997
-2023-06-30,GB,United Kingdom,165.7527
-2023-06-30,GR,Greece,97.4852
+2023-06-30,GB,United Kingdom,163.9235
+2023-06-30,GR,Greece,97.8066
 2023-06-30,HK,Hong Kong SAR,232.3486
 2023-06-30,HR,Croatia,162.5707
-2023-06-30,HU,Hungary,285.882
+2023-06-30,HU,Hungary,289.8319
 2023-06-30,ID,Indonesia,162.9882
-2023-06-30,IE,Ireland,156.9198
+2023-06-30,IE,Ireland,156.9485
 2023-06-30,IL,Israel,214.3425
-2023-06-30,IN,India,326.22
-2023-06-30,IS,Iceland,325.965
+2023-06-30,IN,India,321.7928
+2023-06-30,IS,Iceland,325.9762
 2023-06-30,IT,Italy,92.1253
 2023-06-30,JP,Japan,134.8112
-2023-06-30,KR,Korea,143.6185
+2023-06-30,KR,Korea,143.6407
 2023-06-30,LT,Lithuania,251.8334
 2023-06-30,LU,Luxembourg,221.2347
 2023-06-30,LV,Latvia,243.36
-2023-06-30,MA,Morocco,103.1513
-2023-06-30,MK,North Macedonia,138.49
-2023-06-30,MT,Malta,165.9528
+2023-06-30,MA,Morocco,101.3816
+2023-06-30,MK,North Macedonia,138.7635
+2023-06-30,MT,Malta,167.1609
 2023-06-30,MX,Mexico,241.6118
 2023-06-30,MY,Malaysia,214.7066
-2023-06-30,NL,Netherlands,161.8133
+2023-06-30,NL,Netherlands,162.2844
 2023-06-30,NO,Norway,190.2583
 2023-06-30,NZ,New Zealand,230.1902
 2023-06-30,PE,Peru,174.7652
-2023-06-30,PH,Philippines,249.2343
+2023-06-30,PH,Philippines,263.0274
 2023-06-30,PL,Poland,165.704
 2023-06-30,PT,Portugal,190.7086
 2023-06-30,RO,Romania,121.3389
-2023-06-30,RS,Serbia,202.4746
+2023-06-30,RS,Serbia,220.2704
 2023-06-30,RU,Russia,155.4562
-2023-06-30,SE,Sweden,180.0198
+2023-06-30,SE,Sweden,180.1013
 2023-06-30,SG,Singapore,146.3029
-2023-06-30,SI,Slovenia,157.954
-2023-06-30,SK,Slovak Republic,177.9555
-2023-06-30,TH,Thailand,164.2708
-2023-06-30,TR,Türkiye,1963.7527
-2023-06-30,US,United States,219.9983
-2023-06-30,XM,Euro area,142.5339
-2023-06-30,XW,World,188.2368
-2023-06-30,ZA,South Africa,175.264
-2023-09-30,4T,Emerging market economies (aggregate),
-2023-09-30,5R,Advanced economies,178.6159
-2023-09-30,AE,United Arab Emirates,163.0899
+2023-06-30,SI,Slovenia,158.1758
+2023-06-30,SK,Slovakia,176.9558
+2023-06-30,TH,Thailand,173.8554
+2023-06-30,TR,Türkiye,1947.3292
+2023-06-30,US,United States,218.9529
+2023-06-30,XM,Euro area,142.6022
+2023-06-30,XW,World,185.7621
+2023-06-30,ZA,South Africa,176.4023
+2023-09-30,4T,Emerging market economies (aggregate),202.4649
+2023-09-30,5R,Advanced economies,176.3838
 2023-09-30,AT,Austria,212.2962
-2023-09-30,AU,Australia,180.8997
-2023-09-30,BE,Belgium,150.0476
+2023-09-30,AU,Australia,181.3528
+2023-09-30,BE,Belgium,148.8141
 2023-09-30,BG,Bulgaria,180.025
-2023-09-30,BR,Brazil,186.1861
-2023-09-30,CA,Canada,224.6664
-2023-09-30,CH,Switzerland,157.95
-2023-09-30,CL,Chile,
-2023-09-30,CN,China,136.6639
-2023-09-30,CO,Colombia,252.9944
+2023-09-30,BR,Brazil,192.5327
+2023-09-30,CA,Canada,221.3456
+2023-09-30,CH,Switzerland,157.9503
+2023-09-30,CL,Chile,335.4608
+2023-09-30,CN,China,136.6428
+2023-09-30,CO,Colombia,249.2054
 2023-09-30,CY,Cyprus,91.798
 2023-09-30,CZ,Czechia,222.3156
-2023-09-30,DE,Germany,173.8
-2023-09-30,DK,Denmark,151.241
+2023-09-30,DE,Germany,174.9
+2023-09-30,DK,Denmark,152.3442
 2023-09-30,EE,Estonia,310.2224
 2023-09-30,ES,Spain,111.986
-2023-09-30,FI,Finland,
-2023-09-30,FR,France,132.5983
-2023-09-30,GB,United Kingdom,169.5579
-2023-09-30,GR,Greece,99.5206
-2023-09-30,HK,Hong Kong SAR,223.1598
+2023-09-30,FI,Finland,110.2236
+2023-09-30,FR,France,132.4981
+2023-09-30,GB,United Kingdom,166.7498
+2023-09-30,GR,Greece,100.2705
+2023-09-30,HK,Hong Kong SAR,223.1156
 2023-09-30,HR,Croatia,163.0233
-2023-09-30,HU,Hungary,284.9213
+2023-09-30,HU,Hungary,291.0061
 2023-09-30,ID,Indonesia,163.9152
-2023-09-30,IE,Ireland,159.2771
-2023-09-30,IL,Israel,212.83
-2023-09-30,IN,India,
-2023-09-30,IS,Iceland,319.9175
-2023-09-30,IT,Italy,92.1253
-2023-09-30,JP,Japan,135.0113
-2023-09-30,KR,Korea,142.8535
+2023-09-30,IE,Ireland,159.2764
+2023-09-30,IL,Israel,212.919
+2023-09-30,IN,India,326.3556
+2023-09-30,IS,Iceland,319.9285
+2023-09-30,IT,Italy,92.0406
+2023-09-30,JP,Japan,135.0779
+2023-09-30,KR,Korea,142.8322
 2023-09-30,LT,Lithuania,257.8902
-2023-09-30,LU,Luxembourg,207.2593
-2023-09-30,LV,Latvia,241.08
-2023-09-30,MA,Morocco,104.0173
-2023-09-30,MK,North Macedonia,142.44
-2023-09-30,MT,Malta,167.9736
+2023-09-30,LU,Luxembourg,206.5106
+2023-09-30,LV,Latvia,240.77
+2023-09-30,MA,Morocco,101.6675
+2023-09-30,MK,North Macedonia,142.8136
+2023-09-30,MT,Malta,169.687
 2023-09-30,MX,Mexico,246.5366
-2023-09-30,MY,Malaysia,210.5472
-2023-09-30,NL,Netherlands,163.5548
+2023-09-30,MY,Malaysia,217.2815
+2023-09-30,NL,Netherlands,164.0933
 2023-09-30,NO,Norway,184.7663
-2023-09-30,NZ,New Zealand,233.1982
-2023-09-30,PE,Peru,176.1214
-2023-09-30,PH,Philippines,257.6855
+2023-09-30,NZ,New Zealand,233.7665
+2023-09-30,PE,Peru,175.0558
+2023-09-30,PH,Philippines,267.7573
 2023-09-30,PL,Poland,173.1654
-2023-09-30,PT,Portugal,
-2023-09-30,RO,Romania,
-2023-09-30,RS,Serbia,204.7169
-2023-09-30,RU,Russia,
-2023-09-30,SE,Sweden,179.2823
+2023-09-30,PT,Portugal,194.1923
+2023-09-30,RO,Romania,125.523
+2023-09-30,RS,Serbia,223.2864
+2023-09-30,RU,Russia,159.0976
+2023-09-30,SE,Sweden,179.3868
 2023-09-30,SG,Singapore,147.5071
-2023-09-30,SI,Slovenia,159.1058
-2023-09-30,SK,Slovak Republic,179.4551
-2023-09-30,TH,Thailand,164.7917
-2023-09-30,TR,Türkiye,2319.6162
-2023-09-30,US,United States,224.5659
-2023-09-30,XM,Euro area,142.9823
-2023-09-30,XW,World,
-2023-09-30,ZA,South Africa,174.7899
+2023-09-30,SI,Slovenia,158.9779
+2023-09-30,SK,Slovakia,178.4554
+2023-09-30,TH,Thailand,174.063
+2023-09-30,TR,Türkiye,2321.3487
+2023-09-30,US,United States,222.9563
+2023-09-30,XM,Euro area,142.9005
+2023-09-30,XW,World,187.5829
+2023-09-30,ZA,South Africa,176.4154
+2023-12-31,4T,Emerging market economies (aggregate),203.4518
+2023-12-31,5R,Advanced economies,176.3127
+2023-12-31,AT,Austria,209.3891
+2023-12-31,AU,Australia,185.0522
+2023-12-31,BE,Belgium,150.9648
+2023-12-31,BG,Bulgaria,182.1988
+2023-12-31,BR,Brazil,195.4477
+2023-12-31,CA,Canada,212.7942
+2023-12-31,CH,Switzerland,159.7388
+2023-12-31,CL,Chile,340.3534
+2023-12-31,CN,China,134.1976
+2023-12-31,CO,Colombia,239.2801
+2023-12-31,CY,Cyprus,93.9163
+2023-12-31,CZ,Czechia,222.9457
+2023-12-31,DE,Germany,171.5
+2023-12-31,DK,Denmark,154.7711
+2023-12-31,EE,Estonia,316.7208
+2023-12-31,ES,Spain,110.8341
+2023-12-31,FI,Finland,109.1587
+2023-12-31,FR,France,128.9902
+2023-12-31,GB,United Kingdom,164.5885
+2023-12-31,GR,Greece,102.413
+2023-12-31,HK,Hong Kong SAR,209.5974
+2023-12-31,HR,Croatia,168.5449
+2023-12-31,HU,Hungary,296.1302
+2023-12-31,ID,Indonesia,164.3406
+2023-12-31,IE,Ireland,163.9324
+2023-12-31,IL,Israel,212.9698
+2023-12-31,IN,India,330.6303
+2023-12-31,IS,Iceland,330.3744
+2023-12-31,IT,Italy,92.0406
+2023-12-31,JP,Japan,133.9778
+2023-12-31,KR,Korea,142.9153
+2023-12-31,LT,Lithuania,261.7499
+2023-12-31,LU,Luxembourg,202.1434
+2023-12-31,LV,Latvia,234.15
+2023-12-31,MA,Morocco,101.5722
+2023-12-31,MK,North Macedonia,143.9436
+2023-12-31,MT,Malta,172.5426
+2023-12-31,MX,Mexico,251.5062
+2023-12-31,MY,Malaysia,219.0641
+2023-12-31,NL,Netherlands,166.9358
+2023-12-31,NO,Norway,178.3589
+2023-12-31,NZ,New Zealand,237.4259
+2023-12-31,PE,Peru,178.202
+2023-12-31,PH,Philippines,259.9342
+2023-12-31,PL,Poland,181.5358
+2023-12-31,PT,Portugal,196.7911
+2023-12-31,RO,Romania,127.1967
+2023-12-31,RS,Serbia,226.0642
+2023-12-31,RU,Russia,163.965
+2023-12-31,SE,Sweden,175.3292
+2023-12-31,SG,Singapore,151.6463
+2023-12-31,SI,Slovenia,163.1244
+2023-12-31,SK,Slovakia,181.8545
+2023-12-31,TH,Thailand,176.8654
+2023-12-31,TR,Türkiye,2567.3824
+2023-12-31,US,United States,225.5267
+2023-12-31,XM,Euro area,141.8266
+2023-12-31,XW,World,188.0353
+2023-12-31,ZA,South Africa,177.3418
+2024-03-31,4T,Emerging market economies (aggregate),206.0043
+2024-03-31,5R,Advanced economies,177.5577
+2024-03-31,AT,Austria,208.0534
+2024-03-31,AU,Australia,188.104
+2024-03-31,BE,Belgium,152.1439
+2024-03-31,BG,Bulgaria,195.0901
+2024-03-31,BR,Brazil,198.5654
+2024-03-31,CA,Canada,213.501
+2024-03-31,CH,Switzerland,158.1655
+2024-03-31,CL,Chile,344.2192
+2024-03-31,CN,China,131.5333
+2024-03-31,CO,Colombia,261.3792
+2024-03-31,CY,Cyprus,95.382
+2024-03-31,CZ,Czechia,225.0459
+2024-03-31,DE,Germany,170.8
+2024-03-31,DK,Denmark,150.7998
+2024-03-31,EE,Estonia,322.9193
+2024-03-31,ES,Spain,113.844
+2024-03-31,FI,Finland,108.0937
+2024-03-31,FR,France,126.2841
+2024-03-31,GB,United Kingdom,162.5935
+2024-03-31,GR,Greece,105.4126
+2024-03-31,HK,Hong Kong SAR,202.7279
+2024-03-31,HR,Croatia,171.4415
+2024-03-31,HU,Hungary,321.3237
+2024-03-31,ID,Indonesia,165.2676
+2024-03-31,IE,Ireland,167.7389
+2024-03-31,IL,Israel,219.0576
+2024-03-31,IN,India,339.0119
+2024-03-31,IS,Iceland,336.9718
+2024-03-31,IT,Italy,91.8713
+2024-03-31,JP,Japan,138.7116
+2024-03-31,KR,Korea,142.5474
+2024-03-31,LT,Lithuania,270.4195
+2024-03-31,LU,Luxembourg,200.7708
+2024-03-31,LV,Latvia,240.38
+2024-03-31,MA,Morocco,100.9052
+2024-03-31,MK,North Macedonia,142.8436
+2024-03-31,MT,Malta,175.7276
+2024-03-31,MX,Mexico,258.7062
+2024-03-31,MY,Malaysia,221.2429
+2024-03-31,NL,Netherlands,170.2952
+2024-03-31,NO,Norway,185.2893
+2024-03-31,NZ,New Zealand,237.62
+2024-03-31,PE,Peru,175.2357
+2024-03-31,PH,Philippines,272.1933
+2024-03-31,PL,Poland,189.4139
+2024-03-31,PT,Portugal,197.8902
+2024-03-31,RO,Romania,128.8703
+2024-03-31,RS,Serbia,228.9347
+2024-03-31,RU,Russia,181.9888
+2024-03-31,SE,Sweden,176.4818
+2024-03-31,SG,Singapore,153.7535
+2024-03-31,SI,Slovenia,166.7506
+2024-03-31,SK,Slovakia,178.7553
+2024-03-31,TH,Thailand,175.4123
+2024-03-31,TR,Türkiye,2747.6131
+2024-03-31,US,United States,227.6843
+2024-03-31,XM,Euro area,141.9857
+2024-03-31,XW,World,189.9204
+2024-03-31,ZA,South Africa,178.0924
+2024-06-30,4T,Emerging market economies (aggregate),206.035
+2024-06-30,5R,Advanced economies,179.5351
+2024-06-30,AT,Austria,207.8177
+2024-06-30,AU,Australia,192.1255
+2024-06-30,BE,Belgium,151.7072
+2024-06-30,BG,Bulgaria,201.8099
+2024-06-30,BR,Brazil,201.683
+2024-06-30,CA,Canada,216.3985
+2024-06-30,CH,Switzerland,159.8522
+2024-06-30,CL,Chile,351.5844
+2024-06-30,CN,China,128.2121
+2024-06-30,CO,Colombia,259.8358
+2024-06-30,CY,Cyprus,96.9381
+2024-06-30,CZ,Czechia,230.9268
+2024-06-30,DE,Germany,173.2
+2024-06-30,DK,Denmark,155.433
+2024-06-30,EE,Estonia,331.817
+2024-06-30,ES,Spain,117.8945
+2024-06-30,FI,Finland,108.5197
+2024-06-30,FR,France,125.9835
+2024-06-30,GB,United Kingdom,164.5885
+2024-06-30,GR,Greece,107.3501
+2024-06-30,HK,Hong Kong SAR,202.6837
+2024-06-30,HR,Croatia,178.7735
+2024-06-30,HU,Hungary,327.1951
+2024-06-30,ID,Indonesia,165.8602
+2024-06-30,IE,Ireland,170.1927
+2024-06-30,IL,Israel,224.0015
+2024-06-30,IN,India,346.3137
+2024-06-30,IS,Iceland,346.4556
+2024-06-30,IT,Italy,94.8349
+2024-06-30,JP,Japan,138.5449
+2024-06-30,KR,Korea,142.2513
+2024-06-30,LT,Lithuania,277.9134
+2024-06-30,LU,Luxembourg,202.6425
+2024-06-30,LV,Latvia,245.1
+2024-06-30,MA,Morocco,101.0958
+2024-06-30,MK,North Macedonia,154.5639
+2024-06-30,MT,Malta,178.693
+2024-06-30,MX,Mexico,264.2148
+2024-06-30,MY,Malaysia,223.5207
+2024-06-30,NL,Netherlands,174.6883
+2024-06-30,NO,Norway,193.135
+2024-06-30,NZ,New Zealand,232.9556
+2024-06-30,PE,Peru,175.5393
+2024-06-30,PH,Philippines,283.7909
+2024-06-30,PL,Poland,194.9815
+2024-06-30,PT,Portugal,205.6121
+2024-06-30,RO,Romania,129.7071
+2024-06-30,RS,Serbia,231.9506
+2024-06-30,RU,Russia,185.3952
+2024-06-30,SE,Sweden,178.7262
+2024-06-30,SG,Singapore,155.1082
+2024-06-30,SI,Slovenia,169.2163
+2024-06-30,SK,Slovakia,184.054
+2024-06-30,TH,Thailand,176.0351
+2024-06-30,TR,Türkiye,2914.8536
+2024-06-30,US,United States,229.4409
+2024-06-30,XM,Euro area,144.6009
+2024-06-30,XW,World,190.9078
+2024-06-30,ZA,South Africa,177.4785
+2024-09-30,4T,Emerging market economies (aggregate),205.4545
+2024-09-30,5R,Advanced economies,181.2328
+2024-09-30,AT,Austria,207.5034
+2024-09-30,AU,Australia,194.8374
+2024-09-30,BE,Belgium,154.109
+2024-09-30,BG,Bulgaria,209.7299
+2024-09-30,BR,Brazil,204.6494
+2024-09-30,CA,Canada,212.4409
+2024-09-30,CH,Switzerland,160.7093
+2024-09-30,CL,Chile,358.2646
+2024-09-30,CN,China,124.9274
+2024-09-30,CO,Colombia,267.6299
+2024-09-30,CY,Cyprus,97.7713
+2024-09-30,CZ,Czechia,235.9674
+2024-09-30,DE,Germany,174.6
+2024-09-30,DK,Denmark,160.2868
+2024-09-30,EE,Estonia,330.2174
+2024-09-30,ES,Spain,121.2315
+2024-09-30,FI,Finland,108.0937
+2024-09-30,FR,France,127.8877
+2024-09-30,GB,United Kingdom,168.2461
+2024-09-30,GR,Greece,108.8511
+2024-09-30,HK,Hong Kong SAR,193.8263
+2024-09-30,HR,Croatia,183.0278
+2024-09-30,HU,Hungary,330.7179
+2024-09-30,ID,Indonesia,166.3009
+2024-09-30,IE,Ireland,175.0688
+2024-09-30,IL,Israel,226.0986
+2024-09-30,IN,India,349.1572
+2024-09-30,IS,Iceland,357.9553
+2024-09-30,IT,Italy,95.5123
+2024-09-30,JP,Japan,139.445
+2024-09-30,KR,Korea,142.3632
+2024-09-30,LT,Lithuania,280.7518
+2024-09-30,LU,Luxembourg,202.6425
+2024-09-30,LV,Latvia,253.42
+2024-09-30,MA,Morocco,101.3816
+2024-09-30,MK,North Macedonia,154.1639
+2024-09-30,MT,Malta,181.5047
+2024-09-30,MX,Mexico,269.1844
+2024-09-30,MY,Malaysia,226.6898
+2024-09-30,NL,Netherlands,181.1487
+2024-09-30,NO,Norway,190.7813
+2024-09-30,NZ,New Zealand,231.4447
+2024-09-30,PE,Peru,175.1899
+2024-09-30,PH,Philippines,288.063
+2024-09-30,PL,Poland,198.0873
+2024-09-30,PT,Portugal,213.2035
+2024-09-30,RO,Romania,130.5439
+2024-09-30,RS,Serbia,235.0459
+2024-09-30,RU,Russia,187.2631
+2024-09-30,SE,Sweden,179.7835
+2024-09-30,SG,Singapore,154.0546
+2024-09-30,SI,Slovenia,171.9551
+2024-09-30,SK,Slovakia,189.4526
+2024-09-30,TH,Thailand,179.3565
+2024-09-30,TR,Türkiye,3093.8066
+2024-09-30,US,United States,231.3056
+2024-09-30,XM,Euro area,146.8879
+2024-09-30,XW,World,191.4469
+2024-09-30,ZA,South Africa,177.5598
+2024-12-31,4T,Emerging market economies (aggregate),205.7471
+2024-12-31,5R,Advanced economies,182.0103
+2024-12-31,AT,Austria,207.1106
+2024-12-31,AU,Australia,195.7362
+2024-12-31,BE,Belgium,155.2226
+2024-12-31,BG,Bulgaria,215.4857
+2024-12-31,BR,Brazil,207.3645
+2024-12-31,CA,Canada,208.9073
+2024-12-31,CH,Switzerland,163.5224
+2024-12-31,CL,Chile,365.6664
+2024-12-31,CN,China,122.7012
+2024-12-31,CO,Colombia,263.7067
+2024-12-31,CY,Cyprus,98.1729
+2024-12-31,CZ,Czechia,241.7432
+2024-12-31,DE,Germany,174.8
+2024-12-31,DK,Denmark,160.5074
+2024-12-31,EE,Estonia,328.018
+2024-12-31,ES,Spain,123.4239
+2024-12-31,FI,Finland,107.1353
+2024-12-31,FR,France,126.5848
+2024-12-31,GB,United Kingdom,168.5786
+2024-12-31,GR,Greece,110.0027
+2024-12-31,HK,Hong Kong SAR,192.5451
+2024-12-31,HR,Croatia,185.5623
+2024-12-31,HU,Hungary,343.8484
+2024-12-31,ID,Indonesia,166.62
+2024-12-31,IE,Ireland,179.2843
+2024-12-31,IL,Israel,228.9963
+2024-12-31,IN,India,353.3654
+2024-12-31,IS,Iceland,359.1465
+2024-12-31,IT,Italy,96.105
+2024-12-31,JP,Japan,137.7115
+2024-12-31,KR,Korea,142.6825
+2024-12-31,LT,Lithuania,287.3786
+2024-12-31,LU,Luxembourg,205.0133
+2024-12-31,LV,Latvia,251.28
+2024-12-31,MA,Morocco,103.2873
+2024-12-31,MK,North Macedonia,159.174
+2024-12-31,MT,Malta,183.3718
+2024-12-31,MX,Mexico,273.4206
+2024-12-31,MY,Malaysia,228.7695
+2024-12-31,NL,Netherlands,185.0249
+2024-12-31,NO,Norway,186.9892
+2024-12-31,NZ,New Zealand,233.6487
+2024-12-31,PE,Peru,175.5361
+2024-12-31,PH,Philippines,285.3213
+2024-12-31,PL,Poland,200.4072
+2024-12-31,PT,Portugal,219.5282
+2024-12-31,RO,Romania,132.2176
+2024-12-31,RS,Serbia,238.3132
+2024-12-31,RU,Russia,192.012
+2024-12-31,SE,Sweden,179.0445
+2024-12-31,SG,Singapore,157.5917
+2024-12-31,SI,Slovenia,175.513
+2024-12-31,SK,Slovakia,196.3509
+2024-12-31,TH,Thailand,181.4324
+2024-12-31,TR,Türkiye,3300.2307
+2024-12-31,US,United States,233.3305
+2024-12-31,XM,Euro area,147.7133
+2024-12-31,XW,World,191.9717
+2024-12-31,ZA,South Africa,179.2479
+2025-03-31,4T,Emerging market economies (aggregate),207.9478
+2025-03-31,5R,Advanced economies,183.9183
+2025-03-31,AT,Austria,208.8391
+2025-03-31,AU,Australia,196.5064
+2025-03-31,BE,Belgium,156.2051
+2025-03-31,BG,Bulgaria,224.5115
+2025-03-31,BR,Brazil,209.8341
+2025-03-31,CA,Canada,210.3207
+2025-03-31,CH,Switzerland,164.697
+2025-03-31,CL,Chile,368.0156
+2025-03-31,CN,China,121.6428
+2025-03-31,CO,Colombia,272.2486
+2025-03-31,CY,Cyprus,99.99
+2025-03-31,CZ,Czechia,247.414
+2025-03-31,DE,Germany,176.8
+2025-03-31,DK,Denmark,164.0375
+2025-03-31,EE,Estonia,337.8155
+2025-03-31,ES,Spain,127.8311
+2025-03-31,FI,Finland,106.0703
+2025-03-31,FR,France,126.7853
+2025-03-31,GB,United Kingdom,169.4098
+2025-03-31,GR,Greece,113.2928
+2025-03-31,HK,Hong Kong SAR,189.4528
+2025-03-31,HR,Croatia,193.89
+2025-03-31,HU,Hungary,376.0875
+2025-03-31,ID,Indonesia,167.0455
+2025-03-31,IE,Ireland,181.046
+2025-03-31,IL,Israel,232.0465
+2025-03-31,IN,India,352.0101
+2025-03-31,IS,Iceland,360.5667
+2025-03-31,IT,Italy,95.9356
+2025-03-31,JP,Japan,145.2121
+2025-03-31,KR,Korea,142.3289
+2025-03-31,LT,Lithuania,294.1599
+2025-03-31,LU,Luxembourg,202.7673
+2025-03-31,LV,Latvia,253.45
+2025-03-31,MA,Morocco,101.3816
+2025-03-31,MK,North Macedonia,170.6343
+2025-03-31,MT,Malta,186.0077
+2025-03-31,MX,Mexico,279.7973
+2025-03-31,MY,Malaysia,229.0666
+2025-03-31,NL,Netherlands,188.6427
+2025-03-31,NO,Norway,197.3194
+2025-03-31,NZ,New Zealand,233.0942
+2025-03-31,PE,Peru,176.5378
+2025-03-31,PH,Philippines,292.78
+2025-03-31,PL,Poland,201.8748
+2025-03-31,PT,Portugal,230.119
+2025-03-31,RO,Romania,135.5649
+2025-03-31,RS,Serbia,241.6731
+2025-03-31,RU,Russia,213.0127
+2025-03-31,SE,Sweden,180.1981
+2025-03-31,SG,Singapore,158.8711
+2025-03-31,SI,Slovenia,172.0575
+2025-03-31,SK,Slovakia,202.3494
+2025-03-31,TH,Thailand,181.5362
+2025-03-31,TR,Türkiye,3622.4312
+2025-03-31,US,United States,233.7533
+2025-03-31,XM,Euro area,149.5429
+2025-03-31,XW,World,194.0065
+2025-03-31,ZA,South Africa,181.2646
+2025-06-30,4T,Emerging market economies (aggregate),208.8457
+2025-06-30,5R,Advanced economies,184.8024
+2025-06-30,AT,Austria,207.8177
+2025-06-30,AU,Australia,199.9377
+2025-06-30,BE,Belgium,156.0523
+2025-06-30,BG,Bulgaria,233.112
+2025-06-30,BR,Brazil,212.1123
+2025-06-30,CA,Canada,210.1087
+2025-06-30,CH,Switzerland,167.7727
+2025-06-30,CL,Chile,374.3793
+2025-06-30,CN,China,120.0004
+2025-06-30,CO,Colombia,285.6878
+2025-06-30,CY,Cyprus,101.4758
+2025-06-30,CZ,Czechia,255.1851
+2025-06-30,DE,Germany,178.6
+2025-06-30,DK,Denmark,166.9057
+2025-06-30,EE,Estonia,350.1125
+2025-06-30,ES,Spain,132.9518
+2025-06-30,FI,Finland,107.0288
+2025-06-30,FR,France,126.7853
+2025-06-30,GB,United Kingdom,168.0798
+2025-06-30,GR,Greece,115.9299
+2025-06-30,HK,Hong Kong SAR,189.8945
+2025-06-30,HR,Croatia,202.4893
+2025-06-30,HU,Hungary,372.5647
+2025-06-30,ID,Indonesia,167.3494
+2025-06-30,IE,Ireland,183.4054
+2025-06-30,IL,Israel,229.9876
+2025-06-30,IN,India,358.932
+2025-06-30,IS,Iceland,366.706
+2025-06-30,IT,Italy,98.5605
+2025-06-30,JP,Japan,143.612
+2025-06-30,KR,Korea,142.4055
+2025-06-30,LT,Lithuania,302.2832
+2025-06-30,LU,Luxembourg,211.7514
+2025-06-30,LV,Latvia,260.95
+2025-06-30,MA,Morocco,101.3816
+2025-06-30,MK,North Macedonia,185.3246
+2025-06-30,MT,Malta,188.7315
+2025-06-30,MX,Mexico,287.2368
+2025-06-30,MY,Malaysia,230.255
+2025-06-30,NL,Netherlands,191.356
+2025-06-30,NO,Norway,201.896
+2025-06-30,NZ,New Zealand,230.3843
+2025-06-30,PE,Peru,179.4641
+2025-06-30,PH,Philippines,305.2098
+2025-06-30,PL,Poland,204.2041
+2025-06-30,PT,Portugal,241.0451
+2025-06-30,RO,Romania,135.5649
+2025-06-30,RS,Serbia,245.1388
+2025-06-30,RU,Russia,215.5209
+2025-06-30,SE,Sweden,179.767
+2025-06-30,SG,Singapore,160.4516
+2025-06-30,SI,Slovenia,178.5845
+2025-06-30,SK,Slovakia,204.8488
+2025-06-30,TH,Thailand,181.0172
+2025-06-30,TR,Türkiye,3866.5484
+2025-06-30,US,United States,233.7577
+2025-06-30,XM,Euro area,152.0487
+2025-06-30,XW,World,194.8872
+2025-06-30,ZA,South Africa,183.3456
+2025-09-30,4T,Emerging market economies (aggregate),208.878
+2025-09-30,5R,Advanced economies,186.3407
+2025-09-30,AT,Austria,210.5677
+2025-09-30,AU,Australia,204.6152
+2025-09-30,BE,Belgium,159.7424
+2025-09-30,BG,Bulgaria,241.9583
+2025-09-30,BR,Brazil,214.2964
+2025-09-30,CA,Canada,205.6563
+2025-09-30,CH,Switzerland,169.102
+2025-09-30,CL,Chile,383.7914
+2025-09-30,CN,China,118.0296
+2025-09-30,CO,Colombia,289.9695
+2025-09-30,CY,Cyprus,102.6905
+2025-09-30,CZ,Czechia,261.486
+2025-09-30,DE,Germany,180
+2025-09-30,DK,Denmark,170.4357
+2025-09-30,EE,Estonia,347.3132
+2025-09-30,ES,Spain,136.7942
+2025-09-30,FI,Finland,104.6858
+2025-09-30,FR,France,128.7898
+2025-09-30,GB,United Kingdom,172.4023
+2025-09-30,GR,Greece,117.8347
+2025-09-30,HK,Hong Kong SAR,192.2359
+2025-09-30,HR,Croatia,208.2824
+2025-09-30,HU,Hungary,400
+2025-09-30,ID,Indonesia,167.6989
+2025-09-30,IE,Ireland,188.1557
+2025-09-30,IL,Israel,227.6237
+2025-09-30,IN,India,361.5126
+2025-09-30,IS,Iceland,368.0805
+2025-09-30,IT,Italy,99.0686
+2025-09-30,JP,Japan,145.4788
+2025-09-30,KR,Korea,142.8669
+2025-09-30,LT,Lithuania,311.1665
+2025-09-30,LU,Luxembourg,204.3894
+2025-09-30,LV,Latvia,273.55
+2025-09-30,MA,Morocco,103.3826
+2025-09-30,MK,North Macedonia,192.8448
+2025-09-30,MT,Malta,191.7957
+2025-09-30,MX,Mexico,293.0447
+2025-09-30,MY,Malaysia,231.9386
+2025-09-30,NL,Netherlands,195.103
+2025-09-30,NO,Norway,200.3269
+2025-09-30,NZ,New Zealand,230.218
+2025-09-30,PE,Peru,182.3113
+2025-09-30,PH,Philippines,293.5066
+2025-09-30,PL,Poland,205.9843
+2025-09-30,PT,Portugal,250.8907
+2025-09-30,RO,Romania,138.9121
+2025-09-30,RS,Serbia,248.5648
+2025-09-30,RU,Russia,217.2466
+2025-09-30,SE,Sweden,180.3509
+2025-09-30,SG,Singapore,161.8815
+2025-09-30,SI,Slovenia,176.6392
+2025-09-30,SK,Slovakia,214.8463
+2025-09-30,TH,Thailand,180.083
+2025-09-30,TR,Türkiye,4087.8793
+2025-09-30,US,United States,234.2654
+2025-09-30,XM,Euro area,154.3059
+2025-09-30,XW,World,195.6388
+2025-09-30,ZA,South Africa,186.2415
+2025-12-31,5R,Advanced economies,187.1474
+2025-12-31,AT,Austria,211.5105
+2025-12-31,AU,Australia,211.0449
+2025-12-31,BE,Belgium,160.5939
+2025-12-31,BG,Bulgaria,242.6199
+2025-12-31,BR,Brazil,216.4377
+2025-12-31,CA,Canada,201.84
+2025-12-31,CH,Switzerland,169.9662
+2025-12-31,CN,China,115.6573
+2025-12-31,CO,Colombia,297.6892
+2025-12-31,CY,Cyprus,105.1099
+2025-12-31,CZ,Czechia,266.8417
+2025-12-31,DE,Germany,180.1
+2025-12-31,DK,Denmark,172.7523
+2025-12-31,EE,Estonia,346.2134
+2025-12-31,ES,Spain,139.3137
+2025-12-31,FR,France,127.8877
+2025-12-31,GB,United Kingdom,172.7348
+2025-12-31,GR,Greece,118.3852
+2025-12-31,HK,Hong Kong SAR,197.3163
+2025-12-31,HR,Croatia,215.3428
+2025-12-31,HU,Hungary,416.8668
+2025-12-31,IE,Ireland,191.7735
+2025-12-31,IL,Israel,228.615
+2025-12-31,IN,India,366.009
+2025-12-31,IS,Iceland,372.2496
+2025-12-31,IT,Italy,100
+2025-12-31,JP,Japan,144.6454
+2025-12-31,KR,Korea,143.6856
+2025-12-31,LT,Lithuania,318.5416
+2025-12-31,LU,Luxembourg,205.1381
+2025-12-31,LV,Latvia,278.81
+2025-12-31,MA,Morocco,103.5731
+2025-12-31,MK,North Macedonia,198.985
+2025-12-31,MX,Mexico,297.8198
+2025-12-31,MY,Malaysia,232.1367
+2025-12-31,NO,Norway,198.104
+2025-12-31,NZ,New Zealand,230.6962
+2025-12-31,PE,Peru,186.2488
+2025-12-31,PH,Philippines,289.794
+2025-12-31,PL,Poland,209.09
+2025-12-31,PT,Portugal,261.0065
+2025-12-31,RO,Romania,141.4226
+2025-12-31,RS,Serbia,251.8982
+2025-12-31,RU,Russia,219.4072
+2025-12-31,SE,Sweden,181.1673
+2025-12-31,SG,Singapore,162.8598
+2025-12-31,SI,Slovenia,185.632
+2025-12-31,SK,Slovakia,221.3447
+2025-12-31,TH,Thailand,182.5741
+2025-12-31,TR,Türkiye,4310.701
+2025-12-31,US,United States,235.367
+2025-12-31,XM,Euro area,155.3003
+2025-12-31,ZA,South Africa,188.8822

--- a/data/nominal_year.csv
+++ b/data/nominal_year.csv
@@ -1,20353 +1,4628 @@
 date,country_code,country,price
-1927-03-31,4T,Emerging market economies (aggregate),
-1927-03-31,5R,Advanced economies,
-1927-03-31,AE,United Arab Emirates,
-1927-03-31,AT,Austria,
-1927-03-31,AU,Australia,
-1927-03-31,BE,Belgium,
-1927-03-31,BG,Bulgaria,
-1927-03-31,BR,Brazil,
-1927-03-31,CA,Canada,
-1927-03-31,CH,Switzerland,
-1927-03-31,CL,Chile,
-1927-03-31,CN,China,
-1927-03-31,CO,Colombia,
-1927-03-31,CY,Cyprus,
-1927-03-31,CZ,Czechia,
-1927-03-31,DE,Germany,
-1927-03-31,DK,Denmark,
-1927-03-31,EE,Estonia,
-1927-03-31,ES,Spain,
-1927-03-31,FI,Finland,
-1927-03-31,FR,France,
-1927-03-31,GB,United Kingdom,
-1927-03-31,GR,Greece,
-1927-03-31,HK,Hong Kong SAR,
-1927-03-31,HR,Croatia,
-1927-03-31,HU,Hungary,
-1927-03-31,ID,Indonesia,
-1927-03-31,IE,Ireland,
-1927-03-31,IL,Israel,
-1927-03-31,IN,India,
-1927-03-31,IS,Iceland,
-1927-03-31,IT,Italy,
-1927-03-31,JP,Japan,
-1927-03-31,KR,Korea,
-1927-03-31,LT,Lithuania,
-1927-03-31,LU,Luxembourg,
-1927-03-31,LV,Latvia,
-1927-03-31,MA,Morocco,
-1927-03-31,MK,North Macedonia,
-1927-03-31,MT,Malta,
-1927-03-31,MX,Mexico,
-1927-03-31,MY,Malaysia,
-1927-03-31,NL,Netherlands,
-1927-03-31,NO,Norway,
-1927-03-31,NZ,New Zealand,
-1927-03-31,PE,Peru,
-1927-03-31,PH,Philippines,
-1927-03-31,PL,Poland,
-1927-03-31,PT,Portugal,
-1927-03-31,RO,Romania,
-1927-03-31,RS,Serbia,
-1927-03-31,RU,Russia,
-1927-03-31,SE,Sweden,
-1927-03-31,SG,Singapore,
-1927-03-31,SI,Slovenia,
-1927-03-31,SK,Slovak Republic,
-1927-03-31,TH,Thailand,
-1927-03-31,TR,Türkiye,
-1927-03-31,US,United States,
-1927-03-31,XM,Euro area,
-1927-03-31,XW,World,
-1927-03-31,ZA,South Africa,
-1927-06-30,4T,Emerging market economies (aggregate),
-1927-06-30,5R,Advanced economies,
-1927-06-30,AE,United Arab Emirates,
-1927-06-30,AT,Austria,
-1927-06-30,AU,Australia,
-1927-06-30,BE,Belgium,
-1927-06-30,BG,Bulgaria,
-1927-06-30,BR,Brazil,
-1927-06-30,CA,Canada,
-1927-06-30,CH,Switzerland,
-1927-06-30,CL,Chile,
-1927-06-30,CN,China,
-1927-06-30,CO,Colombia,
-1927-06-30,CY,Cyprus,
-1927-06-30,CZ,Czechia,
-1927-06-30,DE,Germany,
-1927-06-30,DK,Denmark,
-1927-06-30,EE,Estonia,
-1927-06-30,ES,Spain,
-1927-06-30,FI,Finland,
-1927-06-30,FR,France,
-1927-06-30,GB,United Kingdom,
-1927-06-30,GR,Greece,
-1927-06-30,HK,Hong Kong SAR,
-1927-06-30,HR,Croatia,
-1927-06-30,HU,Hungary,
-1927-06-30,ID,Indonesia,
-1927-06-30,IE,Ireland,
-1927-06-30,IL,Israel,
-1927-06-30,IN,India,
-1927-06-30,IS,Iceland,
-1927-06-30,IT,Italy,
-1927-06-30,JP,Japan,
-1927-06-30,KR,Korea,
-1927-06-30,LT,Lithuania,
-1927-06-30,LU,Luxembourg,
-1927-06-30,LV,Latvia,
-1927-06-30,MA,Morocco,
-1927-06-30,MK,North Macedonia,
-1927-06-30,MT,Malta,
-1927-06-30,MX,Mexico,
-1927-06-30,MY,Malaysia,
-1927-06-30,NL,Netherlands,
-1927-06-30,NO,Norway,
-1927-06-30,NZ,New Zealand,
-1927-06-30,PE,Peru,
-1927-06-30,PH,Philippines,
-1927-06-30,PL,Poland,
-1927-06-30,PT,Portugal,
-1927-06-30,RO,Romania,
-1927-06-30,RS,Serbia,
-1927-06-30,RU,Russia,
-1927-06-30,SE,Sweden,
-1927-06-30,SG,Singapore,
-1927-06-30,SI,Slovenia,
-1927-06-30,SK,Slovak Republic,
-1927-06-30,TH,Thailand,
-1927-06-30,TR,Türkiye,
-1927-06-30,US,United States,
-1927-06-30,XM,Euro area,
-1927-06-30,XW,World,
-1927-06-30,ZA,South Africa,
-1927-09-30,4T,Emerging market economies (aggregate),
-1927-09-30,5R,Advanced economies,
-1927-09-30,AE,United Arab Emirates,
-1927-09-30,AT,Austria,
-1927-09-30,AU,Australia,
-1927-09-30,BE,Belgium,
-1927-09-30,BG,Bulgaria,
-1927-09-30,BR,Brazil,
-1927-09-30,CA,Canada,
-1927-09-30,CH,Switzerland,
-1927-09-30,CL,Chile,
-1927-09-30,CN,China,
-1927-09-30,CO,Colombia,
-1927-09-30,CY,Cyprus,
-1927-09-30,CZ,Czechia,
-1927-09-30,DE,Germany,
-1927-09-30,DK,Denmark,
-1927-09-30,EE,Estonia,
-1927-09-30,ES,Spain,
-1927-09-30,FI,Finland,
-1927-09-30,FR,France,
-1927-09-30,GB,United Kingdom,
-1927-09-30,GR,Greece,
-1927-09-30,HK,Hong Kong SAR,
-1927-09-30,HR,Croatia,
-1927-09-30,HU,Hungary,
-1927-09-30,ID,Indonesia,
-1927-09-30,IE,Ireland,
-1927-09-30,IL,Israel,
-1927-09-30,IN,India,
-1927-09-30,IS,Iceland,
-1927-09-30,IT,Italy,
-1927-09-30,JP,Japan,
-1927-09-30,KR,Korea,
-1927-09-30,LT,Lithuania,
-1927-09-30,LU,Luxembourg,
-1927-09-30,LV,Latvia,
-1927-09-30,MA,Morocco,
-1927-09-30,MK,North Macedonia,
-1927-09-30,MT,Malta,
-1927-09-30,MX,Mexico,
-1927-09-30,MY,Malaysia,
-1927-09-30,NL,Netherlands,
-1927-09-30,NO,Norway,
-1927-09-30,NZ,New Zealand,
-1927-09-30,PE,Peru,
-1927-09-30,PH,Philippines,
-1927-09-30,PL,Poland,
-1927-09-30,PT,Portugal,
-1927-09-30,RO,Romania,
-1927-09-30,RS,Serbia,
-1927-09-30,RU,Russia,
-1927-09-30,SE,Sweden,
-1927-09-30,SG,Singapore,
-1927-09-30,SI,Slovenia,
-1927-09-30,SK,Slovak Republic,
-1927-09-30,TH,Thailand,
-1927-09-30,TR,Türkiye,
-1927-09-30,US,United States,
-1927-09-30,XM,Euro area,
-1927-09-30,XW,World,
-1927-09-30,ZA,South Africa,
-1927-12-31,4T,Emerging market economies (aggregate),
-1927-12-31,5R,Advanced economies,
-1927-12-31,AE,United Arab Emirates,
-1927-12-31,AT,Austria,
-1927-12-31,AU,Australia,
-1927-12-31,BE,Belgium,
-1927-12-31,BG,Bulgaria,
-1927-12-31,BR,Brazil,
-1927-12-31,CA,Canada,
-1927-12-31,CH,Switzerland,
-1927-12-31,CL,Chile,
-1927-12-31,CN,China,
-1927-12-31,CO,Colombia,
-1927-12-31,CY,Cyprus,
-1927-12-31,CZ,Czechia,
-1927-12-31,DE,Germany,
-1927-12-31,DK,Denmark,
-1927-12-31,EE,Estonia,
-1927-12-31,ES,Spain,
-1927-12-31,FI,Finland,
-1927-12-31,FR,France,
-1927-12-31,GB,United Kingdom,
-1927-12-31,GR,Greece,
-1927-12-31,HK,Hong Kong SAR,
-1927-12-31,HR,Croatia,
-1927-12-31,HU,Hungary,
-1927-12-31,ID,Indonesia,
-1927-12-31,IE,Ireland,
-1927-12-31,IL,Israel,
-1927-12-31,IN,India,
-1927-12-31,IS,Iceland,
-1927-12-31,IT,Italy,
-1927-12-31,JP,Japan,
-1927-12-31,KR,Korea,
-1927-12-31,LT,Lithuania,
-1927-12-31,LU,Luxembourg,
-1927-12-31,LV,Latvia,
-1927-12-31,MA,Morocco,
-1927-12-31,MK,North Macedonia,
-1927-12-31,MT,Malta,
-1927-12-31,MX,Mexico,
-1927-12-31,MY,Malaysia,
-1927-12-31,NL,Netherlands,
-1927-12-31,NO,Norway,
-1927-12-31,NZ,New Zealand,
-1927-12-31,PE,Peru,
-1927-12-31,PH,Philippines,
-1927-12-31,PL,Poland,
-1927-12-31,PT,Portugal,
-1927-12-31,RO,Romania,
-1927-12-31,RS,Serbia,
-1927-12-31,RU,Russia,
-1927-12-31,SE,Sweden,
-1927-12-31,SG,Singapore,
-1927-12-31,SI,Slovenia,
-1927-12-31,SK,Slovak Republic,
-1927-12-31,TH,Thailand,
-1927-12-31,TR,Türkiye,
-1927-12-31,US,United States,
-1927-12-31,XM,Euro area,
-1927-12-31,XW,World,
-1927-12-31,ZA,South Africa,
-1928-03-31,4T,Emerging market economies (aggregate),
-1928-03-31,5R,Advanced economies,
-1928-03-31,AE,United Arab Emirates,
-1928-03-31,AT,Austria,
-1928-03-31,AU,Australia,
-1928-03-31,BE,Belgium,
-1928-03-31,BG,Bulgaria,
-1928-03-31,BR,Brazil,
-1928-03-31,CA,Canada,
-1928-03-31,CH,Switzerland,
-1928-03-31,CL,Chile,
-1928-03-31,CN,China,
-1928-03-31,CO,Colombia,
-1928-03-31,CY,Cyprus,
-1928-03-31,CZ,Czechia,
-1928-03-31,DE,Germany,
-1928-03-31,DK,Denmark,
-1928-03-31,EE,Estonia,
-1928-03-31,ES,Spain,
-1928-03-31,FI,Finland,
-1928-03-31,FR,France,
-1928-03-31,GB,United Kingdom,
-1928-03-31,GR,Greece,
-1928-03-31,HK,Hong Kong SAR,
-1928-03-31,HR,Croatia,
-1928-03-31,HU,Hungary,
-1928-03-31,ID,Indonesia,
-1928-03-31,IE,Ireland,
-1928-03-31,IL,Israel,
-1928-03-31,IN,India,
-1928-03-31,IS,Iceland,
 1928-03-31,IT,Italy,-1.7232
-1928-03-31,JP,Japan,
-1928-03-31,KR,Korea,
-1928-03-31,LT,Lithuania,
-1928-03-31,LU,Luxembourg,
-1928-03-31,LV,Latvia,
-1928-03-31,MA,Morocco,
-1928-03-31,MK,North Macedonia,
-1928-03-31,MT,Malta,
-1928-03-31,MX,Mexico,
-1928-03-31,MY,Malaysia,
-1928-03-31,NL,Netherlands,
-1928-03-31,NO,Norway,
-1928-03-31,NZ,New Zealand,
-1928-03-31,PE,Peru,
-1928-03-31,PH,Philippines,
-1928-03-31,PL,Poland,
-1928-03-31,PT,Portugal,
-1928-03-31,RO,Romania,
-1928-03-31,RS,Serbia,
-1928-03-31,RU,Russia,
-1928-03-31,SE,Sweden,
-1928-03-31,SG,Singapore,
-1928-03-31,SI,Slovenia,
-1928-03-31,SK,Slovak Republic,
-1928-03-31,TH,Thailand,
-1928-03-31,TR,Türkiye,
-1928-03-31,US,United States,
-1928-03-31,XM,Euro area,
-1928-03-31,XW,World,
-1928-03-31,ZA,South Africa,
-1928-06-30,4T,Emerging market economies (aggregate),
-1928-06-30,5R,Advanced economies,
-1928-06-30,AE,United Arab Emirates,
-1928-06-30,AT,Austria,
-1928-06-30,AU,Australia,
-1928-06-30,BE,Belgium,
-1928-06-30,BG,Bulgaria,
-1928-06-30,BR,Brazil,
-1928-06-30,CA,Canada,
-1928-06-30,CH,Switzerland,
-1928-06-30,CL,Chile,
-1928-06-30,CN,China,
-1928-06-30,CO,Colombia,
-1928-06-30,CY,Cyprus,
-1928-06-30,CZ,Czechia,
-1928-06-30,DE,Germany,
-1928-06-30,DK,Denmark,
-1928-06-30,EE,Estonia,
-1928-06-30,ES,Spain,
-1928-06-30,FI,Finland,
-1928-06-30,FR,France,
-1928-06-30,GB,United Kingdom,
-1928-06-30,GR,Greece,
-1928-06-30,HK,Hong Kong SAR,
-1928-06-30,HR,Croatia,
-1928-06-30,HU,Hungary,
-1928-06-30,ID,Indonesia,
-1928-06-30,IE,Ireland,
-1928-06-30,IL,Israel,
-1928-06-30,IN,India,
-1928-06-30,IS,Iceland,
 1928-06-30,IT,Italy,-1.733
-1928-06-30,JP,Japan,
-1928-06-30,KR,Korea,
-1928-06-30,LT,Lithuania,
-1928-06-30,LU,Luxembourg,
-1928-06-30,LV,Latvia,
-1928-06-30,MA,Morocco,
-1928-06-30,MK,North Macedonia,
-1928-06-30,MT,Malta,
-1928-06-30,MX,Mexico,
-1928-06-30,MY,Malaysia,
-1928-06-30,NL,Netherlands,
-1928-06-30,NO,Norway,
-1928-06-30,NZ,New Zealand,
-1928-06-30,PE,Peru,
-1928-06-30,PH,Philippines,
-1928-06-30,PL,Poland,
-1928-06-30,PT,Portugal,
-1928-06-30,RO,Romania,
-1928-06-30,RS,Serbia,
-1928-06-30,RU,Russia,
-1928-06-30,SE,Sweden,
-1928-06-30,SG,Singapore,
-1928-06-30,SI,Slovenia,
-1928-06-30,SK,Slovak Republic,
-1928-06-30,TH,Thailand,
-1928-06-30,TR,Türkiye,
-1928-06-30,US,United States,
-1928-06-30,XM,Euro area,
-1928-06-30,XW,World,
-1928-06-30,ZA,South Africa,
-1928-09-30,4T,Emerging market economies (aggregate),
-1928-09-30,5R,Advanced economies,
-1928-09-30,AE,United Arab Emirates,
-1928-09-30,AT,Austria,
-1928-09-30,AU,Australia,
-1928-09-30,BE,Belgium,
-1928-09-30,BG,Bulgaria,
-1928-09-30,BR,Brazil,
-1928-09-30,CA,Canada,
-1928-09-30,CH,Switzerland,
-1928-09-30,CL,Chile,
-1928-09-30,CN,China,
-1928-09-30,CO,Colombia,
-1928-09-30,CY,Cyprus,
-1928-09-30,CZ,Czechia,
-1928-09-30,DE,Germany,
-1928-09-30,DK,Denmark,
-1928-09-30,EE,Estonia,
-1928-09-30,ES,Spain,
-1928-09-30,FI,Finland,
-1928-09-30,FR,France,
-1928-09-30,GB,United Kingdom,
-1928-09-30,GR,Greece,
-1928-09-30,HK,Hong Kong SAR,
-1928-09-30,HR,Croatia,
-1928-09-30,HU,Hungary,
-1928-09-30,ID,Indonesia,
-1928-09-30,IE,Ireland,
-1928-09-30,IL,Israel,
-1928-09-30,IN,India,
-1928-09-30,IS,Iceland,
 1928-09-30,IT,Italy,-2.0023
-1928-09-30,JP,Japan,
-1928-09-30,KR,Korea,
-1928-09-30,LT,Lithuania,
-1928-09-30,LU,Luxembourg,
-1928-09-30,LV,Latvia,
-1928-09-30,MA,Morocco,
-1928-09-30,MK,North Macedonia,
-1928-09-30,MT,Malta,
-1928-09-30,MX,Mexico,
-1928-09-30,MY,Malaysia,
-1928-09-30,NL,Netherlands,
-1928-09-30,NO,Norway,
-1928-09-30,NZ,New Zealand,
-1928-09-30,PE,Peru,
-1928-09-30,PH,Philippines,
-1928-09-30,PL,Poland,
-1928-09-30,PT,Portugal,
-1928-09-30,RO,Romania,
-1928-09-30,RS,Serbia,
-1928-09-30,RU,Russia,
-1928-09-30,SE,Sweden,
-1928-09-30,SG,Singapore,
-1928-09-30,SI,Slovenia,
-1928-09-30,SK,Slovak Republic,
-1928-09-30,TH,Thailand,
-1928-09-30,TR,Türkiye,
-1928-09-30,US,United States,
-1928-09-30,XM,Euro area,
-1928-09-30,XW,World,
-1928-09-30,ZA,South Africa,
-1928-12-31,4T,Emerging market economies (aggregate),
-1928-12-31,5R,Advanced economies,
-1928-12-31,AE,United Arab Emirates,
-1928-12-31,AT,Austria,
-1928-12-31,AU,Australia,
-1928-12-31,BE,Belgium,
-1928-12-31,BG,Bulgaria,
-1928-12-31,BR,Brazil,
-1928-12-31,CA,Canada,
-1928-12-31,CH,Switzerland,
-1928-12-31,CL,Chile,
-1928-12-31,CN,China,
-1928-12-31,CO,Colombia,
-1928-12-31,CY,Cyprus,
-1928-12-31,CZ,Czechia,
-1928-12-31,DE,Germany,
-1928-12-31,DK,Denmark,
-1928-12-31,EE,Estonia,
-1928-12-31,ES,Spain,
-1928-12-31,FI,Finland,
-1928-12-31,FR,France,
-1928-12-31,GB,United Kingdom,
-1928-12-31,GR,Greece,
-1928-12-31,HK,Hong Kong SAR,
-1928-12-31,HR,Croatia,
-1928-12-31,HU,Hungary,
-1928-12-31,ID,Indonesia,
-1928-12-31,IE,Ireland,
-1928-12-31,IL,Israel,
-1928-12-31,IN,India,
-1928-12-31,IS,Iceland,
 1928-12-31,IT,Italy,-2.5485
-1928-12-31,JP,Japan,
-1928-12-31,KR,Korea,
-1928-12-31,LT,Lithuania,
-1928-12-31,LU,Luxembourg,
-1928-12-31,LV,Latvia,
-1928-12-31,MA,Morocco,
-1928-12-31,MK,North Macedonia,
-1928-12-31,MT,Malta,
-1928-12-31,MX,Mexico,
-1928-12-31,MY,Malaysia,
-1928-12-31,NL,Netherlands,
-1928-12-31,NO,Norway,
-1928-12-31,NZ,New Zealand,
-1928-12-31,PE,Peru,
-1928-12-31,PH,Philippines,
-1928-12-31,PL,Poland,
-1928-12-31,PT,Portugal,
-1928-12-31,RO,Romania,
-1928-12-31,RS,Serbia,
-1928-12-31,RU,Russia,
-1928-12-31,SE,Sweden,
-1928-12-31,SG,Singapore,
-1928-12-31,SI,Slovenia,
-1928-12-31,SK,Slovak Republic,
-1928-12-31,TH,Thailand,
-1928-12-31,TR,Türkiye,
-1928-12-31,US,United States,
-1928-12-31,XM,Euro area,
-1928-12-31,XW,World,
-1928-12-31,ZA,South Africa,
-1929-03-31,4T,Emerging market economies (aggregate),
-1929-03-31,5R,Advanced economies,
-1929-03-31,AE,United Arab Emirates,
-1929-03-31,AT,Austria,
-1929-03-31,AU,Australia,
-1929-03-31,BE,Belgium,
-1929-03-31,BG,Bulgaria,
-1929-03-31,BR,Brazil,
-1929-03-31,CA,Canada,
-1929-03-31,CH,Switzerland,
-1929-03-31,CL,Chile,
-1929-03-31,CN,China,
-1929-03-31,CO,Colombia,
-1929-03-31,CY,Cyprus,
-1929-03-31,CZ,Czechia,
-1929-03-31,DE,Germany,
-1929-03-31,DK,Denmark,
-1929-03-31,EE,Estonia,
-1929-03-31,ES,Spain,
-1929-03-31,FI,Finland,
-1929-03-31,FR,France,
-1929-03-31,GB,United Kingdom,
-1929-03-31,GR,Greece,
-1929-03-31,HK,Hong Kong SAR,
-1929-03-31,HR,Croatia,
-1929-03-31,HU,Hungary,
-1929-03-31,ID,Indonesia,
-1929-03-31,IE,Ireland,
-1929-03-31,IL,Israel,
-1929-03-31,IN,India,
-1929-03-31,IS,Iceland,
 1929-03-31,IT,Italy,-3.0912
-1929-03-31,JP,Japan,
-1929-03-31,KR,Korea,
-1929-03-31,LT,Lithuania,
-1929-03-31,LU,Luxembourg,
-1929-03-31,LV,Latvia,
-1929-03-31,MA,Morocco,
-1929-03-31,MK,North Macedonia,
-1929-03-31,MT,Malta,
-1929-03-31,MX,Mexico,
-1929-03-31,MY,Malaysia,
-1929-03-31,NL,Netherlands,
-1929-03-31,NO,Norway,
-1929-03-31,NZ,New Zealand,
-1929-03-31,PE,Peru,
-1929-03-31,PH,Philippines,
-1929-03-31,PL,Poland,
-1929-03-31,PT,Portugal,
-1929-03-31,RO,Romania,
-1929-03-31,RS,Serbia,
-1929-03-31,RU,Russia,
-1929-03-31,SE,Sweden,
-1929-03-31,SG,Singapore,
-1929-03-31,SI,Slovenia,
-1929-03-31,SK,Slovak Republic,
-1929-03-31,TH,Thailand,
-1929-03-31,TR,Türkiye,
-1929-03-31,US,United States,
-1929-03-31,XM,Euro area,
-1929-03-31,XW,World,
-1929-03-31,ZA,South Africa,
-1929-06-30,4T,Emerging market economies (aggregate),
-1929-06-30,5R,Advanced economies,
-1929-06-30,AE,United Arab Emirates,
-1929-06-30,AT,Austria,
-1929-06-30,AU,Australia,
-1929-06-30,BE,Belgium,
-1929-06-30,BG,Bulgaria,
-1929-06-30,BR,Brazil,
-1929-06-30,CA,Canada,
-1929-06-30,CH,Switzerland,
-1929-06-30,CL,Chile,
-1929-06-30,CN,China,
-1929-06-30,CO,Colombia,
-1929-06-30,CY,Cyprus,
-1929-06-30,CZ,Czechia,
-1929-06-30,DE,Germany,
-1929-06-30,DK,Denmark,
-1929-06-30,EE,Estonia,
-1929-06-30,ES,Spain,
-1929-06-30,FI,Finland,
-1929-06-30,FR,France,
-1929-06-30,GB,United Kingdom,
-1929-06-30,GR,Greece,
-1929-06-30,HK,Hong Kong SAR,
-1929-06-30,HR,Croatia,
-1929-06-30,HU,Hungary,
-1929-06-30,ID,Indonesia,
-1929-06-30,IE,Ireland,
-1929-06-30,IL,Israel,
-1929-06-30,IN,India,
-1929-06-30,IS,Iceland,
 1929-06-30,IT,Italy,-3.6357
-1929-06-30,JP,Japan,
-1929-06-30,KR,Korea,
-1929-06-30,LT,Lithuania,
-1929-06-30,LU,Luxembourg,
-1929-06-30,LV,Latvia,
-1929-06-30,MA,Morocco,
-1929-06-30,MK,North Macedonia,
-1929-06-30,MT,Malta,
-1929-06-30,MX,Mexico,
-1929-06-30,MY,Malaysia,
-1929-06-30,NL,Netherlands,
-1929-06-30,NO,Norway,
-1929-06-30,NZ,New Zealand,
-1929-06-30,PE,Peru,
-1929-06-30,PH,Philippines,
-1929-06-30,PL,Poland,
-1929-06-30,PT,Portugal,
-1929-06-30,RO,Romania,
-1929-06-30,RS,Serbia,
-1929-06-30,RU,Russia,
-1929-06-30,SE,Sweden,
-1929-06-30,SG,Singapore,
-1929-06-30,SI,Slovenia,
-1929-06-30,SK,Slovak Republic,
-1929-06-30,TH,Thailand,
-1929-06-30,TR,Türkiye,
-1929-06-30,US,United States,
-1929-06-30,XM,Euro area,
-1929-06-30,XW,World,
-1929-06-30,ZA,South Africa,
-1929-09-30,4T,Emerging market economies (aggregate),
-1929-09-30,5R,Advanced economies,
-1929-09-30,AE,United Arab Emirates,
-1929-09-30,AT,Austria,
-1929-09-30,AU,Australia,
-1929-09-30,BE,Belgium,
-1929-09-30,BG,Bulgaria,
-1929-09-30,BR,Brazil,
-1929-09-30,CA,Canada,
-1929-09-30,CH,Switzerland,
-1929-09-30,CL,Chile,
-1929-09-30,CN,China,
-1929-09-30,CO,Colombia,
-1929-09-30,CY,Cyprus,
-1929-09-30,CZ,Czechia,
-1929-09-30,DE,Germany,
-1929-09-30,DK,Denmark,
-1929-09-30,EE,Estonia,
-1929-09-30,ES,Spain,
-1929-09-30,FI,Finland,
-1929-09-30,FR,France,
-1929-09-30,GB,United Kingdom,
-1929-09-30,GR,Greece,
-1929-09-30,HK,Hong Kong SAR,
-1929-09-30,HR,Croatia,
-1929-09-30,HU,Hungary,
-1929-09-30,ID,Indonesia,
-1929-09-30,IE,Ireland,
-1929-09-30,IL,Israel,
-1929-09-30,IN,India,
-1929-09-30,IS,Iceland,
 1929-09-30,IT,Italy,-4.3463
-1929-09-30,JP,Japan,
-1929-09-30,KR,Korea,
-1929-09-30,LT,Lithuania,
-1929-09-30,LU,Luxembourg,
-1929-09-30,LV,Latvia,
-1929-09-30,MA,Morocco,
-1929-09-30,MK,North Macedonia,
-1929-09-30,MT,Malta,
-1929-09-30,MX,Mexico,
-1929-09-30,MY,Malaysia,
-1929-09-30,NL,Netherlands,
-1929-09-30,NO,Norway,
-1929-09-30,NZ,New Zealand,
-1929-09-30,PE,Peru,
-1929-09-30,PH,Philippines,
-1929-09-30,PL,Poland,
-1929-09-30,PT,Portugal,
-1929-09-30,RO,Romania,
-1929-09-30,RS,Serbia,
-1929-09-30,RU,Russia,
-1929-09-30,SE,Sweden,
-1929-09-30,SG,Singapore,
-1929-09-30,SI,Slovenia,
-1929-09-30,SK,Slovak Republic,
-1929-09-30,TH,Thailand,
-1929-09-30,TR,Türkiye,
-1929-09-30,US,United States,
-1929-09-30,XM,Euro area,
-1929-09-30,XW,World,
-1929-09-30,ZA,South Africa,
-1929-12-31,4T,Emerging market economies (aggregate),
-1929-12-31,5R,Advanced economies,
-1929-12-31,AE,United Arab Emirates,
-1929-12-31,AT,Austria,
-1929-12-31,AU,Australia,
-1929-12-31,BE,Belgium,
-1929-12-31,BG,Bulgaria,
-1929-12-31,BR,Brazil,
-1929-12-31,CA,Canada,
-1929-12-31,CH,Switzerland,
-1929-12-31,CL,Chile,
-1929-12-31,CN,China,
-1929-12-31,CO,Colombia,
-1929-12-31,CY,Cyprus,
-1929-12-31,CZ,Czechia,
-1929-12-31,DE,Germany,
-1929-12-31,DK,Denmark,
-1929-12-31,EE,Estonia,
-1929-12-31,ES,Spain,
-1929-12-31,FI,Finland,
-1929-12-31,FR,France,
-1929-12-31,GB,United Kingdom,
-1929-12-31,GR,Greece,
-1929-12-31,HK,Hong Kong SAR,
-1929-12-31,HR,Croatia,
-1929-12-31,HU,Hungary,
-1929-12-31,ID,Indonesia,
-1929-12-31,IE,Ireland,
-1929-12-31,IL,Israel,
-1929-12-31,IN,India,
-1929-12-31,IS,Iceland,
 1929-12-31,IT,Italy,-5.243
-1929-12-31,JP,Japan,
-1929-12-31,KR,Korea,
-1929-12-31,LT,Lithuania,
-1929-12-31,LU,Luxembourg,
-1929-12-31,LV,Latvia,
-1929-12-31,MA,Morocco,
-1929-12-31,MK,North Macedonia,
-1929-12-31,MT,Malta,
-1929-12-31,MX,Mexico,
-1929-12-31,MY,Malaysia,
-1929-12-31,NL,Netherlands,
-1929-12-31,NO,Norway,
-1929-12-31,NZ,New Zealand,
-1929-12-31,PE,Peru,
-1929-12-31,PH,Philippines,
-1929-12-31,PL,Poland,
-1929-12-31,PT,Portugal,
-1929-12-31,RO,Romania,
-1929-12-31,RS,Serbia,
-1929-12-31,RU,Russia,
-1929-12-31,SE,Sweden,
-1929-12-31,SG,Singapore,
-1929-12-31,SI,Slovenia,
-1929-12-31,SK,Slovak Republic,
-1929-12-31,TH,Thailand,
-1929-12-31,TR,Türkiye,
-1929-12-31,US,United States,
-1929-12-31,XM,Euro area,
-1929-12-31,XW,World,
-1929-12-31,ZA,South Africa,
-1930-03-31,4T,Emerging market economies (aggregate),
-1930-03-31,5R,Advanced economies,
-1930-03-31,AE,United Arab Emirates,
-1930-03-31,AT,Austria,
-1930-03-31,AU,Australia,
-1930-03-31,BE,Belgium,
-1930-03-31,BG,Bulgaria,
-1930-03-31,BR,Brazil,
-1930-03-31,CA,Canada,
-1930-03-31,CH,Switzerland,
-1930-03-31,CL,Chile,
-1930-03-31,CN,China,
-1930-03-31,CO,Colombia,
-1930-03-31,CY,Cyprus,
-1930-03-31,CZ,Czechia,
-1930-03-31,DE,Germany,
-1930-03-31,DK,Denmark,
-1930-03-31,EE,Estonia,
-1930-03-31,ES,Spain,
-1930-03-31,FI,Finland,
-1930-03-31,FR,France,
-1930-03-31,GB,United Kingdom,
-1930-03-31,GR,Greece,
-1930-03-31,HK,Hong Kong SAR,
-1930-03-31,HR,Croatia,
-1930-03-31,HU,Hungary,
-1930-03-31,ID,Indonesia,
-1930-03-31,IE,Ireland,
-1930-03-31,IL,Israel,
-1930-03-31,IN,India,
-1930-03-31,IS,Iceland,
 1930-03-31,IT,Italy,-6.1479
-1930-03-31,JP,Japan,
-1930-03-31,KR,Korea,
-1930-03-31,LT,Lithuania,
-1930-03-31,LU,Luxembourg,
-1930-03-31,LV,Latvia,
-1930-03-31,MA,Morocco,
-1930-03-31,MK,North Macedonia,
-1930-03-31,MT,Malta,
-1930-03-31,MX,Mexico,
-1930-03-31,MY,Malaysia,
-1930-03-31,NL,Netherlands,
-1930-03-31,NO,Norway,
-1930-03-31,NZ,New Zealand,
-1930-03-31,PE,Peru,
-1930-03-31,PH,Philippines,
-1930-03-31,PL,Poland,
-1930-03-31,PT,Portugal,
-1930-03-31,RO,Romania,
-1930-03-31,RS,Serbia,
-1930-03-31,RU,Russia,
-1930-03-31,SE,Sweden,
-1930-03-31,SG,Singapore,
-1930-03-31,SI,Slovenia,
-1930-03-31,SK,Slovak Republic,
-1930-03-31,TH,Thailand,
-1930-03-31,TR,Türkiye,
-1930-03-31,US,United States,
-1930-03-31,XM,Euro area,
-1930-03-31,XW,World,
-1930-03-31,ZA,South Africa,
-1930-06-30,4T,Emerging market economies (aggregate),
-1930-06-30,5R,Advanced economies,
-1930-06-30,AE,United Arab Emirates,
-1930-06-30,AT,Austria,
-1930-06-30,AU,Australia,
-1930-06-30,BE,Belgium,
-1930-06-30,BG,Bulgaria,
-1930-06-30,BR,Brazil,
-1930-06-30,CA,Canada,
-1930-06-30,CH,Switzerland,
-1930-06-30,CL,Chile,
-1930-06-30,CN,China,
-1930-06-30,CO,Colombia,
-1930-06-30,CY,Cyprus,
-1930-06-30,CZ,Czechia,
-1930-06-30,DE,Germany,
-1930-06-30,DK,Denmark,
-1930-06-30,EE,Estonia,
-1930-06-30,ES,Spain,
-1930-06-30,FI,Finland,
-1930-06-30,FR,France,
-1930-06-30,GB,United Kingdom,
-1930-06-30,GR,Greece,
-1930-06-30,HK,Hong Kong SAR,
-1930-06-30,HR,Croatia,
-1930-06-30,HU,Hungary,
-1930-06-30,ID,Indonesia,
-1930-06-30,IE,Ireland,
-1930-06-30,IL,Israel,
-1930-06-30,IN,India,
-1930-06-30,IS,Iceland,
 1930-06-30,IT,Italy,-7.066
-1930-06-30,JP,Japan,
-1930-06-30,KR,Korea,
-1930-06-30,LT,Lithuania,
-1930-06-30,LU,Luxembourg,
-1930-06-30,LV,Latvia,
-1930-06-30,MA,Morocco,
-1930-06-30,MK,North Macedonia,
-1930-06-30,MT,Malta,
-1930-06-30,MX,Mexico,
-1930-06-30,MY,Malaysia,
-1930-06-30,NL,Netherlands,
-1930-06-30,NO,Norway,
-1930-06-30,NZ,New Zealand,
-1930-06-30,PE,Peru,
-1930-06-30,PH,Philippines,
-1930-06-30,PL,Poland,
-1930-06-30,PT,Portugal,
-1930-06-30,RO,Romania,
-1930-06-30,RS,Serbia,
-1930-06-30,RU,Russia,
-1930-06-30,SE,Sweden,
-1930-06-30,SG,Singapore,
-1930-06-30,SI,Slovenia,
-1930-06-30,SK,Slovak Republic,
-1930-06-30,TH,Thailand,
-1930-06-30,TR,Türkiye,
-1930-06-30,US,United States,
-1930-06-30,XM,Euro area,
-1930-06-30,XW,World,
-1930-06-30,ZA,South Africa,
-1930-09-30,4T,Emerging market economies (aggregate),
-1930-09-30,5R,Advanced economies,
-1930-09-30,AE,United Arab Emirates,
-1930-09-30,AT,Austria,
-1930-09-30,AU,Australia,
-1930-09-30,BE,Belgium,
-1930-09-30,BG,Bulgaria,
-1930-09-30,BR,Brazil,
-1930-09-30,CA,Canada,
-1930-09-30,CH,Switzerland,
-1930-09-30,CL,Chile,
-1930-09-30,CN,China,
-1930-09-30,CO,Colombia,
-1930-09-30,CY,Cyprus,
-1930-09-30,CZ,Czechia,
-1930-09-30,DE,Germany,
-1930-09-30,DK,Denmark,
-1930-09-30,EE,Estonia,
-1930-09-30,ES,Spain,
-1930-09-30,FI,Finland,
-1930-09-30,FR,France,
-1930-09-30,GB,United Kingdom,
-1930-09-30,GR,Greece,
-1930-09-30,HK,Hong Kong SAR,
-1930-09-30,HR,Croatia,
-1930-09-30,HU,Hungary,
-1930-09-30,ID,Indonesia,
-1930-09-30,IE,Ireland,
-1930-09-30,IL,Israel,
-1930-09-30,IN,India,
-1930-09-30,IS,Iceland,
 1930-09-30,IT,Italy,-7.9139
-1930-09-30,JP,Japan,
-1930-09-30,KR,Korea,
-1930-09-30,LT,Lithuania,
-1930-09-30,LU,Luxembourg,
-1930-09-30,LV,Latvia,
-1930-09-30,MA,Morocco,
-1930-09-30,MK,North Macedonia,
-1930-09-30,MT,Malta,
-1930-09-30,MX,Mexico,
-1930-09-30,MY,Malaysia,
-1930-09-30,NL,Netherlands,
-1930-09-30,NO,Norway,
-1930-09-30,NZ,New Zealand,
-1930-09-30,PE,Peru,
-1930-09-30,PH,Philippines,
-1930-09-30,PL,Poland,
-1930-09-30,PT,Portugal,
-1930-09-30,RO,Romania,
-1930-09-30,RS,Serbia,
-1930-09-30,RU,Russia,
-1930-09-30,SE,Sweden,
-1930-09-30,SG,Singapore,
-1930-09-30,SI,Slovenia,
-1930-09-30,SK,Slovak Republic,
-1930-09-30,TH,Thailand,
-1930-09-30,TR,Türkiye,
-1930-09-30,US,United States,
-1930-09-30,XM,Euro area,
-1930-09-30,XW,World,
-1930-09-30,ZA,South Africa,
-1930-12-31,4T,Emerging market economies (aggregate),
-1930-12-31,5R,Advanced economies,
-1930-12-31,AE,United Arab Emirates,
-1930-12-31,AT,Austria,
-1930-12-31,AU,Australia,
-1930-12-31,BE,Belgium,
-1930-12-31,BG,Bulgaria,
-1930-12-31,BR,Brazil,
-1930-12-31,CA,Canada,
-1930-12-31,CH,Switzerland,
-1930-12-31,CL,Chile,
-1930-12-31,CN,China,
-1930-12-31,CO,Colombia,
-1930-12-31,CY,Cyprus,
-1930-12-31,CZ,Czechia,
-1930-12-31,DE,Germany,
-1930-12-31,DK,Denmark,
-1930-12-31,EE,Estonia,
-1930-12-31,ES,Spain,
-1930-12-31,FI,Finland,
-1930-12-31,FR,France,
-1930-12-31,GB,United Kingdom,
-1930-12-31,GR,Greece,
-1930-12-31,HK,Hong Kong SAR,
-1930-12-31,HR,Croatia,
-1930-12-31,HU,Hungary,
-1930-12-31,ID,Indonesia,
-1930-12-31,IE,Ireland,
-1930-12-31,IL,Israel,
-1930-12-31,IN,India,
-1930-12-31,IS,Iceland,
 1930-12-31,IT,Italy,-8.6879
-1930-12-31,JP,Japan,
-1930-12-31,KR,Korea,
-1930-12-31,LT,Lithuania,
-1930-12-31,LU,Luxembourg,
-1930-12-31,LV,Latvia,
-1930-12-31,MA,Morocco,
-1930-12-31,MK,North Macedonia,
-1930-12-31,MT,Malta,
-1930-12-31,MX,Mexico,
-1930-12-31,MY,Malaysia,
-1930-12-31,NL,Netherlands,
-1930-12-31,NO,Norway,
-1930-12-31,NZ,New Zealand,
-1930-12-31,PE,Peru,
-1930-12-31,PH,Philippines,
-1930-12-31,PL,Poland,
-1930-12-31,PT,Portugal,
-1930-12-31,RO,Romania,
-1930-12-31,RS,Serbia,
-1930-12-31,RU,Russia,
-1930-12-31,SE,Sweden,
-1930-12-31,SG,Singapore,
-1930-12-31,SI,Slovenia,
-1930-12-31,SK,Slovak Republic,
-1930-12-31,TH,Thailand,
-1930-12-31,TR,Türkiye,
-1930-12-31,US,United States,
-1930-12-31,XM,Euro area,
-1930-12-31,XW,World,
-1930-12-31,ZA,South Africa,
-1931-03-31,4T,Emerging market economies (aggregate),
-1931-03-31,5R,Advanced economies,
-1931-03-31,AE,United Arab Emirates,
-1931-03-31,AT,Austria,
-1931-03-31,AU,Australia,
-1931-03-31,BE,Belgium,
-1931-03-31,BG,Bulgaria,
-1931-03-31,BR,Brazil,
-1931-03-31,CA,Canada,
-1931-03-31,CH,Switzerland,
-1931-03-31,CL,Chile,
-1931-03-31,CN,China,
-1931-03-31,CO,Colombia,
-1931-03-31,CY,Cyprus,
-1931-03-31,CZ,Czechia,
-1931-03-31,DE,Germany,
-1931-03-31,DK,Denmark,
-1931-03-31,EE,Estonia,
-1931-03-31,ES,Spain,
-1931-03-31,FI,Finland,
-1931-03-31,FR,France,
-1931-03-31,GB,United Kingdom,
-1931-03-31,GR,Greece,
-1931-03-31,HK,Hong Kong SAR,
-1931-03-31,HR,Croatia,
-1931-03-31,HU,Hungary,
-1931-03-31,ID,Indonesia,
-1931-03-31,IE,Ireland,
-1931-03-31,IL,Israel,
-1931-03-31,IN,India,
-1931-03-31,IS,Iceland,
 1931-03-31,IT,Italy,-9.4839
-1931-03-31,JP,Japan,
-1931-03-31,KR,Korea,
-1931-03-31,LT,Lithuania,
-1931-03-31,LU,Luxembourg,
-1931-03-31,LV,Latvia,
-1931-03-31,MA,Morocco,
-1931-03-31,MK,North Macedonia,
-1931-03-31,MT,Malta,
-1931-03-31,MX,Mexico,
-1931-03-31,MY,Malaysia,
-1931-03-31,NL,Netherlands,
-1931-03-31,NO,Norway,
-1931-03-31,NZ,New Zealand,
-1931-03-31,PE,Peru,
-1931-03-31,PH,Philippines,
-1931-03-31,PL,Poland,
-1931-03-31,PT,Portugal,
-1931-03-31,RO,Romania,
-1931-03-31,RS,Serbia,
-1931-03-31,RU,Russia,
-1931-03-31,SE,Sweden,
-1931-03-31,SG,Singapore,
-1931-03-31,SI,Slovenia,
-1931-03-31,SK,Slovak Republic,
-1931-03-31,TH,Thailand,
-1931-03-31,TR,Türkiye,
-1931-03-31,US,United States,
-1931-03-31,XM,Euro area,
-1931-03-31,XW,World,
-1931-03-31,ZA,South Africa,
-1931-06-30,4T,Emerging market economies (aggregate),
-1931-06-30,5R,Advanced economies,
-1931-06-30,AE,United Arab Emirates,
-1931-06-30,AT,Austria,
-1931-06-30,AU,Australia,
-1931-06-30,BE,Belgium,
-1931-06-30,BG,Bulgaria,
-1931-06-30,BR,Brazil,
-1931-06-30,CA,Canada,
-1931-06-30,CH,Switzerland,
-1931-06-30,CL,Chile,
-1931-06-30,CN,China,
-1931-06-30,CO,Colombia,
-1931-06-30,CY,Cyprus,
-1931-06-30,CZ,Czechia,
-1931-06-30,DE,Germany,
-1931-06-30,DK,Denmark,
-1931-06-30,EE,Estonia,
-1931-06-30,ES,Spain,
-1931-06-30,FI,Finland,
-1931-06-30,FR,France,
-1931-06-30,GB,United Kingdom,
-1931-06-30,GR,Greece,
-1931-06-30,HK,Hong Kong SAR,
-1931-06-30,HR,Croatia,
-1931-06-30,HU,Hungary,
-1931-06-30,ID,Indonesia,
-1931-06-30,IE,Ireland,
-1931-06-30,IL,Israel,
-1931-06-30,IN,India,
-1931-06-30,IS,Iceland,
 1931-06-30,IT,Italy,-10.3074
-1931-06-30,JP,Japan,
-1931-06-30,KR,Korea,
-1931-06-30,LT,Lithuania,
-1931-06-30,LU,Luxembourg,
-1931-06-30,LV,Latvia,
-1931-06-30,MA,Morocco,
-1931-06-30,MK,North Macedonia,
-1931-06-30,MT,Malta,
-1931-06-30,MX,Mexico,
-1931-06-30,MY,Malaysia,
-1931-06-30,NL,Netherlands,
-1931-06-30,NO,Norway,
-1931-06-30,NZ,New Zealand,
-1931-06-30,PE,Peru,
-1931-06-30,PH,Philippines,
-1931-06-30,PL,Poland,
-1931-06-30,PT,Portugal,
-1931-06-30,RO,Romania,
-1931-06-30,RS,Serbia,
-1931-06-30,RU,Russia,
-1931-06-30,SE,Sweden,
-1931-06-30,SG,Singapore,
-1931-06-30,SI,Slovenia,
-1931-06-30,SK,Slovak Republic,
-1931-06-30,TH,Thailand,
-1931-06-30,TR,Türkiye,
-1931-06-30,US,United States,
-1931-06-30,XM,Euro area,
-1931-06-30,XW,World,
-1931-06-30,ZA,South Africa,
-1931-09-30,4T,Emerging market economies (aggregate),
-1931-09-30,5R,Advanced economies,
-1931-09-30,AE,United Arab Emirates,
-1931-09-30,AT,Austria,
-1931-09-30,AU,Australia,
-1931-09-30,BE,Belgium,
-1931-09-30,BG,Bulgaria,
-1931-09-30,BR,Brazil,
-1931-09-30,CA,Canada,
-1931-09-30,CH,Switzerland,
-1931-09-30,CL,Chile,
-1931-09-30,CN,China,
-1931-09-30,CO,Colombia,
-1931-09-30,CY,Cyprus,
-1931-09-30,CZ,Czechia,
-1931-09-30,DE,Germany,
-1931-09-30,DK,Denmark,
-1931-09-30,EE,Estonia,
-1931-09-30,ES,Spain,
-1931-09-30,FI,Finland,
-1931-09-30,FR,France,
-1931-09-30,GB,United Kingdom,
-1931-09-30,GR,Greece,
-1931-09-30,HK,Hong Kong SAR,
-1931-09-30,HR,Croatia,
-1931-09-30,HU,Hungary,
-1931-09-30,ID,Indonesia,
-1931-09-30,IE,Ireland,
-1931-09-30,IL,Israel,
-1931-09-30,IN,India,
-1931-09-30,IS,Iceland,
 1931-09-30,IT,Italy,-10.7781
-1931-09-30,JP,Japan,
-1931-09-30,KR,Korea,
-1931-09-30,LT,Lithuania,
-1931-09-30,LU,Luxembourg,
-1931-09-30,LV,Latvia,
-1931-09-30,MA,Morocco,
-1931-09-30,MK,North Macedonia,
-1931-09-30,MT,Malta,
-1931-09-30,MX,Mexico,
-1931-09-30,MY,Malaysia,
-1931-09-30,NL,Netherlands,
-1931-09-30,NO,Norway,
-1931-09-30,NZ,New Zealand,
-1931-09-30,PE,Peru,
-1931-09-30,PH,Philippines,
-1931-09-30,PL,Poland,
-1931-09-30,PT,Portugal,
-1931-09-30,RO,Romania,
-1931-09-30,RS,Serbia,
-1931-09-30,RU,Russia,
-1931-09-30,SE,Sweden,
-1931-09-30,SG,Singapore,
-1931-09-30,SI,Slovenia,
-1931-09-30,SK,Slovak Republic,
-1931-09-30,TH,Thailand,
-1931-09-30,TR,Türkiye,
-1931-09-30,US,United States,
-1931-09-30,XM,Euro area,
-1931-09-30,XW,World,
-1931-09-30,ZA,South Africa,
-1931-12-31,4T,Emerging market economies (aggregate),
-1931-12-31,5R,Advanced economies,
-1931-12-31,AE,United Arab Emirates,
-1931-12-31,AT,Austria,
-1931-12-31,AU,Australia,
-1931-12-31,BE,Belgium,
-1931-12-31,BG,Bulgaria,
-1931-12-31,BR,Brazil,
-1931-12-31,CA,Canada,
-1931-12-31,CH,Switzerland,
-1931-12-31,CL,Chile,
-1931-12-31,CN,China,
-1931-12-31,CO,Colombia,
-1931-12-31,CY,Cyprus,
-1931-12-31,CZ,Czechia,
-1931-12-31,DE,Germany,
-1931-12-31,DK,Denmark,
-1931-12-31,EE,Estonia,
-1931-12-31,ES,Spain,
-1931-12-31,FI,Finland,
-1931-12-31,FR,France,
-1931-12-31,GB,United Kingdom,
-1931-12-31,GR,Greece,
-1931-12-31,HK,Hong Kong SAR,
-1931-12-31,HR,Croatia,
-1931-12-31,HU,Hungary,
-1931-12-31,ID,Indonesia,
-1931-12-31,IE,Ireland,
-1931-12-31,IL,Israel,
-1931-12-31,IN,India,
-1931-12-31,IS,Iceland,
 1931-12-31,IT,Italy,-10.8428
-1931-12-31,JP,Japan,
-1931-12-31,KR,Korea,
-1931-12-31,LT,Lithuania,
-1931-12-31,LU,Luxembourg,
-1931-12-31,LV,Latvia,
-1931-12-31,MA,Morocco,
-1931-12-31,MK,North Macedonia,
-1931-12-31,MT,Malta,
-1931-12-31,MX,Mexico,
-1931-12-31,MY,Malaysia,
-1931-12-31,NL,Netherlands,
-1931-12-31,NO,Norway,
-1931-12-31,NZ,New Zealand,
-1931-12-31,PE,Peru,
-1931-12-31,PH,Philippines,
-1931-12-31,PL,Poland,
-1931-12-31,PT,Portugal,
-1931-12-31,RO,Romania,
-1931-12-31,RS,Serbia,
-1931-12-31,RU,Russia,
-1931-12-31,SE,Sweden,
-1931-12-31,SG,Singapore,
-1931-12-31,SI,Slovenia,
-1931-12-31,SK,Slovak Republic,
-1931-12-31,TH,Thailand,
-1931-12-31,TR,Türkiye,
-1931-12-31,US,United States,
-1931-12-31,XM,Euro area,
-1931-12-31,XW,World,
-1931-12-31,ZA,South Africa,
-1932-03-31,4T,Emerging market economies (aggregate),
-1932-03-31,5R,Advanced economies,
-1932-03-31,AE,United Arab Emirates,
-1932-03-31,AT,Austria,
-1932-03-31,AU,Australia,
-1932-03-31,BE,Belgium,
-1932-03-31,BG,Bulgaria,
-1932-03-31,BR,Brazil,
-1932-03-31,CA,Canada,
-1932-03-31,CH,Switzerland,
-1932-03-31,CL,Chile,
-1932-03-31,CN,China,
-1932-03-31,CO,Colombia,
-1932-03-31,CY,Cyprus,
-1932-03-31,CZ,Czechia,
-1932-03-31,DE,Germany,
-1932-03-31,DK,Denmark,
-1932-03-31,EE,Estonia,
-1932-03-31,ES,Spain,
-1932-03-31,FI,Finland,
-1932-03-31,FR,France,
-1932-03-31,GB,United Kingdom,
-1932-03-31,GR,Greece,
-1932-03-31,HK,Hong Kong SAR,
-1932-03-31,HR,Croatia,
-1932-03-31,HU,Hungary,
-1932-03-31,ID,Indonesia,
-1932-03-31,IE,Ireland,
-1932-03-31,IL,Israel,
-1932-03-31,IN,India,
-1932-03-31,IS,Iceland,
 1932-03-31,IT,Italy,-10.9248
-1932-03-31,JP,Japan,
-1932-03-31,KR,Korea,
-1932-03-31,LT,Lithuania,
-1932-03-31,LU,Luxembourg,
-1932-03-31,LV,Latvia,
-1932-03-31,MA,Morocco,
-1932-03-31,MK,North Macedonia,
-1932-03-31,MT,Malta,
-1932-03-31,MX,Mexico,
-1932-03-31,MY,Malaysia,
-1932-03-31,NL,Netherlands,
-1932-03-31,NO,Norway,
-1932-03-31,NZ,New Zealand,
-1932-03-31,PE,Peru,
-1932-03-31,PH,Philippines,
-1932-03-31,PL,Poland,
-1932-03-31,PT,Portugal,
-1932-03-31,RO,Romania,
-1932-03-31,RS,Serbia,
-1932-03-31,RU,Russia,
-1932-03-31,SE,Sweden,
-1932-03-31,SG,Singapore,
-1932-03-31,SI,Slovenia,
-1932-03-31,SK,Slovak Republic,
-1932-03-31,TH,Thailand,
-1932-03-31,TR,Türkiye,
-1932-03-31,US,United States,
-1932-03-31,XM,Euro area,
-1932-03-31,XW,World,
-1932-03-31,ZA,South Africa,
-1932-06-30,4T,Emerging market economies (aggregate),
-1932-06-30,5R,Advanced economies,
-1932-06-30,AE,United Arab Emirates,
-1932-06-30,AT,Austria,
-1932-06-30,AU,Australia,
-1932-06-30,BE,Belgium,
-1932-06-30,BG,Bulgaria,
-1932-06-30,BR,Brazil,
-1932-06-30,CA,Canada,
-1932-06-30,CH,Switzerland,
-1932-06-30,CL,Chile,
-1932-06-30,CN,China,
-1932-06-30,CO,Colombia,
-1932-06-30,CY,Cyprus,
-1932-06-30,CZ,Czechia,
-1932-06-30,DE,Germany,
-1932-06-30,DK,Denmark,
-1932-06-30,EE,Estonia,
-1932-06-30,ES,Spain,
-1932-06-30,FI,Finland,
-1932-06-30,FR,France,
-1932-06-30,GB,United Kingdom,
-1932-06-30,GR,Greece,
-1932-06-30,HK,Hong Kong SAR,
-1932-06-30,HR,Croatia,
-1932-06-30,HU,Hungary,
-1932-06-30,ID,Indonesia,
-1932-06-30,IE,Ireland,
-1932-06-30,IL,Israel,
-1932-06-30,IN,India,
-1932-06-30,IS,Iceland,
 1932-06-30,IT,Italy,-11.0112
-1932-06-30,JP,Japan,
-1932-06-30,KR,Korea,
-1932-06-30,LT,Lithuania,
-1932-06-30,LU,Luxembourg,
-1932-06-30,LV,Latvia,
-1932-06-30,MA,Morocco,
-1932-06-30,MK,North Macedonia,
-1932-06-30,MT,Malta,
-1932-06-30,MX,Mexico,
-1932-06-30,MY,Malaysia,
-1932-06-30,NL,Netherlands,
-1932-06-30,NO,Norway,
-1932-06-30,NZ,New Zealand,
-1932-06-30,PE,Peru,
-1932-06-30,PH,Philippines,
-1932-06-30,PL,Poland,
-1932-06-30,PT,Portugal,
-1932-06-30,RO,Romania,
-1932-06-30,RS,Serbia,
-1932-06-30,RU,Russia,
-1932-06-30,SE,Sweden,
-1932-06-30,SG,Singapore,
-1932-06-30,SI,Slovenia,
-1932-06-30,SK,Slovak Republic,
-1932-06-30,TH,Thailand,
-1932-06-30,TR,Türkiye,
-1932-06-30,US,United States,
-1932-06-30,XM,Euro area,
-1932-06-30,XW,World,
-1932-06-30,ZA,South Africa,
-1932-09-30,4T,Emerging market economies (aggregate),
-1932-09-30,5R,Advanced economies,
-1932-09-30,AE,United Arab Emirates,
-1932-09-30,AT,Austria,
-1932-09-30,AU,Australia,
-1932-09-30,BE,Belgium,
-1932-09-30,BG,Bulgaria,
-1932-09-30,BR,Brazil,
-1932-09-30,CA,Canada,
-1932-09-30,CH,Switzerland,
-1932-09-30,CL,Chile,
-1932-09-30,CN,China,
-1932-09-30,CO,Colombia,
-1932-09-30,CY,Cyprus,
-1932-09-30,CZ,Czechia,
-1932-09-30,DE,Germany,
-1932-09-30,DK,Denmark,
-1932-09-30,EE,Estonia,
-1932-09-30,ES,Spain,
-1932-09-30,FI,Finland,
-1932-09-30,FR,France,
-1932-09-30,GB,United Kingdom,
-1932-09-30,GR,Greece,
-1932-09-30,HK,Hong Kong SAR,
-1932-09-30,HR,Croatia,
-1932-09-30,HU,Hungary,
-1932-09-30,ID,Indonesia,
-1932-09-30,IE,Ireland,
-1932-09-30,IL,Israel,
-1932-09-30,IN,India,
-1932-09-30,IS,Iceland,
 1932-09-30,IT,Italy,-10.3099
-1932-09-30,JP,Japan,
-1932-09-30,KR,Korea,
-1932-09-30,LT,Lithuania,
-1932-09-30,LU,Luxembourg,
-1932-09-30,LV,Latvia,
-1932-09-30,MA,Morocco,
-1932-09-30,MK,North Macedonia,
-1932-09-30,MT,Malta,
-1932-09-30,MX,Mexico,
-1932-09-30,MY,Malaysia,
-1932-09-30,NL,Netherlands,
-1932-09-30,NO,Norway,
-1932-09-30,NZ,New Zealand,
-1932-09-30,PE,Peru,
-1932-09-30,PH,Philippines,
-1932-09-30,PL,Poland,
-1932-09-30,PT,Portugal,
-1932-09-30,RO,Romania,
-1932-09-30,RS,Serbia,
-1932-09-30,RU,Russia,
-1932-09-30,SE,Sweden,
-1932-09-30,SG,Singapore,
-1932-09-30,SI,Slovenia,
-1932-09-30,SK,Slovak Republic,
-1932-09-30,TH,Thailand,
-1932-09-30,TR,Türkiye,
-1932-09-30,US,United States,
-1932-09-30,XM,Euro area,
-1932-09-30,XW,World,
-1932-09-30,ZA,South Africa,
-1932-12-31,4T,Emerging market economies (aggregate),
-1932-12-31,5R,Advanced economies,
-1932-12-31,AE,United Arab Emirates,
-1932-12-31,AT,Austria,
-1932-12-31,AU,Australia,
-1932-12-31,BE,Belgium,
-1932-12-31,BG,Bulgaria,
-1932-12-31,BR,Brazil,
-1932-12-31,CA,Canada,
-1932-12-31,CH,Switzerland,
-1932-12-31,CL,Chile,
-1932-12-31,CN,China,
-1932-12-31,CO,Colombia,
-1932-12-31,CY,Cyprus,
-1932-12-31,CZ,Czechia,
-1932-12-31,DE,Germany,
-1932-12-31,DK,Denmark,
-1932-12-31,EE,Estonia,
-1932-12-31,ES,Spain,
-1932-12-31,FI,Finland,
-1932-12-31,FR,France,
-1932-12-31,GB,United Kingdom,
-1932-12-31,GR,Greece,
-1932-12-31,HK,Hong Kong SAR,
-1932-12-31,HR,Croatia,
-1932-12-31,HU,Hungary,
-1932-12-31,ID,Indonesia,
-1932-12-31,IE,Ireland,
-1932-12-31,IL,Israel,
-1932-12-31,IN,India,
-1932-12-31,IS,Iceland,
 1932-12-31,IT,Italy,-8.7347
-1932-12-31,JP,Japan,
-1932-12-31,KR,Korea,
-1932-12-31,LT,Lithuania,
-1932-12-31,LU,Luxembourg,
-1932-12-31,LV,Latvia,
-1932-12-31,MA,Morocco,
-1932-12-31,MK,North Macedonia,
-1932-12-31,MT,Malta,
-1932-12-31,MX,Mexico,
-1932-12-31,MY,Malaysia,
-1932-12-31,NL,Netherlands,
-1932-12-31,NO,Norway,
-1932-12-31,NZ,New Zealand,
-1932-12-31,PE,Peru,
-1932-12-31,PH,Philippines,
-1932-12-31,PL,Poland,
-1932-12-31,PT,Portugal,
-1932-12-31,RO,Romania,
-1932-12-31,RS,Serbia,
-1932-12-31,RU,Russia,
-1932-12-31,SE,Sweden,
-1932-12-31,SG,Singapore,
-1932-12-31,SI,Slovenia,
-1932-12-31,SK,Slovak Republic,
-1932-12-31,TH,Thailand,
-1932-12-31,TR,Türkiye,
-1932-12-31,US,United States,
-1932-12-31,XM,Euro area,
-1932-12-31,XW,World,
-1932-12-31,ZA,South Africa,
-1933-03-31,4T,Emerging market economies (aggregate),
-1933-03-31,5R,Advanced economies,
-1933-03-31,AE,United Arab Emirates,
-1933-03-31,AT,Austria,
-1933-03-31,AU,Australia,
-1933-03-31,BE,Belgium,
-1933-03-31,BG,Bulgaria,
-1933-03-31,BR,Brazil,
-1933-03-31,CA,Canada,
-1933-03-31,CH,Switzerland,
-1933-03-31,CL,Chile,
-1933-03-31,CN,China,
-1933-03-31,CO,Colombia,
-1933-03-31,CY,Cyprus,
-1933-03-31,CZ,Czechia,
-1933-03-31,DE,Germany,
-1933-03-31,DK,Denmark,
-1933-03-31,EE,Estonia,
-1933-03-31,ES,Spain,
-1933-03-31,FI,Finland,
-1933-03-31,FR,France,
-1933-03-31,GB,United Kingdom,
-1933-03-31,GR,Greece,
-1933-03-31,HK,Hong Kong SAR,
-1933-03-31,HR,Croatia,
-1933-03-31,HU,Hungary,
-1933-03-31,ID,Indonesia,
-1933-03-31,IE,Ireland,
-1933-03-31,IL,Israel,
-1933-03-31,IN,India,
-1933-03-31,IS,Iceland,
 1933-03-31,IT,Italy,-7.069
-1933-03-31,JP,Japan,
-1933-03-31,KR,Korea,
-1933-03-31,LT,Lithuania,
-1933-03-31,LU,Luxembourg,
-1933-03-31,LV,Latvia,
-1933-03-31,MA,Morocco,
-1933-03-31,MK,North Macedonia,
-1933-03-31,MT,Malta,
-1933-03-31,MX,Mexico,
-1933-03-31,MY,Malaysia,
-1933-03-31,NL,Netherlands,
-1933-03-31,NO,Norway,
-1933-03-31,NZ,New Zealand,
-1933-03-31,PE,Peru,
-1933-03-31,PH,Philippines,
-1933-03-31,PL,Poland,
-1933-03-31,PT,Portugal,
-1933-03-31,RO,Romania,
-1933-03-31,RS,Serbia,
-1933-03-31,RU,Russia,
-1933-03-31,SE,Sweden,
-1933-03-31,SG,Singapore,
-1933-03-31,SI,Slovenia,
-1933-03-31,SK,Slovak Republic,
-1933-03-31,TH,Thailand,
-1933-03-31,TR,Türkiye,
-1933-03-31,US,United States,
-1933-03-31,XM,Euro area,
-1933-03-31,XW,World,
-1933-03-31,ZA,South Africa,
-1933-06-30,4T,Emerging market economies (aggregate),
-1933-06-30,5R,Advanced economies,
-1933-06-30,AE,United Arab Emirates,
-1933-06-30,AT,Austria,
-1933-06-30,AU,Australia,
-1933-06-30,BE,Belgium,
-1933-06-30,BG,Bulgaria,
-1933-06-30,BR,Brazil,
-1933-06-30,CA,Canada,
-1933-06-30,CH,Switzerland,
-1933-06-30,CL,Chile,
-1933-06-30,CN,China,
-1933-06-30,CO,Colombia,
-1933-06-30,CY,Cyprus,
-1933-06-30,CZ,Czechia,
-1933-06-30,DE,Germany,
-1933-06-30,DK,Denmark,
-1933-06-30,EE,Estonia,
-1933-06-30,ES,Spain,
-1933-06-30,FI,Finland,
-1933-06-30,FR,France,
-1933-06-30,GB,United Kingdom,
-1933-06-30,GR,Greece,
-1933-06-30,HK,Hong Kong SAR,
-1933-06-30,HR,Croatia,
-1933-06-30,HU,Hungary,
-1933-06-30,ID,Indonesia,
-1933-06-30,IE,Ireland,
-1933-06-30,IL,Israel,
-1933-06-30,IN,India,
-1933-06-30,IS,Iceland,
 1933-06-30,IT,Italy,-5.3114
-1933-06-30,JP,Japan,
-1933-06-30,KR,Korea,
-1933-06-30,LT,Lithuania,
-1933-06-30,LU,Luxembourg,
-1933-06-30,LV,Latvia,
-1933-06-30,MA,Morocco,
-1933-06-30,MK,North Macedonia,
-1933-06-30,MT,Malta,
-1933-06-30,MX,Mexico,
-1933-06-30,MY,Malaysia,
-1933-06-30,NL,Netherlands,
-1933-06-30,NO,Norway,
-1933-06-30,NZ,New Zealand,
-1933-06-30,PE,Peru,
-1933-06-30,PH,Philippines,
-1933-06-30,PL,Poland,
-1933-06-30,PT,Portugal,
-1933-06-30,RO,Romania,
-1933-06-30,RS,Serbia,
-1933-06-30,RU,Russia,
-1933-06-30,SE,Sweden,
-1933-06-30,SG,Singapore,
-1933-06-30,SI,Slovenia,
-1933-06-30,SK,Slovak Republic,
-1933-06-30,TH,Thailand,
-1933-06-30,TR,Türkiye,
-1933-06-30,US,United States,
-1933-06-30,XM,Euro area,
-1933-06-30,XW,World,
-1933-06-30,ZA,South Africa,
-1933-09-30,4T,Emerging market economies (aggregate),
-1933-09-30,5R,Advanced economies,
-1933-09-30,AE,United Arab Emirates,
-1933-09-30,AT,Austria,
-1933-09-30,AU,Australia,
-1933-09-30,BE,Belgium,
-1933-09-30,BG,Bulgaria,
-1933-09-30,BR,Brazil,
-1933-09-30,CA,Canada,
-1933-09-30,CH,Switzerland,
-1933-09-30,CL,Chile,
-1933-09-30,CN,China,
-1933-09-30,CO,Colombia,
-1933-09-30,CY,Cyprus,
-1933-09-30,CZ,Czechia,
-1933-09-30,DE,Germany,
-1933-09-30,DK,Denmark,
-1933-09-30,EE,Estonia,
-1933-09-30,ES,Spain,
-1933-09-30,FI,Finland,
-1933-09-30,FR,France,
-1933-09-30,GB,United Kingdom,
-1933-09-30,GR,Greece,
-1933-09-30,HK,Hong Kong SAR,
-1933-09-30,HR,Croatia,
-1933-09-30,HU,Hungary,
-1933-09-30,ID,Indonesia,
-1933-09-30,IE,Ireland,
-1933-09-30,IL,Israel,
-1933-09-30,IN,India,
-1933-09-30,IS,Iceland,
 1933-09-30,IT,Italy,-4.7778
-1933-09-30,JP,Japan,
-1933-09-30,KR,Korea,
-1933-09-30,LT,Lithuania,
-1933-09-30,LU,Luxembourg,
-1933-09-30,LV,Latvia,
-1933-09-30,MA,Morocco,
-1933-09-30,MK,North Macedonia,
-1933-09-30,MT,Malta,
-1933-09-30,MX,Mexico,
-1933-09-30,MY,Malaysia,
-1933-09-30,NL,Netherlands,
-1933-09-30,NO,Norway,
-1933-09-30,NZ,New Zealand,
-1933-09-30,PE,Peru,
-1933-09-30,PH,Philippines,
-1933-09-30,PL,Poland,
-1933-09-30,PT,Portugal,
-1933-09-30,RO,Romania,
-1933-09-30,RS,Serbia,
-1933-09-30,RU,Russia,
-1933-09-30,SE,Sweden,
-1933-09-30,SG,Singapore,
-1933-09-30,SI,Slovenia,
-1933-09-30,SK,Slovak Republic,
-1933-09-30,TH,Thailand,
-1933-09-30,TR,Türkiye,
-1933-09-30,US,United States,
-1933-09-30,XM,Euro area,
-1933-09-30,XW,World,
-1933-09-30,ZA,South Africa,
-1933-12-31,4T,Emerging market economies (aggregate),
-1933-12-31,5R,Advanced economies,
-1933-12-31,AE,United Arab Emirates,
-1933-12-31,AT,Austria,
-1933-12-31,AU,Australia,
-1933-12-31,BE,Belgium,
-1933-12-31,BG,Bulgaria,
-1933-12-31,BR,Brazil,
-1933-12-31,CA,Canada,
-1933-12-31,CH,Switzerland,
-1933-12-31,CL,Chile,
-1933-12-31,CN,China,
-1933-12-31,CO,Colombia,
-1933-12-31,CY,Cyprus,
-1933-12-31,CZ,Czechia,
-1933-12-31,DE,Germany,
-1933-12-31,DK,Denmark,
-1933-12-31,EE,Estonia,
-1933-12-31,ES,Spain,
-1933-12-31,FI,Finland,
-1933-12-31,FR,France,
-1933-12-31,GB,United Kingdom,
-1933-12-31,GR,Greece,
-1933-12-31,HK,Hong Kong SAR,
-1933-12-31,HR,Croatia,
-1933-12-31,HU,Hungary,
-1933-12-31,ID,Indonesia,
-1933-12-31,IE,Ireland,
-1933-12-31,IL,Israel,
-1933-12-31,IN,India,
-1933-12-31,IS,Iceland,
 1933-12-31,IT,Italy,-5.6245
-1933-12-31,JP,Japan,
-1933-12-31,KR,Korea,
-1933-12-31,LT,Lithuania,
-1933-12-31,LU,Luxembourg,
-1933-12-31,LV,Latvia,
-1933-12-31,MA,Morocco,
-1933-12-31,MK,North Macedonia,
-1933-12-31,MT,Malta,
-1933-12-31,MX,Mexico,
-1933-12-31,MY,Malaysia,
-1933-12-31,NL,Netherlands,
-1933-12-31,NO,Norway,
-1933-12-31,NZ,New Zealand,
-1933-12-31,PE,Peru,
-1933-12-31,PH,Philippines,
-1933-12-31,PL,Poland,
-1933-12-31,PT,Portugal,
-1933-12-31,RO,Romania,
-1933-12-31,RS,Serbia,
-1933-12-31,RU,Russia,
-1933-12-31,SE,Sweden,
-1933-12-31,SG,Singapore,
-1933-12-31,SI,Slovenia,
-1933-12-31,SK,Slovak Republic,
-1933-12-31,TH,Thailand,
-1933-12-31,TR,Türkiye,
-1933-12-31,US,United States,
-1933-12-31,XM,Euro area,
-1933-12-31,XW,World,
-1933-12-31,ZA,South Africa,
-1934-03-31,4T,Emerging market economies (aggregate),
-1934-03-31,5R,Advanced economies,
-1934-03-31,AE,United Arab Emirates,
-1934-03-31,AT,Austria,
-1934-03-31,AU,Australia,
-1934-03-31,BE,Belgium,
-1934-03-31,BG,Bulgaria,
-1934-03-31,BR,Brazil,
-1934-03-31,CA,Canada,
-1934-03-31,CH,Switzerland,
-1934-03-31,CL,Chile,
-1934-03-31,CN,China,
-1934-03-31,CO,Colombia,
-1934-03-31,CY,Cyprus,
-1934-03-31,CZ,Czechia,
-1934-03-31,DE,Germany,
-1934-03-31,DK,Denmark,
-1934-03-31,EE,Estonia,
-1934-03-31,ES,Spain,
-1934-03-31,FI,Finland,
-1934-03-31,FR,France,
-1934-03-31,GB,United Kingdom,
-1934-03-31,GR,Greece,
-1934-03-31,HK,Hong Kong SAR,
-1934-03-31,HR,Croatia,
-1934-03-31,HU,Hungary,
-1934-03-31,ID,Indonesia,
-1934-03-31,IE,Ireland,
-1934-03-31,IL,Israel,
-1934-03-31,IN,India,
-1934-03-31,IS,Iceland,
 1934-03-31,IT,Italy,-6.481
-1934-03-31,JP,Japan,
-1934-03-31,KR,Korea,
-1934-03-31,LT,Lithuania,
-1934-03-31,LU,Luxembourg,
-1934-03-31,LV,Latvia,
-1934-03-31,MA,Morocco,
-1934-03-31,MK,North Macedonia,
-1934-03-31,MT,Malta,
-1934-03-31,MX,Mexico,
-1934-03-31,MY,Malaysia,
-1934-03-31,NL,Netherlands,
-1934-03-31,NO,Norway,
-1934-03-31,NZ,New Zealand,
-1934-03-31,PE,Peru,
-1934-03-31,PH,Philippines,
-1934-03-31,PL,Poland,
-1934-03-31,PT,Portugal,
-1934-03-31,RO,Romania,
-1934-03-31,RS,Serbia,
-1934-03-31,RU,Russia,
-1934-03-31,SE,Sweden,
-1934-03-31,SG,Singapore,
-1934-03-31,SI,Slovenia,
-1934-03-31,SK,Slovak Republic,
-1934-03-31,TH,Thailand,
-1934-03-31,TR,Türkiye,
-1934-03-31,US,United States,
-1934-03-31,XM,Euro area,
-1934-03-31,XW,World,
-1934-03-31,ZA,South Africa,
-1934-06-30,4T,Emerging market economies (aggregate),
-1934-06-30,5R,Advanced economies,
-1934-06-30,AE,United Arab Emirates,
-1934-06-30,AT,Austria,
-1934-06-30,AU,Australia,
-1934-06-30,BE,Belgium,
-1934-06-30,BG,Bulgaria,
-1934-06-30,BR,Brazil,
-1934-06-30,CA,Canada,
-1934-06-30,CH,Switzerland,
-1934-06-30,CL,Chile,
-1934-06-30,CN,China,
-1934-06-30,CO,Colombia,
-1934-06-30,CY,Cyprus,
-1934-06-30,CZ,Czechia,
-1934-06-30,DE,Germany,
-1934-06-30,DK,Denmark,
-1934-06-30,EE,Estonia,
-1934-06-30,ES,Spain,
-1934-06-30,FI,Finland,
-1934-06-30,FR,France,
-1934-06-30,GB,United Kingdom,
-1934-06-30,GR,Greece,
-1934-06-30,HK,Hong Kong SAR,
-1934-06-30,HR,Croatia,
-1934-06-30,HU,Hungary,
-1934-06-30,ID,Indonesia,
-1934-06-30,IE,Ireland,
-1934-06-30,IL,Israel,
-1934-06-30,IN,India,
-1934-06-30,IS,Iceland,
 1934-06-30,IT,Italy,-7.3521
-1934-06-30,JP,Japan,
-1934-06-30,KR,Korea,
-1934-06-30,LT,Lithuania,
-1934-06-30,LU,Luxembourg,
-1934-06-30,LV,Latvia,
-1934-06-30,MA,Morocco,
-1934-06-30,MK,North Macedonia,
-1934-06-30,MT,Malta,
-1934-06-30,MX,Mexico,
-1934-06-30,MY,Malaysia,
-1934-06-30,NL,Netherlands,
-1934-06-30,NO,Norway,
-1934-06-30,NZ,New Zealand,
-1934-06-30,PE,Peru,
-1934-06-30,PH,Philippines,
-1934-06-30,PL,Poland,
-1934-06-30,PT,Portugal,
-1934-06-30,RO,Romania,
-1934-06-30,RS,Serbia,
-1934-06-30,RU,Russia,
-1934-06-30,SE,Sweden,
-1934-06-30,SG,Singapore,
-1934-06-30,SI,Slovenia,
-1934-06-30,SK,Slovak Republic,
-1934-06-30,TH,Thailand,
-1934-06-30,TR,Türkiye,
-1934-06-30,US,United States,
-1934-06-30,XM,Euro area,
-1934-06-30,XW,World,
-1934-06-30,ZA,South Africa,
-1934-09-30,4T,Emerging market economies (aggregate),
-1934-09-30,5R,Advanced economies,
-1934-09-30,AE,United Arab Emirates,
-1934-09-30,AT,Austria,
-1934-09-30,AU,Australia,
-1934-09-30,BE,Belgium,
-1934-09-30,BG,Bulgaria,
-1934-09-30,BR,Brazil,
-1934-09-30,CA,Canada,
-1934-09-30,CH,Switzerland,
-1934-09-30,CL,Chile,
-1934-09-30,CN,China,
-1934-09-30,CO,Colombia,
-1934-09-30,CY,Cyprus,
-1934-09-30,CZ,Czechia,
-1934-09-30,DE,Germany,
-1934-09-30,DK,Denmark,
-1934-09-30,EE,Estonia,
-1934-09-30,ES,Spain,
-1934-09-30,FI,Finland,
-1934-09-30,FR,France,
-1934-09-30,GB,United Kingdom,
-1934-09-30,GR,Greece,
-1934-09-30,HK,Hong Kong SAR,
-1934-09-30,HR,Croatia,
-1934-09-30,HU,Hungary,
-1934-09-30,ID,Indonesia,
-1934-09-30,IE,Ireland,
-1934-09-30,IL,Israel,
-1934-09-30,IN,India,
-1934-09-30,IS,Iceland,
 1934-09-30,IT,Italy,-6.5364
-1934-09-30,JP,Japan,
-1934-09-30,KR,Korea,
-1934-09-30,LT,Lithuania,
-1934-09-30,LU,Luxembourg,
-1934-09-30,LV,Latvia,
-1934-09-30,MA,Morocco,
-1934-09-30,MK,North Macedonia,
-1934-09-30,MT,Malta,
-1934-09-30,MX,Mexico,
-1934-09-30,MY,Malaysia,
-1934-09-30,NL,Netherlands,
-1934-09-30,NO,Norway,
-1934-09-30,NZ,New Zealand,
-1934-09-30,PE,Peru,
-1934-09-30,PH,Philippines,
-1934-09-30,PL,Poland,
-1934-09-30,PT,Portugal,
-1934-09-30,RO,Romania,
-1934-09-30,RS,Serbia,
-1934-09-30,RU,Russia,
-1934-09-30,SE,Sweden,
-1934-09-30,SG,Singapore,
-1934-09-30,SI,Slovenia,
-1934-09-30,SK,Slovak Republic,
-1934-09-30,TH,Thailand,
-1934-09-30,TR,Türkiye,
-1934-09-30,US,United States,
-1934-09-30,XM,Euro area,
-1934-09-30,XW,World,
-1934-09-30,ZA,South Africa,
-1934-12-31,4T,Emerging market economies (aggregate),
-1934-12-31,5R,Advanced economies,
-1934-12-31,AE,United Arab Emirates,
-1934-12-31,AT,Austria,
-1934-12-31,AU,Australia,
-1934-12-31,BE,Belgium,
-1934-12-31,BG,Bulgaria,
-1934-12-31,BR,Brazil,
-1934-12-31,CA,Canada,
-1934-12-31,CH,Switzerland,
-1934-12-31,CL,Chile,
-1934-12-31,CN,China,
-1934-12-31,CO,Colombia,
-1934-12-31,CY,Cyprus,
-1934-12-31,CZ,Czechia,
-1934-12-31,DE,Germany,
-1934-12-31,DK,Denmark,
-1934-12-31,EE,Estonia,
-1934-12-31,ES,Spain,
-1934-12-31,FI,Finland,
-1934-12-31,FR,France,
-1934-12-31,GB,United Kingdom,
-1934-12-31,GR,Greece,
-1934-12-31,HK,Hong Kong SAR,
-1934-12-31,HR,Croatia,
-1934-12-31,HU,Hungary,
-1934-12-31,ID,Indonesia,
-1934-12-31,IE,Ireland,
-1934-12-31,IL,Israel,
-1934-12-31,IN,India,
-1934-12-31,IS,Iceland,
 1934-12-31,IT,Italy,-3.8205
-1934-12-31,JP,Japan,
-1934-12-31,KR,Korea,
-1934-12-31,LT,Lithuania,
-1934-12-31,LU,Luxembourg,
-1934-12-31,LV,Latvia,
-1934-12-31,MA,Morocco,
-1934-12-31,MK,North Macedonia,
-1934-12-31,MT,Malta,
-1934-12-31,MX,Mexico,
-1934-12-31,MY,Malaysia,
-1934-12-31,NL,Netherlands,
-1934-12-31,NO,Norway,
-1934-12-31,NZ,New Zealand,
-1934-12-31,PE,Peru,
-1934-12-31,PH,Philippines,
-1934-12-31,PL,Poland,
-1934-12-31,PT,Portugal,
-1934-12-31,RO,Romania,
-1934-12-31,RS,Serbia,
-1934-12-31,RU,Russia,
-1934-12-31,SE,Sweden,
-1934-12-31,SG,Singapore,
-1934-12-31,SI,Slovenia,
-1934-12-31,SK,Slovak Republic,
-1934-12-31,TH,Thailand,
-1934-12-31,TR,Türkiye,
-1934-12-31,US,United States,
-1934-12-31,XM,Euro area,
-1934-12-31,XW,World,
-1934-12-31,ZA,South Africa,
-1935-03-31,4T,Emerging market economies (aggregate),
-1935-03-31,5R,Advanced economies,
-1935-03-31,AE,United Arab Emirates,
-1935-03-31,AT,Austria,
-1935-03-31,AU,Australia,
-1935-03-31,BE,Belgium,
-1935-03-31,BG,Bulgaria,
-1935-03-31,BR,Brazil,
-1935-03-31,CA,Canada,
-1935-03-31,CH,Switzerland,
-1935-03-31,CL,Chile,
-1935-03-31,CN,China,
-1935-03-31,CO,Colombia,
-1935-03-31,CY,Cyprus,
-1935-03-31,CZ,Czechia,
-1935-03-31,DE,Germany,
-1935-03-31,DK,Denmark,
-1935-03-31,EE,Estonia,
-1935-03-31,ES,Spain,
-1935-03-31,FI,Finland,
-1935-03-31,FR,France,
-1935-03-31,GB,United Kingdom,
-1935-03-31,GR,Greece,
-1935-03-31,HK,Hong Kong SAR,
-1935-03-31,HR,Croatia,
-1935-03-31,HU,Hungary,
-1935-03-31,ID,Indonesia,
-1935-03-31,IE,Ireland,
-1935-03-31,IL,Israel,
-1935-03-31,IN,India,
-1935-03-31,IS,Iceland,
 1935-03-31,IT,Italy,-1.0231
-1935-03-31,JP,Japan,
-1935-03-31,KR,Korea,
-1935-03-31,LT,Lithuania,
-1935-03-31,LU,Luxembourg,
-1935-03-31,LV,Latvia,
-1935-03-31,MA,Morocco,
-1935-03-31,MK,North Macedonia,
-1935-03-31,MT,Malta,
-1935-03-31,MX,Mexico,
-1935-03-31,MY,Malaysia,
-1935-03-31,NL,Netherlands,
-1935-03-31,NO,Norway,
-1935-03-31,NZ,New Zealand,
-1935-03-31,PE,Peru,
-1935-03-31,PH,Philippines,
-1935-03-31,PL,Poland,
-1935-03-31,PT,Portugal,
-1935-03-31,RO,Romania,
-1935-03-31,RS,Serbia,
-1935-03-31,RU,Russia,
-1935-03-31,SE,Sweden,
-1935-03-31,SG,Singapore,
-1935-03-31,SI,Slovenia,
-1935-03-31,SK,Slovak Republic,
-1935-03-31,TH,Thailand,
-1935-03-31,TR,Türkiye,
-1935-03-31,US,United States,
-1935-03-31,XM,Euro area,
-1935-03-31,XW,World,
-1935-03-31,ZA,South Africa,
-1935-06-30,4T,Emerging market economies (aggregate),
-1935-06-30,5R,Advanced economies,
-1935-06-30,AE,United Arab Emirates,
-1935-06-30,AT,Austria,
-1935-06-30,AU,Australia,
-1935-06-30,BE,Belgium,
-1935-06-30,BG,Bulgaria,
-1935-06-30,BR,Brazil,
-1935-06-30,CA,Canada,
-1935-06-30,CH,Switzerland,
-1935-06-30,CL,Chile,
-1935-06-30,CN,China,
-1935-06-30,CO,Colombia,
-1935-06-30,CY,Cyprus,
-1935-06-30,CZ,Czechia,
-1935-06-30,DE,Germany,
-1935-06-30,DK,Denmark,
-1935-06-30,EE,Estonia,
-1935-06-30,ES,Spain,
-1935-06-30,FI,Finland,
-1935-06-30,FR,France,
-1935-06-30,GB,United Kingdom,
-1935-06-30,GR,Greece,
-1935-06-30,HK,Hong Kong SAR,
-1935-06-30,HR,Croatia,
-1935-06-30,HU,Hungary,
-1935-06-30,ID,Indonesia,
-1935-06-30,IE,Ireland,
-1935-06-30,IL,Israel,
-1935-06-30,IN,India,
-1935-06-30,IS,Iceland,
 1935-06-30,IT,Italy,1.8749
-1935-06-30,JP,Japan,
-1935-06-30,KR,Korea,
-1935-06-30,LT,Lithuania,
-1935-06-30,LU,Luxembourg,
-1935-06-30,LV,Latvia,
-1935-06-30,MA,Morocco,
-1935-06-30,MK,North Macedonia,
-1935-06-30,MT,Malta,
-1935-06-30,MX,Mexico,
-1935-06-30,MY,Malaysia,
-1935-06-30,NL,Netherlands,
-1935-06-30,NO,Norway,
-1935-06-30,NZ,New Zealand,
-1935-06-30,PE,Peru,
-1935-06-30,PH,Philippines,
-1935-06-30,PL,Poland,
-1935-06-30,PT,Portugal,
-1935-06-30,RO,Romania,
-1935-06-30,RS,Serbia,
-1935-06-30,RU,Russia,
-1935-06-30,SE,Sweden,
-1935-06-30,SG,Singapore,
-1935-06-30,SI,Slovenia,
-1935-06-30,SK,Slovak Republic,
-1935-06-30,TH,Thailand,
-1935-06-30,TR,Türkiye,
-1935-06-30,US,United States,
-1935-06-30,XM,Euro area,
-1935-06-30,XW,World,
-1935-06-30,ZA,South Africa,
-1935-09-30,4T,Emerging market economies (aggregate),
-1935-09-30,5R,Advanced economies,
-1935-09-30,AE,United Arab Emirates,
-1935-09-30,AT,Austria,
-1935-09-30,AU,Australia,
-1935-09-30,BE,Belgium,
-1935-09-30,BG,Bulgaria,
-1935-09-30,BR,Brazil,
-1935-09-30,CA,Canada,
-1935-09-30,CH,Switzerland,
-1935-09-30,CL,Chile,
-1935-09-30,CN,China,
-1935-09-30,CO,Colombia,
-1935-09-30,CY,Cyprus,
-1935-09-30,CZ,Czechia,
-1935-09-30,DE,Germany,
-1935-09-30,DK,Denmark,
-1935-09-30,EE,Estonia,
-1935-09-30,ES,Spain,
-1935-09-30,FI,Finland,
-1935-09-30,FR,France,
-1935-09-30,GB,United Kingdom,
-1935-09-30,GR,Greece,
-1935-09-30,HK,Hong Kong SAR,
-1935-09-30,HR,Croatia,
-1935-09-30,HU,Hungary,
-1935-09-30,ID,Indonesia,
-1935-09-30,IE,Ireland,
-1935-09-30,IL,Israel,
-1935-09-30,IN,India,
-1935-09-30,IS,Iceland,
 1935-09-30,IT,Italy,3.1186
-1935-09-30,JP,Japan,
-1935-09-30,KR,Korea,
-1935-09-30,LT,Lithuania,
-1935-09-30,LU,Luxembourg,
-1935-09-30,LV,Latvia,
-1935-09-30,MA,Morocco,
-1935-09-30,MK,North Macedonia,
-1935-09-30,MT,Malta,
-1935-09-30,MX,Mexico,
-1935-09-30,MY,Malaysia,
-1935-09-30,NL,Netherlands,
-1935-09-30,NO,Norway,
-1935-09-30,NZ,New Zealand,
-1935-09-30,PE,Peru,
-1935-09-30,PH,Philippines,
-1935-09-30,PL,Poland,
-1935-09-30,PT,Portugal,
-1935-09-30,RO,Romania,
-1935-09-30,RS,Serbia,
-1935-09-30,RU,Russia,
-1935-09-30,SE,Sweden,
-1935-09-30,SG,Singapore,
-1935-09-30,SI,Slovenia,
-1935-09-30,SK,Slovak Republic,
-1935-09-30,TH,Thailand,
-1935-09-30,TR,Türkiye,
-1935-09-30,US,United States,
-1935-09-30,XM,Euro area,
-1935-09-30,XW,World,
-1935-09-30,ZA,South Africa,
-1935-12-31,4T,Emerging market economies (aggregate),
-1935-12-31,5R,Advanced economies,
-1935-12-31,AE,United Arab Emirates,
-1935-12-31,AT,Austria,
-1935-12-31,AU,Australia,
-1935-12-31,BE,Belgium,
-1935-12-31,BG,Bulgaria,
-1935-12-31,BR,Brazil,
-1935-12-31,CA,Canada,
-1935-12-31,CH,Switzerland,
-1935-12-31,CL,Chile,
-1935-12-31,CN,China,
-1935-12-31,CO,Colombia,
-1935-12-31,CY,Cyprus,
-1935-12-31,CZ,Czechia,
-1935-12-31,DE,Germany,
-1935-12-31,DK,Denmark,
-1935-12-31,EE,Estonia,
-1935-12-31,ES,Spain,
-1935-12-31,FI,Finland,
-1935-12-31,FR,France,
-1935-12-31,GB,United Kingdom,
-1935-12-31,GR,Greece,
-1935-12-31,HK,Hong Kong SAR,
-1935-12-31,HR,Croatia,
-1935-12-31,HU,Hungary,
-1935-12-31,ID,Indonesia,
-1935-12-31,IE,Ireland,
-1935-12-31,IL,Israel,
-1935-12-31,IN,India,
-1935-12-31,IS,Iceland,
 1935-12-31,IT,Italy,2.4887
-1935-12-31,JP,Japan,
-1935-12-31,KR,Korea,
-1935-12-31,LT,Lithuania,
-1935-12-31,LU,Luxembourg,
-1935-12-31,LV,Latvia,
-1935-12-31,MA,Morocco,
-1935-12-31,MK,North Macedonia,
-1935-12-31,MT,Malta,
-1935-12-31,MX,Mexico,
-1935-12-31,MY,Malaysia,
-1935-12-31,NL,Netherlands,
-1935-12-31,NO,Norway,
-1935-12-31,NZ,New Zealand,
-1935-12-31,PE,Peru,
-1935-12-31,PH,Philippines,
-1935-12-31,PL,Poland,
-1935-12-31,PT,Portugal,
-1935-12-31,RO,Romania,
-1935-12-31,RS,Serbia,
-1935-12-31,RU,Russia,
-1935-12-31,SE,Sweden,
-1935-12-31,SG,Singapore,
-1935-12-31,SI,Slovenia,
-1935-12-31,SK,Slovak Republic,
-1935-12-31,TH,Thailand,
-1935-12-31,TR,Türkiye,
-1935-12-31,US,United States,
-1935-12-31,XM,Euro area,
-1935-12-31,XW,World,
-1935-12-31,ZA,South Africa,
-1936-03-31,4T,Emerging market economies (aggregate),
-1936-03-31,5R,Advanced economies,
-1936-03-31,AE,United Arab Emirates,
-1936-03-31,AT,Austria,
-1936-03-31,AU,Australia,
-1936-03-31,BE,Belgium,
-1936-03-31,BG,Bulgaria,
-1936-03-31,BR,Brazil,
-1936-03-31,CA,Canada,
-1936-03-31,CH,Switzerland,
-1936-03-31,CL,Chile,
-1936-03-31,CN,China,
-1936-03-31,CO,Colombia,
-1936-03-31,CY,Cyprus,
-1936-03-31,CZ,Czechia,
-1936-03-31,DE,Germany,
-1936-03-31,DK,Denmark,
-1936-03-31,EE,Estonia,
-1936-03-31,ES,Spain,
-1936-03-31,FI,Finland,
-1936-03-31,FR,France,
-1936-03-31,GB,United Kingdom,
-1936-03-31,GR,Greece,
-1936-03-31,HK,Hong Kong SAR,
-1936-03-31,HR,Croatia,
-1936-03-31,HU,Hungary,
-1936-03-31,ID,Indonesia,
-1936-03-31,IE,Ireland,
-1936-03-31,IL,Israel,
-1936-03-31,IN,India,
-1936-03-31,IS,Iceland,
 1936-03-31,IT,Italy,1.877
-1936-03-31,JP,Japan,
-1936-03-31,KR,Korea,
-1936-03-31,LT,Lithuania,
-1936-03-31,LU,Luxembourg,
-1936-03-31,LV,Latvia,
-1936-03-31,MA,Morocco,
-1936-03-31,MK,North Macedonia,
-1936-03-31,MT,Malta,
-1936-03-31,MX,Mexico,
-1936-03-31,MY,Malaysia,
-1936-03-31,NL,Netherlands,
-1936-03-31,NO,Norway,
-1936-03-31,NZ,New Zealand,
-1936-03-31,PE,Peru,
-1936-03-31,PH,Philippines,
-1936-03-31,PL,Poland,
-1936-03-31,PT,Portugal,
-1936-03-31,RO,Romania,
-1936-03-31,RS,Serbia,
-1936-03-31,RU,Russia,
-1936-03-31,SE,Sweden,
-1936-03-31,SG,Singapore,
-1936-03-31,SI,Slovenia,
-1936-03-31,SK,Slovak Republic,
-1936-03-31,TH,Thailand,
-1936-03-31,TR,Türkiye,
-1936-03-31,US,United States,
-1936-03-31,XM,Euro area,
-1936-03-31,XW,World,
-1936-03-31,ZA,South Africa,
-1936-06-30,4T,Emerging market economies (aggregate),
-1936-06-30,5R,Advanced economies,
-1936-06-30,AE,United Arab Emirates,
-1936-06-30,AT,Austria,
-1936-06-30,AU,Australia,
-1936-06-30,BE,Belgium,
-1936-06-30,BG,Bulgaria,
-1936-06-30,BR,Brazil,
-1936-06-30,CA,Canada,
-1936-06-30,CH,Switzerland,
-1936-06-30,CL,Chile,
-1936-06-30,CN,China,
-1936-06-30,CO,Colombia,
-1936-06-30,CY,Cyprus,
-1936-06-30,CZ,Czechia,
-1936-06-30,DE,Germany,
-1936-06-30,DK,Denmark,
-1936-06-30,EE,Estonia,
-1936-06-30,ES,Spain,
-1936-06-30,FI,Finland,
-1936-06-30,FR,France,
-1936-06-30,GB,United Kingdom,
-1936-06-30,GR,Greece,
-1936-06-30,HK,Hong Kong SAR,
-1936-06-30,HR,Croatia,
-1936-06-30,HU,Hungary,
-1936-06-30,ID,Indonesia,
-1936-06-30,IE,Ireland,
-1936-06-30,IL,Israel,
-1936-06-30,IN,India,
-1936-06-30,IS,Iceland,
 1936-06-30,IT,Italy,1.2788
-1936-06-30,JP,Japan,
-1936-06-30,KR,Korea,
-1936-06-30,LT,Lithuania,
-1936-06-30,LU,Luxembourg,
-1936-06-30,LV,Latvia,
-1936-06-30,MA,Morocco,
-1936-06-30,MK,North Macedonia,
-1936-06-30,MT,Malta,
-1936-06-30,MX,Mexico,
-1936-06-30,MY,Malaysia,
-1936-06-30,NL,Netherlands,
-1936-06-30,NO,Norway,
-1936-06-30,NZ,New Zealand,
-1936-06-30,PE,Peru,
-1936-06-30,PH,Philippines,
-1936-06-30,PL,Poland,
-1936-06-30,PT,Portugal,
-1936-06-30,RO,Romania,
-1936-06-30,RS,Serbia,
-1936-06-30,RU,Russia,
-1936-06-30,SE,Sweden,
-1936-06-30,SG,Singapore,
-1936-06-30,SI,Slovenia,
-1936-06-30,SK,Slovak Republic,
-1936-06-30,TH,Thailand,
-1936-06-30,TR,Türkiye,
-1936-06-30,US,United States,
-1936-06-30,XM,Euro area,
-1936-06-30,XW,World,
-1936-06-30,ZA,South Africa,
-1936-09-30,4T,Emerging market economies (aggregate),
-1936-09-30,5R,Advanced economies,
-1936-09-30,AE,United Arab Emirates,
-1936-09-30,AT,Austria,
-1936-09-30,AU,Australia,
-1936-09-30,BE,Belgium,
-1936-09-30,BG,Bulgaria,
-1936-09-30,BR,Brazil,
-1936-09-30,CA,Canada,
-1936-09-30,CH,Switzerland,
-1936-09-30,CL,Chile,
-1936-09-30,CN,China,
-1936-09-30,CO,Colombia,
-1936-09-30,CY,Cyprus,
-1936-09-30,CZ,Czechia,
-1936-09-30,DE,Germany,
-1936-09-30,DK,Denmark,
-1936-09-30,EE,Estonia,
-1936-09-30,ES,Spain,
-1936-09-30,FI,Finland,
-1936-09-30,FR,France,
-1936-09-30,GB,United Kingdom,
-1936-09-30,GR,Greece,
-1936-09-30,HK,Hong Kong SAR,
-1936-09-30,HR,Croatia,
-1936-09-30,HU,Hungary,
-1936-09-30,ID,Indonesia,
-1936-09-30,IE,Ireland,
-1936-09-30,IL,Israel,
-1936-09-30,IN,India,
-1936-09-30,IS,Iceland,
 1936-09-30,IT,Italy,1.2841
-1936-09-30,JP,Japan,
-1936-09-30,KR,Korea,
-1936-09-30,LT,Lithuania,
-1936-09-30,LU,Luxembourg,
-1936-09-30,LV,Latvia,
-1936-09-30,MA,Morocco,
-1936-09-30,MK,North Macedonia,
-1936-09-30,MT,Malta,
-1936-09-30,MX,Mexico,
-1936-09-30,MY,Malaysia,
-1936-09-30,NL,Netherlands,
-1936-09-30,NO,Norway,
-1936-09-30,NZ,New Zealand,
-1936-09-30,PE,Peru,
-1936-09-30,PH,Philippines,
-1936-09-30,PL,Poland,
-1936-09-30,PT,Portugal,
-1936-09-30,RO,Romania,
-1936-09-30,RS,Serbia,
-1936-09-30,RU,Russia,
-1936-09-30,SE,Sweden,
-1936-09-30,SG,Singapore,
-1936-09-30,SI,Slovenia,
-1936-09-30,SK,Slovak Republic,
-1936-09-30,TH,Thailand,
-1936-09-30,TR,Türkiye,
-1936-09-30,US,United States,
-1936-09-30,XM,Euro area,
-1936-09-30,XW,World,
-1936-09-30,ZA,South Africa,
-1936-12-31,4T,Emerging market economies (aggregate),
-1936-12-31,5R,Advanced economies,
-1936-12-31,AE,United Arab Emirates,
-1936-12-31,AT,Austria,
-1936-12-31,AU,Australia,
-1936-12-31,BE,Belgium,
-1936-12-31,BG,Bulgaria,
-1936-12-31,BR,Brazil,
-1936-12-31,CA,Canada,
-1936-12-31,CH,Switzerland,
-1936-12-31,CL,Chile,
-1936-12-31,CN,China,
-1936-12-31,CO,Colombia,
-1936-12-31,CY,Cyprus,
-1936-12-31,CZ,Czechia,
-1936-12-31,DE,Germany,
-1936-12-31,DK,Denmark,
-1936-12-31,EE,Estonia,
-1936-12-31,ES,Spain,
-1936-12-31,FI,Finland,
-1936-12-31,FR,France,
-1936-12-31,GB,United Kingdom,
-1936-12-31,GR,Greece,
-1936-12-31,HK,Hong Kong SAR,
-1936-12-31,HR,Croatia,
-1936-12-31,HU,Hungary,
-1936-12-31,ID,Indonesia,
-1936-12-31,IE,Ireland,
-1936-12-31,IL,Israel,
-1936-12-31,IN,India,
-1936-12-31,IS,Iceland,
 1936-12-31,IT,Italy,1.921
-1936-12-31,JP,Japan,
-1936-12-31,KR,Korea,
-1936-12-31,LT,Lithuania,
-1936-12-31,LU,Luxembourg,
-1936-12-31,LV,Latvia,
-1936-12-31,MA,Morocco,
-1936-12-31,MK,North Macedonia,
-1936-12-31,MT,Malta,
-1936-12-31,MX,Mexico,
-1936-12-31,MY,Malaysia,
-1936-12-31,NL,Netherlands,
-1936-12-31,NO,Norway,
-1936-12-31,NZ,New Zealand,
-1936-12-31,PE,Peru,
-1936-12-31,PH,Philippines,
-1936-12-31,PL,Poland,
-1936-12-31,PT,Portugal,
-1936-12-31,RO,Romania,
-1936-12-31,RS,Serbia,
-1936-12-31,RU,Russia,
-1936-12-31,SE,Sweden,
-1936-12-31,SG,Singapore,
-1936-12-31,SI,Slovenia,
-1936-12-31,SK,Slovak Republic,
-1936-12-31,TH,Thailand,
-1936-12-31,TR,Türkiye,
-1936-12-31,US,United States,
-1936-12-31,XM,Euro area,
-1936-12-31,XW,World,
-1936-12-31,ZA,South Africa,
-1937-03-31,4T,Emerging market economies (aggregate),
-1937-03-31,5R,Advanced economies,
-1937-03-31,AE,United Arab Emirates,
-1937-03-31,AT,Austria,
-1937-03-31,AU,Australia,
-1937-03-31,BE,Belgium,
-1937-03-31,BG,Bulgaria,
-1937-03-31,BR,Brazil,
-1937-03-31,CA,Canada,
-1937-03-31,CH,Switzerland,
-1937-03-31,CL,Chile,
-1937-03-31,CN,China,
-1937-03-31,CO,Colombia,
-1937-03-31,CY,Cyprus,
-1937-03-31,CZ,Czechia,
-1937-03-31,DE,Germany,
-1937-03-31,DK,Denmark,
-1937-03-31,EE,Estonia,
-1937-03-31,ES,Spain,
-1937-03-31,FI,Finland,
-1937-03-31,FR,France,
-1937-03-31,GB,United Kingdom,
-1937-03-31,GR,Greece,
-1937-03-31,HK,Hong Kong SAR,
-1937-03-31,HR,Croatia,
-1937-03-31,HU,Hungary,
-1937-03-31,ID,Indonesia,
-1937-03-31,IE,Ireland,
-1937-03-31,IL,Israel,
-1937-03-31,IN,India,
-1937-03-31,IS,Iceland,
 1937-03-31,IT,Italy,2.5468
-1937-03-31,JP,Japan,
-1937-03-31,KR,Korea,
-1937-03-31,LT,Lithuania,
-1937-03-31,LU,Luxembourg,
-1937-03-31,LV,Latvia,
-1937-03-31,MA,Morocco,
-1937-03-31,MK,North Macedonia,
-1937-03-31,MT,Malta,
-1937-03-31,MX,Mexico,
-1937-03-31,MY,Malaysia,
-1937-03-31,NL,Netherlands,
-1937-03-31,NO,Norway,
-1937-03-31,NZ,New Zealand,
-1937-03-31,PE,Peru,
-1937-03-31,PH,Philippines,
-1937-03-31,PL,Poland,
-1937-03-31,PT,Portugal,
-1937-03-31,RO,Romania,
-1937-03-31,RS,Serbia,
-1937-03-31,RU,Russia,
-1937-03-31,SE,Sweden,
-1937-03-31,SG,Singapore,
-1937-03-31,SI,Slovenia,
-1937-03-31,SK,Slovak Republic,
-1937-03-31,TH,Thailand,
-1937-03-31,TR,Türkiye,
-1937-03-31,US,United States,
-1937-03-31,XM,Euro area,
-1937-03-31,XW,World,
-1937-03-31,ZA,South Africa,
-1937-06-30,4T,Emerging market economies (aggregate),
-1937-06-30,5R,Advanced economies,
-1937-06-30,AE,United Arab Emirates,
-1937-06-30,AT,Austria,
-1937-06-30,AU,Australia,
-1937-06-30,BE,Belgium,
-1937-06-30,BG,Bulgaria,
-1937-06-30,BR,Brazil,
-1937-06-30,CA,Canada,
-1937-06-30,CH,Switzerland,
-1937-06-30,CL,Chile,
-1937-06-30,CN,China,
-1937-06-30,CO,Colombia,
-1937-06-30,CY,Cyprus,
-1937-06-30,CZ,Czechia,
-1937-06-30,DE,Germany,
-1937-06-30,DK,Denmark,
-1937-06-30,EE,Estonia,
-1937-06-30,ES,Spain,
-1937-06-30,FI,Finland,
-1937-06-30,FR,France,
-1937-06-30,GB,United Kingdom,
-1937-06-30,GR,Greece,
-1937-06-30,HK,Hong Kong SAR,
-1937-06-30,HR,Croatia,
-1937-06-30,HU,Hungary,
-1937-06-30,ID,Indonesia,
-1937-06-30,IE,Ireland,
-1937-06-30,IL,Israel,
-1937-06-30,IN,India,
-1937-06-30,IS,Iceland,
 1937-06-30,IT,Italy,3.1661
-1937-06-30,JP,Japan,
-1937-06-30,KR,Korea,
-1937-06-30,LT,Lithuania,
-1937-06-30,LU,Luxembourg,
-1937-06-30,LV,Latvia,
-1937-06-30,MA,Morocco,
-1937-06-30,MK,North Macedonia,
-1937-06-30,MT,Malta,
-1937-06-30,MX,Mexico,
-1937-06-30,MY,Malaysia,
-1937-06-30,NL,Netherlands,
-1937-06-30,NO,Norway,
-1937-06-30,NZ,New Zealand,
-1937-06-30,PE,Peru,
-1937-06-30,PH,Philippines,
-1937-06-30,PL,Poland,
-1937-06-30,PT,Portugal,
-1937-06-30,RO,Romania,
-1937-06-30,RS,Serbia,
-1937-06-30,RU,Russia,
-1937-06-30,SE,Sweden,
-1937-06-30,SG,Singapore,
-1937-06-30,SI,Slovenia,
-1937-06-30,SK,Slovak Republic,
-1937-06-30,TH,Thailand,
-1937-06-30,TR,Türkiye,
-1937-06-30,US,United States,
-1937-06-30,XM,Euro area,
-1937-06-30,XW,World,
-1937-06-30,ZA,South Africa,
-1937-09-30,4T,Emerging market economies (aggregate),
-1937-09-30,5R,Advanced economies,
-1937-09-30,AE,United Arab Emirates,
-1937-09-30,AT,Austria,
-1937-09-30,AU,Australia,
-1937-09-30,BE,Belgium,
-1937-09-30,BG,Bulgaria,
-1937-09-30,BR,Brazil,
-1937-09-30,CA,Canada,
-1937-09-30,CH,Switzerland,
-1937-09-30,CL,Chile,
-1937-09-30,CN,China,
-1937-09-30,CO,Colombia,
-1937-09-30,CY,Cyprus,
-1937-09-30,CZ,Czechia,
-1937-09-30,DE,Germany,
-1937-09-30,DK,Denmark,
-1937-09-30,EE,Estonia,
-1937-09-30,ES,Spain,
-1937-09-30,FI,Finland,
-1937-09-30,FR,France,
-1937-09-30,GB,United Kingdom,
-1937-09-30,GR,Greece,
-1937-09-30,HK,Hong Kong SAR,
-1937-09-30,HR,Croatia,
-1937-09-30,HU,Hungary,
-1937-09-30,ID,Indonesia,
-1937-09-30,IE,Ireland,
-1937-09-30,IL,Israel,
-1937-09-30,IN,India,
-1937-09-30,IS,Iceland,
 1937-09-30,IT,Italy,3.4327
-1937-09-30,JP,Japan,
-1937-09-30,KR,Korea,
-1937-09-30,LT,Lithuania,
-1937-09-30,LU,Luxembourg,
-1937-09-30,LV,Latvia,
-1937-09-30,MA,Morocco,
-1937-09-30,MK,North Macedonia,
-1937-09-30,MT,Malta,
-1937-09-30,MX,Mexico,
-1937-09-30,MY,Malaysia,
-1937-09-30,NL,Netherlands,
-1937-09-30,NO,Norway,
-1937-09-30,NZ,New Zealand,
-1937-09-30,PE,Peru,
-1937-09-30,PH,Philippines,
-1937-09-30,PL,Poland,
-1937-09-30,PT,Portugal,
-1937-09-30,RO,Romania,
-1937-09-30,RS,Serbia,
-1937-09-30,RU,Russia,
-1937-09-30,SE,Sweden,
-1937-09-30,SG,Singapore,
-1937-09-30,SI,Slovenia,
-1937-09-30,SK,Slovak Republic,
-1937-09-30,TH,Thailand,
-1937-09-30,TR,Türkiye,
-1937-09-30,US,United States,
-1937-09-30,XM,Euro area,
-1937-09-30,XW,World,
-1937-09-30,ZA,South Africa,
-1937-12-31,4T,Emerging market economies (aggregate),
-1937-12-31,5R,Advanced economies,
-1937-12-31,AE,United Arab Emirates,
-1937-12-31,AT,Austria,
-1937-12-31,AU,Australia,
-1937-12-31,BE,Belgium,
-1937-12-31,BG,Bulgaria,
-1937-12-31,BR,Brazil,
-1937-12-31,CA,Canada,
-1937-12-31,CH,Switzerland,
-1937-12-31,CL,Chile,
-1937-12-31,CN,China,
-1937-12-31,CO,Colombia,
-1937-12-31,CY,Cyprus,
-1937-12-31,CZ,Czechia,
-1937-12-31,DE,Germany,
-1937-12-31,DK,Denmark,
-1937-12-31,EE,Estonia,
-1937-12-31,ES,Spain,
-1937-12-31,FI,Finland,
-1937-12-31,FR,France,
-1937-12-31,GB,United Kingdom,
-1937-12-31,GR,Greece,
-1937-12-31,HK,Hong Kong SAR,
-1937-12-31,HR,Croatia,
-1937-12-31,HU,Hungary,
-1937-12-31,ID,Indonesia,
-1937-12-31,IE,Ireland,
-1937-12-31,IL,Israel,
-1937-12-31,IN,India,
-1937-12-31,IS,Iceland,
 1937-12-31,IT,Italy,3.3288
-1937-12-31,JP,Japan,
-1937-12-31,KR,Korea,
-1937-12-31,LT,Lithuania,
-1937-12-31,LU,Luxembourg,
-1937-12-31,LV,Latvia,
-1937-12-31,MA,Morocco,
-1937-12-31,MK,North Macedonia,
-1937-12-31,MT,Malta,
-1937-12-31,MX,Mexico,
-1937-12-31,MY,Malaysia,
-1937-12-31,NL,Netherlands,
-1937-12-31,NO,Norway,
-1937-12-31,NZ,New Zealand,
-1937-12-31,PE,Peru,
-1937-12-31,PH,Philippines,
-1937-12-31,PL,Poland,
-1937-12-31,PT,Portugal,
-1937-12-31,RO,Romania,
-1937-12-31,RS,Serbia,
-1937-12-31,RU,Russia,
-1937-12-31,SE,Sweden,
-1937-12-31,SG,Singapore,
-1937-12-31,SI,Slovenia,
-1937-12-31,SK,Slovak Republic,
-1937-12-31,TH,Thailand,
-1937-12-31,TR,Türkiye,
-1937-12-31,US,United States,
-1937-12-31,XM,Euro area,
-1937-12-31,XW,World,
-1937-12-31,ZA,South Africa,
-1938-03-31,4T,Emerging market economies (aggregate),
-1938-03-31,5R,Advanced economies,
-1938-03-31,AE,United Arab Emirates,
-1938-03-31,AT,Austria,
-1938-03-31,AU,Australia,
-1938-03-31,BE,Belgium,
-1938-03-31,BG,Bulgaria,
-1938-03-31,BR,Brazil,
-1938-03-31,CA,Canada,
-1938-03-31,CH,Switzerland,
-1938-03-31,CL,Chile,
-1938-03-31,CN,China,
-1938-03-31,CO,Colombia,
-1938-03-31,CY,Cyprus,
-1938-03-31,CZ,Czechia,
-1938-03-31,DE,Germany,
-1938-03-31,DK,Denmark,
-1938-03-31,EE,Estonia,
-1938-03-31,ES,Spain,
-1938-03-31,FI,Finland,
-1938-03-31,FR,France,
-1938-03-31,GB,United Kingdom,
-1938-03-31,GR,Greece,
-1938-03-31,HK,Hong Kong SAR,
-1938-03-31,HR,Croatia,
-1938-03-31,HU,Hungary,
-1938-03-31,ID,Indonesia,
-1938-03-31,IE,Ireland,
-1938-03-31,IL,Israel,
-1938-03-31,IN,India,
-1938-03-31,IS,Iceland,
 1938-03-31,IT,Italy,3.2278
-1938-03-31,JP,Japan,
-1938-03-31,KR,Korea,
-1938-03-31,LT,Lithuania,
-1938-03-31,LU,Luxembourg,
-1938-03-31,LV,Latvia,
-1938-03-31,MA,Morocco,
-1938-03-31,MK,North Macedonia,
-1938-03-31,MT,Malta,
-1938-03-31,MX,Mexico,
-1938-03-31,MY,Malaysia,
-1938-03-31,NL,Netherlands,
-1938-03-31,NO,Norway,
-1938-03-31,NZ,New Zealand,
-1938-03-31,PE,Peru,
-1938-03-31,PH,Philippines,
-1938-03-31,PL,Poland,
-1938-03-31,PT,Portugal,
-1938-03-31,RO,Romania,
-1938-03-31,RS,Serbia,
-1938-03-31,RU,Russia,
-1938-03-31,SE,Sweden,
-1938-03-31,SG,Singapore,
-1938-03-31,SI,Slovenia,
-1938-03-31,SK,Slovak Republic,
-1938-03-31,TH,Thailand,
-1938-03-31,TR,Türkiye,
-1938-03-31,US,United States,
-1938-03-31,XM,Euro area,
-1938-03-31,XW,World,
-1938-03-31,ZA,South Africa,
-1938-06-30,4T,Emerging market economies (aggregate),
-1938-06-30,5R,Advanced economies,
-1938-06-30,AE,United Arab Emirates,
-1938-06-30,AT,Austria,
-1938-06-30,AU,Australia,
-1938-06-30,BE,Belgium,
-1938-06-30,BG,Bulgaria,
-1938-06-30,BR,Brazil,
-1938-06-30,CA,Canada,
-1938-06-30,CH,Switzerland,
-1938-06-30,CL,Chile,
-1938-06-30,CN,China,
-1938-06-30,CO,Colombia,
-1938-06-30,CY,Cyprus,
-1938-06-30,CZ,Czechia,
-1938-06-30,DE,Germany,
-1938-06-30,DK,Denmark,
-1938-06-30,EE,Estonia,
-1938-06-30,ES,Spain,
-1938-06-30,FI,Finland,
-1938-06-30,FR,France,
-1938-06-30,GB,United Kingdom,
-1938-06-30,GR,Greece,
-1938-06-30,HK,Hong Kong SAR,
-1938-06-30,HR,Croatia,
-1938-06-30,HU,Hungary,
-1938-06-30,ID,Indonesia,
-1938-06-30,IE,Ireland,
-1938-06-30,IL,Israel,
-1938-06-30,IN,India,
-1938-06-30,IS,Iceland,
 1938-06-30,IT,Italy,3.129
-1938-06-30,JP,Japan,
-1938-06-30,KR,Korea,
-1938-06-30,LT,Lithuania,
-1938-06-30,LU,Luxembourg,
-1938-06-30,LV,Latvia,
-1938-06-30,MA,Morocco,
-1938-06-30,MK,North Macedonia,
-1938-06-30,MT,Malta,
-1938-06-30,MX,Mexico,
-1938-06-30,MY,Malaysia,
-1938-06-30,NL,Netherlands,
-1938-06-30,NO,Norway,
-1938-06-30,NZ,New Zealand,
-1938-06-30,PE,Peru,
-1938-06-30,PH,Philippines,
-1938-06-30,PL,Poland,
-1938-06-30,PT,Portugal,
-1938-06-30,RO,Romania,
-1938-06-30,RS,Serbia,
-1938-06-30,RU,Russia,
-1938-06-30,SE,Sweden,
-1938-06-30,SG,Singapore,
-1938-06-30,SI,Slovenia,
-1938-06-30,SK,Slovak Republic,
-1938-06-30,TH,Thailand,
-1938-06-30,TR,Türkiye,
-1938-06-30,US,United States,
-1938-06-30,XM,Euro area,
-1938-06-30,XW,World,
-1938-06-30,ZA,South Africa,
-1938-09-30,4T,Emerging market economies (aggregate),
-1938-09-30,5R,Advanced economies,
-1938-09-30,AE,United Arab Emirates,
-1938-09-30,AT,Austria,
-1938-09-30,AU,Australia,
-1938-09-30,BE,Belgium,
-1938-09-30,BG,Bulgaria,
-1938-09-30,BR,Brazil,
-1938-09-30,CA,Canada,
-1938-09-30,CH,Switzerland,
-1938-09-30,CL,Chile,
-1938-09-30,CN,China,
-1938-09-30,CO,Colombia,
-1938-09-30,CY,Cyprus,
-1938-09-30,CZ,Czechia,
-1938-09-30,DE,Germany,
-1938-09-30,DK,Denmark,
-1938-09-30,EE,Estonia,
-1938-09-30,ES,Spain,
-1938-09-30,FI,Finland,
-1938-09-30,FR,France,
-1938-09-30,GB,United Kingdom,
-1938-09-30,GR,Greece,
-1938-09-30,HK,Hong Kong SAR,
-1938-09-30,HR,Croatia,
-1938-09-30,HU,Hungary,
-1938-09-30,ID,Indonesia,
-1938-09-30,IE,Ireland,
-1938-09-30,IL,Israel,
-1938-09-30,IN,India,
-1938-09-30,IS,Iceland,
 1938-09-30,IT,Italy,2.9841
-1938-09-30,JP,Japan,
-1938-09-30,KR,Korea,
-1938-09-30,LT,Lithuania,
-1938-09-30,LU,Luxembourg,
-1938-09-30,LV,Latvia,
-1938-09-30,MA,Morocco,
-1938-09-30,MK,North Macedonia,
-1938-09-30,MT,Malta,
-1938-09-30,MX,Mexico,
-1938-09-30,MY,Malaysia,
-1938-09-30,NL,Netherlands,
-1938-09-30,NO,Norway,
-1938-09-30,NZ,New Zealand,
-1938-09-30,PE,Peru,
-1938-09-30,PH,Philippines,
-1938-09-30,PL,Poland,
-1938-09-30,PT,Portugal,
-1938-09-30,RO,Romania,
-1938-09-30,RS,Serbia,
-1938-09-30,RU,Russia,
-1938-09-30,SE,Sweden,
-1938-09-30,SG,Singapore,
-1938-09-30,SI,Slovenia,
-1938-09-30,SK,Slovak Republic,
-1938-09-30,TH,Thailand,
-1938-09-30,TR,Türkiye,
-1938-09-30,US,United States,
-1938-09-30,XM,Euro area,
-1938-09-30,XW,World,
-1938-09-30,ZA,South Africa,
-1938-12-31,4T,Emerging market economies (aggregate),
-1938-12-31,5R,Advanced economies,
-1938-12-31,AE,United Arab Emirates,
-1938-12-31,AT,Austria,
-1938-12-31,AU,Australia,
-1938-12-31,BE,Belgium,
-1938-12-31,BG,Bulgaria,
-1938-12-31,BR,Brazil,
-1938-12-31,CA,Canada,
-1938-12-31,CH,Switzerland,
-1938-12-31,CL,Chile,
-1938-12-31,CN,China,
-1938-12-31,CO,Colombia,
-1938-12-31,CY,Cyprus,
-1938-12-31,CZ,Czechia,
-1938-12-31,DE,Germany,
-1938-12-31,DK,Denmark,
-1938-12-31,EE,Estonia,
-1938-12-31,ES,Spain,
-1938-12-31,FI,Finland,
-1938-12-31,FR,France,
-1938-12-31,GB,United Kingdom,
-1938-12-31,GR,Greece,
-1938-12-31,HK,Hong Kong SAR,
-1938-12-31,HR,Croatia,
-1938-12-31,HU,Hungary,
-1938-12-31,ID,Indonesia,
-1938-12-31,IE,Ireland,
-1938-12-31,IL,Israel,
-1938-12-31,IN,India,
-1938-12-31,IS,Iceland,
 1938-12-31,IT,Italy,2.7915
-1938-12-31,JP,Japan,
-1938-12-31,KR,Korea,
-1938-12-31,LT,Lithuania,
-1938-12-31,LU,Luxembourg,
-1938-12-31,LV,Latvia,
-1938-12-31,MA,Morocco,
-1938-12-31,MK,North Macedonia,
-1938-12-31,MT,Malta,
-1938-12-31,MX,Mexico,
-1938-12-31,MY,Malaysia,
-1938-12-31,NL,Netherlands,
-1938-12-31,NO,Norway,
-1938-12-31,NZ,New Zealand,
-1938-12-31,PE,Peru,
-1938-12-31,PH,Philippines,
-1938-12-31,PL,Poland,
-1938-12-31,PT,Portugal,
-1938-12-31,RO,Romania,
-1938-12-31,RS,Serbia,
-1938-12-31,RU,Russia,
-1938-12-31,SE,Sweden,
-1938-12-31,SG,Singapore,
-1938-12-31,SI,Slovenia,
-1938-12-31,SK,Slovak Republic,
-1938-12-31,TH,Thailand,
-1938-12-31,TR,Türkiye,
-1938-12-31,US,United States,
-1938-12-31,XM,Euro area,
-1938-12-31,XW,World,
-1938-12-31,ZA,South Africa,
-1939-03-31,4T,Emerging market economies (aggregate),
-1939-03-31,5R,Advanced economies,
-1939-03-31,AE,United Arab Emirates,
-1939-03-31,AT,Austria,
-1939-03-31,AU,Australia,
-1939-03-31,BE,Belgium,
-1939-03-31,BG,Bulgaria,
-1939-03-31,BR,Brazil,
-1939-03-31,CA,Canada,
-1939-03-31,CH,Switzerland,
-1939-03-31,CL,Chile,
-1939-03-31,CN,China,
-1939-03-31,CO,Colombia,
-1939-03-31,CY,Cyprus,
-1939-03-31,CZ,Czechia,
-1939-03-31,DE,Germany,
-1939-03-31,DK,Denmark,
-1939-03-31,EE,Estonia,
-1939-03-31,ES,Spain,
-1939-03-31,FI,Finland,
-1939-03-31,FR,France,
-1939-03-31,GB,United Kingdom,
-1939-03-31,GR,Greece,
-1939-03-31,HK,Hong Kong SAR,
-1939-03-31,HR,Croatia,
-1939-03-31,HU,Hungary,
-1939-03-31,ID,Indonesia,
-1939-03-31,IE,Ireland,
-1939-03-31,IL,Israel,
-1939-03-31,IN,India,
-1939-03-31,IS,Iceland,
 1939-03-31,IT,Italy,2.6038
-1939-03-31,JP,Japan,
-1939-03-31,KR,Korea,
-1939-03-31,LT,Lithuania,
-1939-03-31,LU,Luxembourg,
-1939-03-31,LV,Latvia,
-1939-03-31,MA,Morocco,
-1939-03-31,MK,North Macedonia,
-1939-03-31,MT,Malta,
-1939-03-31,MX,Mexico,
-1939-03-31,MY,Malaysia,
-1939-03-31,NL,Netherlands,
-1939-03-31,NO,Norway,
-1939-03-31,NZ,New Zealand,
-1939-03-31,PE,Peru,
-1939-03-31,PH,Philippines,
-1939-03-31,PL,Poland,
-1939-03-31,PT,Portugal,
-1939-03-31,RO,Romania,
-1939-03-31,RS,Serbia,
-1939-03-31,RU,Russia,
-1939-03-31,SE,Sweden,
-1939-03-31,SG,Singapore,
-1939-03-31,SI,Slovenia,
-1939-03-31,SK,Slovak Republic,
-1939-03-31,TH,Thailand,
-1939-03-31,TR,Türkiye,
-1939-03-31,US,United States,
-1939-03-31,XM,Euro area,
-1939-03-31,XW,World,
-1939-03-31,ZA,South Africa,
-1939-06-30,4T,Emerging market economies (aggregate),
-1939-06-30,5R,Advanced economies,
-1939-06-30,AE,United Arab Emirates,
-1939-06-30,AT,Austria,
-1939-06-30,AU,Australia,
-1939-06-30,BE,Belgium,
-1939-06-30,BG,Bulgaria,
-1939-06-30,BR,Brazil,
-1939-06-30,CA,Canada,
-1939-06-30,CH,Switzerland,
-1939-06-30,CL,Chile,
-1939-06-30,CN,China,
-1939-06-30,CO,Colombia,
-1939-06-30,CY,Cyprus,
-1939-06-30,CZ,Czechia,
-1939-06-30,DE,Germany,
-1939-06-30,DK,Denmark,
-1939-06-30,EE,Estonia,
-1939-06-30,ES,Spain,
-1939-06-30,FI,Finland,
-1939-06-30,FR,France,
-1939-06-30,GB,United Kingdom,
-1939-06-30,GR,Greece,
-1939-06-30,HK,Hong Kong SAR,
-1939-06-30,HR,Croatia,
-1939-06-30,HU,Hungary,
-1939-06-30,ID,Indonesia,
-1939-06-30,IE,Ireland,
-1939-06-30,IL,Israel,
-1939-06-30,IN,India,
-1939-06-30,IS,Iceland,
 1939-06-30,IT,Italy,2.4199
-1939-06-30,JP,Japan,
-1939-06-30,KR,Korea,
-1939-06-30,LT,Lithuania,
-1939-06-30,LU,Luxembourg,
-1939-06-30,LV,Latvia,
-1939-06-30,MA,Morocco,
-1939-06-30,MK,North Macedonia,
-1939-06-30,MT,Malta,
-1939-06-30,MX,Mexico,
-1939-06-30,MY,Malaysia,
-1939-06-30,NL,Netherlands,
-1939-06-30,NO,Norway,
-1939-06-30,NZ,New Zealand,
-1939-06-30,PE,Peru,
-1939-06-30,PH,Philippines,
-1939-06-30,PL,Poland,
-1939-06-30,PT,Portugal,
-1939-06-30,RO,Romania,
-1939-06-30,RS,Serbia,
-1939-06-30,RU,Russia,
-1939-06-30,SE,Sweden,
-1939-06-30,SG,Singapore,
-1939-06-30,SI,Slovenia,
-1939-06-30,SK,Slovak Republic,
-1939-06-30,TH,Thailand,
-1939-06-30,TR,Türkiye,
-1939-06-30,US,United States,
-1939-06-30,XM,Euro area,
-1939-06-30,XW,World,
-1939-06-30,ZA,South Africa,
-1939-09-30,4T,Emerging market economies (aggregate),
-1939-09-30,5R,Advanced economies,
-1939-09-30,AE,United Arab Emirates,
-1939-09-30,AT,Austria,
-1939-09-30,AU,Australia,
-1939-09-30,BE,Belgium,
-1939-09-30,BG,Bulgaria,
-1939-09-30,BR,Brazil,
-1939-09-30,CA,Canada,
-1939-09-30,CH,Switzerland,
-1939-09-30,CL,Chile,
-1939-09-30,CN,China,
-1939-09-30,CO,Colombia,
-1939-09-30,CY,Cyprus,
-1939-09-30,CZ,Czechia,
-1939-09-30,DE,Germany,
-1939-09-30,DK,Denmark,
-1939-09-30,EE,Estonia,
-1939-09-30,ES,Spain,
-1939-09-30,FI,Finland,
-1939-09-30,FR,France,
-1939-09-30,GB,United Kingdom,
-1939-09-30,GR,Greece,
-1939-09-30,HK,Hong Kong SAR,
-1939-09-30,HR,Croatia,
-1939-09-30,HU,Hungary,
-1939-09-30,ID,Indonesia,
-1939-09-30,IE,Ireland,
-1939-09-30,IL,Israel,
-1939-09-30,IN,India,
-1939-09-30,IS,Iceland,
 1939-09-30,IT,Italy,2.8352
-1939-09-30,JP,Japan,
-1939-09-30,KR,Korea,
-1939-09-30,LT,Lithuania,
-1939-09-30,LU,Luxembourg,
-1939-09-30,LV,Latvia,
-1939-09-30,MA,Morocco,
-1939-09-30,MK,North Macedonia,
-1939-09-30,MT,Malta,
-1939-09-30,MX,Mexico,
-1939-09-30,MY,Malaysia,
-1939-09-30,NL,Netherlands,
-1939-09-30,NO,Norway,
-1939-09-30,NZ,New Zealand,
-1939-09-30,PE,Peru,
-1939-09-30,PH,Philippines,
-1939-09-30,PL,Poland,
-1939-09-30,PT,Portugal,
-1939-09-30,RO,Romania,
-1939-09-30,RS,Serbia,
-1939-09-30,RU,Russia,
-1939-09-30,SE,Sweden,
-1939-09-30,SG,Singapore,
-1939-09-30,SI,Slovenia,
-1939-09-30,SK,Slovak Republic,
-1939-09-30,TH,Thailand,
-1939-09-30,TR,Türkiye,
-1939-09-30,US,United States,
-1939-09-30,XM,Euro area,
-1939-09-30,XW,World,
-1939-09-30,ZA,South Africa,
-1939-12-31,4T,Emerging market economies (aggregate),
-1939-12-31,5R,Advanced economies,
-1939-12-31,AE,United Arab Emirates,
-1939-12-31,AT,Austria,
-1939-12-31,AU,Australia,
-1939-12-31,BE,Belgium,
-1939-12-31,BG,Bulgaria,
-1939-12-31,BR,Brazil,
-1939-12-31,CA,Canada,
-1939-12-31,CH,Switzerland,
-1939-12-31,CL,Chile,
-1939-12-31,CN,China,
-1939-12-31,CO,Colombia,
-1939-12-31,CY,Cyprus,
-1939-12-31,CZ,Czechia,
-1939-12-31,DE,Germany,
-1939-12-31,DK,Denmark,
-1939-12-31,EE,Estonia,
-1939-12-31,ES,Spain,
-1939-12-31,FI,Finland,
-1939-12-31,FR,France,
-1939-12-31,GB,United Kingdom,
-1939-12-31,GR,Greece,
-1939-12-31,HK,Hong Kong SAR,
-1939-12-31,HR,Croatia,
-1939-12-31,HU,Hungary,
-1939-12-31,ID,Indonesia,
-1939-12-31,IE,Ireland,
-1939-12-31,IL,Israel,
-1939-12-31,IN,India,
-1939-12-31,IS,Iceland,
 1939-12-31,IT,Italy,3.8793
-1939-12-31,JP,Japan,
-1939-12-31,KR,Korea,
-1939-12-31,LT,Lithuania,
-1939-12-31,LU,Luxembourg,
-1939-12-31,LV,Latvia,
-1939-12-31,MA,Morocco,
-1939-12-31,MK,North Macedonia,
-1939-12-31,MT,Malta,
-1939-12-31,MX,Mexico,
-1939-12-31,MY,Malaysia,
-1939-12-31,NL,Netherlands,
-1939-12-31,NO,Norway,
-1939-12-31,NZ,New Zealand,
-1939-12-31,PE,Peru,
-1939-12-31,PH,Philippines,
-1939-12-31,PL,Poland,
-1939-12-31,PT,Portugal,
-1939-12-31,RO,Romania,
-1939-12-31,RS,Serbia,
-1939-12-31,RU,Russia,
-1939-12-31,SE,Sweden,
-1939-12-31,SG,Singapore,
-1939-12-31,SI,Slovenia,
-1939-12-31,SK,Slovak Republic,
-1939-12-31,TH,Thailand,
-1939-12-31,TR,Türkiye,
-1939-12-31,US,United States,
-1939-12-31,XM,Euro area,
-1939-12-31,XW,World,
-1939-12-31,ZA,South Africa,
-1940-03-31,4T,Emerging market economies (aggregate),
-1940-03-31,5R,Advanced economies,
-1940-03-31,AE,United Arab Emirates,
-1940-03-31,AT,Austria,
-1940-03-31,AU,Australia,
-1940-03-31,BE,Belgium,
-1940-03-31,BG,Bulgaria,
-1940-03-31,BR,Brazil,
-1940-03-31,CA,Canada,
-1940-03-31,CH,Switzerland,
-1940-03-31,CL,Chile,
-1940-03-31,CN,China,
-1940-03-31,CO,Colombia,
-1940-03-31,CY,Cyprus,
-1940-03-31,CZ,Czechia,
-1940-03-31,DE,Germany,
-1940-03-31,DK,Denmark,
-1940-03-31,EE,Estonia,
-1940-03-31,ES,Spain,
-1940-03-31,FI,Finland,
-1940-03-31,FR,France,
-1940-03-31,GB,United Kingdom,
-1940-03-31,GR,Greece,
-1940-03-31,HK,Hong Kong SAR,
-1940-03-31,HR,Croatia,
-1940-03-31,HU,Hungary,
-1940-03-31,ID,Indonesia,
-1940-03-31,IE,Ireland,
-1940-03-31,IL,Israel,
-1940-03-31,IN,India,
-1940-03-31,IS,Iceland,
 1940-03-31,IT,Italy,4.9092
-1940-03-31,JP,Japan,
-1940-03-31,KR,Korea,
-1940-03-31,LT,Lithuania,
-1940-03-31,LU,Luxembourg,
-1940-03-31,LV,Latvia,
-1940-03-31,MA,Morocco,
-1940-03-31,MK,North Macedonia,
-1940-03-31,MT,Malta,
-1940-03-31,MX,Mexico,
-1940-03-31,MY,Malaysia,
-1940-03-31,NL,Netherlands,
-1940-03-31,NO,Norway,
-1940-03-31,NZ,New Zealand,
-1940-03-31,PE,Peru,
-1940-03-31,PH,Philippines,
-1940-03-31,PL,Poland,
-1940-03-31,PT,Portugal,
-1940-03-31,RO,Romania,
-1940-03-31,RS,Serbia,
-1940-03-31,RU,Russia,
-1940-03-31,SE,Sweden,
-1940-03-31,SG,Singapore,
-1940-03-31,SI,Slovenia,
-1940-03-31,SK,Slovak Republic,
-1940-03-31,TH,Thailand,
-1940-03-31,TR,Türkiye,
-1940-03-31,US,United States,
-1940-03-31,XM,Euro area,
-1940-03-31,XW,World,
-1940-03-31,ZA,South Africa,
-1940-06-30,4T,Emerging market economies (aggregate),
-1940-06-30,5R,Advanced economies,
-1940-06-30,AE,United Arab Emirates,
-1940-06-30,AT,Austria,
-1940-06-30,AU,Australia,
-1940-06-30,BE,Belgium,
-1940-06-30,BG,Bulgaria,
-1940-06-30,BR,Brazil,
-1940-06-30,CA,Canada,
-1940-06-30,CH,Switzerland,
-1940-06-30,CL,Chile,
-1940-06-30,CN,China,
-1940-06-30,CO,Colombia,
-1940-06-30,CY,Cyprus,
-1940-06-30,CZ,Czechia,
-1940-06-30,DE,Germany,
-1940-06-30,DK,Denmark,
-1940-06-30,EE,Estonia,
-1940-06-30,ES,Spain,
-1940-06-30,FI,Finland,
-1940-06-30,FR,France,
-1940-06-30,GB,United Kingdom,
-1940-06-30,GR,Greece,
-1940-06-30,HK,Hong Kong SAR,
-1940-06-30,HR,Croatia,
-1940-06-30,HU,Hungary,
-1940-06-30,ID,Indonesia,
-1940-06-30,IE,Ireland,
-1940-06-30,IL,Israel,
-1940-06-30,IN,India,
-1940-06-30,IS,Iceland,
 1940-06-30,IT,Italy,5.9218
-1940-06-30,JP,Japan,
-1940-06-30,KR,Korea,
-1940-06-30,LT,Lithuania,
-1940-06-30,LU,Luxembourg,
-1940-06-30,LV,Latvia,
-1940-06-30,MA,Morocco,
-1940-06-30,MK,North Macedonia,
-1940-06-30,MT,Malta,
-1940-06-30,MX,Mexico,
-1940-06-30,MY,Malaysia,
-1940-06-30,NL,Netherlands,
-1940-06-30,NO,Norway,
-1940-06-30,NZ,New Zealand,
-1940-06-30,PE,Peru,
-1940-06-30,PH,Philippines,
-1940-06-30,PL,Poland,
-1940-06-30,PT,Portugal,
-1940-06-30,RO,Romania,
-1940-06-30,RS,Serbia,
-1940-06-30,RU,Russia,
-1940-06-30,SE,Sweden,
-1940-06-30,SG,Singapore,
-1940-06-30,SI,Slovenia,
-1940-06-30,SK,Slovak Republic,
-1940-06-30,TH,Thailand,
-1940-06-30,TR,Türkiye,
-1940-06-30,US,United States,
-1940-06-30,XM,Euro area,
-1940-06-30,XW,World,
-1940-06-30,ZA,South Africa,
-1940-09-30,4T,Emerging market economies (aggregate),
-1940-09-30,5R,Advanced economies,
-1940-09-30,AE,United Arab Emirates,
-1940-09-30,AT,Austria,
-1940-09-30,AU,Australia,
-1940-09-30,BE,Belgium,
-1940-09-30,BG,Bulgaria,
-1940-09-30,BR,Brazil,
-1940-09-30,CA,Canada,
-1940-09-30,CH,Switzerland,
-1940-09-30,CL,Chile,
-1940-09-30,CN,China,
-1940-09-30,CO,Colombia,
-1940-09-30,CY,Cyprus,
-1940-09-30,CZ,Czechia,
-1940-09-30,DE,Germany,
-1940-09-30,DK,Denmark,
-1940-09-30,EE,Estonia,
-1940-09-30,ES,Spain,
-1940-09-30,FI,Finland,
-1940-09-30,FR,France,
-1940-09-30,GB,United Kingdom,
-1940-09-30,GR,Greece,
-1940-09-30,HK,Hong Kong SAR,
-1940-09-30,HR,Croatia,
-1940-09-30,HU,Hungary,
-1940-09-30,ID,Indonesia,
-1940-09-30,IE,Ireland,
-1940-09-30,IL,Israel,
-1940-09-30,IN,India,
-1940-09-30,IS,Iceland,
 1940-09-30,IT,Italy,7.6267
-1940-09-30,JP,Japan,
-1940-09-30,KR,Korea,
-1940-09-30,LT,Lithuania,
-1940-09-30,LU,Luxembourg,
-1940-09-30,LV,Latvia,
-1940-09-30,MA,Morocco,
-1940-09-30,MK,North Macedonia,
-1940-09-30,MT,Malta,
-1940-09-30,MX,Mexico,
-1940-09-30,MY,Malaysia,
-1940-09-30,NL,Netherlands,
-1940-09-30,NO,Norway,
-1940-09-30,NZ,New Zealand,
-1940-09-30,PE,Peru,
-1940-09-30,PH,Philippines,
-1940-09-30,PL,Poland,
-1940-09-30,PT,Portugal,
-1940-09-30,RO,Romania,
-1940-09-30,RS,Serbia,
-1940-09-30,RU,Russia,
-1940-09-30,SE,Sweden,
-1940-09-30,SG,Singapore,
-1940-09-30,SI,Slovenia,
-1940-09-30,SK,Slovak Republic,
-1940-09-30,TH,Thailand,
-1940-09-30,TR,Türkiye,
-1940-09-30,US,United States,
-1940-09-30,XM,Euro area,
-1940-09-30,XW,World,
-1940-09-30,ZA,South Africa,
-1940-12-31,4T,Emerging market economies (aggregate),
-1940-12-31,5R,Advanced economies,
-1940-12-31,AE,United Arab Emirates,
-1940-12-31,AT,Austria,
-1940-12-31,AU,Australia,
-1940-12-31,BE,Belgium,
-1940-12-31,BG,Bulgaria,
-1940-12-31,BR,Brazil,
-1940-12-31,CA,Canada,
-1940-12-31,CH,Switzerland,
-1940-12-31,CL,Chile,
-1940-12-31,CN,China,
-1940-12-31,CO,Colombia,
-1940-12-31,CY,Cyprus,
-1940-12-31,CZ,Czechia,
-1940-12-31,DE,Germany,
-1940-12-31,DK,Denmark,
-1940-12-31,EE,Estonia,
-1940-12-31,ES,Spain,
-1940-12-31,FI,Finland,
-1940-12-31,FR,France,
-1940-12-31,GB,United Kingdom,
-1940-12-31,GR,Greece,
-1940-12-31,HK,Hong Kong SAR,
-1940-12-31,HR,Croatia,
-1940-12-31,HU,Hungary,
-1940-12-31,ID,Indonesia,
-1940-12-31,IE,Ireland,
-1940-12-31,IL,Israel,
-1940-12-31,IN,India,
-1940-12-31,IS,Iceland,
 1940-12-31,IT,Italy,9.9974
-1940-12-31,JP,Japan,
-1940-12-31,KR,Korea,
-1940-12-31,LT,Lithuania,
-1940-12-31,LU,Luxembourg,
-1940-12-31,LV,Latvia,
-1940-12-31,MA,Morocco,
-1940-12-31,MK,North Macedonia,
-1940-12-31,MT,Malta,
-1940-12-31,MX,Mexico,
-1940-12-31,MY,Malaysia,
-1940-12-31,NL,Netherlands,
-1940-12-31,NO,Norway,
-1940-12-31,NZ,New Zealand,
-1940-12-31,PE,Peru,
-1940-12-31,PH,Philippines,
-1940-12-31,PL,Poland,
-1940-12-31,PT,Portugal,
-1940-12-31,RO,Romania,
-1940-12-31,RS,Serbia,
-1940-12-31,RU,Russia,
-1940-12-31,SE,Sweden,
-1940-12-31,SG,Singapore,
-1940-12-31,SI,Slovenia,
-1940-12-31,SK,Slovak Republic,
-1940-12-31,TH,Thailand,
-1940-12-31,TR,Türkiye,
-1940-12-31,US,United States,
-1940-12-31,XM,Euro area,
-1940-12-31,XW,World,
-1940-12-31,ZA,South Africa,
-1941-03-31,4T,Emerging market economies (aggregate),
-1941-03-31,5R,Advanced economies,
-1941-03-31,AE,United Arab Emirates,
-1941-03-31,AT,Austria,
-1941-03-31,AU,Australia,
-1941-03-31,BE,Belgium,
-1941-03-31,BG,Bulgaria,
-1941-03-31,BR,Brazil,
-1941-03-31,CA,Canada,
-1941-03-31,CH,Switzerland,
-1941-03-31,CL,Chile,
-1941-03-31,CN,China,
-1941-03-31,CO,Colombia,
-1941-03-31,CY,Cyprus,
-1941-03-31,CZ,Czechia,
-1941-03-31,DE,Germany,
-1941-03-31,DK,Denmark,
-1941-03-31,EE,Estonia,
-1941-03-31,ES,Spain,
-1941-03-31,FI,Finland,
-1941-03-31,FR,France,
-1941-03-31,GB,United Kingdom,
-1941-03-31,GR,Greece,
-1941-03-31,HK,Hong Kong SAR,
-1941-03-31,HR,Croatia,
-1941-03-31,HU,Hungary,
-1941-03-31,ID,Indonesia,
-1941-03-31,IE,Ireland,
-1941-03-31,IL,Israel,
-1941-03-31,IN,India,
-1941-03-31,IS,Iceland,
 1941-03-31,IT,Italy,12.2601
-1941-03-31,JP,Japan,
-1941-03-31,KR,Korea,
-1941-03-31,LT,Lithuania,
-1941-03-31,LU,Luxembourg,
-1941-03-31,LV,Latvia,
-1941-03-31,MA,Morocco,
-1941-03-31,MK,North Macedonia,
-1941-03-31,MT,Malta,
-1941-03-31,MX,Mexico,
-1941-03-31,MY,Malaysia,
-1941-03-31,NL,Netherlands,
-1941-03-31,NO,Norway,
-1941-03-31,NZ,New Zealand,
-1941-03-31,PE,Peru,
-1941-03-31,PH,Philippines,
-1941-03-31,PL,Poland,
-1941-03-31,PT,Portugal,
-1941-03-31,RO,Romania,
-1941-03-31,RS,Serbia,
-1941-03-31,RU,Russia,
-1941-03-31,SE,Sweden,
-1941-03-31,SG,Singapore,
-1941-03-31,SI,Slovenia,
-1941-03-31,SK,Slovak Republic,
-1941-03-31,TH,Thailand,
-1941-03-31,TR,Türkiye,
-1941-03-31,US,United States,
-1941-03-31,XM,Euro area,
-1941-03-31,XW,World,
-1941-03-31,ZA,South Africa,
-1941-06-30,4T,Emerging market economies (aggregate),
-1941-06-30,5R,Advanced economies,
-1941-06-30,AE,United Arab Emirates,
-1941-06-30,AT,Austria,
-1941-06-30,AU,Australia,
-1941-06-30,BE,Belgium,
-1941-06-30,BG,Bulgaria,
-1941-06-30,BR,Brazil,
-1941-06-30,CA,Canada,
-1941-06-30,CH,Switzerland,
-1941-06-30,CL,Chile,
-1941-06-30,CN,China,
-1941-06-30,CO,Colombia,
-1941-06-30,CY,Cyprus,
-1941-06-30,CZ,Czechia,
-1941-06-30,DE,Germany,
-1941-06-30,DK,Denmark,
-1941-06-30,EE,Estonia,
-1941-06-30,ES,Spain,
-1941-06-30,FI,Finland,
-1941-06-30,FR,France,
-1941-06-30,GB,United Kingdom,
-1941-06-30,GR,Greece,
-1941-06-30,HK,Hong Kong SAR,
-1941-06-30,HR,Croatia,
-1941-06-30,HU,Hungary,
-1941-06-30,ID,Indonesia,
-1941-06-30,IE,Ireland,
-1941-06-30,IL,Israel,
-1941-06-30,IN,India,
-1941-06-30,IS,Iceland,
 1941-06-30,IT,Italy,14.442
-1941-06-30,JP,Japan,
-1941-06-30,KR,Korea,
-1941-06-30,LT,Lithuania,
-1941-06-30,LU,Luxembourg,
-1941-06-30,LV,Latvia,
-1941-06-30,MA,Morocco,
-1941-06-30,MK,North Macedonia,
-1941-06-30,MT,Malta,
-1941-06-30,MX,Mexico,
-1941-06-30,MY,Malaysia,
-1941-06-30,NL,Netherlands,
-1941-06-30,NO,Norway,
-1941-06-30,NZ,New Zealand,
-1941-06-30,PE,Peru,
-1941-06-30,PH,Philippines,
-1941-06-30,PL,Poland,
-1941-06-30,PT,Portugal,
-1941-06-30,RO,Romania,
-1941-06-30,RS,Serbia,
-1941-06-30,RU,Russia,
-1941-06-30,SE,Sweden,
-1941-06-30,SG,Singapore,
-1941-06-30,SI,Slovenia,
-1941-06-30,SK,Slovak Republic,
-1941-06-30,TH,Thailand,
-1941-06-30,TR,Türkiye,
-1941-06-30,US,United States,
-1941-06-30,XM,Euro area,
-1941-06-30,XW,World,
-1941-06-30,ZA,South Africa,
-1941-09-30,4T,Emerging market economies (aggregate),
-1941-09-30,5R,Advanced economies,
-1941-09-30,AE,United Arab Emirates,
-1941-09-30,AT,Austria,
-1941-09-30,AU,Australia,
-1941-09-30,BE,Belgium,
-1941-09-30,BG,Bulgaria,
-1941-09-30,BR,Brazil,
-1941-09-30,CA,Canada,
-1941-09-30,CH,Switzerland,
-1941-09-30,CL,Chile,
-1941-09-30,CN,China,
-1941-09-30,CO,Colombia,
-1941-09-30,CY,Cyprus,
-1941-09-30,CZ,Czechia,
-1941-09-30,DE,Germany,
-1941-09-30,DK,Denmark,
-1941-09-30,EE,Estonia,
-1941-09-30,ES,Spain,
-1941-09-30,FI,Finland,
-1941-09-30,FR,France,
-1941-09-30,GB,United Kingdom,
-1941-09-30,GR,Greece,
-1941-09-30,HK,Hong Kong SAR,
-1941-09-30,HR,Croatia,
-1941-09-30,HU,Hungary,
-1941-09-30,ID,Indonesia,
-1941-09-30,IE,Ireland,
-1941-09-30,IL,Israel,
-1941-09-30,IN,India,
-1941-09-30,IS,Iceland,
 1941-09-30,IT,Italy,14.4081
-1941-09-30,JP,Japan,
-1941-09-30,KR,Korea,
-1941-09-30,LT,Lithuania,
-1941-09-30,LU,Luxembourg,
-1941-09-30,LV,Latvia,
-1941-09-30,MA,Morocco,
-1941-09-30,MK,North Macedonia,
-1941-09-30,MT,Malta,
-1941-09-30,MX,Mexico,
-1941-09-30,MY,Malaysia,
-1941-09-30,NL,Netherlands,
-1941-09-30,NO,Norway,
-1941-09-30,NZ,New Zealand,
-1941-09-30,PE,Peru,
-1941-09-30,PH,Philippines,
-1941-09-30,PL,Poland,
-1941-09-30,PT,Portugal,
-1941-09-30,RO,Romania,
-1941-09-30,RS,Serbia,
-1941-09-30,RU,Russia,
-1941-09-30,SE,Sweden,
-1941-09-30,SG,Singapore,
-1941-09-30,SI,Slovenia,
-1941-09-30,SK,Slovak Republic,
-1941-09-30,TH,Thailand,
-1941-09-30,TR,Türkiye,
-1941-09-30,US,United States,
-1941-09-30,XM,Euro area,
-1941-09-30,XW,World,
-1941-09-30,ZA,South Africa,
-1941-12-31,4T,Emerging market economies (aggregate),
-1941-12-31,5R,Advanced economies,
-1941-12-31,AE,United Arab Emirates,
-1941-12-31,AT,Austria,
-1941-12-31,AU,Australia,
-1941-12-31,BE,Belgium,
-1941-12-31,BG,Bulgaria,
-1941-12-31,BR,Brazil,
-1941-12-31,CA,Canada,
-1941-12-31,CH,Switzerland,
-1941-12-31,CL,Chile,
-1941-12-31,CN,China,
-1941-12-31,CO,Colombia,
-1941-12-31,CY,Cyprus,
-1941-12-31,CZ,Czechia,
-1941-12-31,DE,Germany,
-1941-12-31,DK,Denmark,
-1941-12-31,EE,Estonia,
-1941-12-31,ES,Spain,
-1941-12-31,FI,Finland,
-1941-12-31,FR,France,
-1941-12-31,GB,United Kingdom,
-1941-12-31,GR,Greece,
-1941-12-31,HK,Hong Kong SAR,
-1941-12-31,HR,Croatia,
-1941-12-31,HU,Hungary,
-1941-12-31,ID,Indonesia,
-1941-12-31,IE,Ireland,
-1941-12-31,IL,Israel,
-1941-12-31,IN,India,
-1941-12-31,IS,Iceland,
 1941-12-31,IT,Italy,12.1993
-1941-12-31,JP,Japan,
-1941-12-31,KR,Korea,
-1941-12-31,LT,Lithuania,
-1941-12-31,LU,Luxembourg,
-1941-12-31,LV,Latvia,
-1941-12-31,MA,Morocco,
-1941-12-31,MK,North Macedonia,
-1941-12-31,MT,Malta,
-1941-12-31,MX,Mexico,
-1941-12-31,MY,Malaysia,
-1941-12-31,NL,Netherlands,
-1941-12-31,NO,Norway,
-1941-12-31,NZ,New Zealand,
-1941-12-31,PE,Peru,
-1941-12-31,PH,Philippines,
-1941-12-31,PL,Poland,
-1941-12-31,PT,Portugal,
-1941-12-31,RO,Romania,
-1941-12-31,RS,Serbia,
-1941-12-31,RU,Russia,
-1941-12-31,SE,Sweden,
-1941-12-31,SG,Singapore,
-1941-12-31,SI,Slovenia,
-1941-12-31,SK,Slovak Republic,
-1941-12-31,TH,Thailand,
-1941-12-31,TR,Türkiye,
-1941-12-31,US,United States,
-1941-12-31,XM,Euro area,
-1941-12-31,XW,World,
-1941-12-31,ZA,South Africa,
-1942-03-31,4T,Emerging market economies (aggregate),
-1942-03-31,5R,Advanced economies,
-1942-03-31,AE,United Arab Emirates,
-1942-03-31,AT,Austria,
-1942-03-31,AU,Australia,
-1942-03-31,BE,Belgium,
-1942-03-31,BG,Bulgaria,
-1942-03-31,BR,Brazil,
-1942-03-31,CA,Canada,
-1942-03-31,CH,Switzerland,
-1942-03-31,CL,Chile,
-1942-03-31,CN,China,
-1942-03-31,CO,Colombia,
-1942-03-31,CY,Cyprus,
-1942-03-31,CZ,Czechia,
-1942-03-31,DE,Germany,
-1942-03-31,DK,Denmark,
-1942-03-31,EE,Estonia,
-1942-03-31,ES,Spain,
-1942-03-31,FI,Finland,
-1942-03-31,FR,France,
-1942-03-31,GB,United Kingdom,
-1942-03-31,GR,Greece,
-1942-03-31,HK,Hong Kong SAR,
-1942-03-31,HR,Croatia,
-1942-03-31,HU,Hungary,
-1942-03-31,ID,Indonesia,
-1942-03-31,IE,Ireland,
-1942-03-31,IL,Israel,
-1942-03-31,IN,India,
-1942-03-31,IS,Iceland,
 1942-03-31,IT,Italy,10.1693
-1942-03-31,JP,Japan,
-1942-03-31,KR,Korea,
-1942-03-31,LT,Lithuania,
-1942-03-31,LU,Luxembourg,
-1942-03-31,LV,Latvia,
-1942-03-31,MA,Morocco,
-1942-03-31,MK,North Macedonia,
-1942-03-31,MT,Malta,
-1942-03-31,MX,Mexico,
-1942-03-31,MY,Malaysia,
-1942-03-31,NL,Netherlands,
-1942-03-31,NO,Norway,
-1942-03-31,NZ,New Zealand,
-1942-03-31,PE,Peru,
-1942-03-31,PH,Philippines,
-1942-03-31,PL,Poland,
-1942-03-31,PT,Portugal,
-1942-03-31,RO,Romania,
-1942-03-31,RS,Serbia,
-1942-03-31,RU,Russia,
-1942-03-31,SE,Sweden,
-1942-03-31,SG,Singapore,
-1942-03-31,SI,Slovenia,
-1942-03-31,SK,Slovak Republic,
-1942-03-31,TH,Thailand,
-1942-03-31,TR,Türkiye,
-1942-03-31,US,United States,
-1942-03-31,XM,Euro area,
-1942-03-31,XW,World,
-1942-03-31,ZA,South Africa,
-1942-06-30,4T,Emerging market economies (aggregate),
-1942-06-30,5R,Advanced economies,
-1942-06-30,AE,United Arab Emirates,
-1942-06-30,AT,Austria,
-1942-06-30,AU,Australia,
-1942-06-30,BE,Belgium,
-1942-06-30,BG,Bulgaria,
-1942-06-30,BR,Brazil,
-1942-06-30,CA,Canada,
-1942-06-30,CH,Switzerland,
-1942-06-30,CL,Chile,
-1942-06-30,CN,China,
-1942-06-30,CO,Colombia,
-1942-06-30,CY,Cyprus,
-1942-06-30,CZ,Czechia,
-1942-06-30,DE,Germany,
-1942-06-30,DK,Denmark,
-1942-06-30,EE,Estonia,
-1942-06-30,ES,Spain,
-1942-06-30,FI,Finland,
-1942-06-30,FR,France,
-1942-06-30,GB,United Kingdom,
-1942-06-30,GR,Greece,
-1942-06-30,HK,Hong Kong SAR,
-1942-06-30,HR,Croatia,
-1942-06-30,HU,Hungary,
-1942-06-30,ID,Indonesia,
-1942-06-30,IE,Ireland,
-1942-06-30,IL,Israel,
-1942-06-30,IN,India,
-1942-06-30,IS,Iceland,
 1942-06-30,IT,Italy,8.2878
-1942-06-30,JP,Japan,
-1942-06-30,KR,Korea,
-1942-06-30,LT,Lithuania,
-1942-06-30,LU,Luxembourg,
-1942-06-30,LV,Latvia,
-1942-06-30,MA,Morocco,
-1942-06-30,MK,North Macedonia,
-1942-06-30,MT,Malta,
-1942-06-30,MX,Mexico,
-1942-06-30,MY,Malaysia,
-1942-06-30,NL,Netherlands,
-1942-06-30,NO,Norway,
-1942-06-30,NZ,New Zealand,
-1942-06-30,PE,Peru,
-1942-06-30,PH,Philippines,
-1942-06-30,PL,Poland,
-1942-06-30,PT,Portugal,
-1942-06-30,RO,Romania,
-1942-06-30,RS,Serbia,
-1942-06-30,RU,Russia,
-1942-06-30,SE,Sweden,
-1942-06-30,SG,Singapore,
-1942-06-30,SI,Slovenia,
-1942-06-30,SK,Slovak Republic,
-1942-06-30,TH,Thailand,
-1942-06-30,TR,Türkiye,
-1942-06-30,US,United States,
-1942-06-30,XM,Euro area,
-1942-06-30,XW,World,
-1942-06-30,ZA,South Africa,
-1942-09-30,4T,Emerging market economies (aggregate),
-1942-09-30,5R,Advanced economies,
-1942-09-30,AE,United Arab Emirates,
-1942-09-30,AT,Austria,
-1942-09-30,AU,Australia,
-1942-09-30,BE,Belgium,
-1942-09-30,BG,Bulgaria,
-1942-09-30,BR,Brazil,
-1942-09-30,CA,Canada,
-1942-09-30,CH,Switzerland,
-1942-09-30,CL,Chile,
-1942-09-30,CN,China,
-1942-09-30,CO,Colombia,
-1942-09-30,CY,Cyprus,
-1942-09-30,CZ,Czechia,
-1942-09-30,DE,Germany,
-1942-09-30,DK,Denmark,
-1942-09-30,EE,Estonia,
-1942-09-30,ES,Spain,
-1942-09-30,FI,Finland,
-1942-09-30,FR,France,
-1942-09-30,GB,United Kingdom,
-1942-09-30,GR,Greece,
-1942-09-30,HK,Hong Kong SAR,
-1942-09-30,HR,Croatia,
-1942-09-30,HU,Hungary,
-1942-09-30,ID,Indonesia,
-1942-09-30,IE,Ireland,
-1942-09-30,IL,Israel,
-1942-09-30,IN,India,
-1942-09-30,IS,Iceland,
 1942-09-30,IT,Italy,9.6024
-1942-09-30,JP,Japan,
-1942-09-30,KR,Korea,
-1942-09-30,LT,Lithuania,
-1942-09-30,LU,Luxembourg,
-1942-09-30,LV,Latvia,
-1942-09-30,MA,Morocco,
-1942-09-30,MK,North Macedonia,
-1942-09-30,MT,Malta,
-1942-09-30,MX,Mexico,
-1942-09-30,MY,Malaysia,
-1942-09-30,NL,Netherlands,
-1942-09-30,NO,Norway,
-1942-09-30,NZ,New Zealand,
-1942-09-30,PE,Peru,
-1942-09-30,PH,Philippines,
-1942-09-30,PL,Poland,
-1942-09-30,PT,Portugal,
-1942-09-30,RO,Romania,
-1942-09-30,RS,Serbia,
-1942-09-30,RU,Russia,
-1942-09-30,SE,Sweden,
-1942-09-30,SG,Singapore,
-1942-09-30,SI,Slovenia,
-1942-09-30,SK,Slovak Republic,
-1942-09-30,TH,Thailand,
-1942-09-30,TR,Türkiye,
-1942-09-30,US,United States,
-1942-09-30,XM,Euro area,
-1942-09-30,XW,World,
-1942-09-30,ZA,South Africa,
-1942-12-31,4T,Emerging market economies (aggregate),
-1942-12-31,5R,Advanced economies,
-1942-12-31,AE,United Arab Emirates,
-1942-12-31,AT,Austria,
-1942-12-31,AU,Australia,
-1942-12-31,BE,Belgium,
-1942-12-31,BG,Bulgaria,
-1942-12-31,BR,Brazil,
-1942-12-31,CA,Canada,
-1942-12-31,CH,Switzerland,
-1942-12-31,CL,Chile,
-1942-12-31,CN,China,
-1942-12-31,CO,Colombia,
-1942-12-31,CY,Cyprus,
-1942-12-31,CZ,Czechia,
-1942-12-31,DE,Germany,
-1942-12-31,DK,Denmark,
-1942-12-31,EE,Estonia,
-1942-12-31,ES,Spain,
-1942-12-31,FI,Finland,
-1942-12-31,FR,France,
-1942-12-31,GB,United Kingdom,
-1942-12-31,GR,Greece,
-1942-12-31,HK,Hong Kong SAR,
-1942-12-31,HR,Croatia,
-1942-12-31,HU,Hungary,
-1942-12-31,ID,Indonesia,
-1942-12-31,IE,Ireland,
-1942-12-31,IL,Israel,
-1942-12-31,IN,India,
-1942-12-31,IS,Iceland,
 1942-12-31,IT,Italy,14.1111
-1942-12-31,JP,Japan,
-1942-12-31,KR,Korea,
-1942-12-31,LT,Lithuania,
-1942-12-31,LU,Luxembourg,
-1942-12-31,LV,Latvia,
-1942-12-31,MA,Morocco,
-1942-12-31,MK,North Macedonia,
-1942-12-31,MT,Malta,
-1942-12-31,MX,Mexico,
-1942-12-31,MY,Malaysia,
-1942-12-31,NL,Netherlands,
-1942-12-31,NO,Norway,
-1942-12-31,NZ,New Zealand,
-1942-12-31,PE,Peru,
-1942-12-31,PH,Philippines,
-1942-12-31,PL,Poland,
-1942-12-31,PT,Portugal,
-1942-12-31,RO,Romania,
-1942-12-31,RS,Serbia,
-1942-12-31,RU,Russia,
-1942-12-31,SE,Sweden,
-1942-12-31,SG,Singapore,
-1942-12-31,SI,Slovenia,
-1942-12-31,SK,Slovak Republic,
-1942-12-31,TH,Thailand,
-1942-12-31,TR,Türkiye,
-1942-12-31,US,United States,
-1942-12-31,XM,Euro area,
-1942-12-31,XW,World,
-1942-12-31,ZA,South Africa,
-1943-03-31,4T,Emerging market economies (aggregate),
-1943-03-31,5R,Advanced economies,
-1943-03-31,AE,United Arab Emirates,
-1943-03-31,AT,Austria,
-1943-03-31,AU,Australia,
-1943-03-31,BE,Belgium,
-1943-03-31,BG,Bulgaria,
-1943-03-31,BR,Brazil,
-1943-03-31,CA,Canada,
-1943-03-31,CH,Switzerland,
-1943-03-31,CL,Chile,
-1943-03-31,CN,China,
-1943-03-31,CO,Colombia,
-1943-03-31,CY,Cyprus,
-1943-03-31,CZ,Czechia,
-1943-03-31,DE,Germany,
-1943-03-31,DK,Denmark,
-1943-03-31,EE,Estonia,
-1943-03-31,ES,Spain,
-1943-03-31,FI,Finland,
-1943-03-31,FR,France,
-1943-03-31,GB,United Kingdom,
-1943-03-31,GR,Greece,
-1943-03-31,HK,Hong Kong SAR,
-1943-03-31,HR,Croatia,
-1943-03-31,HU,Hungary,
-1943-03-31,ID,Indonesia,
-1943-03-31,IE,Ireland,
-1943-03-31,IL,Israel,
-1943-03-31,IN,India,
-1943-03-31,IS,Iceland,
 1943-03-31,IT,Italy,18.4143
-1943-03-31,JP,Japan,
-1943-03-31,KR,Korea,
-1943-03-31,LT,Lithuania,
-1943-03-31,LU,Luxembourg,
-1943-03-31,LV,Latvia,
-1943-03-31,MA,Morocco,
-1943-03-31,MK,North Macedonia,
-1943-03-31,MT,Malta,
-1943-03-31,MX,Mexico,
-1943-03-31,MY,Malaysia,
-1943-03-31,NL,Netherlands,
-1943-03-31,NO,Norway,
-1943-03-31,NZ,New Zealand,
-1943-03-31,PE,Peru,
-1943-03-31,PH,Philippines,
-1943-03-31,PL,Poland,
-1943-03-31,PT,Portugal,
-1943-03-31,RO,Romania,
-1943-03-31,RS,Serbia,
-1943-03-31,RU,Russia,
-1943-03-31,SE,Sweden,
-1943-03-31,SG,Singapore,
-1943-03-31,SI,Slovenia,
-1943-03-31,SK,Slovak Republic,
-1943-03-31,TH,Thailand,
-1943-03-31,TR,Türkiye,
-1943-03-31,US,United States,
-1943-03-31,XM,Euro area,
-1943-03-31,XW,World,
-1943-03-31,ZA,South Africa,
-1943-06-30,4T,Emerging market economies (aggregate),
-1943-06-30,5R,Advanced economies,
-1943-06-30,AE,United Arab Emirates,
-1943-06-30,AT,Austria,
-1943-06-30,AU,Australia,
-1943-06-30,BE,Belgium,
-1943-06-30,BG,Bulgaria,
-1943-06-30,BR,Brazil,
-1943-06-30,CA,Canada,
-1943-06-30,CH,Switzerland,
-1943-06-30,CL,Chile,
-1943-06-30,CN,China,
-1943-06-30,CO,Colombia,
-1943-06-30,CY,Cyprus,
-1943-06-30,CZ,Czechia,
-1943-06-30,DE,Germany,
-1943-06-30,DK,Denmark,
-1943-06-30,EE,Estonia,
-1943-06-30,ES,Spain,
-1943-06-30,FI,Finland,
-1943-06-30,FR,France,
-1943-06-30,GB,United Kingdom,
-1943-06-30,GR,Greece,
-1943-06-30,HK,Hong Kong SAR,
-1943-06-30,HR,Croatia,
-1943-06-30,HU,Hungary,
-1943-06-30,ID,Indonesia,
-1943-06-30,IE,Ireland,
-1943-06-30,IL,Israel,
-1943-06-30,IN,India,
-1943-06-30,IS,Iceland,
 1943-06-30,IT,Italy,22.5467
-1943-06-30,JP,Japan,
-1943-06-30,KR,Korea,
-1943-06-30,LT,Lithuania,
-1943-06-30,LU,Luxembourg,
-1943-06-30,LV,Latvia,
-1943-06-30,MA,Morocco,
-1943-06-30,MK,North Macedonia,
-1943-06-30,MT,Malta,
-1943-06-30,MX,Mexico,
-1943-06-30,MY,Malaysia,
-1943-06-30,NL,Netherlands,
-1943-06-30,NO,Norway,
-1943-06-30,NZ,New Zealand,
-1943-06-30,PE,Peru,
-1943-06-30,PH,Philippines,
-1943-06-30,PL,Poland,
-1943-06-30,PT,Portugal,
-1943-06-30,RO,Romania,
-1943-06-30,RS,Serbia,
-1943-06-30,RU,Russia,
-1943-06-30,SE,Sweden,
-1943-06-30,SG,Singapore,
-1943-06-30,SI,Slovenia,
-1943-06-30,SK,Slovak Republic,
-1943-06-30,TH,Thailand,
-1943-06-30,TR,Türkiye,
-1943-06-30,US,United States,
-1943-06-30,XM,Euro area,
-1943-06-30,XW,World,
-1943-06-30,ZA,South Africa,
-1943-09-30,4T,Emerging market economies (aggregate),
-1943-09-30,5R,Advanced economies,
-1943-09-30,AE,United Arab Emirates,
-1943-09-30,AT,Austria,
-1943-09-30,AU,Australia,
-1943-09-30,BE,Belgium,
-1943-09-30,BG,Bulgaria,
-1943-09-30,BR,Brazil,
-1943-09-30,CA,Canada,
-1943-09-30,CH,Switzerland,
-1943-09-30,CL,Chile,
-1943-09-30,CN,China,
-1943-09-30,CO,Colombia,
-1943-09-30,CY,Cyprus,
-1943-09-30,CZ,Czechia,
-1943-09-30,DE,Germany,
-1943-09-30,DK,Denmark,
-1943-09-30,EE,Estonia,
-1943-09-30,ES,Spain,
-1943-09-30,FI,Finland,
-1943-09-30,FR,France,
-1943-09-30,GB,United Kingdom,
-1943-09-30,GR,Greece,
-1943-09-30,HK,Hong Kong SAR,
-1943-09-30,HR,Croatia,
-1943-09-30,HU,Hungary,
-1943-09-30,ID,Indonesia,
-1943-09-30,IE,Ireland,
-1943-09-30,IL,Israel,
-1943-09-30,IN,India,
-1943-09-30,IS,Iceland,
 1943-09-30,IT,Italy,61.3985
-1943-09-30,JP,Japan,
-1943-09-30,KR,Korea,
-1943-09-30,LT,Lithuania,
-1943-09-30,LU,Luxembourg,
-1943-09-30,LV,Latvia,
-1943-09-30,MA,Morocco,
-1943-09-30,MK,North Macedonia,
-1943-09-30,MT,Malta,
-1943-09-30,MX,Mexico,
-1943-09-30,MY,Malaysia,
-1943-09-30,NL,Netherlands,
-1943-09-30,NO,Norway,
-1943-09-30,NZ,New Zealand,
-1943-09-30,PE,Peru,
-1943-09-30,PH,Philippines,
-1943-09-30,PL,Poland,
-1943-09-30,PT,Portugal,
-1943-09-30,RO,Romania,
-1943-09-30,RS,Serbia,
-1943-09-30,RU,Russia,
-1943-09-30,SE,Sweden,
-1943-09-30,SG,Singapore,
-1943-09-30,SI,Slovenia,
-1943-09-30,SK,Slovak Republic,
-1943-09-30,TH,Thailand,
-1943-09-30,TR,Türkiye,
-1943-09-30,US,United States,
-1943-09-30,XM,Euro area,
-1943-09-30,XW,World,
-1943-09-30,ZA,South Africa,
-1943-12-31,4T,Emerging market economies (aggregate),
-1943-12-31,5R,Advanced economies,
-1943-12-31,AE,United Arab Emirates,
-1943-12-31,AT,Austria,
-1943-12-31,AU,Australia,
-1943-12-31,BE,Belgium,
-1943-12-31,BG,Bulgaria,
-1943-12-31,BR,Brazil,
-1943-12-31,CA,Canada,
-1943-12-31,CH,Switzerland,
-1943-12-31,CL,Chile,
-1943-12-31,CN,China,
-1943-12-31,CO,Colombia,
-1943-12-31,CY,Cyprus,
-1943-12-31,CZ,Czechia,
-1943-12-31,DE,Germany,
-1943-12-31,DK,Denmark,
-1943-12-31,EE,Estonia,
-1943-12-31,ES,Spain,
-1943-12-31,FI,Finland,
-1943-12-31,FR,France,
-1943-12-31,GB,United Kingdom,
-1943-12-31,GR,Greece,
-1943-12-31,HK,Hong Kong SAR,
-1943-12-31,HR,Croatia,
-1943-12-31,HU,Hungary,
-1943-12-31,ID,Indonesia,
-1943-12-31,IE,Ireland,
-1943-12-31,IL,Israel,
-1943-12-31,IN,India,
-1943-12-31,IS,Iceland,
 1943-12-31,IT,Italy,130.9603
-1943-12-31,JP,Japan,
-1943-12-31,KR,Korea,
-1943-12-31,LT,Lithuania,
-1943-12-31,LU,Luxembourg,
-1943-12-31,LV,Latvia,
-1943-12-31,MA,Morocco,
-1943-12-31,MK,North Macedonia,
-1943-12-31,MT,Malta,
-1943-12-31,MX,Mexico,
-1943-12-31,MY,Malaysia,
-1943-12-31,NL,Netherlands,
-1943-12-31,NO,Norway,
-1943-12-31,NZ,New Zealand,
-1943-12-31,PE,Peru,
-1943-12-31,PH,Philippines,
-1943-12-31,PL,Poland,
-1943-12-31,PT,Portugal,
-1943-12-31,RO,Romania,
-1943-12-31,RS,Serbia,
-1943-12-31,RU,Russia,
-1943-12-31,SE,Sweden,
-1943-12-31,SG,Singapore,
-1943-12-31,SI,Slovenia,
-1943-12-31,SK,Slovak Republic,
-1943-12-31,TH,Thailand,
-1943-12-31,TR,Türkiye,
-1943-12-31,US,United States,
-1943-12-31,XM,Euro area,
-1943-12-31,XW,World,
-1943-12-31,ZA,South Africa,
-1944-03-31,4T,Emerging market economies (aggregate),
-1944-03-31,5R,Advanced economies,
-1944-03-31,AE,United Arab Emirates,
-1944-03-31,AT,Austria,
-1944-03-31,AU,Australia,
-1944-03-31,BE,Belgium,
-1944-03-31,BG,Bulgaria,
-1944-03-31,BR,Brazil,
-1944-03-31,CA,Canada,
-1944-03-31,CH,Switzerland,
-1944-03-31,CL,Chile,
-1944-03-31,CN,China,
-1944-03-31,CO,Colombia,
-1944-03-31,CY,Cyprus,
-1944-03-31,CZ,Czechia,
-1944-03-31,DE,Germany,
-1944-03-31,DK,Denmark,
-1944-03-31,EE,Estonia,
-1944-03-31,ES,Spain,
-1944-03-31,FI,Finland,
-1944-03-31,FR,France,
-1944-03-31,GB,United Kingdom,
-1944-03-31,GR,Greece,
-1944-03-31,HK,Hong Kong SAR,
-1944-03-31,HR,Croatia,
-1944-03-31,HU,Hungary,
-1944-03-31,ID,Indonesia,
-1944-03-31,IE,Ireland,
-1944-03-31,IL,Israel,
-1944-03-31,IN,India,
-1944-03-31,IS,Iceland,
 1944-03-31,IT,Italy,192.8116
-1944-03-31,JP,Japan,
-1944-03-31,KR,Korea,
-1944-03-31,LT,Lithuania,
-1944-03-31,LU,Luxembourg,
-1944-03-31,LV,Latvia,
-1944-03-31,MA,Morocco,
-1944-03-31,MK,North Macedonia,
-1944-03-31,MT,Malta,
-1944-03-31,MX,Mexico,
-1944-03-31,MY,Malaysia,
-1944-03-31,NL,Netherlands,
-1944-03-31,NO,Norway,
-1944-03-31,NZ,New Zealand,
-1944-03-31,PE,Peru,
-1944-03-31,PH,Philippines,
-1944-03-31,PL,Poland,
-1944-03-31,PT,Portugal,
-1944-03-31,RO,Romania,
-1944-03-31,RS,Serbia,
-1944-03-31,RU,Russia,
-1944-03-31,SE,Sweden,
-1944-03-31,SG,Singapore,
-1944-03-31,SI,Slovenia,
-1944-03-31,SK,Slovak Republic,
-1944-03-31,TH,Thailand,
-1944-03-31,TR,Türkiye,
-1944-03-31,US,United States,
-1944-03-31,XM,Euro area,
-1944-03-31,XW,World,
-1944-03-31,ZA,South Africa,
-1944-06-30,4T,Emerging market economies (aggregate),
-1944-06-30,5R,Advanced economies,
-1944-06-30,AE,United Arab Emirates,
-1944-06-30,AT,Austria,
-1944-06-30,AU,Australia,
-1944-06-30,BE,Belgium,
-1944-06-30,BG,Bulgaria,
-1944-06-30,BR,Brazil,
-1944-06-30,CA,Canada,
-1944-06-30,CH,Switzerland,
-1944-06-30,CL,Chile,
-1944-06-30,CN,China,
-1944-06-30,CO,Colombia,
-1944-06-30,CY,Cyprus,
-1944-06-30,CZ,Czechia,
-1944-06-30,DE,Germany,
-1944-06-30,DK,Denmark,
-1944-06-30,EE,Estonia,
-1944-06-30,ES,Spain,
-1944-06-30,FI,Finland,
-1944-06-30,FR,France,
-1944-06-30,GB,United Kingdom,
-1944-06-30,GR,Greece,
-1944-06-30,HK,Hong Kong SAR,
-1944-06-30,HR,Croatia,
-1944-06-30,HU,Hungary,
-1944-06-30,ID,Indonesia,
-1944-06-30,IE,Ireland,
-1944-06-30,IL,Israel,
-1944-06-30,IN,India,
-1944-06-30,IS,Iceland,
 1944-06-30,IT,Italy,248.1211
-1944-06-30,JP,Japan,
-1944-06-30,KR,Korea,
-1944-06-30,LT,Lithuania,
-1944-06-30,LU,Luxembourg,
-1944-06-30,LV,Latvia,
-1944-06-30,MA,Morocco,
-1944-06-30,MK,North Macedonia,
-1944-06-30,MT,Malta,
-1944-06-30,MX,Mexico,
-1944-06-30,MY,Malaysia,
-1944-06-30,NL,Netherlands,
-1944-06-30,NO,Norway,
-1944-06-30,NZ,New Zealand,
-1944-06-30,PE,Peru,
-1944-06-30,PH,Philippines,
-1944-06-30,PL,Poland,
-1944-06-30,PT,Portugal,
-1944-06-30,RO,Romania,
-1944-06-30,RS,Serbia,
-1944-06-30,RU,Russia,
-1944-06-30,SE,Sweden,
-1944-06-30,SG,Singapore,
-1944-06-30,SI,Slovenia,
-1944-06-30,SK,Slovak Republic,
-1944-06-30,TH,Thailand,
-1944-06-30,TR,Türkiye,
-1944-06-30,US,United States,
-1944-06-30,XM,Euro area,
-1944-06-30,XW,World,
-1944-06-30,ZA,South Africa,
-1944-09-30,4T,Emerging market economies (aggregate),
-1944-09-30,5R,Advanced economies,
-1944-09-30,AE,United Arab Emirates,
-1944-09-30,AT,Austria,
-1944-09-30,AU,Australia,
-1944-09-30,BE,Belgium,
-1944-09-30,BG,Bulgaria,
-1944-09-30,BR,Brazil,
-1944-09-30,CA,Canada,
-1944-09-30,CH,Switzerland,
-1944-09-30,CL,Chile,
-1944-09-30,CN,China,
-1944-09-30,CO,Colombia,
-1944-09-30,CY,Cyprus,
-1944-09-30,CZ,Czechia,
-1944-09-30,DE,Germany,
-1944-09-30,DK,Denmark,
-1944-09-30,EE,Estonia,
-1944-09-30,ES,Spain,
-1944-09-30,FI,Finland,
-1944-09-30,FR,France,
-1944-09-30,GB,United Kingdom,
-1944-09-30,GR,Greece,
-1944-09-30,HK,Hong Kong SAR,
-1944-09-30,HR,Croatia,
-1944-09-30,HU,Hungary,
-1944-09-30,ID,Indonesia,
-1944-09-30,IE,Ireland,
-1944-09-30,IL,Israel,
-1944-09-30,IN,India,
-1944-09-30,IS,Iceland,
 1944-09-30,IT,Italy,306.3075
-1944-09-30,JP,Japan,
-1944-09-30,KR,Korea,
-1944-09-30,LT,Lithuania,
-1944-09-30,LU,Luxembourg,
-1944-09-30,LV,Latvia,
-1944-09-30,MA,Morocco,
-1944-09-30,MK,North Macedonia,
-1944-09-30,MT,Malta,
-1944-09-30,MX,Mexico,
-1944-09-30,MY,Malaysia,
-1944-09-30,NL,Netherlands,
-1944-09-30,NO,Norway,
-1944-09-30,NZ,New Zealand,
-1944-09-30,PE,Peru,
-1944-09-30,PH,Philippines,
-1944-09-30,PL,Poland,
-1944-09-30,PT,Portugal,
-1944-09-30,RO,Romania,
-1944-09-30,RS,Serbia,
-1944-09-30,RU,Russia,
-1944-09-30,SE,Sweden,
-1944-09-30,SG,Singapore,
-1944-09-30,SI,Slovenia,
-1944-09-30,SK,Slovak Republic,
-1944-09-30,TH,Thailand,
-1944-09-30,TR,Türkiye,
-1944-09-30,US,United States,
-1944-09-30,XM,Euro area,
-1944-09-30,XW,World,
-1944-09-30,ZA,South Africa,
-1944-12-31,4T,Emerging market economies (aggregate),
-1944-12-31,5R,Advanced economies,
-1944-12-31,AE,United Arab Emirates,
-1944-12-31,AT,Austria,
-1944-12-31,AU,Australia,
-1944-12-31,BE,Belgium,
-1944-12-31,BG,Bulgaria,
-1944-12-31,BR,Brazil,
-1944-12-31,CA,Canada,
-1944-12-31,CH,Switzerland,
-1944-12-31,CL,Chile,
-1944-12-31,CN,China,
-1944-12-31,CO,Colombia,
-1944-12-31,CY,Cyprus,
-1944-12-31,CZ,Czechia,
-1944-12-31,DE,Germany,
-1944-12-31,DK,Denmark,
-1944-12-31,EE,Estonia,
-1944-12-31,ES,Spain,
-1944-12-31,FI,Finland,
-1944-12-31,FR,France,
-1944-12-31,GB,United Kingdom,
-1944-12-31,GR,Greece,
-1944-12-31,HK,Hong Kong SAR,
-1944-12-31,HR,Croatia,
-1944-12-31,HU,Hungary,
-1944-12-31,ID,Indonesia,
-1944-12-31,IE,Ireland,
-1944-12-31,IL,Israel,
-1944-12-31,IN,India,
-1944-12-31,IS,Iceland,
 1944-12-31,IT,Italy,337.295
-1944-12-31,JP,Japan,
-1944-12-31,KR,Korea,
-1944-12-31,LT,Lithuania,
-1944-12-31,LU,Luxembourg,
-1944-12-31,LV,Latvia,
-1944-12-31,MA,Morocco,
-1944-12-31,MK,North Macedonia,
-1944-12-31,MT,Malta,
-1944-12-31,MX,Mexico,
-1944-12-31,MY,Malaysia,
-1944-12-31,NL,Netherlands,
-1944-12-31,NO,Norway,
-1944-12-31,NZ,New Zealand,
-1944-12-31,PE,Peru,
-1944-12-31,PH,Philippines,
-1944-12-31,PL,Poland,
-1944-12-31,PT,Portugal,
-1944-12-31,RO,Romania,
-1944-12-31,RS,Serbia,
-1944-12-31,RU,Russia,
-1944-12-31,SE,Sweden,
-1944-12-31,SG,Singapore,
-1944-12-31,SI,Slovenia,
-1944-12-31,SK,Slovak Republic,
-1944-12-31,TH,Thailand,
-1944-12-31,TR,Türkiye,
-1944-12-31,US,United States,
-1944-12-31,XM,Euro area,
-1944-12-31,XW,World,
-1944-12-31,ZA,South Africa,
-1945-03-31,4T,Emerging market economies (aggregate),
-1945-03-31,5R,Advanced economies,
-1945-03-31,AE,United Arab Emirates,
-1945-03-31,AT,Austria,
-1945-03-31,AU,Australia,
-1945-03-31,BE,Belgium,
-1945-03-31,BG,Bulgaria,
-1945-03-31,BR,Brazil,
-1945-03-31,CA,Canada,
-1945-03-31,CH,Switzerland,
-1945-03-31,CL,Chile,
-1945-03-31,CN,China,
-1945-03-31,CO,Colombia,
-1945-03-31,CY,Cyprus,
-1945-03-31,CZ,Czechia,
-1945-03-31,DE,Germany,
-1945-03-31,DK,Denmark,
-1945-03-31,EE,Estonia,
-1945-03-31,ES,Spain,
-1945-03-31,FI,Finland,
-1945-03-31,FR,France,
-1945-03-31,GB,United Kingdom,
-1945-03-31,GR,Greece,
-1945-03-31,HK,Hong Kong SAR,
-1945-03-31,HR,Croatia,
-1945-03-31,HU,Hungary,
-1945-03-31,ID,Indonesia,
-1945-03-31,IE,Ireland,
-1945-03-31,IL,Israel,
-1945-03-31,IN,India,
-1945-03-31,IS,Iceland,
 1945-03-31,IT,Italy,351.768
-1945-03-31,JP,Japan,
-1945-03-31,KR,Korea,
-1945-03-31,LT,Lithuania,
-1945-03-31,LU,Luxembourg,
-1945-03-31,LV,Latvia,
-1945-03-31,MA,Morocco,
-1945-03-31,MK,North Macedonia,
-1945-03-31,MT,Malta,
-1945-03-31,MX,Mexico,
-1945-03-31,MY,Malaysia,
-1945-03-31,NL,Netherlands,
-1945-03-31,NO,Norway,
-1945-03-31,NZ,New Zealand,
-1945-03-31,PE,Peru,
-1945-03-31,PH,Philippines,
-1945-03-31,PL,Poland,
-1945-03-31,PT,Portugal,
-1945-03-31,RO,Romania,
-1945-03-31,RS,Serbia,
-1945-03-31,RU,Russia,
-1945-03-31,SE,Sweden,
-1945-03-31,SG,Singapore,
-1945-03-31,SI,Slovenia,
-1945-03-31,SK,Slovak Republic,
-1945-03-31,TH,Thailand,
-1945-03-31,TR,Türkiye,
-1945-03-31,US,United States,
-1945-03-31,XM,Euro area,
-1945-03-31,XW,World,
-1945-03-31,ZA,South Africa,
-1945-06-30,4T,Emerging market economies (aggregate),
-1945-06-30,5R,Advanced economies,
-1945-06-30,AE,United Arab Emirates,
-1945-06-30,AT,Austria,
-1945-06-30,AU,Australia,
-1945-06-30,BE,Belgium,
-1945-06-30,BG,Bulgaria,
-1945-06-30,BR,Brazil,
-1945-06-30,CA,Canada,
-1945-06-30,CH,Switzerland,
-1945-06-30,CL,Chile,
-1945-06-30,CN,China,
-1945-06-30,CO,Colombia,
-1945-06-30,CY,Cyprus,
-1945-06-30,CZ,Czechia,
-1945-06-30,DE,Germany,
-1945-06-30,DK,Denmark,
-1945-06-30,EE,Estonia,
-1945-06-30,ES,Spain,
-1945-06-30,FI,Finland,
-1945-06-30,FR,France,
-1945-06-30,GB,United Kingdom,
-1945-06-30,GR,Greece,
-1945-06-30,HK,Hong Kong SAR,
-1945-06-30,HR,Croatia,
-1945-06-30,HU,Hungary,
-1945-06-30,ID,Indonesia,
-1945-06-30,IE,Ireland,
-1945-06-30,IL,Israel,
-1945-06-30,IN,India,
-1945-06-30,IS,Iceland,
 1945-06-30,IT,Italy,360.3514
-1945-06-30,JP,Japan,
-1945-06-30,KR,Korea,
-1945-06-30,LT,Lithuania,
-1945-06-30,LU,Luxembourg,
-1945-06-30,LV,Latvia,
-1945-06-30,MA,Morocco,
-1945-06-30,MK,North Macedonia,
-1945-06-30,MT,Malta,
-1945-06-30,MX,Mexico,
-1945-06-30,MY,Malaysia,
-1945-06-30,NL,Netherlands,
-1945-06-30,NO,Norway,
-1945-06-30,NZ,New Zealand,
-1945-06-30,PE,Peru,
-1945-06-30,PH,Philippines,
-1945-06-30,PL,Poland,
-1945-06-30,PT,Portugal,
-1945-06-30,RO,Romania,
-1945-06-30,RS,Serbia,
-1945-06-30,RU,Russia,
-1945-06-30,SE,Sweden,
-1945-06-30,SG,Singapore,
-1945-06-30,SI,Slovenia,
-1945-06-30,SK,Slovak Republic,
-1945-06-30,TH,Thailand,
-1945-06-30,TR,Türkiye,
-1945-06-30,US,United States,
-1945-06-30,XM,Euro area,
-1945-06-30,XW,World,
-1945-06-30,ZA,South Africa,
-1945-09-30,4T,Emerging market economies (aggregate),
-1945-09-30,5R,Advanced economies,
-1945-09-30,AE,United Arab Emirates,
-1945-09-30,AT,Austria,
-1945-09-30,AU,Australia,
-1945-09-30,BE,Belgium,
-1945-09-30,BG,Bulgaria,
-1945-09-30,BR,Brazil,
-1945-09-30,CA,Canada,
-1945-09-30,CH,Switzerland,
-1945-09-30,CL,Chile,
-1945-09-30,CN,China,
-1945-09-30,CO,Colombia,
-1945-09-30,CY,Cyprus,
-1945-09-30,CZ,Czechia,
-1945-09-30,DE,Germany,
-1945-09-30,DK,Denmark,
-1945-09-30,EE,Estonia,
-1945-09-30,ES,Spain,
-1945-09-30,FI,Finland,
-1945-09-30,FR,France,
-1945-09-30,GB,United Kingdom,
-1945-09-30,GR,Greece,
-1945-09-30,HK,Hong Kong SAR,
-1945-09-30,HR,Croatia,
-1945-09-30,HU,Hungary,
-1945-09-30,ID,Indonesia,
-1945-09-30,IE,Ireland,
-1945-09-30,IL,Israel,
-1945-09-30,IN,India,
-1945-09-30,IS,Iceland,
 1945-09-30,IT,Italy,240.1619
-1945-09-30,JP,Japan,
-1945-09-30,KR,Korea,
-1945-09-30,LT,Lithuania,
-1945-09-30,LU,Luxembourg,
-1945-09-30,LV,Latvia,
-1945-09-30,MA,Morocco,
-1945-09-30,MK,North Macedonia,
-1945-09-30,MT,Malta,
-1945-09-30,MX,Mexico,
-1945-09-30,MY,Malaysia,
-1945-09-30,NL,Netherlands,
-1945-09-30,NO,Norway,
-1945-09-30,NZ,New Zealand,
-1945-09-30,PE,Peru,
-1945-09-30,PH,Philippines,
-1945-09-30,PL,Poland,
-1945-09-30,PT,Portugal,
-1945-09-30,RO,Romania,
-1945-09-30,RS,Serbia,
-1945-09-30,RU,Russia,
-1945-09-30,SE,Sweden,
-1945-09-30,SG,Singapore,
-1945-09-30,SI,Slovenia,
-1945-09-30,SK,Slovak Republic,
-1945-09-30,TH,Thailand,
-1945-09-30,TR,Türkiye,
-1945-09-30,US,United States,
-1945-09-30,XM,Euro area,
-1945-09-30,XW,World,
-1945-09-30,ZA,South Africa,
-1945-12-31,4T,Emerging market economies (aggregate),
-1945-12-31,5R,Advanced economies,
-1945-12-31,AE,United Arab Emirates,
-1945-12-31,AT,Austria,
-1945-12-31,AU,Australia,
-1945-12-31,BE,Belgium,
-1945-12-31,BG,Bulgaria,
-1945-12-31,BR,Brazil,
-1945-12-31,CA,Canada,
-1945-12-31,CH,Switzerland,
-1945-12-31,CL,Chile,
-1945-12-31,CN,China,
-1945-12-31,CO,Colombia,
-1945-12-31,CY,Cyprus,
-1945-12-31,CZ,Czechia,
-1945-12-31,DE,Germany,
-1945-12-31,DK,Denmark,
-1945-12-31,EE,Estonia,
-1945-12-31,ES,Spain,
-1945-12-31,FI,Finland,
-1945-12-31,FR,France,
-1945-12-31,GB,United Kingdom,
-1945-12-31,GR,Greece,
-1945-12-31,HK,Hong Kong SAR,
-1945-12-31,HR,Croatia,
-1945-12-31,HU,Hungary,
-1945-12-31,ID,Indonesia,
-1945-12-31,IE,Ireland,
-1945-12-31,IL,Israel,
-1945-12-31,IN,India,
-1945-12-31,IS,Iceland,
 1945-12-31,IT,Italy,133.1864
-1945-12-31,JP,Japan,
-1945-12-31,KR,Korea,
-1945-12-31,LT,Lithuania,
-1945-12-31,LU,Luxembourg,
-1945-12-31,LV,Latvia,
-1945-12-31,MA,Morocco,
-1945-12-31,MK,North Macedonia,
-1945-12-31,MT,Malta,
-1945-12-31,MX,Mexico,
-1945-12-31,MY,Malaysia,
-1945-12-31,NL,Netherlands,
-1945-12-31,NO,Norway,
-1945-12-31,NZ,New Zealand,
-1945-12-31,PE,Peru,
-1945-12-31,PH,Philippines,
-1945-12-31,PL,Poland,
-1945-12-31,PT,Portugal,
-1945-12-31,RO,Romania,
-1945-12-31,RS,Serbia,
-1945-12-31,RU,Russia,
-1945-12-31,SE,Sweden,
-1945-12-31,SG,Singapore,
-1945-12-31,SI,Slovenia,
-1945-12-31,SK,Slovak Republic,
-1945-12-31,TH,Thailand,
-1945-12-31,TR,Türkiye,
-1945-12-31,US,United States,
-1945-12-31,XM,Euro area,
-1945-12-31,XW,World,
-1945-12-31,ZA,South Africa,
-1946-03-31,4T,Emerging market economies (aggregate),
-1946-03-31,5R,Advanced economies,
-1946-03-31,AE,United Arab Emirates,
-1946-03-31,AT,Austria,
-1946-03-31,AU,Australia,
-1946-03-31,BE,Belgium,
-1946-03-31,BG,Bulgaria,
-1946-03-31,BR,Brazil,
-1946-03-31,CA,Canada,
-1946-03-31,CH,Switzerland,
-1946-03-31,CL,Chile,
-1946-03-31,CN,China,
-1946-03-31,CO,Colombia,
-1946-03-31,CY,Cyprus,
-1946-03-31,CZ,Czechia,
-1946-03-31,DE,Germany,
-1946-03-31,DK,Denmark,
-1946-03-31,EE,Estonia,
-1946-03-31,ES,Spain,
-1946-03-31,FI,Finland,
-1946-03-31,FR,France,
-1946-03-31,GB,United Kingdom,
-1946-03-31,GR,Greece,
-1946-03-31,HK,Hong Kong SAR,
-1946-03-31,HR,Croatia,
-1946-03-31,HU,Hungary,
-1946-03-31,ID,Indonesia,
-1946-03-31,IE,Ireland,
-1946-03-31,IL,Israel,
-1946-03-31,IN,India,
-1946-03-31,IS,Iceland,
 1946-03-31,IT,Italy,86.3435
-1946-03-31,JP,Japan,
-1946-03-31,KR,Korea,
-1946-03-31,LT,Lithuania,
-1946-03-31,LU,Luxembourg,
-1946-03-31,LV,Latvia,
-1946-03-31,MA,Morocco,
-1946-03-31,MK,North Macedonia,
-1946-03-31,MT,Malta,
-1946-03-31,MX,Mexico,
-1946-03-31,MY,Malaysia,
-1946-03-31,NL,Netherlands,
-1946-03-31,NO,Norway,
-1946-03-31,NZ,New Zealand,
-1946-03-31,PE,Peru,
-1946-03-31,PH,Philippines,
-1946-03-31,PL,Poland,
-1946-03-31,PT,Portugal,
-1946-03-31,RO,Romania,
-1946-03-31,RS,Serbia,
-1946-03-31,RU,Russia,
-1946-03-31,SE,Sweden,
-1946-03-31,SG,Singapore,
-1946-03-31,SI,Slovenia,
-1946-03-31,SK,Slovak Republic,
-1946-03-31,TH,Thailand,
-1946-03-31,TR,Türkiye,
-1946-03-31,US,United States,
-1946-03-31,XM,Euro area,
-1946-03-31,XW,World,
-1946-03-31,ZA,South Africa,
-1946-06-30,4T,Emerging market economies (aggregate),
-1946-06-30,5R,Advanced economies,
-1946-06-30,AE,United Arab Emirates,
-1946-06-30,AT,Austria,
-1946-06-30,AU,Australia,
-1946-06-30,BE,Belgium,
-1946-06-30,BG,Bulgaria,
-1946-06-30,BR,Brazil,
-1946-06-30,CA,Canada,
-1946-06-30,CH,Switzerland,
-1946-06-30,CL,Chile,
-1946-06-30,CN,China,
-1946-06-30,CO,Colombia,
-1946-06-30,CY,Cyprus,
-1946-06-30,CZ,Czechia,
-1946-06-30,DE,Germany,
-1946-06-30,DK,Denmark,
-1946-06-30,EE,Estonia,
-1946-06-30,ES,Spain,
-1946-06-30,FI,Finland,
-1946-06-30,FR,France,
-1946-06-30,GB,United Kingdom,
-1946-06-30,GR,Greece,
-1946-06-30,HK,Hong Kong SAR,
-1946-06-30,HR,Croatia,
-1946-06-30,HU,Hungary,
-1946-06-30,ID,Indonesia,
-1946-06-30,IE,Ireland,
-1946-06-30,IL,Israel,
-1946-06-30,IN,India,
-1946-06-30,IS,Iceland,
 1946-06-30,IT,Italy,59.9456
-1946-06-30,JP,Japan,
-1946-06-30,KR,Korea,
-1946-06-30,LT,Lithuania,
-1946-06-30,LU,Luxembourg,
-1946-06-30,LV,Latvia,
-1946-06-30,MA,Morocco,
-1946-06-30,MK,North Macedonia,
-1946-06-30,MT,Malta,
-1946-06-30,MX,Mexico,
-1946-06-30,MY,Malaysia,
-1946-06-30,NL,Netherlands,
-1946-06-30,NO,Norway,
-1946-06-30,NZ,New Zealand,
-1946-06-30,PE,Peru,
-1946-06-30,PH,Philippines,
-1946-06-30,PL,Poland,
-1946-06-30,PT,Portugal,
-1946-06-30,RO,Romania,
-1946-06-30,RS,Serbia,
-1946-06-30,RU,Russia,
-1946-06-30,SE,Sweden,
-1946-06-30,SG,Singapore,
-1946-06-30,SI,Slovenia,
-1946-06-30,SK,Slovak Republic,
-1946-06-30,TH,Thailand,
-1946-06-30,TR,Türkiye,
-1946-06-30,US,United States,
-1946-06-30,XM,Euro area,
-1946-06-30,XW,World,
-1946-06-30,ZA,South Africa,
-1946-09-30,4T,Emerging market economies (aggregate),
-1946-09-30,5R,Advanced economies,
-1946-09-30,AE,United Arab Emirates,
-1946-09-30,AT,Austria,
-1946-09-30,AU,Australia,
-1946-09-30,BE,Belgium,
-1946-09-30,BG,Bulgaria,
-1946-09-30,BR,Brazil,
-1946-09-30,CA,Canada,
-1946-09-30,CH,Switzerland,
-1946-09-30,CL,Chile,
-1946-09-30,CN,China,
-1946-09-30,CO,Colombia,
-1946-09-30,CY,Cyprus,
-1946-09-30,CZ,Czechia,
-1946-09-30,DE,Germany,
-1946-09-30,DK,Denmark,
-1946-09-30,EE,Estonia,
-1946-09-30,ES,Spain,
-1946-09-30,FI,Finland,
-1946-09-30,FR,France,
-1946-09-30,GB,United Kingdom,
-1946-09-30,GR,Greece,
-1946-09-30,HK,Hong Kong SAR,
-1946-09-30,HR,Croatia,
-1946-09-30,HU,Hungary,
-1946-09-30,ID,Indonesia,
-1946-09-30,IE,Ireland,
-1946-09-30,IL,Israel,
-1946-09-30,IN,India,
-1946-09-30,IS,Iceland,
 1946-09-30,IT,Italy,51.3545
-1946-09-30,JP,Japan,
-1946-09-30,KR,Korea,
-1946-09-30,LT,Lithuania,
-1946-09-30,LU,Luxembourg,
-1946-09-30,LV,Latvia,
-1946-09-30,MA,Morocco,
-1946-09-30,MK,North Macedonia,
-1946-09-30,MT,Malta,
-1946-09-30,MX,Mexico,
-1946-09-30,MY,Malaysia,
-1946-09-30,NL,Netherlands,
-1946-09-30,NO,Norway,
-1946-09-30,NZ,New Zealand,
-1946-09-30,PE,Peru,
-1946-09-30,PH,Philippines,
-1946-09-30,PL,Poland,
-1946-09-30,PT,Portugal,
-1946-09-30,RO,Romania,
-1946-09-30,RS,Serbia,
-1946-09-30,RU,Russia,
-1946-09-30,SE,Sweden,
-1946-09-30,SG,Singapore,
-1946-09-30,SI,Slovenia,
-1946-09-30,SK,Slovak Republic,
-1946-09-30,TH,Thailand,
-1946-09-30,TR,Türkiye,
-1946-09-30,US,United States,
-1946-09-30,XM,Euro area,
-1946-09-30,XW,World,
-1946-09-30,ZA,South Africa,
-1946-12-31,4T,Emerging market economies (aggregate),
-1946-12-31,5R,Advanced economies,
-1946-12-31,AE,United Arab Emirates,
-1946-12-31,AT,Austria,
-1946-12-31,AU,Australia,
-1946-12-31,BE,Belgium,
-1946-12-31,BG,Bulgaria,
-1946-12-31,BR,Brazil,
-1946-12-31,CA,Canada,
-1946-12-31,CH,Switzerland,
-1946-12-31,CL,Chile,
-1946-12-31,CN,China,
-1946-12-31,CO,Colombia,
-1946-12-31,CY,Cyprus,
-1946-12-31,CZ,Czechia,
-1946-12-31,DE,Germany,
-1946-12-31,DK,Denmark,
-1946-12-31,EE,Estonia,
-1946-12-31,ES,Spain,
-1946-12-31,FI,Finland,
-1946-12-31,FR,France,
-1946-12-31,GB,United Kingdom,
-1946-12-31,GR,Greece,
-1946-12-31,HK,Hong Kong SAR,
-1946-12-31,HR,Croatia,
-1946-12-31,HU,Hungary,
-1946-12-31,ID,Indonesia,
-1946-12-31,IE,Ireland,
-1946-12-31,IL,Israel,
-1946-12-31,IN,India,
-1946-12-31,IS,Iceland,
 1946-12-31,IT,Italy,53.2128
-1946-12-31,JP,Japan,
-1946-12-31,KR,Korea,
-1946-12-31,LT,Lithuania,
-1946-12-31,LU,Luxembourg,
-1946-12-31,LV,Latvia,
-1946-12-31,MA,Morocco,
-1946-12-31,MK,North Macedonia,
-1946-12-31,MT,Malta,
-1946-12-31,MX,Mexico,
-1946-12-31,MY,Malaysia,
-1946-12-31,NL,Netherlands,
-1946-12-31,NO,Norway,
-1946-12-31,NZ,New Zealand,
-1946-12-31,PE,Peru,
-1946-12-31,PH,Philippines,
-1946-12-31,PL,Poland,
-1946-12-31,PT,Portugal,
-1946-12-31,RO,Romania,
-1946-12-31,RS,Serbia,
-1946-12-31,RU,Russia,
-1946-12-31,SE,Sweden,
-1946-12-31,SG,Singapore,
-1946-12-31,SI,Slovenia,
-1946-12-31,SK,Slovak Republic,
-1946-12-31,TH,Thailand,
-1946-12-31,TR,Türkiye,
-1946-12-31,US,United States,
-1946-12-31,XM,Euro area,
-1946-12-31,XW,World,
-1946-12-31,ZA,South Africa,
-1947-03-31,4T,Emerging market economies (aggregate),
-1947-03-31,5R,Advanced economies,
-1947-03-31,AE,United Arab Emirates,
-1947-03-31,AT,Austria,
-1947-03-31,AU,Australia,
-1947-03-31,BE,Belgium,
-1947-03-31,BG,Bulgaria,
-1947-03-31,BR,Brazil,
-1947-03-31,CA,Canada,
-1947-03-31,CH,Switzerland,
-1947-03-31,CL,Chile,
-1947-03-31,CN,China,
-1947-03-31,CO,Colombia,
-1947-03-31,CY,Cyprus,
-1947-03-31,CZ,Czechia,
-1947-03-31,DE,Germany,
-1947-03-31,DK,Denmark,
-1947-03-31,EE,Estonia,
-1947-03-31,ES,Spain,
-1947-03-31,FI,Finland,
-1947-03-31,FR,France,
-1947-03-31,GB,United Kingdom,
-1947-03-31,GR,Greece,
-1947-03-31,HK,Hong Kong SAR,
-1947-03-31,HR,Croatia,
-1947-03-31,HU,Hungary,
-1947-03-31,ID,Indonesia,
-1947-03-31,IE,Ireland,
-1947-03-31,IL,Israel,
-1947-03-31,IN,India,
-1947-03-31,IS,Iceland,
 1947-03-31,IT,Italy,54.7001
-1947-03-31,JP,Japan,
-1947-03-31,KR,Korea,
-1947-03-31,LT,Lithuania,
-1947-03-31,LU,Luxembourg,
-1947-03-31,LV,Latvia,
-1947-03-31,MA,Morocco,
-1947-03-31,MK,North Macedonia,
-1947-03-31,MT,Malta,
-1947-03-31,MX,Mexico,
-1947-03-31,MY,Malaysia,
-1947-03-31,NL,Netherlands,
-1947-03-31,NO,Norway,
-1947-03-31,NZ,New Zealand,
-1947-03-31,PE,Peru,
-1947-03-31,PH,Philippines,
-1947-03-31,PL,Poland,
-1947-03-31,PT,Portugal,
-1947-03-31,RO,Romania,
-1947-03-31,RS,Serbia,
-1947-03-31,RU,Russia,
-1947-03-31,SE,Sweden,
-1947-03-31,SG,Singapore,
-1947-03-31,SI,Slovenia,
-1947-03-31,SK,Slovak Republic,
-1947-03-31,TH,Thailand,
-1947-03-31,TR,Türkiye,
-1947-03-31,US,United States,
-1947-03-31,XM,Euro area,
-1947-03-31,XW,World,
-1947-03-31,ZA,South Africa,
-1947-06-30,4T,Emerging market economies (aggregate),
-1947-06-30,5R,Advanced economies,
-1947-06-30,AE,United Arab Emirates,
-1947-06-30,AT,Austria,
-1947-06-30,AU,Australia,
-1947-06-30,BE,Belgium,
-1947-06-30,BG,Bulgaria,
-1947-06-30,BR,Brazil,
-1947-06-30,CA,Canada,
-1947-06-30,CH,Switzerland,
-1947-06-30,CL,Chile,
-1947-06-30,CN,China,
-1947-06-30,CO,Colombia,
-1947-06-30,CY,Cyprus,
-1947-06-30,CZ,Czechia,
-1947-06-30,DE,Germany,
-1947-06-30,DK,Denmark,
-1947-06-30,EE,Estonia,
-1947-06-30,ES,Spain,
-1947-06-30,FI,Finland,
-1947-06-30,FR,France,
-1947-06-30,GB,United Kingdom,
-1947-06-30,GR,Greece,
-1947-06-30,HK,Hong Kong SAR,
-1947-06-30,HR,Croatia,
-1947-06-30,HU,Hungary,
-1947-06-30,ID,Indonesia,
-1947-06-30,IE,Ireland,
-1947-06-30,IL,Israel,
-1947-06-30,IN,India,
-1947-06-30,IS,Iceland,
 1947-06-30,IT,Italy,55.922
-1947-06-30,JP,Japan,
-1947-06-30,KR,Korea,
-1947-06-30,LT,Lithuania,
-1947-06-30,LU,Luxembourg,
-1947-06-30,LV,Latvia,
-1947-06-30,MA,Morocco,
-1947-06-30,MK,North Macedonia,
-1947-06-30,MT,Malta,
-1947-06-30,MX,Mexico,
-1947-06-30,MY,Malaysia,
-1947-06-30,NL,Netherlands,
-1947-06-30,NO,Norway,
-1947-06-30,NZ,New Zealand,
-1947-06-30,PE,Peru,
-1947-06-30,PH,Philippines,
-1947-06-30,PL,Poland,
-1947-06-30,PT,Portugal,
-1947-06-30,RO,Romania,
-1947-06-30,RS,Serbia,
-1947-06-30,RU,Russia,
-1947-06-30,SE,Sweden,
-1947-06-30,SG,Singapore,
-1947-06-30,SI,Slovenia,
-1947-06-30,SK,Slovak Republic,
-1947-06-30,TH,Thailand,
-1947-06-30,TR,Türkiye,
-1947-06-30,US,United States,
-1947-06-30,XM,Euro area,
-1947-06-30,XW,World,
-1947-06-30,ZA,South Africa,
-1947-09-30,4T,Emerging market economies (aggregate),
-1947-09-30,5R,Advanced economies,
-1947-09-30,AE,United Arab Emirates,
-1947-09-30,AT,Austria,
-1947-09-30,AU,Australia,
-1947-09-30,BE,Belgium,
-1947-09-30,BG,Bulgaria,
-1947-09-30,BR,Brazil,
-1947-09-30,CA,Canada,
-1947-09-30,CH,Switzerland,
-1947-09-30,CL,Chile,
-1947-09-30,CN,China,
-1947-09-30,CO,Colombia,
-1947-09-30,CY,Cyprus,
-1947-09-30,CZ,Czechia,
-1947-09-30,DE,Germany,
-1947-09-30,DK,Denmark,
-1947-09-30,EE,Estonia,
-1947-09-30,ES,Spain,
-1947-09-30,FI,Finland,
-1947-09-30,FR,France,
-1947-09-30,GB,United Kingdom,
-1947-09-30,GR,Greece,
-1947-09-30,HK,Hong Kong SAR,
-1947-09-30,HR,Croatia,
-1947-09-30,HU,Hungary,
-1947-09-30,ID,Indonesia,
-1947-09-30,IE,Ireland,
-1947-09-30,IL,Israel,
-1947-09-30,IN,India,
-1947-09-30,IS,Iceland,
 1947-09-30,IT,Italy,50.1634
-1947-09-30,JP,Japan,
-1947-09-30,KR,Korea,
-1947-09-30,LT,Lithuania,
-1947-09-30,LU,Luxembourg,
-1947-09-30,LV,Latvia,
-1947-09-30,MA,Morocco,
-1947-09-30,MK,North Macedonia,
-1947-09-30,MT,Malta,
-1947-09-30,MX,Mexico,
-1947-09-30,MY,Malaysia,
-1947-09-30,NL,Netherlands,
-1947-09-30,NO,Norway,
-1947-09-30,NZ,New Zealand,
-1947-09-30,PE,Peru,
-1947-09-30,PH,Philippines,
-1947-09-30,PL,Poland,
-1947-09-30,PT,Portugal,
-1947-09-30,RO,Romania,
-1947-09-30,RS,Serbia,
-1947-09-30,RU,Russia,
-1947-09-30,SE,Sweden,
-1947-09-30,SG,Singapore,
-1947-09-30,SI,Slovenia,
-1947-09-30,SK,Slovak Republic,
-1947-09-30,TH,Thailand,
-1947-09-30,TR,Türkiye,
-1947-09-30,US,United States,
-1947-09-30,XM,Euro area,
-1947-09-30,XW,World,
-1947-09-30,ZA,South Africa,
-1947-12-31,4T,Emerging market economies (aggregate),
-1947-12-31,5R,Advanced economies,
-1947-12-31,AE,United Arab Emirates,
-1947-12-31,AT,Austria,
-1947-12-31,AU,Australia,
-1947-12-31,BE,Belgium,
-1947-12-31,BG,Bulgaria,
-1947-12-31,BR,Brazil,
-1947-12-31,CA,Canada,
-1947-12-31,CH,Switzerland,
-1947-12-31,CL,Chile,
-1947-12-31,CN,China,
-1947-12-31,CO,Colombia,
-1947-12-31,CY,Cyprus,
-1947-12-31,CZ,Czechia,
-1947-12-31,DE,Germany,
-1947-12-31,DK,Denmark,
-1947-12-31,EE,Estonia,
-1947-12-31,ES,Spain,
-1947-12-31,FI,Finland,
-1947-12-31,FR,France,
-1947-12-31,GB,United Kingdom,
-1947-12-31,GR,Greece,
-1947-12-31,HK,Hong Kong SAR,
-1947-12-31,HR,Croatia,
-1947-12-31,HU,Hungary,
-1947-12-31,ID,Indonesia,
-1947-12-31,IE,Ireland,
-1947-12-31,IL,Israel,
-1947-12-31,IN,India,
-1947-12-31,IS,Iceland,
 1947-12-31,IT,Italy,39.3923
-1947-12-31,JP,Japan,
-1947-12-31,KR,Korea,
-1947-12-31,LT,Lithuania,
-1947-12-31,LU,Luxembourg,
-1947-12-31,LV,Latvia,
-1947-12-31,MA,Morocco,
-1947-12-31,MK,North Macedonia,
-1947-12-31,MT,Malta,
-1947-12-31,MX,Mexico,
-1947-12-31,MY,Malaysia,
-1947-12-31,NL,Netherlands,
-1947-12-31,NO,Norway,
-1947-12-31,NZ,New Zealand,
-1947-12-31,PE,Peru,
-1947-12-31,PH,Philippines,
-1947-12-31,PL,Poland,
-1947-12-31,PT,Portugal,
-1947-12-31,RO,Romania,
-1947-12-31,RS,Serbia,
-1947-12-31,RU,Russia,
-1947-12-31,SE,Sweden,
-1947-12-31,SG,Singapore,
-1947-12-31,SI,Slovenia,
-1947-12-31,SK,Slovak Republic,
-1947-12-31,TH,Thailand,
-1947-12-31,TR,Türkiye,
-1947-12-31,US,United States,
-1947-12-31,XM,Euro area,
-1947-12-31,XW,World,
-1947-12-31,ZA,South Africa,
-1948-03-31,4T,Emerging market economies (aggregate),
-1948-03-31,5R,Advanced economies,
-1948-03-31,AE,United Arab Emirates,
-1948-03-31,AT,Austria,
-1948-03-31,AU,Australia,
-1948-03-31,BE,Belgium,
-1948-03-31,BG,Bulgaria,
-1948-03-31,BR,Brazil,
-1948-03-31,CA,Canada,
-1948-03-31,CH,Switzerland,
-1948-03-31,CL,Chile,
-1948-03-31,CN,China,
-1948-03-31,CO,Colombia,
-1948-03-31,CY,Cyprus,
-1948-03-31,CZ,Czechia,
-1948-03-31,DE,Germany,
-1948-03-31,DK,Denmark,
-1948-03-31,EE,Estonia,
-1948-03-31,ES,Spain,
-1948-03-31,FI,Finland,
-1948-03-31,FR,France,
-1948-03-31,GB,United Kingdom,
-1948-03-31,GR,Greece,
-1948-03-31,HK,Hong Kong SAR,
-1948-03-31,HR,Croatia,
-1948-03-31,HU,Hungary,
-1948-03-31,ID,Indonesia,
-1948-03-31,IE,Ireland,
-1948-03-31,IL,Israel,
-1948-03-31,IN,India,
-1948-03-31,IS,Iceland,
-1948-03-31,IT,Italy,37.114
-1948-03-31,JP,Japan,
-1948-03-31,KR,Korea,
-1948-03-31,LT,Lithuania,
-1948-03-31,LU,Luxembourg,
-1948-03-31,LV,Latvia,
-1948-03-31,MA,Morocco,
-1948-03-31,MK,North Macedonia,
-1948-03-31,MT,Malta,
-1948-03-31,MX,Mexico,
-1948-03-31,MY,Malaysia,
-1948-03-31,NL,Netherlands,
-1948-03-31,NO,Norway,
-1948-03-31,NZ,New Zealand,
-1948-03-31,PE,Peru,
-1948-03-31,PH,Philippines,
-1948-03-31,PL,Poland,
-1948-03-31,PT,Portugal,
-1948-03-31,RO,Romania,
-1948-03-31,RS,Serbia,
-1948-03-31,RU,Russia,
-1948-03-31,SE,Sweden,
-1948-03-31,SG,Singapore,
-1948-03-31,SI,Slovenia,
-1948-03-31,SK,Slovak Republic,
-1948-03-31,TH,Thailand,
-1948-03-31,TR,Türkiye,
-1948-03-31,US,United States,
-1948-03-31,XM,Euro area,
-1948-03-31,XW,World,
-1948-03-31,ZA,South Africa,
-1948-06-30,4T,Emerging market economies (aggregate),
-1948-06-30,5R,Advanced economies,
-1948-06-30,AE,United Arab Emirates,
-1948-06-30,AT,Austria,
-1948-06-30,AU,Australia,
-1948-06-30,BE,Belgium,
-1948-06-30,BG,Bulgaria,
-1948-06-30,BR,Brazil,
-1948-06-30,CA,Canada,
-1948-06-30,CH,Switzerland,
-1948-06-30,CL,Chile,
-1948-06-30,CN,China,
-1948-06-30,CO,Colombia,
-1948-06-30,CY,Cyprus,
-1948-06-30,CZ,Czechia,
-1948-06-30,DE,Germany,
-1948-06-30,DK,Denmark,
-1948-06-30,EE,Estonia,
-1948-06-30,ES,Spain,
-1948-06-30,FI,Finland,
-1948-06-30,FR,France,
-1948-06-30,GB,United Kingdom,
-1948-06-30,GR,Greece,
-1948-06-30,HK,Hong Kong SAR,
-1948-06-30,HR,Croatia,
-1948-06-30,HU,Hungary,
-1948-06-30,ID,Indonesia,
-1948-06-30,IE,Ireland,
-1948-06-30,IL,Israel,
-1948-06-30,IN,India,
-1948-06-30,IS,Iceland,
-1948-06-30,IT,Italy,27.8783
-1948-06-30,JP,Japan,
-1948-06-30,KR,Korea,
-1948-06-30,LT,Lithuania,
-1948-06-30,LU,Luxembourg,
-1948-06-30,LV,Latvia,
-1948-06-30,MA,Morocco,
-1948-06-30,MK,North Macedonia,
-1948-06-30,MT,Malta,
-1948-06-30,MX,Mexico,
-1948-06-30,MY,Malaysia,
-1948-06-30,NL,Netherlands,
-1948-06-30,NO,Norway,
-1948-06-30,NZ,New Zealand,
-1948-06-30,PE,Peru,
-1948-06-30,PH,Philippines,
-1948-06-30,PL,Poland,
-1948-06-30,PT,Portugal,
-1948-06-30,RO,Romania,
-1948-06-30,RS,Serbia,
-1948-06-30,RU,Russia,
-1948-06-30,SE,Sweden,
-1948-06-30,SG,Singapore,
-1948-06-30,SI,Slovenia,
-1948-06-30,SK,Slovak Republic,
-1948-06-30,TH,Thailand,
-1948-06-30,TR,Türkiye,
-1948-06-30,US,United States,
-1948-06-30,XM,Euro area,
-1948-06-30,XW,World,
-1948-06-30,ZA,South Africa,
-1948-09-30,4T,Emerging market economies (aggregate),
-1948-09-30,5R,Advanced economies,
-1948-09-30,AE,United Arab Emirates,
-1948-09-30,AT,Austria,
-1948-09-30,AU,Australia,
-1948-09-30,BE,Belgium,
-1948-09-30,BG,Bulgaria,
-1948-09-30,BR,Brazil,
-1948-09-30,CA,Canada,
-1948-09-30,CH,Switzerland,
-1948-09-30,CL,Chile,
-1948-09-30,CN,China,
-1948-09-30,CO,Colombia,
-1948-09-30,CY,Cyprus,
-1948-09-30,CZ,Czechia,
-1948-09-30,DE,Germany,
-1948-09-30,DK,Denmark,
-1948-09-30,EE,Estonia,
-1948-09-30,ES,Spain,
-1948-09-30,FI,Finland,
-1948-09-30,FR,France,
-1948-09-30,GB,United Kingdom,
-1948-09-30,GR,Greece,
-1948-09-30,HK,Hong Kong SAR,
-1948-09-30,HR,Croatia,
-1948-09-30,HU,Hungary,
-1948-09-30,ID,Indonesia,
-1948-09-30,IE,Ireland,
-1948-09-30,IL,Israel,
-1948-09-30,IN,India,
-1948-09-30,IS,Iceland,
-1948-09-30,IT,Italy,10.1533
-1948-09-30,JP,Japan,
-1948-09-30,KR,Korea,
-1948-09-30,LT,Lithuania,
-1948-09-30,LU,Luxembourg,
-1948-09-30,LV,Latvia,
-1948-09-30,MA,Morocco,
-1948-09-30,MK,North Macedonia,
-1948-09-30,MT,Malta,
-1948-09-30,MX,Mexico,
-1948-09-30,MY,Malaysia,
-1948-09-30,NL,Netherlands,
-1948-09-30,NO,Norway,
-1948-09-30,NZ,New Zealand,
-1948-09-30,PE,Peru,
-1948-09-30,PH,Philippines,
-1948-09-30,PL,Poland,
-1948-09-30,PT,Portugal,
-1948-09-30,RO,Romania,
-1948-09-30,RS,Serbia,
-1948-09-30,RU,Russia,
-1948-09-30,SE,Sweden,
-1948-09-30,SG,Singapore,
-1948-09-30,SI,Slovenia,
-1948-09-30,SK,Slovak Republic,
-1948-09-30,TH,Thailand,
-1948-09-30,TR,Türkiye,
-1948-09-30,US,United States,
-1948-09-30,XM,Euro area,
-1948-09-30,XW,World,
-1948-09-30,ZA,South Africa,
-1948-12-31,4T,Emerging market economies (aggregate),
-1948-12-31,5R,Advanced economies,
-1948-12-31,AE,United Arab Emirates,
-1948-12-31,AT,Austria,
-1948-12-31,AU,Australia,
-1948-12-31,BE,Belgium,
-1948-12-31,BG,Bulgaria,
-1948-12-31,BR,Brazil,
-1948-12-31,CA,Canada,
-1948-12-31,CH,Switzerland,
-1948-12-31,CL,Chile,
-1948-12-31,CN,China,
-1948-12-31,CO,Colombia,
-1948-12-31,CY,Cyprus,
-1948-12-31,CZ,Czechia,
-1948-12-31,DE,Germany,
-1948-12-31,DK,Denmark,
-1948-12-31,EE,Estonia,
-1948-12-31,ES,Spain,
-1948-12-31,FI,Finland,
-1948-12-31,FR,France,
-1948-12-31,GB,United Kingdom,
-1948-12-31,GR,Greece,
-1948-12-31,HK,Hong Kong SAR,
-1948-12-31,HR,Croatia,
-1948-12-31,HU,Hungary,
-1948-12-31,ID,Indonesia,
-1948-12-31,IE,Ireland,
-1948-12-31,IL,Israel,
-1948-12-31,IN,India,
-1948-12-31,IS,Iceland,
-1948-12-31,IT,Italy,7.8158
-1948-12-31,JP,Japan,
-1948-12-31,KR,Korea,
-1948-12-31,LT,Lithuania,
-1948-12-31,LU,Luxembourg,
-1948-12-31,LV,Latvia,
-1948-12-31,MA,Morocco,
-1948-12-31,MK,North Macedonia,
-1948-12-31,MT,Malta,
-1948-12-31,MX,Mexico,
-1948-12-31,MY,Malaysia,
-1948-12-31,NL,Netherlands,
-1948-12-31,NO,Norway,
-1948-12-31,NZ,New Zealand,
-1948-12-31,PE,Peru,
-1948-12-31,PH,Philippines,
-1948-12-31,PL,Poland,
-1948-12-31,PT,Portugal,
-1948-12-31,RO,Romania,
-1948-12-31,RS,Serbia,
-1948-12-31,RU,Russia,
-1948-12-31,SE,Sweden,
-1948-12-31,SG,Singapore,
-1948-12-31,SI,Slovenia,
-1948-12-31,SK,Slovak Republic,
-1948-12-31,TH,Thailand,
-1948-12-31,TR,Türkiye,
-1948-12-31,US,United States,
-1948-12-31,XM,Euro area,
-1948-12-31,XW,World,
-1948-12-31,ZA,South Africa,
-1949-03-31,4T,Emerging market economies (aggregate),
-1949-03-31,5R,Advanced economies,
-1949-03-31,AE,United Arab Emirates,
-1949-03-31,AT,Austria,
-1949-03-31,AU,Australia,
-1949-03-31,BE,Belgium,
-1949-03-31,BG,Bulgaria,
-1949-03-31,BR,Brazil,
-1949-03-31,CA,Canada,
-1949-03-31,CH,Switzerland,
-1949-03-31,CL,Chile,
-1949-03-31,CN,China,
-1949-03-31,CO,Colombia,
-1949-03-31,CY,Cyprus,
-1949-03-31,CZ,Czechia,
-1949-03-31,DE,Germany,
-1949-03-31,DK,Denmark,
-1949-03-31,EE,Estonia,
-1949-03-31,ES,Spain,
-1949-03-31,FI,Finland,
-1949-03-31,FR,France,
-1949-03-31,GB,United Kingdom,
-1949-03-31,GR,Greece,
-1949-03-31,HK,Hong Kong SAR,
-1949-03-31,HR,Croatia,
-1949-03-31,HU,Hungary,
-1949-03-31,ID,Indonesia,
-1949-03-31,IE,Ireland,
-1949-03-31,IL,Israel,
-1949-03-31,IN,India,
-1949-03-31,IS,Iceland,
-1949-03-31,IT,Italy,0.7185
-1949-03-31,JP,Japan,
-1949-03-31,KR,Korea,
-1949-03-31,LT,Lithuania,
-1949-03-31,LU,Luxembourg,
-1949-03-31,LV,Latvia,
-1949-03-31,MA,Morocco,
-1949-03-31,MK,North Macedonia,
-1949-03-31,MT,Malta,
-1949-03-31,MX,Mexico,
-1949-03-31,MY,Malaysia,
-1949-03-31,NL,Netherlands,
-1949-03-31,NO,Norway,
-1949-03-31,NZ,New Zealand,
-1949-03-31,PE,Peru,
-1949-03-31,PH,Philippines,
-1949-03-31,PL,Poland,
-1949-03-31,PT,Portugal,
-1949-03-31,RO,Romania,
-1949-03-31,RS,Serbia,
-1949-03-31,RU,Russia,
-1949-03-31,SE,Sweden,
-1949-03-31,SG,Singapore,
-1949-03-31,SI,Slovenia,
-1949-03-31,SK,Slovak Republic,
-1949-03-31,TH,Thailand,
-1949-03-31,TR,Türkiye,
-1949-03-31,US,United States,
-1949-03-31,XM,Euro area,
-1949-03-31,XW,World,
-1949-03-31,ZA,South Africa,
-1949-06-30,4T,Emerging market economies (aggregate),
-1949-06-30,5R,Advanced economies,
-1949-06-30,AE,United Arab Emirates,
-1949-06-30,AT,Austria,
-1949-06-30,AU,Australia,
-1949-06-30,BE,Belgium,
-1949-06-30,BG,Bulgaria,
-1949-06-30,BR,Brazil,
-1949-06-30,CA,Canada,
-1949-06-30,CH,Switzerland,
-1949-06-30,CL,Chile,
-1949-06-30,CN,China,
-1949-06-30,CO,Colombia,
-1949-06-30,CY,Cyprus,
-1949-06-30,CZ,Czechia,
-1949-06-30,DE,Germany,
-1949-06-30,DK,Denmark,
-1949-06-30,EE,Estonia,
-1949-06-30,ES,Spain,
-1949-06-30,FI,Finland,
-1949-06-30,FR,France,
-1949-06-30,GB,United Kingdom,
-1949-06-30,GR,Greece,
-1949-06-30,HK,Hong Kong SAR,
-1949-06-30,HR,Croatia,
-1949-06-30,HU,Hungary,
-1949-06-30,ID,Indonesia,
-1949-06-30,IE,Ireland,
-1949-06-30,IL,Israel,
-1949-06-30,IN,India,
-1949-06-30,IS,Iceland,
-1949-06-30,IT,Italy,-1.8966
-1949-06-30,JP,Japan,
-1949-06-30,KR,Korea,
-1949-06-30,LT,Lithuania,
-1949-06-30,LU,Luxembourg,
-1949-06-30,LV,Latvia,
-1949-06-30,MA,Morocco,
-1949-06-30,MK,North Macedonia,
-1949-06-30,MT,Malta,
-1949-06-30,MX,Mexico,
-1949-06-30,MY,Malaysia,
-1949-06-30,NL,Netherlands,
-1949-06-30,NO,Norway,
-1949-06-30,NZ,New Zealand,
-1949-06-30,PE,Peru,
-1949-06-30,PH,Philippines,
-1949-06-30,PL,Poland,
-1949-06-30,PT,Portugal,
-1949-06-30,RO,Romania,
-1949-06-30,RS,Serbia,
-1949-06-30,RU,Russia,
-1949-06-30,SE,Sweden,
-1949-06-30,SG,Singapore,
-1949-06-30,SI,Slovenia,
-1949-06-30,SK,Slovak Republic,
-1949-06-30,TH,Thailand,
-1949-06-30,TR,Türkiye,
-1949-06-30,US,United States,
-1949-06-30,XM,Euro area,
-1949-06-30,XW,World,
-1949-06-30,ZA,South Africa,
-1949-09-30,4T,Emerging market economies (aggregate),
-1949-09-30,5R,Advanced economies,
-1949-09-30,AE,United Arab Emirates,
-1949-09-30,AT,Austria,
-1949-09-30,AU,Australia,
-1949-09-30,BE,Belgium,
-1949-09-30,BG,Bulgaria,
-1949-09-30,BR,Brazil,
-1949-09-30,CA,Canada,
-1949-09-30,CH,Switzerland,
-1949-09-30,CL,Chile,
-1949-09-30,CN,China,
-1949-09-30,CO,Colombia,
-1949-09-30,CY,Cyprus,
-1949-09-30,CZ,Czechia,
-1949-09-30,DE,Germany,
-1949-09-30,DK,Denmark,
-1949-09-30,EE,Estonia,
-1949-09-30,ES,Spain,
-1949-09-30,FI,Finland,
-1949-09-30,FR,France,
-1949-09-30,GB,United Kingdom,
-1949-09-30,GR,Greece,
-1949-09-30,HK,Hong Kong SAR,
-1949-09-30,HR,Croatia,
-1949-09-30,HU,Hungary,
-1949-09-30,ID,Indonesia,
-1949-09-30,IE,Ireland,
-1949-09-30,IL,Israel,
-1949-09-30,IN,India,
-1949-09-30,IS,Iceland,
-1949-09-30,IT,Italy,-3.0086
-1949-09-30,JP,Japan,
-1949-09-30,KR,Korea,
-1949-09-30,LT,Lithuania,
-1949-09-30,LU,Luxembourg,
-1949-09-30,LV,Latvia,
-1949-09-30,MA,Morocco,
-1949-09-30,MK,North Macedonia,
-1949-09-30,MT,Malta,
-1949-09-30,MX,Mexico,
-1949-09-30,MY,Malaysia,
-1949-09-30,NL,Netherlands,
-1949-09-30,NO,Norway,
-1949-09-30,NZ,New Zealand,
-1949-09-30,PE,Peru,
-1949-09-30,PH,Philippines,
-1949-09-30,PL,Poland,
-1949-09-30,PT,Portugal,
-1949-09-30,RO,Romania,
-1949-09-30,RS,Serbia,
-1949-09-30,RU,Russia,
-1949-09-30,SE,Sweden,
-1949-09-30,SG,Singapore,
-1949-09-30,SI,Slovenia,
-1949-09-30,SK,Slovak Republic,
-1949-09-30,TH,Thailand,
-1949-09-30,TR,Türkiye,
-1949-09-30,US,United States,
-1949-09-30,XM,Euro area,
-1949-09-30,XW,World,
-1949-09-30,ZA,South Africa,
-1949-12-31,4T,Emerging market economies (aggregate),
-1949-12-31,5R,Advanced economies,
-1949-12-31,AE,United Arab Emirates,
-1949-12-31,AT,Austria,
-1949-12-31,AU,Australia,
-1949-12-31,BE,Belgium,
-1949-12-31,BG,Bulgaria,
-1949-12-31,BR,Brazil,
-1949-12-31,CA,Canada,
-1949-12-31,CH,Switzerland,
-1949-12-31,CL,Chile,
-1949-12-31,CN,China,
-1949-12-31,CO,Colombia,
-1949-12-31,CY,Cyprus,
-1949-12-31,CZ,Czechia,
-1949-12-31,DE,Germany,
-1949-12-31,DK,Denmark,
-1949-12-31,EE,Estonia,
-1949-12-31,ES,Spain,
-1949-12-31,FI,Finland,
-1949-12-31,FR,France,
-1949-12-31,GB,United Kingdom,
-1949-12-31,GR,Greece,
-1949-12-31,HK,Hong Kong SAR,
-1949-12-31,HR,Croatia,
-1949-12-31,HU,Hungary,
-1949-12-31,ID,Indonesia,
-1949-12-31,IE,Ireland,
-1949-12-31,IL,Israel,
-1949-12-31,IN,India,
-1949-12-31,IS,Iceland,
-1949-12-31,IT,Italy,-9.44
-1949-12-31,JP,Japan,
-1949-12-31,KR,Korea,
-1949-12-31,LT,Lithuania,
-1949-12-31,LU,Luxembourg,
-1949-12-31,LV,Latvia,
-1949-12-31,MA,Morocco,
-1949-12-31,MK,North Macedonia,
-1949-12-31,MT,Malta,
-1949-12-31,MX,Mexico,
-1949-12-31,MY,Malaysia,
-1949-12-31,NL,Netherlands,
-1949-12-31,NO,Norway,
-1949-12-31,NZ,New Zealand,
-1949-12-31,PE,Peru,
-1949-12-31,PH,Philippines,
-1949-12-31,PL,Poland,
-1949-12-31,PT,Portugal,
-1949-12-31,RO,Romania,
-1949-12-31,RS,Serbia,
-1949-12-31,RU,Russia,
-1949-12-31,SE,Sweden,
-1949-12-31,SG,Singapore,
-1949-12-31,SI,Slovenia,
-1949-12-31,SK,Slovak Republic,
-1949-12-31,TH,Thailand,
-1949-12-31,TR,Türkiye,
-1949-12-31,US,United States,
-1949-12-31,XM,Euro area,
-1949-12-31,XW,World,
-1949-12-31,ZA,South Africa,
-1950-03-31,4T,Emerging market economies (aggregate),
-1950-03-31,5R,Advanced economies,
-1950-03-31,AE,United Arab Emirates,
-1950-03-31,AT,Austria,
-1950-03-31,AU,Australia,
-1950-03-31,BE,Belgium,
-1950-03-31,BG,Bulgaria,
-1950-03-31,BR,Brazil,
-1950-03-31,CA,Canada,
-1950-03-31,CH,Switzerland,
-1950-03-31,CL,Chile,
-1950-03-31,CN,China,
-1950-03-31,CO,Colombia,
-1950-03-31,CY,Cyprus,
-1950-03-31,CZ,Czechia,
-1950-03-31,DE,Germany,
-1950-03-31,DK,Denmark,
-1950-03-31,EE,Estonia,
-1950-03-31,ES,Spain,
-1950-03-31,FI,Finland,
-1950-03-31,FR,France,
-1950-03-31,GB,United Kingdom,
-1950-03-31,GR,Greece,
-1950-03-31,HK,Hong Kong SAR,
-1950-03-31,HR,Croatia,
-1950-03-31,HU,Hungary,
-1950-03-31,ID,Indonesia,
-1950-03-31,IE,Ireland,
-1950-03-31,IL,Israel,
-1950-03-31,IN,India,
-1950-03-31,IS,Iceland,
-1950-03-31,IT,Italy,-12.0455
-1950-03-31,JP,Japan,
-1950-03-31,KR,Korea,
-1950-03-31,LT,Lithuania,
-1950-03-31,LU,Luxembourg,
-1950-03-31,LV,Latvia,
-1950-03-31,MA,Morocco,
-1950-03-31,MK,North Macedonia,
-1950-03-31,MT,Malta,
-1950-03-31,MX,Mexico,
-1950-03-31,MY,Malaysia,
-1950-03-31,NL,Netherlands,
-1950-03-31,NO,Norway,
-1950-03-31,NZ,New Zealand,
-1950-03-31,PE,Peru,
-1950-03-31,PH,Philippines,
-1950-03-31,PL,Poland,
-1950-03-31,PT,Portugal,
-1950-03-31,RO,Romania,
-1950-03-31,RS,Serbia,
-1950-03-31,RU,Russia,
-1950-03-31,SE,Sweden,
-1950-03-31,SG,Singapore,
-1950-03-31,SI,Slovenia,
-1950-03-31,SK,Slovak Republic,
-1950-03-31,TH,Thailand,
-1950-03-31,TR,Türkiye,
-1950-03-31,US,United States,
-1950-03-31,XM,Euro area,
-1950-03-31,XW,World,
-1950-03-31,ZA,South Africa,
-1950-06-30,4T,Emerging market economies (aggregate),
-1950-06-30,5R,Advanced economies,
-1950-06-30,AE,United Arab Emirates,
-1950-06-30,AT,Austria,
-1950-06-30,AU,Australia,
-1950-06-30,BE,Belgium,
-1950-06-30,BG,Bulgaria,
-1950-06-30,BR,Brazil,
-1950-06-30,CA,Canada,
-1950-06-30,CH,Switzerland,
-1950-06-30,CL,Chile,
-1950-06-30,CN,China,
-1950-06-30,CO,Colombia,
-1950-06-30,CY,Cyprus,
-1950-06-30,CZ,Czechia,
-1950-06-30,DE,Germany,
-1950-06-30,DK,Denmark,
-1950-06-30,EE,Estonia,
-1950-06-30,ES,Spain,
-1950-06-30,FI,Finland,
-1950-06-30,FR,France,
-1950-06-30,GB,United Kingdom,
-1950-06-30,GR,Greece,
-1950-06-30,HK,Hong Kong SAR,
-1950-06-30,HR,Croatia,
-1950-06-30,HU,Hungary,
-1950-06-30,ID,Indonesia,
-1950-06-30,IE,Ireland,
-1950-06-30,IL,Israel,
-1950-06-30,IN,India,
-1950-06-30,IS,Iceland,
-1950-06-30,IT,Italy,-6.4585
-1950-06-30,JP,Japan,
-1950-06-30,KR,Korea,
-1950-06-30,LT,Lithuania,
-1950-06-30,LU,Luxembourg,
-1950-06-30,LV,Latvia,
-1950-06-30,MA,Morocco,
-1950-06-30,MK,North Macedonia,
-1950-06-30,MT,Malta,
-1950-06-30,MX,Mexico,
-1950-06-30,MY,Malaysia,
-1950-06-30,NL,Netherlands,
-1950-06-30,NO,Norway,
-1950-06-30,NZ,New Zealand,
-1950-06-30,PE,Peru,
-1950-06-30,PH,Philippines,
-1950-06-30,PL,Poland,
-1950-06-30,PT,Portugal,
-1950-06-30,RO,Romania,
-1950-06-30,RS,Serbia,
-1950-06-30,RU,Russia,
-1950-06-30,SE,Sweden,
-1950-06-30,SG,Singapore,
-1950-06-30,SI,Slovenia,
-1950-06-30,SK,Slovak Republic,
-1950-06-30,TH,Thailand,
-1950-06-30,TR,Türkiye,
-1950-06-30,US,United States,
-1950-06-30,XM,Euro area,
-1950-06-30,XW,World,
-1950-06-30,ZA,South Africa,
-1950-09-30,4T,Emerging market economies (aggregate),
-1950-09-30,5R,Advanced economies,
-1950-09-30,AE,United Arab Emirates,
-1950-09-30,AT,Austria,
-1950-09-30,AU,Australia,
-1950-09-30,BE,Belgium,
-1950-09-30,BG,Bulgaria,
-1950-09-30,BR,Brazil,
-1950-09-30,CA,Canada,
-1950-09-30,CH,Switzerland,
-1950-09-30,CL,Chile,
-1950-09-30,CN,China,
-1950-09-30,CO,Colombia,
-1950-09-30,CY,Cyprus,
-1950-09-30,CZ,Czechia,
-1950-09-30,DE,Germany,
-1950-09-30,DK,Denmark,
-1950-09-30,EE,Estonia,
-1950-09-30,ES,Spain,
-1950-09-30,FI,Finland,
-1950-09-30,FR,France,
-1950-09-30,GB,United Kingdom,
-1950-09-30,GR,Greece,
-1950-09-30,HK,Hong Kong SAR,
-1950-09-30,HR,Croatia,
-1950-09-30,HU,Hungary,
-1950-09-30,ID,Indonesia,
-1950-09-30,IE,Ireland,
-1950-09-30,IL,Israel,
-1950-09-30,IN,India,
-1950-09-30,IS,Iceland,
-1950-09-30,IT,Italy,9.9578
-1950-09-30,JP,Japan,
-1950-09-30,KR,Korea,
-1950-09-30,LT,Lithuania,
-1950-09-30,LU,Luxembourg,
-1950-09-30,LV,Latvia,
-1950-09-30,MA,Morocco,
-1950-09-30,MK,North Macedonia,
-1950-09-30,MT,Malta,
-1950-09-30,MX,Mexico,
-1950-09-30,MY,Malaysia,
-1950-09-30,NL,Netherlands,
-1950-09-30,NO,Norway,
-1950-09-30,NZ,New Zealand,
-1950-09-30,PE,Peru,
-1950-09-30,PH,Philippines,
-1950-09-30,PL,Poland,
-1950-09-30,PT,Portugal,
-1950-09-30,RO,Romania,
-1950-09-30,RS,Serbia,
-1950-09-30,RU,Russia,
-1950-09-30,SE,Sweden,
-1950-09-30,SG,Singapore,
-1950-09-30,SI,Slovenia,
-1950-09-30,SK,Slovak Republic,
-1950-09-30,TH,Thailand,
-1950-09-30,TR,Türkiye,
-1950-09-30,US,United States,
-1950-09-30,XM,Euro area,
-1950-09-30,XW,World,
-1950-09-30,ZA,South Africa,
-1950-12-31,4T,Emerging market economies (aggregate),
-1950-12-31,5R,Advanced economies,
-1950-12-31,AE,United Arab Emirates,
-1950-12-31,AT,Austria,
-1950-12-31,AU,Australia,
-1950-12-31,BE,Belgium,
-1950-12-31,BG,Bulgaria,
-1950-12-31,BR,Brazil,
-1950-12-31,CA,Canada,
-1950-12-31,CH,Switzerland,
-1950-12-31,CL,Chile,
-1950-12-31,CN,China,
-1950-12-31,CO,Colombia,
-1950-12-31,CY,Cyprus,
-1950-12-31,CZ,Czechia,
-1950-12-31,DE,Germany,
-1950-12-31,DK,Denmark,
-1950-12-31,EE,Estonia,
-1950-12-31,ES,Spain,
-1950-12-31,FI,Finland,
-1950-12-31,FR,France,
-1950-12-31,GB,United Kingdom,
-1950-12-31,GR,Greece,
-1950-12-31,HK,Hong Kong SAR,
-1950-12-31,HR,Croatia,
-1950-12-31,HU,Hungary,
-1950-12-31,ID,Indonesia,
-1950-12-31,IE,Ireland,
-1950-12-31,IL,Israel,
-1950-12-31,IN,India,
-1950-12-31,IS,Iceland,
-1950-12-31,IT,Italy,16.1947
-1950-12-31,JP,Japan,
-1950-12-31,KR,Korea,
-1950-12-31,LT,Lithuania,
-1950-12-31,LU,Luxembourg,
-1950-12-31,LV,Latvia,
-1950-12-31,MA,Morocco,
-1950-12-31,MK,North Macedonia,
-1950-12-31,MT,Malta,
-1950-12-31,MX,Mexico,
-1950-12-31,MY,Malaysia,
-1950-12-31,NL,Netherlands,
-1950-12-31,NO,Norway,
-1950-12-31,NZ,New Zealand,
-1950-12-31,PE,Peru,
-1950-12-31,PH,Philippines,
-1950-12-31,PL,Poland,
-1950-12-31,PT,Portugal,
-1950-12-31,RO,Romania,
-1950-12-31,RS,Serbia,
-1950-12-31,RU,Russia,
-1950-12-31,SE,Sweden,
-1950-12-31,SG,Singapore,
-1950-12-31,SI,Slovenia,
-1950-12-31,SK,Slovak Republic,
-1950-12-31,TH,Thailand,
-1950-12-31,TR,Türkiye,
-1950-12-31,US,United States,
-1950-12-31,XM,Euro area,
-1950-12-31,XW,World,
-1950-12-31,ZA,South Africa,
-1951-03-31,4T,Emerging market economies (aggregate),
-1951-03-31,5R,Advanced economies,
-1951-03-31,AE,United Arab Emirates,
-1951-03-31,AT,Austria,
-1951-03-31,AU,Australia,
-1951-03-31,BE,Belgium,
-1951-03-31,BG,Bulgaria,
-1951-03-31,BR,Brazil,
-1951-03-31,CA,Canada,
-1951-03-31,CH,Switzerland,
-1951-03-31,CL,Chile,
-1951-03-31,CN,China,
-1951-03-31,CO,Colombia,
-1951-03-31,CY,Cyprus,
-1951-03-31,CZ,Czechia,
-1951-03-31,DE,Germany,
-1951-03-31,DK,Denmark,
-1951-03-31,EE,Estonia,
-1951-03-31,ES,Spain,
-1951-03-31,FI,Finland,
-1951-03-31,FR,France,
-1951-03-31,GB,United Kingdom,
-1951-03-31,GR,Greece,
-1951-03-31,HK,Hong Kong SAR,
-1951-03-31,HR,Croatia,
-1951-03-31,HU,Hungary,
-1951-03-31,ID,Indonesia,
-1951-03-31,IE,Ireland,
-1951-03-31,IL,Israel,
-1951-03-31,IN,India,
-1951-03-31,IS,Iceland,
-1951-03-31,IT,Italy,24.0236
-1951-03-31,JP,Japan,
-1951-03-31,KR,Korea,
-1951-03-31,LT,Lithuania,
-1951-03-31,LU,Luxembourg,
-1951-03-31,LV,Latvia,
-1951-03-31,MA,Morocco,
-1951-03-31,MK,North Macedonia,
-1951-03-31,MT,Malta,
-1951-03-31,MX,Mexico,
-1951-03-31,MY,Malaysia,
-1951-03-31,NL,Netherlands,
-1951-03-31,NO,Norway,
-1951-03-31,NZ,New Zealand,
-1951-03-31,PE,Peru,
-1951-03-31,PH,Philippines,
-1951-03-31,PL,Poland,
-1951-03-31,PT,Portugal,
-1951-03-31,RO,Romania,
-1951-03-31,RS,Serbia,
-1951-03-31,RU,Russia,
-1951-03-31,SE,Sweden,
-1951-03-31,SG,Singapore,
-1951-03-31,SI,Slovenia,
-1951-03-31,SK,Slovak Republic,
-1951-03-31,TH,Thailand,
-1951-03-31,TR,Türkiye,
-1951-03-31,US,United States,
-1951-03-31,XM,Euro area,
-1951-03-31,XW,World,
-1951-03-31,ZA,South Africa,
-1951-06-30,4T,Emerging market economies (aggregate),
-1951-06-30,5R,Advanced economies,
-1951-06-30,AE,United Arab Emirates,
-1951-06-30,AT,Austria,
-1951-06-30,AU,Australia,
-1951-06-30,BE,Belgium,
-1951-06-30,BG,Bulgaria,
-1951-06-30,BR,Brazil,
-1951-06-30,CA,Canada,
-1951-06-30,CH,Switzerland,
-1951-06-30,CL,Chile,
-1951-06-30,CN,China,
-1951-06-30,CO,Colombia,
-1951-06-30,CY,Cyprus,
-1951-06-30,CZ,Czechia,
-1951-06-30,DE,Germany,
-1951-06-30,DK,Denmark,
-1951-06-30,EE,Estonia,
-1951-06-30,ES,Spain,
-1951-06-30,FI,Finland,
-1951-06-30,FR,France,
-1951-06-30,GB,United Kingdom,
-1951-06-30,GR,Greece,
-1951-06-30,HK,Hong Kong SAR,
-1951-06-30,HR,Croatia,
-1951-06-30,HU,Hungary,
-1951-06-30,ID,Indonesia,
-1951-06-30,IE,Ireland,
-1951-06-30,IL,Israel,
-1951-06-30,IN,India,
-1951-06-30,IS,Iceland,
-1951-06-30,IT,Italy,24.653
-1951-06-30,JP,Japan,
-1951-06-30,KR,Korea,
-1951-06-30,LT,Lithuania,
-1951-06-30,LU,Luxembourg,
-1951-06-30,LV,Latvia,
-1951-06-30,MA,Morocco,
-1951-06-30,MK,North Macedonia,
-1951-06-30,MT,Malta,
-1951-06-30,MX,Mexico,
-1951-06-30,MY,Malaysia,
-1951-06-30,NL,Netherlands,
-1951-06-30,NO,Norway,
-1951-06-30,NZ,New Zealand,
-1951-06-30,PE,Peru,
-1951-06-30,PH,Philippines,
-1951-06-30,PL,Poland,
-1951-06-30,PT,Portugal,
-1951-06-30,RO,Romania,
-1951-06-30,RS,Serbia,
-1951-06-30,RU,Russia,
-1951-06-30,SE,Sweden,
-1951-06-30,SG,Singapore,
-1951-06-30,SI,Slovenia,
-1951-06-30,SK,Slovak Republic,
-1951-06-30,TH,Thailand,
-1951-06-30,TR,Türkiye,
-1951-06-30,US,United States,
-1951-06-30,XM,Euro area,
-1951-06-30,XW,World,
-1951-06-30,ZA,South Africa,
-1951-09-30,4T,Emerging market economies (aggregate),
-1951-09-30,5R,Advanced economies,
-1951-09-30,AE,United Arab Emirates,
-1951-09-30,AT,Austria,
-1951-09-30,AU,Australia,
-1951-09-30,BE,Belgium,
-1951-09-30,BG,Bulgaria,
-1951-09-30,BR,Brazil,
-1951-09-30,CA,Canada,
-1951-09-30,CH,Switzerland,
-1951-09-30,CL,Chile,
-1951-09-30,CN,China,
-1951-09-30,CO,Colombia,
-1951-09-30,CY,Cyprus,
-1951-09-30,CZ,Czechia,
-1951-09-30,DE,Germany,
-1951-09-30,DK,Denmark,
-1951-09-30,EE,Estonia,
-1951-09-30,ES,Spain,
-1951-09-30,FI,Finland,
-1951-09-30,FR,France,
-1951-09-30,GB,United Kingdom,
-1951-09-30,GR,Greece,
-1951-09-30,HK,Hong Kong SAR,
-1951-09-30,HR,Croatia,
-1951-09-30,HU,Hungary,
-1951-09-30,ID,Indonesia,
-1951-09-30,IE,Ireland,
-1951-09-30,IL,Israel,
-1951-09-30,IN,India,
-1951-09-30,IS,Iceland,
-1951-09-30,IT,Italy,15.0583
-1951-09-30,JP,Japan,
-1951-09-30,KR,Korea,
-1951-09-30,LT,Lithuania,
-1951-09-30,LU,Luxembourg,
-1951-09-30,LV,Latvia,
-1951-09-30,MA,Morocco,
-1951-09-30,MK,North Macedonia,
-1951-09-30,MT,Malta,
-1951-09-30,MX,Mexico,
-1951-09-30,MY,Malaysia,
-1951-09-30,NL,Netherlands,
-1951-09-30,NO,Norway,
-1951-09-30,NZ,New Zealand,
-1951-09-30,PE,Peru,
-1951-09-30,PH,Philippines,
-1951-09-30,PL,Poland,
-1951-09-30,PT,Portugal,
-1951-09-30,RO,Romania,
-1951-09-30,RS,Serbia,
-1951-09-30,RU,Russia,
-1951-09-30,SE,Sweden,
-1951-09-30,SG,Singapore,
-1951-09-30,SI,Slovenia,
-1951-09-30,SK,Slovak Republic,
-1951-09-30,TH,Thailand,
-1951-09-30,TR,Türkiye,
-1951-09-30,US,United States,
-1951-09-30,XM,Euro area,
-1951-09-30,XW,World,
-1951-09-30,ZA,South Africa,
-1951-12-31,4T,Emerging market economies (aggregate),
-1951-12-31,5R,Advanced economies,
-1951-12-31,AE,United Arab Emirates,
-1951-12-31,AT,Austria,
-1951-12-31,AU,Australia,
-1951-12-31,BE,Belgium,
-1951-12-31,BG,Bulgaria,
-1951-12-31,BR,Brazil,
-1951-12-31,CA,Canada,
-1951-12-31,CH,Switzerland,
-1951-12-31,CL,Chile,
-1951-12-31,CN,China,
-1951-12-31,CO,Colombia,
-1951-12-31,CY,Cyprus,
-1951-12-31,CZ,Czechia,
-1951-12-31,DE,Germany,
-1951-12-31,DK,Denmark,
-1951-12-31,EE,Estonia,
-1951-12-31,ES,Spain,
-1951-12-31,FI,Finland,
-1951-12-31,FR,France,
-1951-12-31,GB,United Kingdom,
-1951-12-31,GR,Greece,
-1951-12-31,HK,Hong Kong SAR,
-1951-12-31,HR,Croatia,
-1951-12-31,HU,Hungary,
-1951-12-31,ID,Indonesia,
-1951-12-31,IE,Ireland,
-1951-12-31,IL,Israel,
-1951-12-31,IN,India,
-1951-12-31,IS,Iceland,
-1951-12-31,IT,Italy,11.8967
-1951-12-31,JP,Japan,
-1951-12-31,KR,Korea,
-1951-12-31,LT,Lithuania,
-1951-12-31,LU,Luxembourg,
-1951-12-31,LV,Latvia,
-1951-12-31,MA,Morocco,
-1951-12-31,MK,North Macedonia,
-1951-12-31,MT,Malta,
-1951-12-31,MX,Mexico,
-1951-12-31,MY,Malaysia,
-1951-12-31,NL,Netherlands,
-1951-12-31,NO,Norway,
-1951-12-31,NZ,New Zealand,
-1951-12-31,PE,Peru,
-1951-12-31,PH,Philippines,
-1951-12-31,PL,Poland,
-1951-12-31,PT,Portugal,
-1951-12-31,RO,Romania,
-1951-12-31,RS,Serbia,
-1951-12-31,RU,Russia,
-1951-12-31,SE,Sweden,
-1951-12-31,SG,Singapore,
-1951-12-31,SI,Slovenia,
-1951-12-31,SK,Slovak Republic,
-1951-12-31,TH,Thailand,
-1951-12-31,TR,Türkiye,
-1951-12-31,US,United States,
-1951-12-31,XM,Euro area,
-1951-12-31,XW,World,
-1951-12-31,ZA,South Africa,
-1952-03-31,4T,Emerging market economies (aggregate),
-1952-03-31,5R,Advanced economies,
-1952-03-31,AE,United Arab Emirates,
-1952-03-31,AT,Austria,
-1952-03-31,AU,Australia,
-1952-03-31,BE,Belgium,
-1952-03-31,BG,Bulgaria,
-1952-03-31,BR,Brazil,
-1952-03-31,CA,Canada,
-1952-03-31,CH,Switzerland,
-1952-03-31,CL,Chile,
-1952-03-31,CN,China,
-1952-03-31,CO,Colombia,
-1952-03-31,CY,Cyprus,
-1952-03-31,CZ,Czechia,
-1952-03-31,DE,Germany,
-1952-03-31,DK,Denmark,
-1952-03-31,EE,Estonia,
-1952-03-31,ES,Spain,
-1952-03-31,FI,Finland,
-1952-03-31,FR,France,
-1952-03-31,GB,United Kingdom,
-1952-03-31,GR,Greece,
-1952-03-31,HK,Hong Kong SAR,
-1952-03-31,HR,Croatia,
-1952-03-31,HU,Hungary,
-1952-03-31,ID,Indonesia,
-1952-03-31,IE,Ireland,
-1952-03-31,IL,Israel,
-1952-03-31,IN,India,
-1952-03-31,IS,Iceland,
-1952-03-31,IT,Italy,4.8507
-1952-03-31,JP,Japan,
-1952-03-31,KR,Korea,
-1952-03-31,LT,Lithuania,
-1952-03-31,LU,Luxembourg,
-1952-03-31,LV,Latvia,
-1952-03-31,MA,Morocco,
-1952-03-31,MK,North Macedonia,
-1952-03-31,MT,Malta,
-1952-03-31,MX,Mexico,
-1952-03-31,MY,Malaysia,
-1952-03-31,NL,Netherlands,
-1952-03-31,NO,Norway,
-1952-03-31,NZ,New Zealand,
-1952-03-31,PE,Peru,
-1952-03-31,PH,Philippines,
-1952-03-31,PL,Poland,
-1952-03-31,PT,Portugal,
-1952-03-31,RO,Romania,
-1952-03-31,RS,Serbia,
-1952-03-31,RU,Russia,
-1952-03-31,SE,Sweden,
-1952-03-31,SG,Singapore,
-1952-03-31,SI,Slovenia,
-1952-03-31,SK,Slovak Republic,
-1952-03-31,TH,Thailand,
-1952-03-31,TR,Türkiye,
-1952-03-31,US,United States,
-1952-03-31,XM,Euro area,
-1952-03-31,XW,World,
-1952-03-31,ZA,South Africa,
-1952-06-30,4T,Emerging market economies (aggregate),
-1952-06-30,5R,Advanced economies,
-1952-06-30,AE,United Arab Emirates,
-1952-06-30,AT,Austria,
-1952-06-30,AU,Australia,
-1952-06-30,BE,Belgium,
-1952-06-30,BG,Bulgaria,
-1952-06-30,BR,Brazil,
-1952-06-30,CA,Canada,
-1952-06-30,CH,Switzerland,
-1952-06-30,CL,Chile,
-1952-06-30,CN,China,
-1952-06-30,CO,Colombia,
-1952-06-30,CY,Cyprus,
-1952-06-30,CZ,Czechia,
-1952-06-30,DE,Germany,
-1952-06-30,DK,Denmark,
-1952-06-30,EE,Estonia,
-1952-06-30,ES,Spain,
-1952-06-30,FI,Finland,
-1952-06-30,FR,France,
-1952-06-30,GB,United Kingdom,
-1952-06-30,GR,Greece,
-1952-06-30,HK,Hong Kong SAR,
-1952-06-30,HR,Croatia,
-1952-06-30,HU,Hungary,
-1952-06-30,ID,Indonesia,
-1952-06-30,IE,Ireland,
-1952-06-30,IL,Israel,
-1952-06-30,IN,India,
-1952-06-30,IS,Iceland,
-1952-06-30,IT,Italy,-0.8313
-1952-06-30,JP,Japan,
-1952-06-30,KR,Korea,
-1952-06-30,LT,Lithuania,
-1952-06-30,LU,Luxembourg,
-1952-06-30,LV,Latvia,
-1952-06-30,MA,Morocco,
-1952-06-30,MK,North Macedonia,
-1952-06-30,MT,Malta,
-1952-06-30,MX,Mexico,
-1952-06-30,MY,Malaysia,
-1952-06-30,NL,Netherlands,
-1952-06-30,NO,Norway,
-1952-06-30,NZ,New Zealand,
-1952-06-30,PE,Peru,
-1952-06-30,PH,Philippines,
-1952-06-30,PL,Poland,
-1952-06-30,PT,Portugal,
-1952-06-30,RO,Romania,
-1952-06-30,RS,Serbia,
-1952-06-30,RU,Russia,
-1952-06-30,SE,Sweden,
-1952-06-30,SG,Singapore,
-1952-06-30,SI,Slovenia,
-1952-06-30,SK,Slovak Republic,
-1952-06-30,TH,Thailand,
-1952-06-30,TR,Türkiye,
-1952-06-30,US,United States,
-1952-06-30,XM,Euro area,
-1952-06-30,XW,World,
-1952-06-30,ZA,South Africa,
-1952-09-30,4T,Emerging market economies (aggregate),
-1952-09-30,5R,Advanced economies,
-1952-09-30,AE,United Arab Emirates,
-1952-09-30,AT,Austria,
-1952-09-30,AU,Australia,
-1952-09-30,BE,Belgium,
-1952-09-30,BG,Bulgaria,
-1952-09-30,BR,Brazil,
-1952-09-30,CA,Canada,
-1952-09-30,CH,Switzerland,
-1952-09-30,CL,Chile,
-1952-09-30,CN,China,
-1952-09-30,CO,Colombia,
-1952-09-30,CY,Cyprus,
-1952-09-30,CZ,Czechia,
-1952-09-30,DE,Germany,
-1952-09-30,DK,Denmark,
-1952-09-30,EE,Estonia,
-1952-09-30,ES,Spain,
-1952-09-30,FI,Finland,
-1952-09-30,FR,France,
-1952-09-30,GB,United Kingdom,
-1952-09-30,GR,Greece,
-1952-09-30,HK,Hong Kong SAR,
-1952-09-30,HR,Croatia,
-1952-09-30,HU,Hungary,
-1952-09-30,ID,Indonesia,
-1952-09-30,IE,Ireland,
-1952-09-30,IL,Israel,
-1952-09-30,IN,India,
-1952-09-30,IS,Iceland,
-1952-09-30,IT,Italy,0.9382
-1952-09-30,JP,Japan,
-1952-09-30,KR,Korea,
-1952-09-30,LT,Lithuania,
-1952-09-30,LU,Luxembourg,
-1952-09-30,LV,Latvia,
-1952-09-30,MA,Morocco,
-1952-09-30,MK,North Macedonia,
-1952-09-30,MT,Malta,
-1952-09-30,MX,Mexico,
-1952-09-30,MY,Malaysia,
-1952-09-30,NL,Netherlands,
-1952-09-30,NO,Norway,
-1952-09-30,NZ,New Zealand,
-1952-09-30,PE,Peru,
-1952-09-30,PH,Philippines,
-1952-09-30,PL,Poland,
-1952-09-30,PT,Portugal,
-1952-09-30,RO,Romania,
-1952-09-30,RS,Serbia,
-1952-09-30,RU,Russia,
-1952-09-30,SE,Sweden,
-1952-09-30,SG,Singapore,
-1952-09-30,SI,Slovenia,
-1952-09-30,SK,Slovak Republic,
-1952-09-30,TH,Thailand,
-1952-09-30,TR,Türkiye,
-1952-09-30,US,United States,
-1952-09-30,XM,Euro area,
-1952-09-30,XW,World,
-1952-09-30,ZA,South Africa,
-1952-12-31,4T,Emerging market economies (aggregate),
-1952-12-31,5R,Advanced economies,
-1952-12-31,AE,United Arab Emirates,
-1952-12-31,AT,Austria,
-1952-12-31,AU,Australia,
-1952-12-31,BE,Belgium,
-1952-12-31,BG,Bulgaria,
-1952-12-31,BR,Brazil,
-1952-12-31,CA,Canada,
-1952-12-31,CH,Switzerland,
-1952-12-31,CL,Chile,
-1952-12-31,CN,China,
-1952-12-31,CO,Colombia,
-1952-12-31,CY,Cyprus,
-1952-12-31,CZ,Czechia,
-1952-12-31,DE,Germany,
-1952-12-31,DK,Denmark,
-1952-12-31,EE,Estonia,
-1952-12-31,ES,Spain,
-1952-12-31,FI,Finland,
-1952-12-31,FR,France,
-1952-12-31,GB,United Kingdom,
-1952-12-31,GR,Greece,
-1952-12-31,HK,Hong Kong SAR,
-1952-12-31,HR,Croatia,
-1952-12-31,HU,Hungary,
-1952-12-31,ID,Indonesia,
-1952-12-31,IE,Ireland,
-1952-12-31,IL,Israel,
-1952-12-31,IN,India,
-1952-12-31,IS,Iceland,
-1952-12-31,IT,Italy,2.946
-1952-12-31,JP,Japan,
-1952-12-31,KR,Korea,
-1952-12-31,LT,Lithuania,
-1952-12-31,LU,Luxembourg,
-1952-12-31,LV,Latvia,
-1952-12-31,MA,Morocco,
-1952-12-31,MK,North Macedonia,
-1952-12-31,MT,Malta,
-1952-12-31,MX,Mexico,
-1952-12-31,MY,Malaysia,
-1952-12-31,NL,Netherlands,
-1952-12-31,NO,Norway,
-1952-12-31,NZ,New Zealand,
-1952-12-31,PE,Peru,
-1952-12-31,PH,Philippines,
-1952-12-31,PL,Poland,
-1952-12-31,PT,Portugal,
-1952-12-31,RO,Romania,
-1952-12-31,RS,Serbia,
-1952-12-31,RU,Russia,
-1952-12-31,SE,Sweden,
-1952-12-31,SG,Singapore,
-1952-12-31,SI,Slovenia,
-1952-12-31,SK,Slovak Republic,
-1952-12-31,TH,Thailand,
-1952-12-31,TR,Türkiye,
-1952-12-31,US,United States,
-1952-12-31,XM,Euro area,
-1952-12-31,XW,World,
-1952-12-31,ZA,South Africa,
-1953-03-31,4T,Emerging market economies (aggregate),
-1953-03-31,5R,Advanced economies,
-1953-03-31,AE,United Arab Emirates,
-1953-03-31,AT,Austria,
-1953-03-31,AU,Australia,
-1953-03-31,BE,Belgium,
-1953-03-31,BG,Bulgaria,
-1953-03-31,BR,Brazil,
-1953-03-31,CA,Canada,
-1953-03-31,CH,Switzerland,
-1953-03-31,CL,Chile,
-1953-03-31,CN,China,
-1953-03-31,CO,Colombia,
-1953-03-31,CY,Cyprus,
-1953-03-31,CZ,Czechia,
-1953-03-31,DE,Germany,
-1953-03-31,DK,Denmark,
-1953-03-31,EE,Estonia,
-1953-03-31,ES,Spain,
-1953-03-31,FI,Finland,
-1953-03-31,FR,France,
-1953-03-31,GB,United Kingdom,
-1953-03-31,GR,Greece,
-1953-03-31,HK,Hong Kong SAR,
-1953-03-31,HR,Croatia,
-1953-03-31,HU,Hungary,
-1953-03-31,ID,Indonesia,
-1953-03-31,IE,Ireland,
-1953-03-31,IL,Israel,
-1953-03-31,IN,India,
-1953-03-31,IS,Iceland,
-1953-03-31,IT,Italy,1.8342
-1953-03-31,JP,Japan,
-1953-03-31,KR,Korea,
-1953-03-31,LT,Lithuania,
-1953-03-31,LU,Luxembourg,
-1953-03-31,LV,Latvia,
-1953-03-31,MA,Morocco,
-1953-03-31,MK,North Macedonia,
-1953-03-31,MT,Malta,
-1953-03-31,MX,Mexico,
-1953-03-31,MY,Malaysia,
-1953-03-31,NL,Netherlands,
-1953-03-31,NO,Norway,
-1953-03-31,NZ,New Zealand,
-1953-03-31,PE,Peru,
-1953-03-31,PH,Philippines,
-1953-03-31,PL,Poland,
-1953-03-31,PT,Portugal,
-1953-03-31,RO,Romania,
-1953-03-31,RS,Serbia,
-1953-03-31,RU,Russia,
-1953-03-31,SE,Sweden,
-1953-03-31,SG,Singapore,
-1953-03-31,SI,Slovenia,
-1953-03-31,SK,Slovak Republic,
-1953-03-31,TH,Thailand,
-1953-03-31,TR,Türkiye,
-1953-03-31,US,United States,
-1953-03-31,XM,Euro area,
-1953-03-31,XW,World,
-1953-03-31,ZA,South Africa,
-1953-06-30,4T,Emerging market economies (aggregate),
-1953-06-30,5R,Advanced economies,
-1953-06-30,AE,United Arab Emirates,
-1953-06-30,AT,Austria,
-1953-06-30,AU,Australia,
-1953-06-30,BE,Belgium,
-1953-06-30,BG,Bulgaria,
-1953-06-30,BR,Brazil,
-1953-06-30,CA,Canada,
-1953-06-30,CH,Switzerland,
-1953-06-30,CL,Chile,
-1953-06-30,CN,China,
-1953-06-30,CO,Colombia,
-1953-06-30,CY,Cyprus,
-1953-06-30,CZ,Czechia,
-1953-06-30,DE,Germany,
-1953-06-30,DK,Denmark,
-1953-06-30,EE,Estonia,
-1953-06-30,ES,Spain,
-1953-06-30,FI,Finland,
-1953-06-30,FR,France,
-1953-06-30,GB,United Kingdom,
-1953-06-30,GR,Greece,
-1953-06-30,HK,Hong Kong SAR,
-1953-06-30,HR,Croatia,
-1953-06-30,HU,Hungary,
-1953-06-30,ID,Indonesia,
-1953-06-30,IE,Ireland,
-1953-06-30,IL,Israel,
-1953-06-30,IN,India,
-1953-06-30,IS,Iceland,
-1953-06-30,IT,Italy,3.4961
-1953-06-30,JP,Japan,
-1953-06-30,KR,Korea,
-1953-06-30,LT,Lithuania,
-1953-06-30,LU,Luxembourg,
-1953-06-30,LV,Latvia,
-1953-06-30,MA,Morocco,
-1953-06-30,MK,North Macedonia,
-1953-06-30,MT,Malta,
-1953-06-30,MX,Mexico,
-1953-06-30,MY,Malaysia,
-1953-06-30,NL,Netherlands,
-1953-06-30,NO,Norway,
-1953-06-30,NZ,New Zealand,
-1953-06-30,PE,Peru,
-1953-06-30,PH,Philippines,
-1953-06-30,PL,Poland,
-1953-06-30,PT,Portugal,
-1953-06-30,RO,Romania,
-1953-06-30,RS,Serbia,
-1953-06-30,RU,Russia,
-1953-06-30,SE,Sweden,
-1953-06-30,SG,Singapore,
-1953-06-30,SI,Slovenia,
-1953-06-30,SK,Slovak Republic,
-1953-06-30,TH,Thailand,
-1953-06-30,TR,Türkiye,
-1953-06-30,US,United States,
-1953-06-30,XM,Euro area,
-1953-06-30,XW,World,
-1953-06-30,ZA,South Africa,
-1953-09-30,4T,Emerging market economies (aggregate),
-1953-09-30,5R,Advanced economies,
-1953-09-30,AE,United Arab Emirates,
-1953-09-30,AT,Austria,
-1953-09-30,AU,Australia,
-1953-09-30,BE,Belgium,
-1953-09-30,BG,Bulgaria,
-1953-09-30,BR,Brazil,
-1953-09-30,CA,Canada,
-1953-09-30,CH,Switzerland,
-1953-09-30,CL,Chile,
-1953-09-30,CN,China,
-1953-09-30,CO,Colombia,
-1953-09-30,CY,Cyprus,
-1953-09-30,CZ,Czechia,
-1953-09-30,DE,Germany,
-1953-09-30,DK,Denmark,
-1953-09-30,EE,Estonia,
-1953-09-30,ES,Spain,
-1953-09-30,FI,Finland,
-1953-09-30,FR,France,
-1953-09-30,GB,United Kingdom,
-1953-09-30,GR,Greece,
-1953-09-30,HK,Hong Kong SAR,
-1953-09-30,HR,Croatia,
-1953-09-30,HU,Hungary,
-1953-09-30,ID,Indonesia,
-1953-09-30,IE,Ireland,
-1953-09-30,IL,Israel,
-1953-09-30,IN,India,
-1953-09-30,IS,Iceland,
-1953-09-30,IT,Italy,-1.5301
-1953-09-30,JP,Japan,
-1953-09-30,KR,Korea,
-1953-09-30,LT,Lithuania,
-1953-09-30,LU,Luxembourg,
-1953-09-30,LV,Latvia,
-1953-09-30,MA,Morocco,
-1953-09-30,MK,North Macedonia,
-1953-09-30,MT,Malta,
-1953-09-30,MX,Mexico,
-1953-09-30,MY,Malaysia,
-1953-09-30,NL,Netherlands,
-1953-09-30,NO,Norway,
-1953-09-30,NZ,New Zealand,
-1953-09-30,PE,Peru,
-1953-09-30,PH,Philippines,
-1953-09-30,PL,Poland,
-1953-09-30,PT,Portugal,
-1953-09-30,RO,Romania,
-1953-09-30,RS,Serbia,
-1953-09-30,RU,Russia,
-1953-09-30,SE,Sweden,
-1953-09-30,SG,Singapore,
-1953-09-30,SI,Slovenia,
-1953-09-30,SK,Slovak Republic,
-1953-09-30,TH,Thailand,
-1953-09-30,TR,Türkiye,
-1953-09-30,US,United States,
-1953-09-30,XM,Euro area,
-1953-09-30,XW,World,
-1953-09-30,ZA,South Africa,
-1953-12-31,4T,Emerging market economies (aggregate),
-1953-12-31,5R,Advanced economies,
-1953-12-31,AE,United Arab Emirates,
-1953-12-31,AT,Austria,
-1953-12-31,AU,Australia,
-1953-12-31,BE,Belgium,
-1953-12-31,BG,Bulgaria,
-1953-12-31,BR,Brazil,
-1953-12-31,CA,Canada,
-1953-12-31,CH,Switzerland,
-1953-12-31,CL,Chile,
-1953-12-31,CN,China,
-1953-12-31,CO,Colombia,
-1953-12-31,CY,Cyprus,
-1953-12-31,CZ,Czechia,
-1953-12-31,DE,Germany,
-1953-12-31,DK,Denmark,
-1953-12-31,EE,Estonia,
-1953-12-31,ES,Spain,
-1953-12-31,FI,Finland,
-1953-12-31,FR,France,
-1953-12-31,GB,United Kingdom,
-1953-12-31,GR,Greece,
-1953-12-31,HK,Hong Kong SAR,
-1953-12-31,HR,Croatia,
-1953-12-31,HU,Hungary,
-1953-12-31,ID,Indonesia,
-1953-12-31,IE,Ireland,
-1953-12-31,IL,Israel,
-1953-12-31,IN,India,
-1953-12-31,IS,Iceland,
-1953-12-31,IT,Italy,-0.4442
-1953-12-31,JP,Japan,
-1953-12-31,KR,Korea,
-1953-12-31,LT,Lithuania,
-1953-12-31,LU,Luxembourg,
-1953-12-31,LV,Latvia,
-1953-12-31,MA,Morocco,
-1953-12-31,MK,North Macedonia,
-1953-12-31,MT,Malta,
-1953-12-31,MX,Mexico,
-1953-12-31,MY,Malaysia,
-1953-12-31,NL,Netherlands,
-1953-12-31,NO,Norway,
-1953-12-31,NZ,New Zealand,
-1953-12-31,PE,Peru,
-1953-12-31,PH,Philippines,
-1953-12-31,PL,Poland,
-1953-12-31,PT,Portugal,
-1953-12-31,RO,Romania,
-1953-12-31,RS,Serbia,
-1953-12-31,RU,Russia,
-1953-12-31,SE,Sweden,
-1953-12-31,SG,Singapore,
-1953-12-31,SI,Slovenia,
-1953-12-31,SK,Slovak Republic,
-1953-12-31,TH,Thailand,
-1953-12-31,TR,Türkiye,
-1953-12-31,US,United States,
-1953-12-31,XM,Euro area,
-1953-12-31,XW,World,
-1953-12-31,ZA,South Africa,
-1954-03-31,4T,Emerging market economies (aggregate),
-1954-03-31,5R,Advanced economies,
-1954-03-31,AE,United Arab Emirates,
-1954-03-31,AT,Austria,
-1954-03-31,AU,Australia,
-1954-03-31,BE,Belgium,
-1954-03-31,BG,Bulgaria,
-1954-03-31,BR,Brazil,
-1954-03-31,CA,Canada,
-1954-03-31,CH,Switzerland,
-1954-03-31,CL,Chile,
-1954-03-31,CN,China,
-1954-03-31,CO,Colombia,
-1954-03-31,CY,Cyprus,
-1954-03-31,CZ,Czechia,
-1954-03-31,DE,Germany,
-1954-03-31,DK,Denmark,
-1954-03-31,EE,Estonia,
-1954-03-31,ES,Spain,
-1954-03-31,FI,Finland,
-1954-03-31,FR,France,
-1954-03-31,GB,United Kingdom,
-1954-03-31,GR,Greece,
-1954-03-31,HK,Hong Kong SAR,
-1954-03-31,HR,Croatia,
-1954-03-31,HU,Hungary,
-1954-03-31,ID,Indonesia,
-1954-03-31,IE,Ireland,
-1954-03-31,IL,Israel,
-1954-03-31,IN,India,
-1954-03-31,IS,Iceland,
-1954-03-31,IT,Italy,1.1943
-1954-03-31,JP,Japan,
-1954-03-31,KR,Korea,
-1954-03-31,LT,Lithuania,
-1954-03-31,LU,Luxembourg,
-1954-03-31,LV,Latvia,
-1954-03-31,MA,Morocco,
-1954-03-31,MK,North Macedonia,
-1954-03-31,MT,Malta,
-1954-03-31,MX,Mexico,
-1954-03-31,MY,Malaysia,
-1954-03-31,NL,Netherlands,
-1954-03-31,NO,Norway,
-1954-03-31,NZ,New Zealand,
-1954-03-31,PE,Peru,
-1954-03-31,PH,Philippines,
-1954-03-31,PL,Poland,
-1954-03-31,PT,Portugal,
-1954-03-31,RO,Romania,
-1954-03-31,RS,Serbia,
-1954-03-31,RU,Russia,
-1954-03-31,SE,Sweden,
-1954-03-31,SG,Singapore,
-1954-03-31,SI,Slovenia,
-1954-03-31,SK,Slovak Republic,
-1954-03-31,TH,Thailand,
-1954-03-31,TR,Türkiye,
-1954-03-31,US,United States,
-1954-03-31,XM,Euro area,
-1954-03-31,XW,World,
-1954-03-31,ZA,South Africa,
-1954-06-30,4T,Emerging market economies (aggregate),
-1954-06-30,5R,Advanced economies,
-1954-06-30,AE,United Arab Emirates,
-1954-06-30,AT,Austria,
-1954-06-30,AU,Australia,
-1954-06-30,BE,Belgium,
-1954-06-30,BG,Bulgaria,
-1954-06-30,BR,Brazil,
-1954-06-30,CA,Canada,
-1954-06-30,CH,Switzerland,
-1954-06-30,CL,Chile,
-1954-06-30,CN,China,
-1954-06-30,CO,Colombia,
-1954-06-30,CY,Cyprus,
-1954-06-30,CZ,Czechia,
-1954-06-30,DE,Germany,
-1954-06-30,DK,Denmark,
-1954-06-30,EE,Estonia,
-1954-06-30,ES,Spain,
-1954-06-30,FI,Finland,
-1954-06-30,FR,France,
-1954-06-30,GB,United Kingdom,
-1954-06-30,GR,Greece,
-1954-06-30,HK,Hong Kong SAR,
-1954-06-30,HR,Croatia,
-1954-06-30,HU,Hungary,
-1954-06-30,ID,Indonesia,
-1954-06-30,IE,Ireland,
-1954-06-30,IL,Israel,
-1954-06-30,IN,India,
-1954-06-30,IS,Iceland,
-1954-06-30,IT,Italy,2.2135
-1954-06-30,JP,Japan,
-1954-06-30,KR,Korea,
-1954-06-30,LT,Lithuania,
-1954-06-30,LU,Luxembourg,
-1954-06-30,LV,Latvia,
-1954-06-30,MA,Morocco,
-1954-06-30,MK,North Macedonia,
-1954-06-30,MT,Malta,
-1954-06-30,MX,Mexico,
-1954-06-30,MY,Malaysia,
-1954-06-30,NL,Netherlands,
-1954-06-30,NO,Norway,
-1954-06-30,NZ,New Zealand,
-1954-06-30,PE,Peru,
-1954-06-30,PH,Philippines,
-1954-06-30,PL,Poland,
-1954-06-30,PT,Portugal,
-1954-06-30,RO,Romania,
-1954-06-30,RS,Serbia,
-1954-06-30,RU,Russia,
-1954-06-30,SE,Sweden,
-1954-06-30,SG,Singapore,
-1954-06-30,SI,Slovenia,
-1954-06-30,SK,Slovak Republic,
-1954-06-30,TH,Thailand,
-1954-06-30,TR,Türkiye,
-1954-06-30,US,United States,
-1954-06-30,XM,Euro area,
-1954-06-30,XW,World,
-1954-06-30,ZA,South Africa,
-1954-09-30,4T,Emerging market economies (aggregate),
-1954-09-30,5R,Advanced economies,
-1954-09-30,AE,United Arab Emirates,
-1954-09-30,AT,Austria,
-1954-09-30,AU,Australia,
-1954-09-30,BE,Belgium,
-1954-09-30,BG,Bulgaria,
-1954-09-30,BR,Brazil,
-1954-09-30,CA,Canada,
-1954-09-30,CH,Switzerland,
-1954-09-30,CL,Chile,
-1954-09-30,CN,China,
-1954-09-30,CO,Colombia,
-1954-09-30,CY,Cyprus,
-1954-09-30,CZ,Czechia,
-1954-09-30,DE,Germany,
-1954-09-30,DK,Denmark,
-1954-09-30,EE,Estonia,
-1954-09-30,ES,Spain,
-1954-09-30,FI,Finland,
-1954-09-30,FR,France,
-1954-09-30,GB,United Kingdom,
-1954-09-30,GR,Greece,
-1954-09-30,HK,Hong Kong SAR,
-1954-09-30,HR,Croatia,
-1954-09-30,HU,Hungary,
-1954-09-30,ID,Indonesia,
-1954-09-30,IE,Ireland,
-1954-09-30,IL,Israel,
-1954-09-30,IN,India,
-1954-09-30,IS,Iceland,
-1954-09-30,IT,Italy,8.4619
-1954-09-30,JP,Japan,
-1954-09-30,KR,Korea,
-1954-09-30,LT,Lithuania,
-1954-09-30,LU,Luxembourg,
-1954-09-30,LV,Latvia,
-1954-09-30,MA,Morocco,
-1954-09-30,MK,North Macedonia,
-1954-09-30,MT,Malta,
-1954-09-30,MX,Mexico,
-1954-09-30,MY,Malaysia,
-1954-09-30,NL,Netherlands,
-1954-09-30,NO,Norway,
-1954-09-30,NZ,New Zealand,
-1954-09-30,PE,Peru,
-1954-09-30,PH,Philippines,
-1954-09-30,PL,Poland,
-1954-09-30,PT,Portugal,
-1954-09-30,RO,Romania,
-1954-09-30,RS,Serbia,
-1954-09-30,RU,Russia,
-1954-09-30,SE,Sweden,
-1954-09-30,SG,Singapore,
-1954-09-30,SI,Slovenia,
-1954-09-30,SK,Slovak Republic,
-1954-09-30,TH,Thailand,
-1954-09-30,TR,Türkiye,
-1954-09-30,US,United States,
-1954-09-30,XM,Euro area,
-1954-09-30,XW,World,
-1954-09-30,ZA,South Africa,
-1954-12-31,4T,Emerging market economies (aggregate),
-1954-12-31,5R,Advanced economies,
-1954-12-31,AE,United Arab Emirates,
-1954-12-31,AT,Austria,
-1954-12-31,AU,Australia,
-1954-12-31,BE,Belgium,
-1954-12-31,BG,Bulgaria,
-1954-12-31,BR,Brazil,
-1954-12-31,CA,Canada,
-1954-12-31,CH,Switzerland,
-1954-12-31,CL,Chile,
-1954-12-31,CN,China,
-1954-12-31,CO,Colombia,
-1954-12-31,CY,Cyprus,
-1954-12-31,CZ,Czechia,
-1954-12-31,DE,Germany,
-1954-12-31,DK,Denmark,
-1954-12-31,EE,Estonia,
-1954-12-31,ES,Spain,
-1954-12-31,FI,Finland,
-1954-12-31,FR,France,
-1954-12-31,GB,United Kingdom,
-1954-12-31,GR,Greece,
-1954-12-31,HK,Hong Kong SAR,
-1954-12-31,HR,Croatia,
-1954-12-31,HU,Hungary,
-1954-12-31,ID,Indonesia,
-1954-12-31,IE,Ireland,
-1954-12-31,IL,Israel,
-1954-12-31,IN,India,
-1954-12-31,IS,Iceland,
-1954-12-31,IT,Italy,5.5085
-1954-12-31,JP,Japan,
-1954-12-31,KR,Korea,
-1954-12-31,LT,Lithuania,
-1954-12-31,LU,Luxembourg,
-1954-12-31,LV,Latvia,
-1954-12-31,MA,Morocco,
-1954-12-31,MK,North Macedonia,
-1954-12-31,MT,Malta,
-1954-12-31,MX,Mexico,
-1954-12-31,MY,Malaysia,
-1954-12-31,NL,Netherlands,
-1954-12-31,NO,Norway,
-1954-12-31,NZ,New Zealand,
-1954-12-31,PE,Peru,
-1954-12-31,PH,Philippines,
-1954-12-31,PL,Poland,
-1954-12-31,PT,Portugal,
-1954-12-31,RO,Romania,
-1954-12-31,RS,Serbia,
-1954-12-31,RU,Russia,
-1954-12-31,SE,Sweden,
-1954-12-31,SG,Singapore,
-1954-12-31,SI,Slovenia,
-1954-12-31,SK,Slovak Republic,
-1954-12-31,TH,Thailand,
-1954-12-31,TR,Türkiye,
-1954-12-31,US,United States,
-1954-12-31,XM,Euro area,
-1954-12-31,XW,World,
-1954-12-31,ZA,South Africa,
-1955-03-31,4T,Emerging market economies (aggregate),
-1955-03-31,5R,Advanced economies,
-1955-03-31,AE,United Arab Emirates,
-1955-03-31,AT,Austria,
-1955-03-31,AU,Australia,
-1955-03-31,BE,Belgium,
-1955-03-31,BG,Bulgaria,
-1955-03-31,BR,Brazil,
-1955-03-31,CA,Canada,
-1955-03-31,CH,Switzerland,
-1955-03-31,CL,Chile,
-1955-03-31,CN,China,
-1955-03-31,CO,Colombia,
-1955-03-31,CY,Cyprus,
-1955-03-31,CZ,Czechia,
-1955-03-31,DE,Germany,
-1955-03-31,DK,Denmark,
-1955-03-31,EE,Estonia,
-1955-03-31,ES,Spain,
-1955-03-31,FI,Finland,
-1955-03-31,FR,France,
-1955-03-31,GB,United Kingdom,
-1955-03-31,GR,Greece,
-1955-03-31,HK,Hong Kong SAR,
-1955-03-31,HR,Croatia,
-1955-03-31,HU,Hungary,
-1955-03-31,ID,Indonesia,
-1955-03-31,IE,Ireland,
-1955-03-31,IL,Israel,
-1955-03-31,IN,India,
-1955-03-31,IS,Iceland,
-1955-03-31,IT,Italy,4.6373
-1955-03-31,JP,Japan,
-1955-03-31,KR,Korea,
-1955-03-31,LT,Lithuania,
-1955-03-31,LU,Luxembourg,
-1955-03-31,LV,Latvia,
-1955-03-31,MA,Morocco,
-1955-03-31,MK,North Macedonia,
-1955-03-31,MT,Malta,
-1955-03-31,MX,Mexico,
-1955-03-31,MY,Malaysia,
-1955-03-31,NL,Netherlands,
-1955-03-31,NO,Norway,
-1955-03-31,NZ,New Zealand,
-1955-03-31,PE,Peru,
-1955-03-31,PH,Philippines,
-1955-03-31,PL,Poland,
-1955-03-31,PT,Portugal,
-1955-03-31,RO,Romania,
-1955-03-31,RS,Serbia,
-1955-03-31,RU,Russia,
-1955-03-31,SE,Sweden,
-1955-03-31,SG,Singapore,
-1955-03-31,SI,Slovenia,
-1955-03-31,SK,Slovak Republic,
-1955-03-31,TH,Thailand,
-1955-03-31,TR,Türkiye,
-1955-03-31,US,United States,
-1955-03-31,XM,Euro area,
-1955-03-31,XW,World,
-1955-03-31,ZA,South Africa,
-1955-06-30,4T,Emerging market economies (aggregate),
-1955-06-30,5R,Advanced economies,
-1955-06-30,AE,United Arab Emirates,
-1955-06-30,AT,Austria,
-1955-06-30,AU,Australia,
-1955-06-30,BE,Belgium,
-1955-06-30,BG,Bulgaria,
-1955-06-30,BR,Brazil,
-1955-06-30,CA,Canada,
-1955-06-30,CH,Switzerland,
-1955-06-30,CL,Chile,
-1955-06-30,CN,China,
-1955-06-30,CO,Colombia,
-1955-06-30,CY,Cyprus,
-1955-06-30,CZ,Czechia,
-1955-06-30,DE,Germany,
-1955-06-30,DK,Denmark,
-1955-06-30,EE,Estonia,
-1955-06-30,ES,Spain,
-1955-06-30,FI,Finland,
-1955-06-30,FR,France,
-1955-06-30,GB,United Kingdom,
-1955-06-30,GR,Greece,
-1955-06-30,HK,Hong Kong SAR,
-1955-06-30,HR,Croatia,
-1955-06-30,HU,Hungary,
-1955-06-30,ID,Indonesia,
-1955-06-30,IE,Ireland,
-1955-06-30,IL,Israel,
-1955-06-30,IN,India,
-1955-06-30,IS,Iceland,
-1955-06-30,IT,Italy,4.4256
-1955-06-30,JP,Japan,
-1955-06-30,KR,Korea,
-1955-06-30,LT,Lithuania,
-1955-06-30,LU,Luxembourg,
-1955-06-30,LV,Latvia,
-1955-06-30,MA,Morocco,
-1955-06-30,MK,North Macedonia,
-1955-06-30,MT,Malta,
-1955-06-30,MX,Mexico,
-1955-06-30,MY,Malaysia,
-1955-06-30,NL,Netherlands,
-1955-06-30,NO,Norway,
-1955-06-30,NZ,New Zealand,
-1955-06-30,PE,Peru,
-1955-06-30,PH,Philippines,
-1955-06-30,PL,Poland,
-1955-06-30,PT,Portugal,
-1955-06-30,RO,Romania,
-1955-06-30,RS,Serbia,
-1955-06-30,RU,Russia,
-1955-06-30,SE,Sweden,
-1955-06-30,SG,Singapore,
-1955-06-30,SI,Slovenia,
-1955-06-30,SK,Slovak Republic,
-1955-06-30,TH,Thailand,
-1955-06-30,TR,Türkiye,
-1955-06-30,US,United States,
-1955-06-30,XM,Euro area,
-1955-06-30,XW,World,
-1955-06-30,ZA,South Africa,
-1955-09-30,4T,Emerging market economies (aggregate),
-1955-09-30,5R,Advanced economies,
-1955-09-30,AE,United Arab Emirates,
-1955-09-30,AT,Austria,
-1955-09-30,AU,Australia,
-1955-09-30,BE,Belgium,
-1955-09-30,BG,Bulgaria,
-1955-09-30,BR,Brazil,
-1955-09-30,CA,Canada,
-1955-09-30,CH,Switzerland,
-1955-09-30,CL,Chile,
-1955-09-30,CN,China,
-1955-09-30,CO,Colombia,
-1955-09-30,CY,Cyprus,
-1955-09-30,CZ,Czechia,
-1955-09-30,DE,Germany,
-1955-09-30,DK,Denmark,
-1955-09-30,EE,Estonia,
-1955-09-30,ES,Spain,
-1955-09-30,FI,Finland,
-1955-09-30,FR,France,
-1955-09-30,GB,United Kingdom,
-1955-09-30,GR,Greece,
-1955-09-30,HK,Hong Kong SAR,
-1955-09-30,HR,Croatia,
-1955-09-30,HU,Hungary,
-1955-09-30,ID,Indonesia,
-1955-09-30,IE,Ireland,
-1955-09-30,IL,Israel,
-1955-09-30,IN,India,
-1955-09-30,IS,Iceland,
-1955-09-30,IT,Italy,0.9574
-1955-09-30,JP,Japan,
-1955-09-30,KR,Korea,
-1955-09-30,LT,Lithuania,
-1955-09-30,LU,Luxembourg,
-1955-09-30,LV,Latvia,
-1955-09-30,MA,Morocco,
-1955-09-30,MK,North Macedonia,
-1955-09-30,MT,Malta,
-1955-09-30,MX,Mexico,
-1955-09-30,MY,Malaysia,
-1955-09-30,NL,Netherlands,
-1955-09-30,NO,Norway,
-1955-09-30,NZ,New Zealand,
-1955-09-30,PE,Peru,
-1955-09-30,PH,Philippines,
-1955-09-30,PL,Poland,
-1955-09-30,PT,Portugal,
-1955-09-30,RO,Romania,
-1955-09-30,RS,Serbia,
-1955-09-30,RU,Russia,
-1955-09-30,SE,Sweden,
-1955-09-30,SG,Singapore,
-1955-09-30,SI,Slovenia,
-1955-09-30,SK,Slovak Republic,
-1955-09-30,TH,Thailand,
-1955-09-30,TR,Türkiye,
-1955-09-30,US,United States,
-1955-09-30,XM,Euro area,
-1955-09-30,XW,World,
-1955-09-30,ZA,South Africa,
-1955-12-31,4T,Emerging market economies (aggregate),
-1955-12-31,5R,Advanced economies,
-1955-12-31,AE,United Arab Emirates,
-1955-12-31,AT,Austria,
-1955-12-31,AU,Australia,
-1955-12-31,BE,Belgium,
-1955-12-31,BG,Bulgaria,
-1955-12-31,BR,Brazil,
-1955-12-31,CA,Canada,
-1955-12-31,CH,Switzerland,
-1955-12-31,CL,Chile,
-1955-12-31,CN,China,
-1955-12-31,CO,Colombia,
-1955-12-31,CY,Cyprus,
-1955-12-31,CZ,Czechia,
-1955-12-31,DE,Germany,
-1955-12-31,DK,Denmark,
-1955-12-31,EE,Estonia,
-1955-12-31,ES,Spain,
-1955-12-31,FI,Finland,
-1955-12-31,FR,France,
-1955-12-31,GB,United Kingdom,
-1955-12-31,GR,Greece,
-1955-12-31,HK,Hong Kong SAR,
-1955-12-31,HR,Croatia,
-1955-12-31,HU,Hungary,
-1955-12-31,ID,Indonesia,
-1955-12-31,IE,Ireland,
-1955-12-31,IL,Israel,
-1955-12-31,IN,India,
-1955-12-31,IS,Iceland,
-1955-12-31,IT,Italy,-0.3866
-1955-12-31,JP,Japan,
-1955-12-31,KR,Korea,
-1955-12-31,LT,Lithuania,
-1955-12-31,LU,Luxembourg,
-1955-12-31,LV,Latvia,
-1955-12-31,MA,Morocco,
-1955-12-31,MK,North Macedonia,
-1955-12-31,MT,Malta,
-1955-12-31,MX,Mexico,
-1955-12-31,MY,Malaysia,
-1955-12-31,NL,Netherlands,
-1955-12-31,NO,Norway,
-1955-12-31,NZ,New Zealand,
-1955-12-31,PE,Peru,
-1955-12-31,PH,Philippines,
-1955-12-31,PL,Poland,
-1955-12-31,PT,Portugal,
-1955-12-31,RO,Romania,
-1955-12-31,RS,Serbia,
-1955-12-31,RU,Russia,
-1955-12-31,SE,Sweden,
-1955-12-31,SG,Singapore,
-1955-12-31,SI,Slovenia,
-1955-12-31,SK,Slovak Republic,
-1955-12-31,TH,Thailand,
-1955-12-31,TR,Türkiye,
-1955-12-31,US,United States,
-1955-12-31,XM,Euro area,
-1955-12-31,XW,World,
-1955-12-31,ZA,South Africa,
-1956-03-31,4T,Emerging market economies (aggregate),
-1956-03-31,5R,Advanced economies,
-1956-03-31,AE,United Arab Emirates,
-1956-03-31,AT,Austria,
-1956-03-31,AU,Australia,
-1956-03-31,BE,Belgium,
-1956-03-31,BG,Bulgaria,
-1956-03-31,BR,Brazil,
-1956-03-31,CA,Canada,
-1956-03-31,CH,Switzerland,
-1956-03-31,CL,Chile,
-1956-03-31,CN,China,
-1956-03-31,CO,Colombia,
-1956-03-31,CY,Cyprus,
-1956-03-31,CZ,Czechia,
-1956-03-31,DE,Germany,
-1956-03-31,DK,Denmark,
-1956-03-31,EE,Estonia,
-1956-03-31,ES,Spain,
-1956-03-31,FI,Finland,
-1956-03-31,FR,France,
-1956-03-31,GB,United Kingdom,
-1956-03-31,GR,Greece,
-1956-03-31,HK,Hong Kong SAR,
-1956-03-31,HR,Croatia,
-1956-03-31,HU,Hungary,
-1956-03-31,ID,Indonesia,
-1956-03-31,IE,Ireland,
-1956-03-31,IL,Israel,
-1956-03-31,IN,India,
-1956-03-31,IS,Iceland,
-1956-03-31,IT,Italy,3.7871
+1948-03-31,IT,Italy,37.5936
+1948-06-30,IT,Italy,28.1365
+1948-09-30,IT,Italy,9.6388
+1948-12-31,IT,Italy,7.6992
+1949-03-31,IT,Italy,0.5773
+1949-06-30,IT,Italy,-1.7416
+1949-09-30,IT,Italy,-2.7261
+1949-12-31,IT,Italy,-9.7517
+1950-03-31,IT,Italy,-12.6333
+1950-06-30,IT,Italy,-6.7646
+1950-09-30,IT,Italy,10.5288
+1950-12-31,IT,Italy,16.7474
+1951-03-31,IT,Italy,24.6606
+1951-06-30,IT,Italy,24.8103
+1951-09-30,IT,Italy,14.5897
+1951-12-31,IT,Italy,11.7181
+1952-03-31,IT,Italy,4.6438
+1952-06-30,IT,Italy,-1.0193
+1952-09-30,IT,Italy,1.067
+1952-12-31,IT,Italy,3.2035
+1953-03-31,IT,Italy,1.991
+1953-06-30,IT,Italy,3.7506
+1953-09-30,IT,Italy,-1.7047
+1953-12-31,IT,Italy,-0.6621
+1954-03-31,IT,Italy,3.5778
+1954-06-30,IT,Italy,0.5601
+1954-09-30,IT,Italy,6.7261
+1954-12-31,IT,Italy,6.5852
+1955-03-31,IT,Italy,4.6091
+1955-06-30,IT,Italy,3.8441
+1955-09-30,IT,Italy,1.5042
+1955-12-31,IT,Italy,-0.3631
+1956-03-31,IT,Italy,1.6428
 1956-03-31,JP,Japan,13.913
-1956-03-31,KR,Korea,
-1956-03-31,LT,Lithuania,
-1956-03-31,LU,Luxembourg,
-1956-03-31,LV,Latvia,
-1956-03-31,MA,Morocco,
-1956-03-31,MK,North Macedonia,
-1956-03-31,MT,Malta,
-1956-03-31,MX,Mexico,
-1956-03-31,MY,Malaysia,
-1956-03-31,NL,Netherlands,
-1956-03-31,NO,Norway,
-1956-03-31,NZ,New Zealand,
-1956-03-31,PE,Peru,
-1956-03-31,PH,Philippines,
-1956-03-31,PL,Poland,
-1956-03-31,PT,Portugal,
-1956-03-31,RO,Romania,
-1956-03-31,RS,Serbia,
-1956-03-31,RU,Russia,
-1956-03-31,SE,Sweden,
-1956-03-31,SG,Singapore,
-1956-03-31,SI,Slovenia,
-1956-03-31,SK,Slovak Republic,
-1956-03-31,TH,Thailand,
-1956-03-31,TR,Türkiye,
-1956-03-31,US,United States,
-1956-03-31,XM,Euro area,
-1956-03-31,XW,World,
-1956-03-31,ZA,South Africa,
-1956-06-30,4T,Emerging market economies (aggregate),
-1956-06-30,5R,Advanced economies,
-1956-06-30,AE,United Arab Emirates,
-1956-06-30,AT,Austria,
-1956-06-30,AU,Australia,
-1956-06-30,BE,Belgium,
-1956-06-30,BG,Bulgaria,
-1956-06-30,BR,Brazil,
-1956-06-30,CA,Canada,
-1956-06-30,CH,Switzerland,
-1956-06-30,CL,Chile,
-1956-06-30,CN,China,
-1956-06-30,CO,Colombia,
-1956-06-30,CY,Cyprus,
-1956-06-30,CZ,Czechia,
-1956-06-30,DE,Germany,
-1956-06-30,DK,Denmark,
-1956-06-30,EE,Estonia,
-1956-06-30,ES,Spain,
-1956-06-30,FI,Finland,
-1956-06-30,FR,France,
-1956-06-30,GB,United Kingdom,
-1956-06-30,GR,Greece,
-1956-06-30,HK,Hong Kong SAR,
-1956-06-30,HR,Croatia,
-1956-06-30,HU,Hungary,
-1956-06-30,ID,Indonesia,
-1956-06-30,IE,Ireland,
-1956-06-30,IL,Israel,
-1956-06-30,IN,India,
-1956-06-30,IS,Iceland,
-1956-06-30,IT,Italy,2.3562
+1956-06-30,IT,Italy,3.0299
 1956-06-30,JP,Japan,16.8967
-1956-06-30,KR,Korea,
-1956-06-30,LT,Lithuania,
-1956-06-30,LU,Luxembourg,
-1956-06-30,LV,Latvia,
-1956-06-30,MA,Morocco,
-1956-06-30,MK,North Macedonia,
-1956-06-30,MT,Malta,
-1956-06-30,MX,Mexico,
-1956-06-30,MY,Malaysia,
-1956-06-30,NL,Netherlands,
-1956-06-30,NO,Norway,
-1956-06-30,NZ,New Zealand,
-1956-06-30,PE,Peru,
-1956-06-30,PH,Philippines,
-1956-06-30,PL,Poland,
-1956-06-30,PT,Portugal,
-1956-06-30,RO,Romania,
-1956-06-30,RS,Serbia,
-1956-06-30,RU,Russia,
-1956-06-30,SE,Sweden,
-1956-06-30,SG,Singapore,
-1956-06-30,SI,Slovenia,
-1956-06-30,SK,Slovak Republic,
-1956-06-30,TH,Thailand,
-1956-06-30,TR,Türkiye,
-1956-06-30,US,United States,
-1956-06-30,XM,Euro area,
-1956-06-30,XW,World,
-1956-06-30,ZA,South Africa,
-1956-09-30,4T,Emerging market economies (aggregate),
-1956-09-30,5R,Advanced economies,
-1956-09-30,AE,United Arab Emirates,
-1956-09-30,AT,Austria,
-1956-09-30,AU,Australia,
-1956-09-30,BE,Belgium,
-1956-09-30,BG,Bulgaria,
-1956-09-30,BR,Brazil,
-1956-09-30,CA,Canada,
-1956-09-30,CH,Switzerland,
-1956-09-30,CL,Chile,
-1956-09-30,CN,China,
-1956-09-30,CO,Colombia,
-1956-09-30,CY,Cyprus,
-1956-09-30,CZ,Czechia,
-1956-09-30,DE,Germany,
-1956-09-30,DK,Denmark,
-1956-09-30,EE,Estonia,
-1956-09-30,ES,Spain,
-1956-09-30,FI,Finland,
-1956-09-30,FR,France,
-1956-09-30,GB,United Kingdom,
-1956-09-30,GR,Greece,
-1956-09-30,HK,Hong Kong SAR,
-1956-09-30,HR,Croatia,
-1956-09-30,HU,Hungary,
-1956-09-30,ID,Indonesia,
-1956-09-30,IE,Ireland,
-1956-09-30,IL,Israel,
-1956-09-30,IN,India,
-1956-09-30,IS,Iceland,
-1956-09-30,IT,Italy,1.6742
+1956-09-30,IT,Italy,2.6874
 1956-09-30,JP,Japan,19.6721
-1956-09-30,KR,Korea,
-1956-09-30,LT,Lithuania,
-1956-09-30,LU,Luxembourg,
-1956-09-30,LV,Latvia,
-1956-09-30,MA,Morocco,
-1956-09-30,MK,North Macedonia,
-1956-09-30,MT,Malta,
-1956-09-30,MX,Mexico,
-1956-09-30,MY,Malaysia,
-1956-09-30,NL,Netherlands,
-1956-09-30,NO,Norway,
-1956-09-30,NZ,New Zealand,
-1956-09-30,PE,Peru,
-1956-09-30,PH,Philippines,
-1956-09-30,PL,Poland,
-1956-09-30,PT,Portugal,
-1956-09-30,RO,Romania,
-1956-09-30,RS,Serbia,
-1956-09-30,RU,Russia,
-1956-09-30,SE,Sweden,
-1956-09-30,SG,Singapore,
-1956-09-30,SI,Slovenia,
-1956-09-30,SK,Slovak Republic,
-1956-09-30,TH,Thailand,
-1956-09-30,TR,Türkiye,
-1956-09-30,US,United States,
-1956-09-30,XM,Euro area,
-1956-09-30,XW,World,
-1956-09-30,ZA,South Africa,
-1956-12-31,4T,Emerging market economies (aggregate),
-1956-12-31,5R,Advanced economies,
-1956-12-31,AE,United Arab Emirates,
-1956-12-31,AT,Austria,
-1956-12-31,AU,Australia,
-1956-12-31,BE,Belgium,
-1956-12-31,BG,Bulgaria,
-1956-12-31,BR,Brazil,
-1956-12-31,CA,Canada,
-1956-12-31,CH,Switzerland,
-1956-12-31,CL,Chile,
-1956-12-31,CN,China,
-1956-12-31,CO,Colombia,
-1956-12-31,CY,Cyprus,
-1956-12-31,CZ,Czechia,
-1956-12-31,DE,Germany,
-1956-12-31,DK,Denmark,
-1956-12-31,EE,Estonia,
-1956-12-31,ES,Spain,
-1956-12-31,FI,Finland,
-1956-12-31,FR,France,
-1956-12-31,GB,United Kingdom,
-1956-12-31,GR,Greece,
-1956-12-31,HK,Hong Kong SAR,
-1956-12-31,HR,Croatia,
-1956-12-31,HU,Hungary,
-1956-12-31,ID,Indonesia,
-1956-12-31,IE,Ireland,
-1956-12-31,IL,Israel,
-1956-12-31,IN,India,
-1956-12-31,IS,Iceland,
-1956-12-31,IT,Italy,3.8474
+1956-12-31,IT,Italy,4.227
 1956-12-31,JP,Japan,23.1225
-1956-12-31,KR,Korea,
-1956-12-31,LT,Lithuania,
-1956-12-31,LU,Luxembourg,
-1956-12-31,LV,Latvia,
-1956-12-31,MA,Morocco,
-1956-12-31,MK,North Macedonia,
-1956-12-31,MT,Malta,
-1956-12-31,MX,Mexico,
-1956-12-31,MY,Malaysia,
-1956-12-31,NL,Netherlands,
-1956-12-31,NO,Norway,
-1956-12-31,NZ,New Zealand,
-1956-12-31,PE,Peru,
-1956-12-31,PH,Philippines,
-1956-12-31,PL,Poland,
-1956-12-31,PT,Portugal,
-1956-12-31,RO,Romania,
-1956-12-31,RS,Serbia,
-1956-12-31,RU,Russia,
-1956-12-31,SE,Sweden,
-1956-12-31,SG,Singapore,
-1956-12-31,SI,Slovenia,
-1956-12-31,SK,Slovak Republic,
-1956-12-31,TH,Thailand,
-1956-12-31,TR,Türkiye,
-1956-12-31,US,United States,
-1956-12-31,XM,Euro area,
-1956-12-31,XW,World,
-1956-12-31,ZA,South Africa,
-1957-03-31,4T,Emerging market economies (aggregate),
-1957-03-31,5R,Advanced economies,
-1957-03-31,AE,United Arab Emirates,
-1957-03-31,AT,Austria,
-1957-03-31,AU,Australia,
-1957-03-31,BE,Belgium,
-1957-03-31,BG,Bulgaria,
-1957-03-31,BR,Brazil,
-1957-03-31,CA,Canada,
-1957-03-31,CH,Switzerland,
-1957-03-31,CL,Chile,
-1957-03-31,CN,China,
-1957-03-31,CO,Colombia,
-1957-03-31,CY,Cyprus,
-1957-03-31,CZ,Czechia,
-1957-03-31,DE,Germany,
-1957-03-31,DK,Denmark,
-1957-03-31,EE,Estonia,
-1957-03-31,ES,Spain,
-1957-03-31,FI,Finland,
-1957-03-31,FR,France,
-1957-03-31,GB,United Kingdom,
-1957-03-31,GR,Greece,
-1957-03-31,HK,Hong Kong SAR,
-1957-03-31,HR,Croatia,
-1957-03-31,HU,Hungary,
-1957-03-31,ID,Indonesia,
-1957-03-31,IE,Ireland,
-1957-03-31,IL,Israel,
-1957-03-31,IN,India,
-1957-03-31,IS,Iceland,
-1957-03-31,IT,Italy,3.2208
+1957-03-31,IT,Italy,3.0803
 1957-03-31,JP,Japan,26.3359
-1957-03-31,KR,Korea,
-1957-03-31,LT,Lithuania,
-1957-03-31,LU,Luxembourg,
-1957-03-31,LV,Latvia,
-1957-03-31,MA,Morocco,
-1957-03-31,MK,North Macedonia,
-1957-03-31,MT,Malta,
-1957-03-31,MX,Mexico,
-1957-03-31,MY,Malaysia,
-1957-03-31,NL,Netherlands,
-1957-03-31,NO,Norway,
-1957-03-31,NZ,New Zealand,
-1957-03-31,PE,Peru,
-1957-03-31,PH,Philippines,
-1957-03-31,PL,Poland,
-1957-03-31,PT,Portugal,
-1957-03-31,RO,Romania,
-1957-03-31,RS,Serbia,
-1957-03-31,RU,Russia,
-1957-03-31,SE,Sweden,
-1957-03-31,SG,Singapore,
-1957-03-31,SI,Slovenia,
-1957-03-31,SK,Slovak Republic,
-1957-03-31,TH,Thailand,
-1957-03-31,TR,Türkiye,
-1957-03-31,US,United States,
-1957-03-31,XM,Euro area,
-1957-03-31,XW,World,
-1957-03-31,ZA,South Africa,
-1957-06-30,4T,Emerging market economies (aggregate),
-1957-06-30,5R,Advanced economies,
-1957-06-30,AE,United Arab Emirates,
-1957-06-30,AT,Austria,
-1957-06-30,AU,Australia,
-1957-06-30,BE,Belgium,
-1957-06-30,BG,Bulgaria,
-1957-06-30,BR,Brazil,
-1957-06-30,CA,Canada,
-1957-06-30,CH,Switzerland,
-1957-06-30,CL,Chile,
-1957-06-30,CN,China,
-1957-06-30,CO,Colombia,
-1957-06-30,CY,Cyprus,
-1957-06-30,CZ,Czechia,
-1957-06-30,DE,Germany,
-1957-06-30,DK,Denmark,
-1957-06-30,EE,Estonia,
-1957-06-30,ES,Spain,
-1957-06-30,FI,Finland,
-1957-06-30,FR,France,
-1957-06-30,GB,United Kingdom,
-1957-06-30,GR,Greece,
-1957-06-30,HK,Hong Kong SAR,
-1957-06-30,HR,Croatia,
-1957-06-30,HU,Hungary,
-1957-06-30,ID,Indonesia,
-1957-06-30,IE,Ireland,
-1957-06-30,IL,Israel,
-1957-06-30,IN,India,
-1957-06-30,IS,Iceland,
-1957-06-30,IT,Italy,0.4122
+1957-06-30,IT,Italy,1.7066
 1957-06-30,JP,Japan,25.7774
-1957-06-30,KR,Korea,
-1957-06-30,LT,Lithuania,
-1957-06-30,LU,Luxembourg,
-1957-06-30,LV,Latvia,
-1957-06-30,MA,Morocco,
-1957-06-30,MK,North Macedonia,
-1957-06-30,MT,Malta,
-1957-06-30,MX,Mexico,
-1957-06-30,MY,Malaysia,
-1957-06-30,NL,Netherlands,
-1957-06-30,NO,Norway,
-1957-06-30,NZ,New Zealand,
-1957-06-30,PE,Peru,
-1957-06-30,PH,Philippines,
-1957-06-30,PL,Poland,
-1957-06-30,PT,Portugal,
-1957-06-30,RO,Romania,
-1957-06-30,RS,Serbia,
-1957-06-30,RU,Russia,
-1957-06-30,SE,Sweden,
-1957-06-30,SG,Singapore,
-1957-06-30,SI,Slovenia,
-1957-06-30,SK,Slovak Republic,
-1957-06-30,TH,Thailand,
-1957-06-30,TR,Türkiye,
-1957-06-30,US,United States,
-1957-06-30,XM,Euro area,
-1957-06-30,XW,World,
-1957-06-30,ZA,South Africa,
-1957-09-30,4T,Emerging market economies (aggregate),
-1957-09-30,5R,Advanced economies,
-1957-09-30,AE,United Arab Emirates,
-1957-09-30,AT,Austria,
-1957-09-30,AU,Australia,
-1957-09-30,BE,Belgium,
-1957-09-30,BG,Bulgaria,
-1957-09-30,BR,Brazil,
-1957-09-30,CA,Canada,
-1957-09-30,CH,Switzerland,
-1957-09-30,CL,Chile,
-1957-09-30,CN,China,
-1957-09-30,CO,Colombia,
-1957-09-30,CY,Cyprus,
-1957-09-30,CZ,Czechia,
-1957-09-30,DE,Germany,
-1957-09-30,DK,Denmark,
-1957-09-30,EE,Estonia,
-1957-09-30,ES,Spain,
-1957-09-30,FI,Finland,
-1957-09-30,FR,France,
-1957-09-30,GB,United Kingdom,
-1957-09-30,GR,Greece,
-1957-09-30,HK,Hong Kong SAR,
-1957-09-30,HR,Croatia,
-1957-09-30,HU,Hungary,
-1957-09-30,ID,Indonesia,
-1957-09-30,IE,Ireland,
-1957-09-30,IL,Israel,
-1957-09-30,IN,India,
-1957-09-30,IS,Iceland,
-1957-09-30,IT,Italy,3.2131
+1957-09-30,IT,Italy,2.9642
 1957-09-30,JP,Japan,25.3425
-1957-09-30,KR,Korea,
-1957-09-30,LT,Lithuania,
-1957-09-30,LU,Luxembourg,
-1957-09-30,LV,Latvia,
-1957-09-30,MA,Morocco,
-1957-09-30,MK,North Macedonia,
-1957-09-30,MT,Malta,
-1957-09-30,MX,Mexico,
-1957-09-30,MY,Malaysia,
-1957-09-30,NL,Netherlands,
-1957-09-30,NO,Norway,
-1957-09-30,NZ,New Zealand,
-1957-09-30,PE,Peru,
-1957-09-30,PH,Philippines,
-1957-09-30,PL,Poland,
-1957-09-30,PT,Portugal,
-1957-09-30,RO,Romania,
-1957-09-30,RS,Serbia,
-1957-09-30,RU,Russia,
-1957-09-30,SE,Sweden,
-1957-09-30,SG,Singapore,
-1957-09-30,SI,Slovenia,
-1957-09-30,SK,Slovak Republic,
-1957-09-30,TH,Thailand,
-1957-09-30,TR,Türkiye,
-1957-09-30,US,United States,
-1957-09-30,XM,Euro area,
-1957-09-30,XW,World,
-1957-09-30,ZA,South Africa,
-1957-12-31,4T,Emerging market economies (aggregate),
-1957-12-31,5R,Advanced economies,
-1957-12-31,AE,United Arab Emirates,
-1957-12-31,AT,Austria,
-1957-12-31,AU,Australia,
-1957-12-31,BE,Belgium,
-1957-12-31,BG,Bulgaria,
-1957-12-31,BR,Brazil,
-1957-12-31,CA,Canada,
-1957-12-31,CH,Switzerland,
-1957-12-31,CL,Chile,
-1957-12-31,CN,China,
-1957-12-31,CO,Colombia,
-1957-12-31,CY,Cyprus,
-1957-12-31,CZ,Czechia,
-1957-12-31,DE,Germany,
-1957-12-31,DK,Denmark,
-1957-12-31,EE,Estonia,
-1957-12-31,ES,Spain,
-1957-12-31,FI,Finland,
-1957-12-31,FR,France,
-1957-12-31,GB,United Kingdom,
-1957-12-31,GR,Greece,
-1957-12-31,HK,Hong Kong SAR,
-1957-12-31,HR,Croatia,
-1957-12-31,HU,Hungary,
-1957-12-31,ID,Indonesia,
-1957-12-31,IE,Ireland,
-1957-12-31,IL,Israel,
-1957-12-31,IN,India,
-1957-12-31,IS,Iceland,
-1957-12-31,IT,Italy,3.781
+1957-12-31,IT,Italy,2.8474
 1957-12-31,JP,Japan,24.077
-1957-12-31,KR,Korea,
-1957-12-31,LT,Lithuania,
-1957-12-31,LU,Luxembourg,
-1957-12-31,LV,Latvia,
-1957-12-31,MA,Morocco,
-1957-12-31,MK,North Macedonia,
-1957-12-31,MT,Malta,
-1957-12-31,MX,Mexico,
-1957-12-31,MY,Malaysia,
-1957-12-31,NL,Netherlands,
-1957-12-31,NO,Norway,
-1957-12-31,NZ,New Zealand,
-1957-12-31,PE,Peru,
-1957-12-31,PH,Philippines,
-1957-12-31,PL,Poland,
-1957-12-31,PT,Portugal,
-1957-12-31,RO,Romania,
-1957-12-31,RS,Serbia,
-1957-12-31,RU,Russia,
-1957-12-31,SE,Sweden,
-1957-12-31,SG,Singapore,
-1957-12-31,SI,Slovenia,
-1957-12-31,SK,Slovak Republic,
-1957-12-31,TH,Thailand,
-1957-12-31,TR,Türkiye,
-1957-12-31,US,United States,
-1957-12-31,XM,Euro area,
-1957-12-31,XW,World,
-1957-12-31,ZA,South Africa,
-1958-03-31,4T,Emerging market economies (aggregate),
-1958-03-31,5R,Advanced economies,
-1958-03-31,AE,United Arab Emirates,
-1958-03-31,AT,Austria,
-1958-03-31,AU,Australia,
-1958-03-31,BE,Belgium,
-1958-03-31,BG,Bulgaria,
-1958-03-31,BR,Brazil,
-1958-03-31,CA,Canada,
-1958-03-31,CH,Switzerland,
-1958-03-31,CL,Chile,
-1958-03-31,CN,China,
-1958-03-31,CO,Colombia,
-1958-03-31,CY,Cyprus,
-1958-03-31,CZ,Czechia,
-1958-03-31,DE,Germany,
-1958-03-31,DK,Denmark,
-1958-03-31,EE,Estonia,
-1958-03-31,ES,Spain,
-1958-03-31,FI,Finland,
-1958-03-31,FR,France,
-1958-03-31,GB,United Kingdom,
-1958-03-31,GR,Greece,
-1958-03-31,HK,Hong Kong SAR,
-1958-03-31,HR,Croatia,
-1958-03-31,HU,Hungary,
-1958-03-31,ID,Indonesia,
-1958-03-31,IE,Ireland,
-1958-03-31,IL,Israel,
-1958-03-31,IN,India,
-1958-03-31,IS,Iceland,
-1958-03-31,IT,Italy,0.3388
+1958-03-31,IT,Italy,0.3224
 1958-03-31,JP,Japan,22.9607
-1958-03-31,KR,Korea,
-1958-03-31,LT,Lithuania,
-1958-03-31,LU,Luxembourg,
-1958-03-31,LV,Latvia,
-1958-03-31,MA,Morocco,
-1958-03-31,MK,North Macedonia,
-1958-03-31,MT,Malta,
-1958-03-31,MX,Mexico,
-1958-03-31,MY,Malaysia,
-1958-03-31,NL,Netherlands,
-1958-03-31,NO,Norway,
-1958-03-31,NZ,New Zealand,
-1958-03-31,PE,Peru,
-1958-03-31,PH,Philippines,
-1958-03-31,PL,Poland,
-1958-03-31,PT,Portugal,
-1958-03-31,RO,Romania,
-1958-03-31,RS,Serbia,
-1958-03-31,RU,Russia,
-1958-03-31,SE,Sweden,
-1958-03-31,SG,Singapore,
-1958-03-31,SI,Slovenia,
-1958-03-31,SK,Slovak Republic,
-1958-03-31,TH,Thailand,
-1958-03-31,TR,Türkiye,
-1958-03-31,US,United States,
-1958-03-31,XM,Euro area,
-1958-03-31,XW,World,
-1958-03-31,ZA,South Africa,
-1958-06-30,4T,Emerging market economies (aggregate),
-1958-06-30,5R,Advanced economies,
-1958-06-30,AE,United Arab Emirates,
-1958-06-30,AT,Austria,
-1958-06-30,AU,Australia,
-1958-06-30,BE,Belgium,
-1958-06-30,BG,Bulgaria,
-1958-06-30,BR,Brazil,
-1958-06-30,CA,Canada,
-1958-06-30,CH,Switzerland,
-1958-06-30,CL,Chile,
-1958-06-30,CN,China,
-1958-06-30,CO,Colombia,
-1958-06-30,CY,Cyprus,
-1958-06-30,CZ,Czechia,
-1958-06-30,DE,Germany,
-1958-06-30,DK,Denmark,
-1958-06-30,EE,Estonia,
-1958-06-30,ES,Spain,
-1958-06-30,FI,Finland,
-1958-06-30,FR,France,
-1958-06-30,GB,United Kingdom,
-1958-06-30,GR,Greece,
-1958-06-30,HK,Hong Kong SAR,
-1958-06-30,HR,Croatia,
-1958-06-30,HU,Hungary,
-1958-06-30,ID,Indonesia,
-1958-06-30,IE,Ireland,
-1958-06-30,IL,Israel,
-1958-06-30,IN,India,
-1958-06-30,IS,Iceland,
-1958-06-30,IT,Italy,3.4322
+1958-06-30,IT,Italy,2.4414
 1958-06-30,JP,Japan,23.8119
-1958-06-30,KR,Korea,
-1958-06-30,LT,Lithuania,
-1958-06-30,LU,Luxembourg,
-1958-06-30,LV,Latvia,
-1958-06-30,MA,Morocco,
-1958-06-30,MK,North Macedonia,
-1958-06-30,MT,Malta,
-1958-06-30,MX,Mexico,
-1958-06-30,MY,Malaysia,
-1958-06-30,NL,Netherlands,
-1958-06-30,NO,Norway,
-1958-06-30,NZ,New Zealand,
-1958-06-30,PE,Peru,
-1958-06-30,PH,Philippines,
-1958-06-30,PL,Poland,
-1958-06-30,PT,Portugal,
-1958-06-30,RO,Romania,
-1958-06-30,RS,Serbia,
-1958-06-30,RU,Russia,
-1958-06-30,SE,Sweden,
-1958-06-30,SG,Singapore,
-1958-06-30,SI,Slovenia,
-1958-06-30,SK,Slovak Republic,
-1958-06-30,TH,Thailand,
-1958-06-30,TR,Türkiye,
-1958-06-30,US,United States,
-1958-06-30,XM,Euro area,
-1958-06-30,XW,World,
-1958-06-30,ZA,South Africa,
-1958-09-30,4T,Emerging market economies (aggregate),
-1958-09-30,5R,Advanced economies,
-1958-09-30,AE,United Arab Emirates,
-1958-09-30,AT,Austria,
-1958-09-30,AU,Australia,
-1958-09-30,BE,Belgium,
-1958-09-30,BG,Bulgaria,
-1958-09-30,BR,Brazil,
-1958-09-30,CA,Canada,
-1958-09-30,CH,Switzerland,
-1958-09-30,CL,Chile,
-1958-09-30,CN,China,
-1958-09-30,CO,Colombia,
-1958-09-30,CY,Cyprus,
-1958-09-30,CZ,Czechia,
-1958-09-30,DE,Germany,
-1958-09-30,DK,Denmark,
-1958-09-30,EE,Estonia,
-1958-09-30,ES,Spain,
-1958-09-30,FI,Finland,
-1958-09-30,FR,France,
-1958-09-30,GB,United Kingdom,
-1958-09-30,GR,Greece,
-1958-09-30,HK,Hong Kong SAR,
-1958-09-30,HR,Croatia,
-1958-09-30,HU,Hungary,
-1958-09-30,ID,Indonesia,
-1958-09-30,IE,Ireland,
-1958-09-30,IL,Israel,
-1958-09-30,IN,India,
-1958-09-30,IS,Iceland,
-1958-09-30,IT,Italy,1.2449
+1958-09-30,IT,Italy,1.1457
 1958-09-30,JP,Japan,24.5902
-1958-09-30,KR,Korea,
-1958-09-30,LT,Lithuania,
-1958-09-30,LU,Luxembourg,
-1958-09-30,LV,Latvia,
-1958-09-30,MA,Morocco,
-1958-09-30,MK,North Macedonia,
-1958-09-30,MT,Malta,
-1958-09-30,MX,Mexico,
-1958-09-30,MY,Malaysia,
-1958-09-30,NL,Netherlands,
-1958-09-30,NO,Norway,
-1958-09-30,NZ,New Zealand,
-1958-09-30,PE,Peru,
-1958-09-30,PH,Philippines,
-1958-09-30,PL,Poland,
-1958-09-30,PT,Portugal,
-1958-09-30,RO,Romania,
-1958-09-30,RS,Serbia,
-1958-09-30,RU,Russia,
-1958-09-30,SE,Sweden,
-1958-09-30,SG,Singapore,
-1958-09-30,SI,Slovenia,
-1958-09-30,SK,Slovak Republic,
-1958-09-30,TH,Thailand,
-1958-09-30,TR,Türkiye,
-1958-09-30,US,United States,
-1958-09-30,XM,Euro area,
-1958-09-30,XW,World,
-1958-09-30,ZA,South Africa,
-1958-12-31,4T,Emerging market economies (aggregate),
-1958-12-31,5R,Advanced economies,
-1958-12-31,AE,United Arab Emirates,
-1958-12-31,AT,Austria,
-1958-12-31,AU,Australia,
-1958-12-31,BE,Belgium,
-1958-12-31,BG,Bulgaria,
-1958-12-31,BR,Brazil,
-1958-12-31,CA,Canada,
-1958-12-31,CH,Switzerland,
-1958-12-31,CL,Chile,
-1958-12-31,CN,China,
-1958-12-31,CO,Colombia,
-1958-12-31,CY,Cyprus,
-1958-12-31,CZ,Czechia,
-1958-12-31,DE,Germany,
-1958-12-31,DK,Denmark,
-1958-12-31,EE,Estonia,
-1958-12-31,ES,Spain,
-1958-12-31,FI,Finland,
-1958-12-31,FR,France,
-1958-12-31,GB,United Kingdom,
-1958-12-31,GR,Greece,
-1958-12-31,HK,Hong Kong SAR,
-1958-12-31,HR,Croatia,
-1958-12-31,HU,Hungary,
-1958-12-31,ID,Indonesia,
-1958-12-31,IE,Ireland,
-1958-12-31,IL,Israel,
-1958-12-31,IN,India,
-1958-12-31,IS,Iceland,
-1958-12-31,IT,Italy,-2.8428
+1958-12-31,IT,Italy,-1.7478
 1958-12-31,JP,Japan,24.1915
-1958-12-31,KR,Korea,
-1958-12-31,LT,Lithuania,
-1958-12-31,LU,Luxembourg,
-1958-12-31,LV,Latvia,
-1958-12-31,MA,Morocco,
-1958-12-31,MK,North Macedonia,
-1958-12-31,MT,Malta,
-1958-12-31,MX,Mexico,
-1958-12-31,MY,Malaysia,
-1958-12-31,NL,Netherlands,
-1958-12-31,NO,Norway,
-1958-12-31,NZ,New Zealand,
-1958-12-31,PE,Peru,
-1958-12-31,PH,Philippines,
-1958-12-31,PL,Poland,
-1958-12-31,PT,Portugal,
-1958-12-31,RO,Romania,
-1958-12-31,RS,Serbia,
-1958-12-31,RU,Russia,
-1958-12-31,SE,Sweden,
-1958-12-31,SG,Singapore,
-1958-12-31,SI,Slovenia,
-1958-12-31,SK,Slovak Republic,
-1958-12-31,TH,Thailand,
-1958-12-31,TR,Türkiye,
-1958-12-31,US,United States,
-1958-12-31,XM,Euro area,
-1958-12-31,XW,World,
-1958-12-31,ZA,South Africa,
-1959-03-31,4T,Emerging market economies (aggregate),
-1959-03-31,5R,Advanced economies,
-1959-03-31,AE,United Arab Emirates,
-1959-03-31,AT,Austria,
-1959-03-31,AU,Australia,
-1959-03-31,BE,Belgium,
-1959-03-31,BG,Bulgaria,
-1959-03-31,BR,Brazil,
-1959-03-31,CA,Canada,
-1959-03-31,CH,Switzerland,
-1959-03-31,CL,Chile,
-1959-03-31,CN,China,
-1959-03-31,CO,Colombia,
-1959-03-31,CY,Cyprus,
-1959-03-31,CZ,Czechia,
-1959-03-31,DE,Germany,
-1959-03-31,DK,Denmark,
-1959-03-31,EE,Estonia,
-1959-03-31,ES,Spain,
-1959-03-31,FI,Finland,
-1959-03-31,FR,France,
-1959-03-31,GB,United Kingdom,
-1959-03-31,GR,Greece,
-1959-03-31,HK,Hong Kong SAR,
-1959-03-31,HR,Croatia,
-1959-03-31,HU,Hungary,
-1959-03-31,ID,Indonesia,
-1959-03-31,IE,Ireland,
-1959-03-31,IL,Israel,
-1959-03-31,IN,India,
-1959-03-31,IS,Iceland,
-1959-03-31,IT,Italy,-1.8748
+1959-03-31,IT,Italy,-1.6706
 1959-03-31,JP,Japan,23.8329
-1959-03-31,KR,Korea,
-1959-03-31,LT,Lithuania,
-1959-03-31,LU,Luxembourg,
-1959-03-31,LV,Latvia,
-1959-03-31,MA,Morocco,
-1959-03-31,MK,North Macedonia,
-1959-03-31,MT,Malta,
-1959-03-31,MX,Mexico,
-1959-03-31,MY,Malaysia,
-1959-03-31,NL,Netherlands,
-1959-03-31,NO,Norway,
-1959-03-31,NZ,New Zealand,
-1959-03-31,PE,Peru,
-1959-03-31,PH,Philippines,
-1959-03-31,PL,Poland,
-1959-03-31,PT,Portugal,
-1959-03-31,RO,Romania,
-1959-03-31,RS,Serbia,
-1959-03-31,RU,Russia,
-1959-03-31,SE,Sweden,
-1959-03-31,SG,Singapore,
-1959-03-31,SI,Slovenia,
-1959-03-31,SK,Slovak Republic,
-1959-03-31,TH,Thailand,
-1959-03-31,TR,Türkiye,
-1959-03-31,US,United States,
-1959-03-31,XM,Euro area,
-1959-03-31,XW,World,
-1959-03-31,ZA,South Africa,
-1959-06-30,4T,Emerging market economies (aggregate),
-1959-06-30,5R,Advanced economies,
-1959-06-30,AE,United Arab Emirates,
-1959-06-30,AT,Austria,
-1959-06-30,AU,Australia,
-1959-06-30,BE,Belgium,
-1959-06-30,BG,Bulgaria,
-1959-06-30,BR,Brazil,
-1959-06-30,CA,Canada,
-1959-06-30,CH,Switzerland,
-1959-06-30,CL,Chile,
-1959-06-30,CN,China,
-1959-06-30,CO,Colombia,
-1959-06-30,CY,Cyprus,
-1959-06-30,CZ,Czechia,
-1959-06-30,DE,Germany,
-1959-06-30,DK,Denmark,
-1959-06-30,EE,Estonia,
-1959-06-30,ES,Spain,
-1959-06-30,FI,Finland,
-1959-06-30,FR,France,
-1959-06-30,GB,United Kingdom,
-1959-06-30,GR,Greece,
-1959-06-30,HK,Hong Kong SAR,
-1959-06-30,HR,Croatia,
-1959-06-30,HU,Hungary,
-1959-06-30,ID,Indonesia,
-1959-06-30,IE,Ireland,
-1959-06-30,IL,Israel,
-1959-06-30,IN,India,
-1959-06-30,IS,Iceland,
-1959-06-30,IT,Italy,-3.0447
+1959-06-30,IT,Italy,-2.1717
 1959-06-30,JP,Japan,23.7548
-1959-06-30,KR,Korea,
-1959-06-30,LT,Lithuania,
-1959-06-30,LU,Luxembourg,
-1959-06-30,LV,Latvia,
-1959-06-30,MA,Morocco,
-1959-06-30,MK,North Macedonia,
-1959-06-30,MT,Malta,
-1959-06-30,MX,Mexico,
-1959-06-30,MY,Malaysia,
-1959-06-30,NL,Netherlands,
-1959-06-30,NO,Norway,
-1959-06-30,NZ,New Zealand,
-1959-06-30,PE,Peru,
-1959-06-30,PH,Philippines,
-1959-06-30,PL,Poland,
-1959-06-30,PT,Portugal,
-1959-06-30,RO,Romania,
-1959-06-30,RS,Serbia,
-1959-06-30,RU,Russia,
-1959-06-30,SE,Sweden,
-1959-06-30,SG,Singapore,
-1959-06-30,SI,Slovenia,
-1959-06-30,SK,Slovak Republic,
-1959-06-30,TH,Thailand,
-1959-06-30,TR,Türkiye,
-1959-06-30,US,United States,
-1959-06-30,XM,Euro area,
-1959-06-30,XW,World,
-1959-06-30,ZA,South Africa,
-1959-09-30,4T,Emerging market economies (aggregate),
-1959-09-30,5R,Advanced economies,
-1959-09-30,AE,United Arab Emirates,
-1959-09-30,AT,Austria,
-1959-09-30,AU,Australia,
-1959-09-30,BE,Belgium,
-1959-09-30,BG,Bulgaria,
-1959-09-30,BR,Brazil,
-1959-09-30,CA,Canada,
-1959-09-30,CH,Switzerland,
-1959-09-30,CL,Chile,
-1959-09-30,CN,China,
-1959-09-30,CO,Colombia,
-1959-09-30,CY,Cyprus,
-1959-09-30,CZ,Czechia,
-1959-09-30,DE,Germany,
-1959-09-30,DK,Denmark,
-1959-09-30,EE,Estonia,
-1959-09-30,ES,Spain,
-1959-09-30,FI,Finland,
-1959-09-30,FR,France,
-1959-09-30,GB,United Kingdom,
-1959-09-30,GR,Greece,
-1959-09-30,HK,Hong Kong SAR,
-1959-09-30,HR,Croatia,
-1959-09-30,HU,Hungary,
-1959-09-30,ID,Indonesia,
-1959-09-30,IE,Ireland,
-1959-09-30,IL,Israel,
-1959-09-30,IN,India,
-1959-09-30,IS,Iceland,
-1959-09-30,IT,Italy,-1.4167
+1959-09-30,IT,Italy,-1.1999
 1959-09-30,JP,Japan,23.6842
-1959-09-30,KR,Korea,
-1959-09-30,LT,Lithuania,
-1959-09-30,LU,Luxembourg,
-1959-09-30,LV,Latvia,
-1959-09-30,MA,Morocco,
-1959-09-30,MK,North Macedonia,
-1959-09-30,MT,Malta,
-1959-09-30,MX,Mexico,
-1959-09-30,MY,Malaysia,
-1959-09-30,NL,Netherlands,
-1959-09-30,NO,Norway,
-1959-09-30,NZ,New Zealand,
-1959-09-30,PE,Peru,
-1959-09-30,PH,Philippines,
-1959-09-30,PL,Poland,
-1959-09-30,PT,Portugal,
-1959-09-30,RO,Romania,
-1959-09-30,RS,Serbia,
-1959-09-30,RU,Russia,
-1959-09-30,SE,Sweden,
-1959-09-30,SG,Singapore,
-1959-09-30,SI,Slovenia,
-1959-09-30,SK,Slovak Republic,
-1959-09-30,TH,Thailand,
-1959-09-30,TR,Türkiye,
-1959-09-30,US,United States,
-1959-09-30,XM,Euro area,
-1959-09-30,XW,World,
-1959-09-30,ZA,South Africa,
-1959-12-31,4T,Emerging market economies (aggregate),
-1959-12-31,5R,Advanced economies,
-1959-12-31,AE,United Arab Emirates,
-1959-12-31,AT,Austria,
-1959-12-31,AU,Australia,
-1959-12-31,BE,Belgium,
-1959-12-31,BG,Bulgaria,
-1959-12-31,BR,Brazil,
-1959-12-31,CA,Canada,
-1959-12-31,CH,Switzerland,
-1959-12-31,CL,Chile,
-1959-12-31,CN,China,
-1959-12-31,CO,Colombia,
-1959-12-31,CY,Cyprus,
-1959-12-31,CZ,Czechia,
-1959-12-31,DE,Germany,
-1959-12-31,DK,Denmark,
-1959-12-31,EE,Estonia,
-1959-12-31,ES,Spain,
-1959-12-31,FI,Finland,
-1959-12-31,FR,France,
-1959-12-31,GB,United Kingdom,
-1959-12-31,GR,Greece,
-1959-12-31,HK,Hong Kong SAR,
-1959-12-31,HR,Croatia,
-1959-12-31,HU,Hungary,
-1959-12-31,ID,Indonesia,
-1959-12-31,IE,Ireland,
-1959-12-31,IL,Israel,
-1959-12-31,IN,India,
-1959-12-31,IS,Iceland,
-1959-12-31,IT,Italy,4.9788
+1959-12-31,IT,Italy,3.5591
 1959-12-31,JP,Japan,23.3333
-1959-12-31,KR,Korea,
-1959-12-31,LT,Lithuania,
-1959-12-31,LU,Luxembourg,
-1959-12-31,LV,Latvia,
-1959-12-31,MA,Morocco,
-1959-12-31,MK,North Macedonia,
-1959-12-31,MT,Malta,
-1959-12-31,MX,Mexico,
-1959-12-31,MY,Malaysia,
-1959-12-31,NL,Netherlands,
-1959-12-31,NO,Norway,
-1959-12-31,NZ,New Zealand,
-1959-12-31,PE,Peru,
-1959-12-31,PH,Philippines,
-1959-12-31,PL,Poland,
-1959-12-31,PT,Portugal,
-1959-12-31,RO,Romania,
-1959-12-31,RS,Serbia,
-1959-12-31,RU,Russia,
-1959-12-31,SE,Sweden,
-1959-12-31,SG,Singapore,
-1959-12-31,SI,Slovenia,
-1959-12-31,SK,Slovak Republic,
-1959-12-31,TH,Thailand,
-1959-12-31,TR,Türkiye,
-1959-12-31,US,United States,
-1959-12-31,XM,Euro area,
-1959-12-31,XW,World,
-1959-12-31,ZA,South Africa,
-1960-03-31,4T,Emerging market economies (aggregate),
-1960-03-31,5R,Advanced economies,
-1960-03-31,AE,United Arab Emirates,
-1960-03-31,AT,Austria,
-1960-03-31,AU,Australia,
-1960-03-31,BE,Belgium,
-1960-03-31,BG,Bulgaria,
-1960-03-31,BR,Brazil,
-1960-03-31,CA,Canada,
-1960-03-31,CH,Switzerland,
-1960-03-31,CL,Chile,
-1960-03-31,CN,China,
-1960-03-31,CO,Colombia,
-1960-03-31,CY,Cyprus,
-1960-03-31,CZ,Czechia,
-1960-03-31,DE,Germany,
-1960-03-31,DK,Denmark,
-1960-03-31,EE,Estonia,
-1960-03-31,ES,Spain,
-1960-03-31,FI,Finland,
-1960-03-31,FR,France,
-1960-03-31,GB,United Kingdom,
-1960-03-31,GR,Greece,
-1960-03-31,HK,Hong Kong SAR,
-1960-03-31,HR,Croatia,
-1960-03-31,HU,Hungary,
-1960-03-31,ID,Indonesia,
-1960-03-31,IE,Ireland,
-1960-03-31,IL,Israel,
-1960-03-31,IN,India,
-1960-03-31,IS,Iceland,
-1960-03-31,IT,Italy,5.4033
+1960-03-31,IT,Italy,5.0253
 1960-03-31,JP,Japan,23.0159
-1960-03-31,KR,Korea,
-1960-03-31,LT,Lithuania,
-1960-03-31,LU,Luxembourg,
-1960-03-31,LV,Latvia,
-1960-03-31,MA,Morocco,
-1960-03-31,MK,North Macedonia,
-1960-03-31,MT,Malta,
-1960-03-31,MX,Mexico,
-1960-03-31,MY,Malaysia,
-1960-03-31,NL,Netherlands,
-1960-03-31,NO,Norway,
-1960-03-31,NZ,New Zealand,
-1960-03-31,PE,Peru,
-1960-03-31,PH,Philippines,
-1960-03-31,PL,Poland,
-1960-03-31,PT,Portugal,
-1960-03-31,RO,Romania,
-1960-03-31,RS,Serbia,
-1960-03-31,RU,Russia,
-1960-03-31,SE,Sweden,
-1960-03-31,SG,Singapore,
-1960-03-31,SI,Slovenia,
-1960-03-31,SK,Slovak Republic,
-1960-03-31,TH,Thailand,
-1960-03-31,TR,Türkiye,
-1960-03-31,US,United States,
-1960-03-31,XM,Euro area,
-1960-03-31,XW,World,
-1960-03-31,ZA,South Africa,
-1960-06-30,4T,Emerging market economies (aggregate),
-1960-06-30,5R,Advanced economies,
-1960-06-30,AE,United Arab Emirates,
-1960-06-30,AT,Austria,
-1960-06-30,AU,Australia,
-1960-06-30,BE,Belgium,
-1960-06-30,BG,Bulgaria,
-1960-06-30,BR,Brazil,
-1960-06-30,CA,Canada,
-1960-06-30,CH,Switzerland,
-1960-06-30,CL,Chile,
-1960-06-30,CN,China,
-1960-06-30,CO,Colombia,
-1960-06-30,CY,Cyprus,
-1960-06-30,CZ,Czechia,
-1960-06-30,DE,Germany,
-1960-06-30,DK,Denmark,
-1960-06-30,EE,Estonia,
-1960-06-30,ES,Spain,
-1960-06-30,FI,Finland,
-1960-06-30,FR,France,
-1960-06-30,GB,United Kingdom,
-1960-06-30,GR,Greece,
-1960-06-30,HK,Hong Kong SAR,
-1960-06-30,HR,Croatia,
-1960-06-30,HU,Hungary,
-1960-06-30,ID,Indonesia,
-1960-06-30,IE,Ireland,
-1960-06-30,IL,Israel,
-1960-06-30,IN,India,
-1960-06-30,IS,Iceland,
-1960-06-30,IT,Italy,2.8293
+1960-06-30,IT,Italy,2.1331
 1960-06-30,JP,Japan,24.8515
-1960-06-30,KR,Korea,
-1960-06-30,LT,Lithuania,
-1960-06-30,LU,Luxembourg,
-1960-06-30,LV,Latvia,
-1960-06-30,MA,Morocco,
-1960-06-30,MK,North Macedonia,
-1960-06-30,MT,Malta,
-1960-06-30,MX,Mexico,
-1960-06-30,MY,Malaysia,
-1960-06-30,NL,Netherlands,
-1960-06-30,NO,Norway,
-1960-06-30,NZ,New Zealand,
-1960-06-30,PE,Peru,
-1960-06-30,PH,Philippines,
-1960-06-30,PL,Poland,
-1960-06-30,PT,Portugal,
-1960-06-30,RO,Romania,
-1960-06-30,RS,Serbia,
-1960-06-30,RU,Russia,
-1960-06-30,SE,Sweden,
-1960-06-30,SG,Singapore,
-1960-06-30,SI,Slovenia,
-1960-06-30,SK,Slovak Republic,
-1960-06-30,TH,Thailand,
-1960-06-30,TR,Türkiye,
-1960-06-30,US,United States,
-1960-06-30,XM,Euro area,
-1960-06-30,XW,World,
-1960-06-30,ZA,South Africa,
-1960-09-30,4T,Emerging market economies (aggregate),
-1960-09-30,5R,Advanced economies,
-1960-09-30,AE,United Arab Emirates,
-1960-09-30,AT,Austria,
-1960-09-30,AU,Australia,
-1960-09-30,BE,Belgium,
-1960-09-30,BG,Bulgaria,
-1960-09-30,BR,Brazil,
-1960-09-30,CA,Canada,
-1960-09-30,CH,Switzerland,
-1960-09-30,CL,Chile,
-1960-09-30,CN,China,
-1960-09-30,CO,Colombia,
-1960-09-30,CY,Cyprus,
-1960-09-30,CZ,Czechia,
-1960-09-30,DE,Germany,
-1960-09-30,DK,Denmark,
-1960-09-30,EE,Estonia,
-1960-09-30,ES,Spain,
-1960-09-30,FI,Finland,
-1960-09-30,FR,France,
-1960-09-30,GB,United Kingdom,
-1960-09-30,GR,Greece,
-1960-09-30,HK,Hong Kong SAR,
-1960-09-30,HR,Croatia,
-1960-09-30,HU,Hungary,
-1960-09-30,ID,Indonesia,
-1960-09-30,IE,Ireland,
-1960-09-30,IL,Israel,
-1960-09-30,IN,India,
-1960-09-30,IS,Iceland,
-1960-09-30,IT,Italy,2.8111
+1960-09-30,IT,Italy,3.1074
 1960-09-30,JP,Japan,26.4184
-1960-09-30,KR,Korea,
-1960-09-30,LT,Lithuania,
-1960-09-30,LU,Luxembourg,
-1960-09-30,LV,Latvia,
-1960-09-30,MA,Morocco,
-1960-09-30,MK,North Macedonia,
-1960-09-30,MT,Malta,
-1960-09-30,MX,Mexico,
-1960-09-30,MY,Malaysia,
-1960-09-30,NL,Netherlands,
-1960-09-30,NO,Norway,
-1960-09-30,NZ,New Zealand,
-1960-09-30,PE,Peru,
-1960-09-30,PH,Philippines,
-1960-09-30,PL,Poland,
-1960-09-30,PT,Portugal,
-1960-09-30,RO,Romania,
-1960-09-30,RS,Serbia,
-1960-09-30,RU,Russia,
-1960-09-30,SE,Sweden,
-1960-09-30,SG,Singapore,
-1960-09-30,SI,Slovenia,
-1960-09-30,SK,Slovak Republic,
-1960-09-30,TH,Thailand,
-1960-09-30,TR,Türkiye,
-1960-09-30,US,United States,
-1960-09-30,XM,Euro area,
-1960-09-30,XW,World,
-1960-09-30,ZA,South Africa,
-1960-12-31,4T,Emerging market economies (aggregate),
-1960-12-31,5R,Advanced economies,
-1960-12-31,AE,United Arab Emirates,
-1960-12-31,AT,Austria,
-1960-12-31,AU,Australia,
-1960-12-31,BE,Belgium,
-1960-12-31,BG,Bulgaria,
-1960-12-31,BR,Brazil,
-1960-12-31,CA,Canada,
-1960-12-31,CH,Switzerland,
-1960-12-31,CL,Chile,
-1960-12-31,CN,China,
-1960-12-31,CO,Colombia,
-1960-12-31,CY,Cyprus,
-1960-12-31,CZ,Czechia,
-1960-12-31,DE,Germany,
-1960-12-31,DK,Denmark,
-1960-12-31,EE,Estonia,
-1960-12-31,ES,Spain,
-1960-12-31,FI,Finland,
-1960-12-31,FR,France,
-1960-12-31,GB,United Kingdom,
-1960-12-31,GR,Greece,
-1960-12-31,HK,Hong Kong SAR,
-1960-12-31,HR,Croatia,
-1960-12-31,HU,Hungary,
-1960-12-31,ID,Indonesia,
-1960-12-31,IE,Ireland,
-1960-12-31,IL,Israel,
-1960-12-31,IN,India,
-1960-12-31,IS,Iceland,
-1960-12-31,IT,Italy,0.2415
+1960-12-31,IT,Italy,0.9736
 1960-12-31,JP,Japan,32.348
-1960-12-31,KR,Korea,
-1960-12-31,LT,Lithuania,
-1960-12-31,LU,Luxembourg,
-1960-12-31,LV,Latvia,
-1960-12-31,MA,Morocco,
-1960-12-31,MK,North Macedonia,
-1960-12-31,MT,Malta,
-1960-12-31,MX,Mexico,
-1960-12-31,MY,Malaysia,
-1960-12-31,NL,Netherlands,
-1960-12-31,NO,Norway,
-1960-12-31,NZ,New Zealand,
-1960-12-31,PE,Peru,
-1960-12-31,PH,Philippines,
-1960-12-31,PL,Poland,
-1960-12-31,PT,Portugal,
-1960-12-31,RO,Romania,
-1960-12-31,RS,Serbia,
-1960-12-31,RU,Russia,
-1960-12-31,SE,Sweden,
-1960-12-31,SG,Singapore,
-1960-12-31,SI,Slovenia,
-1960-12-31,SK,Slovak Republic,
-1960-12-31,TH,Thailand,
-1960-12-31,TR,Türkiye,
-1960-12-31,US,United States,
-1960-12-31,XM,Euro area,
-1960-12-31,XW,World,
-1960-12-31,ZA,South Africa,
-1961-03-31,4T,Emerging market economies (aggregate),
-1961-03-31,5R,Advanced economies,
-1961-03-31,AE,United Arab Emirates,
-1961-03-31,AT,Austria,
-1961-03-31,AU,Australia,
-1961-03-31,BE,Belgium,
-1961-03-31,BG,Bulgaria,
-1961-03-31,BR,Brazil,
-1961-03-31,CA,Canada,
-1961-03-31,CH,Switzerland,
-1961-03-31,CL,Chile,
-1961-03-31,CN,China,
-1961-03-31,CO,Colombia,
-1961-03-31,CY,Cyprus,
-1961-03-31,CZ,Czechia,
-1961-03-31,DE,Germany,
-1961-03-31,DK,Denmark,
-1961-03-31,EE,Estonia,
-1961-03-31,ES,Spain,
-1961-03-31,FI,Finland,
-1961-03-31,FR,France,
-1961-03-31,GB,United Kingdom,
-1961-03-31,GR,Greece,
-1961-03-31,HK,Hong Kong SAR,
-1961-03-31,HR,Croatia,
-1961-03-31,HU,Hungary,
-1961-03-31,ID,Indonesia,
-1961-03-31,IE,Ireland,
-1961-03-31,IL,Israel,
-1961-03-31,IN,India,
-1961-03-31,IS,Iceland,
-1961-03-31,IT,Italy,2.2628
+1961-03-31,IT,Italy,2.1652
 1961-03-31,JP,Japan,37.7419
-1961-03-31,KR,Korea,
-1961-03-31,LT,Lithuania,
-1961-03-31,LU,Luxembourg,
-1961-03-31,LV,Latvia,
-1961-03-31,MA,Morocco,
-1961-03-31,MK,North Macedonia,
-1961-03-31,MT,Malta,
-1961-03-31,MX,Mexico,
-1961-03-31,MY,Malaysia,
-1961-03-31,NL,Netherlands,
-1961-03-31,NO,Norway,
-1961-03-31,NZ,New Zealand,
-1961-03-31,PE,Peru,
-1961-03-31,PH,Philippines,
-1961-03-31,PL,Poland,
-1961-03-31,PT,Portugal,
-1961-03-31,RO,Romania,
-1961-03-31,RS,Serbia,
-1961-03-31,RU,Russia,
-1961-03-31,SE,Sweden,
-1961-03-31,SG,Singapore,
-1961-03-31,SI,Slovenia,
-1961-03-31,SK,Slovak Republic,
-1961-03-31,TH,Thailand,
-1961-03-31,TR,Türkiye,
-1961-03-31,US,United States,
-1961-03-31,XM,Euro area,
-1961-03-31,XW,World,
-1961-03-31,ZA,South Africa,
-1961-06-30,4T,Emerging market economies (aggregate),
-1961-06-30,5R,Advanced economies,
-1961-06-30,AE,United Arab Emirates,
-1961-06-30,AT,Austria,
-1961-06-30,AU,Australia,
-1961-06-30,BE,Belgium,
-1961-06-30,BG,Bulgaria,
-1961-06-30,BR,Brazil,
-1961-06-30,CA,Canada,
-1961-06-30,CH,Switzerland,
-1961-06-30,CL,Chile,
-1961-06-30,CN,China,
-1961-06-30,CO,Colombia,
-1961-06-30,CY,Cyprus,
-1961-06-30,CZ,Czechia,
-1961-06-30,DE,Germany,
-1961-06-30,DK,Denmark,
-1961-06-30,EE,Estonia,
-1961-06-30,ES,Spain,
-1961-06-30,FI,Finland,
-1961-06-30,FR,France,
-1961-06-30,GB,United Kingdom,
-1961-06-30,GR,Greece,
-1961-06-30,HK,Hong Kong SAR,
-1961-06-30,HR,Croatia,
-1961-06-30,HU,Hungary,
-1961-06-30,ID,Indonesia,
-1961-06-30,IE,Ireland,
-1961-06-30,IL,Israel,
-1961-06-30,IN,India,
-1961-06-30,IS,Iceland,
-1961-06-30,IT,Italy,5.2827
+1961-06-30,IT,Italy,5.5065
 1961-06-30,JP,Japan,38.2036
-1961-06-30,KR,Korea,
-1961-06-30,LT,Lithuania,
-1961-06-30,LU,Luxembourg,
-1961-06-30,LV,Latvia,
-1961-06-30,MA,Morocco,
-1961-06-30,MK,North Macedonia,
-1961-06-30,MT,Malta,
-1961-06-30,MX,Mexico,
-1961-06-30,MY,Malaysia,
-1961-06-30,NL,Netherlands,
-1961-06-30,NO,Norway,
-1961-06-30,NZ,New Zealand,
-1961-06-30,PE,Peru,
-1961-06-30,PH,Philippines,
-1961-06-30,PL,Poland,
-1961-06-30,PT,Portugal,
-1961-06-30,RO,Romania,
-1961-06-30,RS,Serbia,
-1961-06-30,RU,Russia,
-1961-06-30,SE,Sweden,
-1961-06-30,SG,Singapore,
-1961-06-30,SI,Slovenia,
-1961-06-30,SK,Slovak Republic,
-1961-06-30,TH,Thailand,
-1961-06-30,TR,Türkiye,
-1961-06-30,US,United States,
-1961-06-30,XM,Euro area,
-1961-06-30,XW,World,
-1961-06-30,ZA,South Africa,
-1961-09-30,4T,Emerging market economies (aggregate),
-1961-09-30,5R,Advanced economies,
-1961-09-30,AE,United Arab Emirates,
-1961-09-30,AT,Austria,
-1961-09-30,AU,Australia,
-1961-09-30,BE,Belgium,
-1961-09-30,BG,Bulgaria,
-1961-09-30,BR,Brazil,
-1961-09-30,CA,Canada,
-1961-09-30,CH,Switzerland,
-1961-09-30,CL,Chile,
-1961-09-30,CN,China,
-1961-09-30,CO,Colombia,
-1961-09-30,CY,Cyprus,
-1961-09-30,CZ,Czechia,
-1961-09-30,DE,Germany,
-1961-09-30,DK,Denmark,
-1961-09-30,EE,Estonia,
-1961-09-30,ES,Spain,
-1961-09-30,FI,Finland,
-1961-09-30,FR,France,
-1961-09-30,GB,United Kingdom,
-1961-09-30,GR,Greece,
-1961-09-30,HK,Hong Kong SAR,
-1961-09-30,HR,Croatia,
-1961-09-30,HU,Hungary,
-1961-09-30,ID,Indonesia,
-1961-09-30,IE,Ireland,
-1961-09-30,IL,Israel,
-1961-09-30,IN,India,
-1961-09-30,IS,Iceland,
-1961-09-30,IT,Italy,4.8865
+1961-09-30,IT,Italy,5.3138
 1961-09-30,JP,Japan,38.7097
-1961-09-30,KR,Korea,
-1961-09-30,LT,Lithuania,
-1961-09-30,LU,Luxembourg,
-1961-09-30,LV,Latvia,
-1961-09-30,MA,Morocco,
-1961-09-30,MK,North Macedonia,
-1961-09-30,MT,Malta,
-1961-09-30,MX,Mexico,
-1961-09-30,MY,Malaysia,
-1961-09-30,NL,Netherlands,
-1961-09-30,NO,Norway,
-1961-09-30,NZ,New Zealand,
-1961-09-30,PE,Peru,
-1961-09-30,PH,Philippines,
-1961-09-30,PL,Poland,
-1961-09-30,PT,Portugal,
-1961-09-30,RO,Romania,
-1961-09-30,RS,Serbia,
-1961-09-30,RU,Russia,
-1961-09-30,SE,Sweden,
-1961-09-30,SG,Singapore,
-1961-09-30,SI,Slovenia,
-1961-09-30,SK,Slovak Republic,
-1961-09-30,TH,Thailand,
-1961-09-30,TR,Türkiye,
-1961-09-30,US,United States,
-1961-09-30,XM,Euro area,
-1961-09-30,XW,World,
-1961-09-30,ZA,South Africa,
-1961-12-31,4T,Emerging market economies (aggregate),
-1961-12-31,5R,Advanced economies,
-1961-12-31,AE,United Arab Emirates,
-1961-12-31,AT,Austria,
-1961-12-31,AU,Australia,
-1961-12-31,BE,Belgium,
-1961-12-31,BG,Bulgaria,
-1961-12-31,BR,Brazil,
-1961-12-31,CA,Canada,
-1961-12-31,CH,Switzerland,
-1961-12-31,CL,Chile,
-1961-12-31,CN,China,
-1961-12-31,CO,Colombia,
-1961-12-31,CY,Cyprus,
-1961-12-31,CZ,Czechia,
-1961-12-31,DE,Germany,
-1961-12-31,DK,Denmark,
-1961-12-31,EE,Estonia,
-1961-12-31,ES,Spain,
-1961-12-31,FI,Finland,
-1961-12-31,FR,France,
-1961-12-31,GB,United Kingdom,
-1961-12-31,GR,Greece,
-1961-12-31,HK,Hong Kong SAR,
-1961-12-31,HR,Croatia,
-1961-12-31,HU,Hungary,
-1961-12-31,ID,Indonesia,
-1961-12-31,IE,Ireland,
-1961-12-31,IL,Israel,
-1961-12-31,IN,India,
-1961-12-31,IS,Iceland,
-1961-12-31,IT,Italy,6.3503
+1961-12-31,IT,Italy,5.7927
 1961-12-31,JP,Japan,32.0357
-1961-12-31,KR,Korea,
-1961-12-31,LT,Lithuania,
-1961-12-31,LU,Luxembourg,
-1961-12-31,LV,Latvia,
-1961-12-31,MA,Morocco,
-1961-12-31,MK,North Macedonia,
-1961-12-31,MT,Malta,
-1961-12-31,MX,Mexico,
-1961-12-31,MY,Malaysia,
-1961-12-31,NL,Netherlands,
-1961-12-31,NO,Norway,
-1961-12-31,NZ,New Zealand,
-1961-12-31,PE,Peru,
-1961-12-31,PH,Philippines,
-1961-12-31,PL,Poland,
-1961-12-31,PT,Portugal,
-1961-12-31,RO,Romania,
-1961-12-31,RS,Serbia,
-1961-12-31,RU,Russia,
-1961-12-31,SE,Sweden,
-1961-12-31,SG,Singapore,
-1961-12-31,SI,Slovenia,
-1961-12-31,SK,Slovak Republic,
-1961-12-31,TH,Thailand,
-1961-12-31,TR,Türkiye,
-1961-12-31,US,United States,
-1961-12-31,XM,Euro area,
-1961-12-31,XW,World,
-1961-12-31,ZA,South Africa,
-1962-03-31,4T,Emerging market economies (aggregate),
-1962-03-31,5R,Advanced economies,
-1962-03-31,AE,United Arab Emirates,
-1962-03-31,AT,Austria,
-1962-03-31,AU,Australia,
-1962-03-31,BE,Belgium,
-1962-03-31,BG,Bulgaria,
-1962-03-31,BR,Brazil,
-1962-03-31,CA,Canada,
-1962-03-31,CH,Switzerland,
-1962-03-31,CL,Chile,
-1962-03-31,CN,China,
-1962-03-31,CO,Colombia,
-1962-03-31,CY,Cyprus,
-1962-03-31,CZ,Czechia,
-1962-03-31,DE,Germany,
-1962-03-31,DK,Denmark,
-1962-03-31,EE,Estonia,
-1962-03-31,ES,Spain,
-1962-03-31,FI,Finland,
-1962-03-31,FR,France,
-1962-03-31,GB,United Kingdom,
-1962-03-31,GR,Greece,
-1962-03-31,HK,Hong Kong SAR,
-1962-03-31,HR,Croatia,
-1962-03-31,HU,Hungary,
-1962-03-31,ID,Indonesia,
-1962-03-31,IE,Ireland,
-1962-03-31,IL,Israel,
-1962-03-31,IN,India,
-1962-03-31,IS,Iceland,
-1962-03-31,IT,Italy,6.9072
+1962-03-31,IT,Italy,6.797
 1962-03-31,JP,Japan,26.4637
-1962-03-31,KR,Korea,
-1962-03-31,LT,Lithuania,
-1962-03-31,LU,Luxembourg,
-1962-03-31,LV,Latvia,
-1962-03-31,MA,Morocco,
-1962-03-31,MK,North Macedonia,
-1962-03-31,MT,Malta,
-1962-03-31,MX,Mexico,
-1962-03-31,MY,Malaysia,
-1962-03-31,NL,Netherlands,
-1962-03-31,NO,Norway,
-1962-03-31,NZ,New Zealand,
-1962-03-31,PE,Peru,
-1962-03-31,PH,Philippines,
-1962-03-31,PL,Poland,
-1962-03-31,PT,Portugal,
-1962-03-31,RO,Romania,
-1962-03-31,RS,Serbia,
-1962-03-31,RU,Russia,
-1962-03-31,SE,Sweden,
-1962-03-31,SG,Singapore,
-1962-03-31,SI,Slovenia,
-1962-03-31,SK,Slovak Republic,
-1962-03-31,TH,Thailand,
-1962-03-31,TR,Türkiye,
-1962-03-31,US,United States,
-1962-03-31,XM,Euro area,
-1962-03-31,XW,World,
-1962-03-31,ZA,South Africa,
-1962-06-30,4T,Emerging market economies (aggregate),
-1962-06-30,5R,Advanced economies,
-1962-06-30,AE,United Arab Emirates,
-1962-06-30,AT,Austria,
-1962-06-30,AU,Australia,
-1962-06-30,BE,Belgium,
-1962-06-30,BG,Bulgaria,
-1962-06-30,BR,Brazil,
-1962-06-30,CA,Canada,
-1962-06-30,CH,Switzerland,
-1962-06-30,CL,Chile,
-1962-06-30,CN,China,
-1962-06-30,CO,Colombia,
-1962-06-30,CY,Cyprus,
-1962-06-30,CZ,Czechia,
-1962-06-30,DE,Germany,
-1962-06-30,DK,Denmark,
-1962-06-30,EE,Estonia,
-1962-06-30,ES,Spain,
-1962-06-30,FI,Finland,
-1962-06-30,FR,France,
-1962-06-30,GB,United Kingdom,
-1962-06-30,GR,Greece,
-1962-06-30,HK,Hong Kong SAR,
-1962-06-30,HR,Croatia,
-1962-06-30,HU,Hungary,
-1962-06-30,ID,Indonesia,
-1962-06-30,IE,Ireland,
-1962-06-30,IL,Israel,
-1962-06-30,IN,India,
-1962-06-30,IS,Iceland,
-1962-06-30,IT,Italy,8.8679
+1962-06-30,IT,Italy,8.6446
 1962-06-30,JP,Japan,22.106
-1962-06-30,KR,Korea,
-1962-06-30,LT,Lithuania,
-1962-06-30,LU,Luxembourg,
-1962-06-30,LV,Latvia,
-1962-06-30,MA,Morocco,
-1962-06-30,MK,North Macedonia,
-1962-06-30,MT,Malta,
-1962-06-30,MX,Mexico,
-1962-06-30,MY,Malaysia,
-1962-06-30,NL,Netherlands,
-1962-06-30,NO,Norway,
-1962-06-30,NZ,New Zealand,
-1962-06-30,PE,Peru,
-1962-06-30,PH,Philippines,
-1962-06-30,PL,Poland,
-1962-06-30,PT,Portugal,
-1962-06-30,RO,Romania,
-1962-06-30,RS,Serbia,
-1962-06-30,RU,Russia,
-1962-06-30,SE,Sweden,
-1962-06-30,SG,Singapore,
-1962-06-30,SI,Slovenia,
-1962-06-30,SK,Slovak Republic,
-1962-06-30,TH,Thailand,
-1962-06-30,TR,Türkiye,
-1962-06-30,US,United States,
-1962-06-30,XM,Euro area,
-1962-06-30,XW,World,
-1962-06-30,ZA,South Africa,
-1962-09-30,4T,Emerging market economies (aggregate),
-1962-09-30,5R,Advanced economies,
-1962-09-30,AE,United Arab Emirates,
-1962-09-30,AT,Austria,
-1962-09-30,AU,Australia,
-1962-09-30,BE,Belgium,
-1962-09-30,BG,Bulgaria,
-1962-09-30,BR,Brazil,
-1962-09-30,CA,Canada,
-1962-09-30,CH,Switzerland,
-1962-09-30,CL,Chile,
-1962-09-30,CN,China,
-1962-09-30,CO,Colombia,
-1962-09-30,CY,Cyprus,
-1962-09-30,CZ,Czechia,
-1962-09-30,DE,Germany,
-1962-09-30,DK,Denmark,
-1962-09-30,EE,Estonia,
-1962-09-30,ES,Spain,
-1962-09-30,FI,Finland,
-1962-09-30,FR,France,
-1962-09-30,GB,United Kingdom,
-1962-09-30,GR,Greece,
-1962-09-30,HK,Hong Kong SAR,
-1962-09-30,HR,Croatia,
-1962-09-30,HU,Hungary,
-1962-09-30,ID,Indonesia,
-1962-09-30,IE,Ireland,
-1962-09-30,IL,Israel,
-1962-09-30,IN,India,
-1962-09-30,IS,Iceland,
-1962-09-30,IT,Italy,8.3214
+1962-09-30,IT,Italy,7.8896
 1962-09-30,JP,Japan,18.3013
-1962-09-30,KR,Korea,
-1962-09-30,LT,Lithuania,
-1962-09-30,LU,Luxembourg,
-1962-09-30,LV,Latvia,
-1962-09-30,MA,Morocco,
-1962-09-30,MK,North Macedonia,
-1962-09-30,MT,Malta,
-1962-09-30,MX,Mexico,
-1962-09-30,MY,Malaysia,
-1962-09-30,NL,Netherlands,
-1962-09-30,NO,Norway,
-1962-09-30,NZ,New Zealand,
-1962-09-30,PE,Peru,
-1962-09-30,PH,Philippines,
-1962-09-30,PL,Poland,
-1962-09-30,PT,Portugal,
-1962-09-30,RO,Romania,
-1962-09-30,RS,Serbia,
-1962-09-30,RU,Russia,
-1962-09-30,SE,Sweden,
-1962-09-30,SG,Singapore,
-1962-09-30,SI,Slovenia,
-1962-09-30,SK,Slovak Republic,
-1962-09-30,TH,Thailand,
-1962-09-30,TR,Türkiye,
-1962-09-30,US,United States,
-1962-09-30,XM,Euro area,
-1962-09-30,XW,World,
-1962-09-30,ZA,South Africa,
-1962-12-31,4T,Emerging market economies (aggregate),
-1962-12-31,5R,Advanced economies,
-1962-12-31,AE,United Arab Emirates,
-1962-12-31,AT,Austria,
-1962-12-31,AU,Australia,
-1962-12-31,BE,Belgium,
-1962-12-31,BG,Bulgaria,
-1962-12-31,BR,Brazil,
-1962-12-31,CA,Canada,
-1962-12-31,CH,Switzerland,
-1962-12-31,CL,Chile,
-1962-12-31,CN,China,
-1962-12-31,CO,Colombia,
-1962-12-31,CY,Cyprus,
-1962-12-31,CZ,Czechia,
-1962-12-31,DE,Germany,
-1962-12-31,DK,Denmark,
-1962-12-31,EE,Estonia,
-1962-12-31,ES,Spain,
-1962-12-31,FI,Finland,
-1962-12-31,FR,France,
-1962-12-31,GB,United Kingdom,
-1962-12-31,GR,Greece,
-1962-12-31,HK,Hong Kong SAR,
-1962-12-31,HR,Croatia,
-1962-12-31,HU,Hungary,
-1962-12-31,ID,Indonesia,
-1962-12-31,IE,Ireland,
-1962-12-31,IL,Israel,
-1962-12-31,IN,India,
-1962-12-31,IS,Iceland,
-1962-12-31,IT,Italy,6.8007
+1962-12-31,IT,Italy,7.552
 1962-12-31,JP,Japan,16.9647
-1962-12-31,KR,Korea,
-1962-12-31,LT,Lithuania,
-1962-12-31,LU,Luxembourg,
-1962-12-31,LV,Latvia,
-1962-12-31,MA,Morocco,
-1962-12-31,MK,North Macedonia,
-1962-12-31,MT,Malta,
-1962-12-31,MX,Mexico,
-1962-12-31,MY,Malaysia,
-1962-12-31,NL,Netherlands,
-1962-12-31,NO,Norway,
-1962-12-31,NZ,New Zealand,
-1962-12-31,PE,Peru,
-1962-12-31,PH,Philippines,
-1962-12-31,PL,Poland,
-1962-12-31,PT,Portugal,
-1962-12-31,RO,Romania,
-1962-12-31,RS,Serbia,
-1962-12-31,RU,Russia,
-1962-12-31,SE,Sweden,
-1962-12-31,SG,Singapore,
-1962-12-31,SI,Slovenia,
-1962-12-31,SK,Slovak Republic,
-1962-12-31,TH,Thailand,
-1962-12-31,TR,Türkiye,
-1962-12-31,US,United States,
-1962-12-31,XM,Euro area,
-1962-12-31,XW,World,
-1962-12-31,ZA,South Africa,
-1963-03-31,4T,Emerging market economies (aggregate),
-1963-03-31,5R,Advanced economies,
-1963-03-31,AE,United Arab Emirates,
-1963-03-31,AT,Austria,
-1963-03-31,AU,Australia,
-1963-03-31,BE,Belgium,
-1963-03-31,BG,Bulgaria,
-1963-03-31,BR,Brazil,
-1963-03-31,CA,Canada,
-1963-03-31,CH,Switzerland,
-1963-03-31,CL,Chile,
-1963-03-31,CN,China,
-1963-03-31,CO,Colombia,
-1963-03-31,CY,Cyprus,
-1963-03-31,CZ,Czechia,
-1963-03-31,DE,Germany,
-1963-03-31,DK,Denmark,
-1963-03-31,EE,Estonia,
-1963-03-31,ES,Spain,
-1963-03-31,FI,Finland,
-1963-03-31,FR,France,
-1963-03-31,GB,United Kingdom,
-1963-03-31,GR,Greece,
-1963-03-31,HK,Hong Kong SAR,
-1963-03-31,HR,Croatia,
-1963-03-31,HU,Hungary,
-1963-03-31,ID,Indonesia,
-1963-03-31,IE,Ireland,
-1963-03-31,IL,Israel,
-1963-03-31,IN,India,
-1963-03-31,IS,Iceland,
-1963-03-31,IT,Italy,10.6585
+1963-03-31,IT,Italy,10.6536
 1963-03-31,JP,Japan,15.7407
-1963-03-31,KR,Korea,
-1963-03-31,LT,Lithuania,
-1963-03-31,LU,Luxembourg,
-1963-03-31,LV,Latvia,
-1963-03-31,MA,Morocco,
-1963-03-31,MK,North Macedonia,
-1963-03-31,MT,Malta,
-1963-03-31,MX,Mexico,
-1963-03-31,MY,Malaysia,
-1963-03-31,NL,Netherlands,
-1963-03-31,NO,Norway,
-1963-03-31,NZ,New Zealand,
-1963-03-31,PE,Peru,
-1963-03-31,PH,Philippines,
-1963-03-31,PL,Poland,
-1963-03-31,PT,Portugal,
-1963-03-31,RO,Romania,
-1963-03-31,RS,Serbia,
-1963-03-31,RU,Russia,
-1963-03-31,SE,Sweden,
-1963-03-31,SG,Singapore,
-1963-03-31,SI,Slovenia,
-1963-03-31,SK,Slovak Republic,
-1963-03-31,TH,Thailand,
-1963-03-31,TR,Türkiye,
-1963-03-31,US,United States,
-1963-03-31,XM,Euro area,
-1963-03-31,XW,World,
-1963-03-31,ZA,South Africa,
-1963-06-30,4T,Emerging market economies (aggregate),
-1963-06-30,5R,Advanced economies,
-1963-06-30,AE,United Arab Emirates,
-1963-06-30,AT,Austria,
-1963-06-30,AU,Australia,
-1963-06-30,BE,Belgium,
-1963-06-30,BG,Bulgaria,
-1963-06-30,BR,Brazil,
-1963-06-30,CA,Canada,
-1963-06-30,CH,Switzerland,
-1963-06-30,CL,Chile,
-1963-06-30,CN,China,
-1963-06-30,CO,Colombia,
-1963-06-30,CY,Cyprus,
-1963-06-30,CZ,Czechia,
-1963-06-30,DE,Germany,
-1963-06-30,DK,Denmark,
-1963-06-30,EE,Estonia,
-1963-06-30,ES,Spain,
-1963-06-30,FI,Finland,
-1963-06-30,FR,France,
-1963-06-30,GB,United Kingdom,
-1963-06-30,GR,Greece,
-1963-06-30,HK,Hong Kong SAR,
-1963-06-30,HR,Croatia,
-1963-06-30,HU,Hungary,
-1963-06-30,ID,Indonesia,
-1963-06-30,IE,Ireland,
-1963-06-30,IL,Israel,
-1963-06-30,IN,India,
-1963-06-30,IS,Iceland,
-1963-06-30,IT,Italy,7.1201
+1963-06-30,IT,Italy,7.5312
 1963-06-30,JP,Japan,14.6724
-1963-06-30,KR,Korea,
-1963-06-30,LT,Lithuania,
-1963-06-30,LU,Luxembourg,
-1963-06-30,LV,Latvia,
-1963-06-30,MA,Morocco,
-1963-06-30,MK,North Macedonia,
-1963-06-30,MT,Malta,
-1963-06-30,MX,Mexico,
-1963-06-30,MY,Malaysia,
-1963-06-30,NL,Netherlands,
-1963-06-30,NO,Norway,
-1963-06-30,NZ,New Zealand,
-1963-06-30,PE,Peru,
-1963-06-30,PH,Philippines,
-1963-06-30,PL,Poland,
-1963-06-30,PT,Portugal,
-1963-06-30,RO,Romania,
-1963-06-30,RS,Serbia,
-1963-06-30,RU,Russia,
-1963-06-30,SE,Sweden,
-1963-06-30,SG,Singapore,
-1963-06-30,SI,Slovenia,
-1963-06-30,SK,Slovak Republic,
-1963-06-30,TH,Thailand,
-1963-06-30,TR,Türkiye,
-1963-06-30,US,United States,
-1963-06-30,XM,Euro area,
-1963-06-30,XW,World,
-1963-06-30,ZA,South Africa,
-1963-09-30,4T,Emerging market economies (aggregate),
-1963-09-30,5R,Advanced economies,
-1963-09-30,AE,United Arab Emirates,
-1963-09-30,AT,Austria,
-1963-09-30,AU,Australia,
-1963-09-30,BE,Belgium,
-1963-09-30,BG,Bulgaria,
-1963-09-30,BR,Brazil,
-1963-09-30,CA,Canada,
-1963-09-30,CH,Switzerland,
-1963-09-30,CL,Chile,
-1963-09-30,CN,China,
-1963-09-30,CO,Colombia,
-1963-09-30,CY,Cyprus,
-1963-09-30,CZ,Czechia,
-1963-09-30,DE,Germany,
-1963-09-30,DK,Denmark,
-1963-09-30,EE,Estonia,
-1963-09-30,ES,Spain,
-1963-09-30,FI,Finland,
-1963-09-30,FR,France,
-1963-09-30,GB,United Kingdom,
-1963-09-30,GR,Greece,
-1963-09-30,HK,Hong Kong SAR,
-1963-09-30,HR,Croatia,
-1963-09-30,HU,Hungary,
-1963-09-30,ID,Indonesia,
-1963-09-30,IE,Ireland,
-1963-09-30,IL,Israel,
-1963-09-30,IN,India,
-1963-09-30,IS,Iceland,
-1963-09-30,IT,Italy,6.9752
+1963-06-30,NZ,New Zealand,2.3626
+1963-09-30,IT,Italy,6.8492
 1963-09-30,JP,Japan,13.6752
-1963-09-30,KR,Korea,
-1963-09-30,LT,Lithuania,
-1963-09-30,LU,Luxembourg,
-1963-09-30,LV,Latvia,
-1963-09-30,MA,Morocco,
-1963-09-30,MK,North Macedonia,
-1963-09-30,MT,Malta,
-1963-09-30,MX,Mexico,
-1963-09-30,MY,Malaysia,
-1963-09-30,NL,Netherlands,
-1963-09-30,NO,Norway,
-1963-09-30,NZ,New Zealand,
-1963-09-30,PE,Peru,
-1963-09-30,PH,Philippines,
-1963-09-30,PL,Poland,
-1963-09-30,PT,Portugal,
-1963-09-30,RO,Romania,
-1963-09-30,RS,Serbia,
-1963-09-30,RU,Russia,
-1963-09-30,SE,Sweden,
-1963-09-30,SG,Singapore,
-1963-09-30,SI,Slovenia,
-1963-09-30,SK,Slovak Republic,
-1963-09-30,TH,Thailand,
-1963-09-30,TR,Türkiye,
-1963-09-30,US,United States,
-1963-09-30,XM,Euro area,
-1963-09-30,XW,World,
-1963-09-30,ZA,South Africa,
-1963-12-31,4T,Emerging market economies (aggregate),
-1963-12-31,5R,Advanced economies,
-1963-12-31,AE,United Arab Emirates,
-1963-12-31,AT,Austria,
-1963-12-31,AU,Australia,
-1963-12-31,BE,Belgium,
-1963-12-31,BG,Bulgaria,
-1963-12-31,BR,Brazil,
-1963-12-31,CA,Canada,
-1963-12-31,CH,Switzerland,
-1963-12-31,CL,Chile,
-1963-12-31,CN,China,
-1963-12-31,CO,Colombia,
-1963-12-31,CY,Cyprus,
-1963-12-31,CZ,Czechia,
-1963-12-31,DE,Germany,
-1963-12-31,DK,Denmark,
-1963-12-31,EE,Estonia,
-1963-12-31,ES,Spain,
-1963-12-31,FI,Finland,
-1963-12-31,FR,France,
-1963-12-31,GB,United Kingdom,
-1963-12-31,GR,Greece,
-1963-12-31,HK,Hong Kong SAR,
-1963-12-31,HR,Croatia,
-1963-12-31,HU,Hungary,
-1963-12-31,ID,Indonesia,
-1963-12-31,IE,Ireland,
-1963-12-31,IL,Israel,
-1963-12-31,IN,India,
-1963-12-31,IS,Iceland,
-1963-12-31,IT,Italy,12.056
+1963-09-30,NZ,New Zealand,3.1249
+1963-12-31,IT,Italy,11.7412
 1963-12-31,JP,Japan,13.6364
-1963-12-31,KR,Korea,
-1963-12-31,LT,Lithuania,
-1963-12-31,LU,Luxembourg,
-1963-12-31,LV,Latvia,
-1963-12-31,MA,Morocco,
-1963-12-31,MK,North Macedonia,
-1963-12-31,MT,Malta,
-1963-12-31,MX,Mexico,
-1963-12-31,MY,Malaysia,
-1963-12-31,NL,Netherlands,
-1963-12-31,NO,Norway,
-1963-12-31,NZ,New Zealand,
-1963-12-31,PE,Peru,
-1963-12-31,PH,Philippines,
-1963-12-31,PL,Poland,
-1963-12-31,PT,Portugal,
-1963-12-31,RO,Romania,
-1963-12-31,RS,Serbia,
-1963-12-31,RU,Russia,
-1963-12-31,SE,Sweden,
-1963-12-31,SG,Singapore,
-1963-12-31,SI,Slovenia,
-1963-12-31,SK,Slovak Republic,
-1963-12-31,TH,Thailand,
-1963-12-31,TR,Türkiye,
-1963-12-31,US,United States,
-1963-12-31,XM,Euro area,
-1963-12-31,XW,World,
-1963-12-31,ZA,South Africa,
-1964-03-31,4T,Emerging market economies (aggregate),
-1964-03-31,5R,Advanced economies,
-1964-03-31,AE,United Arab Emirates,
-1964-03-31,AT,Austria,
-1964-03-31,AU,Australia,
-1964-03-31,BE,Belgium,
-1964-03-31,BG,Bulgaria,
-1964-03-31,BR,Brazil,
-1964-03-31,CA,Canada,
-1964-03-31,CH,Switzerland,
-1964-03-31,CL,Chile,
-1964-03-31,CN,China,
-1964-03-31,CO,Colombia,
-1964-03-31,CY,Cyprus,
-1964-03-31,CZ,Czechia,
-1964-03-31,DE,Germany,
-1964-03-31,DK,Denmark,
-1964-03-31,EE,Estonia,
-1964-03-31,ES,Spain,
-1964-03-31,FI,Finland,
-1964-03-31,FR,France,
-1964-03-31,GB,United Kingdom,
-1964-03-31,GR,Greece,
-1964-03-31,HK,Hong Kong SAR,
-1964-03-31,HR,Croatia,
-1964-03-31,HU,Hungary,
-1964-03-31,ID,Indonesia,
-1964-03-31,IE,Ireland,
-1964-03-31,IL,Israel,
-1964-03-31,IN,India,
-1964-03-31,IS,Iceland,
-1964-03-31,IT,Italy,8.7121
+1963-12-31,NZ,New Zealand,3.8754
+1964-03-31,IT,Italy,9.4348
 1964-03-31,JP,Japan,13.6
-1964-03-31,KR,Korea,
-1964-03-31,LT,Lithuania,
-1964-03-31,LU,Luxembourg,
-1964-03-31,LV,Latvia,
-1964-03-31,MA,Morocco,
-1964-03-31,MK,North Macedonia,
-1964-03-31,MT,Malta,
-1964-03-31,MX,Mexico,
-1964-03-31,MY,Malaysia,
-1964-03-31,NL,Netherlands,
-1964-03-31,NO,Norway,
-1964-03-31,NZ,New Zealand,
-1964-03-31,PE,Peru,
-1964-03-31,PH,Philippines,
-1964-03-31,PL,Poland,
-1964-03-31,PT,Portugal,
-1964-03-31,RO,Romania,
-1964-03-31,RS,Serbia,
-1964-03-31,RU,Russia,
-1964-03-31,SE,Sweden,
-1964-03-31,SG,Singapore,
-1964-03-31,SI,Slovenia,
-1964-03-31,SK,Slovak Republic,
-1964-03-31,TH,Thailand,
-1964-03-31,TR,Türkiye,
-1964-03-31,US,United States,
-1964-03-31,XM,Euro area,
-1964-03-31,XW,World,
-1964-03-31,ZA,South Africa,
-1964-06-30,4T,Emerging market economies (aggregate),
-1964-06-30,5R,Advanced economies,
-1964-06-30,AE,United Arab Emirates,
-1964-06-30,AT,Austria,
-1964-06-30,AU,Australia,
-1964-06-30,BE,Belgium,
-1964-06-30,BG,Bulgaria,
-1964-06-30,BR,Brazil,
-1964-06-30,CA,Canada,
-1964-06-30,CH,Switzerland,
-1964-06-30,CL,Chile,
-1964-06-30,CN,China,
-1964-06-30,CO,Colombia,
-1964-06-30,CY,Cyprus,
-1964-06-30,CZ,Czechia,
-1964-06-30,DE,Germany,
-1964-06-30,DK,Denmark,
-1964-06-30,EE,Estonia,
-1964-06-30,ES,Spain,
-1964-06-30,FI,Finland,
-1964-06-30,FR,France,
-1964-06-30,GB,United Kingdom,
-1964-06-30,GR,Greece,
-1964-06-30,HK,Hong Kong SAR,
-1964-06-30,HR,Croatia,
-1964-06-30,HU,Hungary,
-1964-06-30,ID,Indonesia,
-1964-06-30,IE,Ireland,
-1964-06-30,IL,Israel,
-1964-06-30,IN,India,
-1964-06-30,IS,Iceland,
-1964-06-30,IT,Italy,11.7842
+1964-03-31,NZ,New Zealand,4.6519
+1964-06-30,IT,Italy,12.3345
 1964-06-30,JP,Japan,13.973
-1964-06-30,KR,Korea,
-1964-06-30,LT,Lithuania,
-1964-06-30,LU,Luxembourg,
-1964-06-30,LV,Latvia,
-1964-06-30,MA,Morocco,
-1964-06-30,MK,North Macedonia,
-1964-06-30,MT,Malta,
-1964-06-30,MX,Mexico,
-1964-06-30,MY,Malaysia,
-1964-06-30,NL,Netherlands,
-1964-06-30,NO,Norway,
-1964-06-30,NZ,New Zealand,
-1964-06-30,PE,Peru,
-1964-06-30,PH,Philippines,
-1964-06-30,PL,Poland,
-1964-06-30,PT,Portugal,
-1964-06-30,RO,Romania,
-1964-06-30,RS,Serbia,
-1964-06-30,RU,Russia,
-1964-06-30,SE,Sweden,
-1964-06-30,SG,Singapore,
-1964-06-30,SI,Slovenia,
-1964-06-30,SK,Slovak Republic,
-1964-06-30,TH,Thailand,
-1964-06-30,TR,Türkiye,
-1964-06-30,US,United States,
-1964-06-30,XM,Euro area,
-1964-06-30,XW,World,
-1964-06-30,ZA,South Africa,
-1964-09-30,4T,Emerging market economies (aggregate),
-1964-09-30,5R,Advanced economies,
-1964-09-30,AE,United Arab Emirates,
-1964-09-30,AT,Austria,
-1964-09-30,AU,Australia,
-1964-09-30,BE,Belgium,
-1964-09-30,BG,Bulgaria,
-1964-09-30,BR,Brazil,
-1964-09-30,CA,Canada,
-1964-09-30,CH,Switzerland,
-1964-09-30,CL,Chile,
-1964-09-30,CN,China,
-1964-09-30,CO,Colombia,
-1964-09-30,CY,Cyprus,
-1964-09-30,CZ,Czechia,
-1964-09-30,DE,Germany,
-1964-09-30,DK,Denmark,
-1964-09-30,EE,Estonia,
-1964-09-30,ES,Spain,
-1964-09-30,FI,Finland,
-1964-09-30,FR,France,
-1964-09-30,GB,United Kingdom,
-1964-09-30,GR,Greece,
-1964-09-30,HK,Hong Kong SAR,
-1964-09-30,HR,Croatia,
-1964-09-30,HU,Hungary,
-1964-09-30,ID,Indonesia,
-1964-09-30,IE,Ireland,
-1964-09-30,IL,Israel,
-1964-09-30,IN,India,
-1964-09-30,IS,Iceland,
-1964-09-30,IT,Italy,15.0601
+1964-06-30,NZ,New Zealand,4.6161
+1964-09-30,IT,Italy,15.0969
 1964-09-30,JP,Japan,14.2857
-1964-09-30,KR,Korea,
-1964-09-30,LT,Lithuania,
-1964-09-30,LU,Luxembourg,
-1964-09-30,LV,Latvia,
-1964-09-30,MA,Morocco,
-1964-09-30,MK,North Macedonia,
-1964-09-30,MT,Malta,
-1964-09-30,MX,Mexico,
-1964-09-30,MY,Malaysia,
-1964-09-30,NL,Netherlands,
-1964-09-30,NO,Norway,
-1964-09-30,NZ,New Zealand,
-1964-09-30,PE,Peru,
-1964-09-30,PH,Philippines,
-1964-09-30,PL,Poland,
-1964-09-30,PT,Portugal,
-1964-09-30,RO,Romania,
-1964-09-30,RS,Serbia,
-1964-09-30,RU,Russia,
-1964-09-30,SE,Sweden,
-1964-09-30,SG,Singapore,
-1964-09-30,SI,Slovenia,
-1964-09-30,SK,Slovak Republic,
-1964-09-30,TH,Thailand,
-1964-09-30,TR,Türkiye,
-1964-09-30,US,United States,
-1964-09-30,XM,Euro area,
-1964-09-30,XW,World,
-1964-09-30,ZA,South Africa,
-1964-12-31,4T,Emerging market economies (aggregate),
-1964-12-31,5R,Advanced economies,
-1964-12-31,AE,United Arab Emirates,
-1964-12-31,AT,Austria,
-1964-12-31,AU,Australia,
-1964-12-31,BE,Belgium,
-1964-12-31,BG,Bulgaria,
-1964-12-31,BR,Brazil,
-1964-12-31,CA,Canada,
-1964-12-31,CH,Switzerland,
-1964-12-31,CL,Chile,
-1964-12-31,CN,China,
-1964-12-31,CO,Colombia,
-1964-12-31,CY,Cyprus,
-1964-12-31,CZ,Czechia,
-1964-12-31,DE,Germany,
-1964-12-31,DK,Denmark,
-1964-12-31,EE,Estonia,
-1964-12-31,ES,Spain,
-1964-12-31,FI,Finland,
-1964-12-31,FR,France,
-1964-12-31,GB,United Kingdom,
-1964-12-31,GR,Greece,
-1964-12-31,HK,Hong Kong SAR,
-1964-12-31,HR,Croatia,
-1964-12-31,HU,Hungary,
-1964-12-31,ID,Indonesia,
-1964-12-31,IE,Ireland,
-1964-12-31,IL,Israel,
-1964-12-31,IN,India,
-1964-12-31,IS,Iceland,
-1964-12-31,IT,Italy,9.8072
+1964-09-30,NZ,New Zealand,4.5445
+1964-12-31,IT,Italy,8.5935
 1964-12-31,JP,Japan,14.5455
-1964-12-31,KR,Korea,
-1964-12-31,LT,Lithuania,
-1964-12-31,LU,Luxembourg,
-1964-12-31,LV,Latvia,
-1964-12-31,MA,Morocco,
-1964-12-31,MK,North Macedonia,
-1964-12-31,MT,Malta,
-1964-12-31,MX,Mexico,
-1964-12-31,MY,Malaysia,
-1964-12-31,NL,Netherlands,
-1964-12-31,NO,Norway,
-1964-12-31,NZ,New Zealand,
-1964-12-31,PE,Peru,
-1964-12-31,PH,Philippines,
-1964-12-31,PL,Poland,
-1964-12-31,PT,Portugal,
-1964-12-31,RO,Romania,
-1964-12-31,RS,Serbia,
-1964-12-31,RU,Russia,
-1964-12-31,SE,Sweden,
-1964-12-31,SG,Singapore,
-1964-12-31,SI,Slovenia,
-1964-12-31,SK,Slovak Republic,
-1964-12-31,TH,Thailand,
-1964-12-31,TR,Türkiye,
-1964-12-31,US,United States,
-1964-12-31,XM,Euro area,
-1964-12-31,XW,World,
-1964-12-31,ZA,South Africa,
-1965-03-31,4T,Emerging market economies (aggregate),
-1965-03-31,5R,Advanced economies,
-1965-03-31,AE,United Arab Emirates,
-1965-03-31,AT,Austria,
-1965-03-31,AU,Australia,
-1965-03-31,BE,Belgium,
-1965-03-31,BG,Bulgaria,
-1965-03-31,BR,Brazil,
-1965-03-31,CA,Canada,
-1965-03-31,CH,Switzerland,
-1965-03-31,CL,Chile,
-1965-03-31,CN,China,
-1965-03-31,CO,Colombia,
-1965-03-31,CY,Cyprus,
-1965-03-31,CZ,Czechia,
-1965-03-31,DE,Germany,
-1965-03-31,DK,Denmark,
-1965-03-31,EE,Estonia,
-1965-03-31,ES,Spain,
-1965-03-31,FI,Finland,
-1965-03-31,FR,France,
-1965-03-31,GB,United Kingdom,
-1965-03-31,GR,Greece,
-1965-03-31,HK,Hong Kong SAR,
-1965-03-31,HR,Croatia,
-1965-03-31,HU,Hungary,
-1965-03-31,ID,Indonesia,
-1965-03-31,IE,Ireland,
-1965-03-31,IL,Israel,
-1965-03-31,IN,India,
-1965-03-31,IS,Iceland,
-1965-03-31,IT,Italy,4.7166
+1964-12-31,NZ,New Zealand,5.2242
+1965-03-31,IT,Italy,4.1833
 1965-03-31,JP,Japan,14.7887
-1965-03-31,KR,Korea,
-1965-03-31,LT,Lithuania,
-1965-03-31,LU,Luxembourg,
-1965-03-31,LV,Latvia,
-1965-03-31,MA,Morocco,
-1965-03-31,MK,North Macedonia,
-1965-03-31,MT,Malta,
-1965-03-31,MX,Mexico,
-1965-03-31,MY,Malaysia,
-1965-03-31,NL,Netherlands,
-1965-03-31,NO,Norway,
-1965-03-31,NZ,New Zealand,
-1965-03-31,PE,Peru,
-1965-03-31,PH,Philippines,
-1965-03-31,PL,Poland,
-1965-03-31,PT,Portugal,
-1965-03-31,RO,Romania,
-1965-03-31,RS,Serbia,
-1965-03-31,RU,Russia,
-1965-03-31,SE,Sweden,
-1965-03-31,SG,Singapore,
-1965-03-31,SI,Slovenia,
-1965-03-31,SK,Slovak Republic,
-1965-03-31,TH,Thailand,
-1965-03-31,TR,Türkiye,
-1965-03-31,US,United States,
-1965-03-31,XM,Euro area,
-1965-03-31,XW,World,
-1965-03-31,ZA,South Africa,
-1965-06-30,4T,Emerging market economies (aggregate),
-1965-06-30,5R,Advanced economies,
-1965-06-30,AE,United Arab Emirates,
-1965-06-30,AT,Austria,
-1965-06-30,AU,Australia,
-1965-06-30,BE,Belgium,
-1965-06-30,BG,Bulgaria,
-1965-06-30,BR,Brazil,
-1965-06-30,CA,Canada,
-1965-06-30,CH,Switzerland,
-1965-06-30,CL,Chile,
-1965-06-30,CN,China,
-1965-06-30,CO,Colombia,
-1965-06-30,CY,Cyprus,
-1965-06-30,CZ,Czechia,
-1965-06-30,DE,Germany,
-1965-06-30,DK,Denmark,
-1965-06-30,EE,Estonia,
-1965-06-30,ES,Spain,
-1965-06-30,FI,Finland,
-1965-06-30,FR,France,
-1965-06-30,GB,United Kingdom,
-1965-06-30,GR,Greece,
-1965-06-30,HK,Hong Kong SAR,
-1965-06-30,HR,Croatia,
-1965-06-30,HU,Hungary,
-1965-06-30,ID,Indonesia,
-1965-06-30,IE,Ireland,
-1965-06-30,IL,Israel,
-1965-06-30,IN,India,
-1965-06-30,IS,Iceland,
-1965-06-30,IT,Italy,-0.1537
+1965-03-31,NZ,New Zealand,6.666
+1965-06-30,IT,Italy,-0.9924
 1965-06-30,JP,Japan,12.2374
-1965-06-30,KR,Korea,
-1965-06-30,LT,Lithuania,
-1965-06-30,LU,Luxembourg,
-1965-06-30,LV,Latvia,
-1965-06-30,MA,Morocco,
-1965-06-30,MK,North Macedonia,
-1965-06-30,MT,Malta,
-1965-06-30,MX,Mexico,
-1965-06-30,MY,Malaysia,
-1965-06-30,NL,Netherlands,
-1965-06-30,NO,Norway,
-1965-06-30,NZ,New Zealand,
-1965-06-30,PE,Peru,
-1965-06-30,PH,Philippines,
-1965-06-30,PL,Poland,
-1965-06-30,PT,Portugal,
-1965-06-30,RO,Romania,
-1965-06-30,RS,Serbia,
-1965-06-30,RU,Russia,
-1965-06-30,SE,Sweden,
-1965-06-30,SG,Singapore,
-1965-06-30,SI,Slovenia,
-1965-06-30,SK,Slovak Republic,
-1965-06-30,TH,Thailand,
-1965-06-30,TR,Türkiye,
-1965-06-30,US,United States,
-1965-06-30,XM,Euro area,
-1965-06-30,XW,World,
-1965-06-30,ZA,South Africa,
-1965-09-30,4T,Emerging market economies (aggregate),
-1965-09-30,5R,Advanced economies,
-1965-09-30,AE,United Arab Emirates,
-1965-09-30,AT,Austria,
-1965-09-30,AU,Australia,
-1965-09-30,BE,Belgium,
-1965-09-30,BG,Bulgaria,
-1965-09-30,BR,Brazil,
-1965-09-30,CA,Canada,
-1965-09-30,CH,Switzerland,
-1965-09-30,CL,Chile,
-1965-09-30,CN,China,
-1965-09-30,CO,Colombia,
-1965-09-30,CY,Cyprus,
-1965-09-30,CZ,Czechia,
-1965-09-30,DE,Germany,
-1965-09-30,DK,Denmark,
-1965-09-30,EE,Estonia,
-1965-09-30,ES,Spain,
-1965-09-30,FI,Finland,
-1965-09-30,FR,France,
-1965-09-30,GB,United Kingdom,
-1965-09-30,GR,Greece,
-1965-09-30,HK,Hong Kong SAR,
-1965-09-30,HR,Croatia,
-1965-09-30,HU,Hungary,
-1965-09-30,ID,Indonesia,
-1965-09-30,IE,Ireland,
-1965-09-30,IL,Israel,
-1965-09-30,IN,India,
-1965-09-30,IS,Iceland,
-1965-09-30,IT,Italy,-2.6811
+1965-06-30,NZ,New Zealand,8.0884
+1965-09-30,IT,Italy,-2.5701
 1965-09-30,JP,Japan,9.8684
-1965-09-30,KR,Korea,
-1965-09-30,LT,Lithuania,
-1965-09-30,LU,Luxembourg,
-1965-09-30,LV,Latvia,
-1965-09-30,MA,Morocco,
-1965-09-30,MK,North Macedonia,
-1965-09-30,MT,Malta,
-1965-09-30,MX,Mexico,
-1965-09-30,MY,Malaysia,
-1965-09-30,NL,Netherlands,
-1965-09-30,NO,Norway,
-1965-09-30,NZ,New Zealand,
-1965-09-30,PE,Peru,
-1965-09-30,PH,Philippines,
-1965-09-30,PL,Poland,
-1965-09-30,PT,Portugal,
-1965-09-30,RO,Romania,
-1965-09-30,RS,Serbia,
-1965-09-30,RU,Russia,
-1965-09-30,SE,Sweden,
-1965-09-30,SG,Singapore,
-1965-09-30,SI,Slovenia,
-1965-09-30,SK,Slovak Republic,
-1965-09-30,TH,Thailand,
-1965-09-30,TR,Türkiye,
-1965-09-30,US,United States,
-1965-09-30,XM,Euro area,
-1965-09-30,XW,World,
-1965-09-30,ZA,South Africa,
-1965-12-31,4T,Emerging market economies (aggregate),
-1965-12-31,5R,Advanced economies,
-1965-12-31,AE,United Arab Emirates,
-1965-12-31,AT,Austria,
-1965-12-31,AU,Australia,
-1965-12-31,BE,Belgium,
-1965-12-31,BG,Bulgaria,
-1965-12-31,BR,Brazil,
-1965-12-31,CA,Canada,
-1965-12-31,CH,Switzerland,
-1965-12-31,CL,Chile,
-1965-12-31,CN,China,
-1965-12-31,CO,Colombia,
-1965-12-31,CY,Cyprus,
-1965-12-31,CZ,Czechia,
-1965-12-31,DE,Germany,
-1965-12-31,DK,Denmark,
-1965-12-31,EE,Estonia,
-1965-12-31,ES,Spain,
-1965-12-31,FI,Finland,
-1965-12-31,FR,France,
-1965-12-31,GB,United Kingdom,
-1965-12-31,GR,Greece,
-1965-12-31,HK,Hong Kong SAR,
-1965-12-31,HR,Croatia,
-1965-12-31,HU,Hungary,
-1965-12-31,ID,Indonesia,
-1965-12-31,IE,Ireland,
-1965-12-31,IL,Israel,
-1965-12-31,IN,India,
-1965-12-31,IS,Iceland,
-1965-12-31,IT,Italy,-2.4347
+1965-09-30,NZ,New Zealand,7.247
+1965-12-31,IT,Italy,-1.2571
 1965-12-31,JP,Japan,7.9365
-1965-12-31,KR,Korea,
-1965-12-31,LT,Lithuania,
-1965-12-31,LU,Luxembourg,
-1965-12-31,LV,Latvia,
-1965-12-31,MA,Morocco,
-1965-12-31,MK,North Macedonia,
-1965-12-31,MT,Malta,
-1965-12-31,MX,Mexico,
-1965-12-31,MY,Malaysia,
-1965-12-31,NL,Netherlands,
-1965-12-31,NO,Norway,
-1965-12-31,NZ,New Zealand,
-1965-12-31,PE,Peru,
-1965-12-31,PH,Philippines,
-1965-12-31,PL,Poland,
-1965-12-31,PT,Portugal,
-1965-12-31,RO,Romania,
-1965-12-31,RS,Serbia,
-1965-12-31,RU,Russia,
-1965-12-31,SE,Sweden,
-1965-12-31,SG,Singapore,
-1965-12-31,SI,Slovenia,
-1965-12-31,SK,Slovak Republic,
-1965-12-31,TH,Thailand,
-1965-12-31,TR,Türkiye,
-1965-12-31,US,United States,
-1965-12-31,XM,Euro area,
-1965-12-31,XW,World,
-1965-12-31,ZA,South Africa,
-1966-03-31,4T,Emerging market economies (aggregate),
-1966-03-31,5R,Advanced economies,
-1966-03-31,AE,United Arab Emirates,
-1966-03-31,AT,Austria,
-1966-03-31,AU,Australia,
-1966-03-31,BE,Belgium,
-1966-03-31,BG,Bulgaria,
-1966-03-31,BR,Brazil,
-1966-03-31,CA,Canada,
-1966-03-31,CH,Switzerland,
-1966-03-31,CL,Chile,
-1966-03-31,CN,China,
-1966-03-31,CO,Colombia,
-1966-03-31,CY,Cyprus,
-1966-03-31,CZ,Czechia,
-1966-03-31,DE,Germany,
-1966-03-31,DK,Denmark,
-1966-03-31,EE,Estonia,
-1966-03-31,ES,Spain,
-1966-03-31,FI,Finland,
-1966-03-31,FR,France,
-1966-03-31,GB,United Kingdom,
-1966-03-31,GR,Greece,
-1966-03-31,HK,Hong Kong SAR,
-1966-03-31,HR,Croatia,
-1966-03-31,HU,Hungary,
-1966-03-31,ID,Indonesia,
-1966-03-31,IE,Ireland,
-1966-03-31,IL,Israel,
-1966-03-31,IN,India,
-1966-03-31,IS,Iceland,
-1966-03-31,IT,Italy,-0.5165
+1965-12-31,NZ,New Zealand,6.3824
+1966-03-31,IT,Italy,0.4573
 1966-03-31,JP,Japan,6.135
-1966-03-31,KR,Korea,
-1966-03-31,LT,Lithuania,
-1966-03-31,LU,Luxembourg,
-1966-03-31,LV,Latvia,
-1966-03-31,MA,Morocco,
-1966-03-31,MK,North Macedonia,
-1966-03-31,MT,Malta,
-1966-03-31,MX,Mexico,
-1966-03-31,MY,Malaysia,
-1966-03-31,NL,Netherlands,
-1966-03-31,NO,Norway,
-1966-03-31,NZ,New Zealand,
-1966-03-31,PE,Peru,
-1966-03-31,PH,Philippines,
-1966-03-31,PL,Poland,
-1966-03-31,PT,Portugal,
-1966-03-31,RO,Romania,
-1966-03-31,RS,Serbia,
-1966-03-31,RU,Russia,
-1966-03-31,SE,Sweden,
-1966-03-31,SG,Singapore,
-1966-03-31,SI,Slovenia,
-1966-03-31,SK,Slovak Republic,
-1966-03-31,TH,Thailand,
-1966-03-31,TR,Türkiye,
-1966-03-31,US,United States,
-1966-03-31,XM,Euro area,
-1966-03-31,XW,World,
-1966-03-31,ZA,South Africa,
-1966-06-30,4T,Emerging market economies (aggregate),
-1966-06-30,5R,Advanced economies,
-1966-06-30,AE,United Arab Emirates,
-1966-06-30,AT,Austria,
-1966-06-30,AU,Australia,
-1966-06-30,BE,Belgium,
-1966-06-30,BG,Bulgaria,
-1966-06-30,BR,Brazil,
-1966-06-30,CA,Canada,
-1966-06-30,CH,Switzerland,
-1966-06-30,CL,Chile,
-1966-06-30,CN,China,
-1966-06-30,CO,Colombia,
-1966-06-30,CY,Cyprus,
-1966-06-30,CZ,Czechia,
-1966-06-30,DE,Germany,
-1966-06-30,DK,Denmark,
-1966-06-30,EE,Estonia,
-1966-06-30,ES,Spain,
-1966-06-30,FI,Finland,
-1966-06-30,FR,France,
-1966-06-30,GB,United Kingdom,
-1966-06-30,GR,Greece,
-1966-06-30,HK,Hong Kong SAR,
-1966-06-30,HR,Croatia,
-1966-06-30,HU,Hungary,
-1966-06-30,ID,Indonesia,
-1966-06-30,IE,Ireland,
-1966-06-30,IL,Israel,
-1966-06-30,IN,India,
-1966-06-30,IS,Iceland,
-1966-06-30,IT,Italy,1.7774
+1966-03-31,NZ,New Zealand,4.8613
+1966-06-30,IT,Italy,2.6459
 1966-06-30,JP,Japan,6.9651
-1966-06-30,KR,Korea,
-1966-06-30,LT,Lithuania,
-1966-06-30,LU,Luxembourg,
-1966-06-30,LV,Latvia,
-1966-06-30,MA,Morocco,
-1966-06-30,MK,North Macedonia,
-1966-06-30,MT,Malta,
-1966-06-30,MX,Mexico,
-1966-06-30,MY,Malaysia,
-1966-06-30,NL,Netherlands,
-1966-06-30,NO,Norway,
-1966-06-30,NZ,New Zealand,
-1966-06-30,PE,Peru,
-1966-06-30,PH,Philippines,
-1966-06-30,PL,Poland,
-1966-06-30,PT,Portugal,
-1966-06-30,RO,Romania,
-1966-06-30,RS,Serbia,
-1966-06-30,RU,Russia,
-1966-06-30,SE,Sweden,
-1966-06-30,SG,Singapore,
-1966-06-30,SI,Slovenia,
-1966-06-30,SK,Slovak Republic,
-1966-06-30,TH,Thailand,
-1966-06-30,TR,Türkiye,
-1966-06-30,US,United States,
-1966-06-30,XM,Euro area,
-1966-06-30,XW,World,
-1966-06-30,ZA,South Africa,
-1966-09-30,4T,Emerging market economies (aggregate),
-1966-09-30,5R,Advanced economies,
-1966-09-30,AE,United Arab Emirates,
-1966-09-30,AT,Austria,
-1966-09-30,AU,Australia,
-1966-09-30,BE,Belgium,
-1966-09-30,BG,Bulgaria,
-1966-09-30,BR,Brazil,
-1966-09-30,CA,Canada,
-1966-09-30,CH,Switzerland,
-1966-09-30,CL,Chile,
-1966-09-30,CN,China,
-1966-09-30,CO,Colombia,
-1966-09-30,CY,Cyprus,
-1966-09-30,CZ,Czechia,
-1966-09-30,DE,Germany,
-1966-09-30,DK,Denmark,
-1966-09-30,EE,Estonia,
-1966-09-30,ES,Spain,
-1966-09-30,FI,Finland,
-1966-09-30,FR,France,
-1966-09-30,GB,United Kingdom,
-1966-09-30,GR,Greece,
-1966-09-30,HK,Hong Kong SAR,
-1966-09-30,HR,Croatia,
-1966-09-30,HU,Hungary,
-1966-09-30,ID,Indonesia,
-1966-09-30,IE,Ireland,
-1966-09-30,IL,Israel,
-1966-09-30,IN,India,
-1966-09-30,IS,Iceland,
-1966-09-30,IT,Italy,1.2741
+1966-06-30,NZ,New Zealand,4.0808
+1966-09-30,IT,Italy,1.0915
 1966-09-30,JP,Japan,7.7844
-1966-09-30,KR,Korea,
-1966-09-30,LT,Lithuania,
-1966-09-30,LU,Luxembourg,
-1966-09-30,LV,Latvia,
-1966-09-30,MA,Morocco,
-1966-09-30,MK,North Macedonia,
-1966-09-30,MT,Malta,
-1966-09-30,MX,Mexico,
-1966-09-30,MY,Malaysia,
-1966-09-30,NL,Netherlands,
-1966-09-30,NO,Norway,
-1966-09-30,NZ,New Zealand,
-1966-09-30,PE,Peru,
-1966-09-30,PH,Philippines,
-1966-09-30,PL,Poland,
-1966-09-30,PT,Portugal,
-1966-09-30,RO,Romania,
-1966-09-30,RS,Serbia,
-1966-09-30,RU,Russia,
-1966-09-30,SE,Sweden,
-1966-09-30,SG,Singapore,
-1966-09-30,SI,Slovenia,
-1966-09-30,SK,Slovak Republic,
-1966-09-30,TH,Thailand,
-1966-09-30,TR,Türkiye,
-1966-09-30,US,United States,
-1966-09-30,XM,Euro area,
-1966-09-30,XW,World,
-1966-09-30,ZA,South Africa,
-1966-12-31,4T,Emerging market economies (aggregate),
-1966-12-31,5R,Advanced economies,
-1966-12-31,AE,United Arab Emirates,
-1966-12-31,AT,Austria,
-1966-12-31,AU,Australia,
-1966-12-31,BE,Belgium,
-1966-12-31,BG,Bulgaria,
-1966-12-31,BR,Brazil,
-1966-12-31,CA,Canada,
-1966-12-31,CH,Switzerland,
-1966-12-31,CL,Chile,
-1966-12-31,CN,China,
-1966-12-31,CO,Colombia,
-1966-12-31,CY,Cyprus,
-1966-12-31,CZ,Czechia,
-1966-12-31,DE,Germany,
-1966-12-31,DK,Denmark,
-1966-12-31,EE,Estonia,
-1966-12-31,ES,Spain,
-1966-12-31,FI,Finland,
-1966-12-31,FR,France,
-1966-12-31,GB,United Kingdom,
-1966-12-31,GR,Greece,
-1966-12-31,HK,Hong Kong SAR,
-1966-12-31,HR,Croatia,
-1966-12-31,HU,Hungary,
-1966-12-31,ID,Indonesia,
-1966-12-31,IE,Ireland,
-1966-12-31,IL,Israel,
-1966-12-31,IN,India,
-1966-12-31,IS,Iceland,
-1966-12-31,IT,Italy,0.9613
+1966-09-30,NZ,New Zealand,5.4052
+1966-12-31,IT,Italy,-0.6592
 1966-12-31,JP,Japan,8.8235
-1966-12-31,KR,Korea,
-1966-12-31,LT,Lithuania,
-1966-12-31,LU,Luxembourg,
-1966-12-31,LV,Latvia,
-1966-12-31,MA,Morocco,
-1966-12-31,MK,North Macedonia,
-1966-12-31,MT,Malta,
-1966-12-31,MX,Mexico,
-1966-12-31,MY,Malaysia,
-1966-12-31,NL,Netherlands,
-1966-12-31,NO,Norway,
-1966-12-31,NZ,New Zealand,
-1966-12-31,PE,Peru,
-1966-12-31,PH,Philippines,
-1966-12-31,PL,Poland,
-1966-12-31,PT,Portugal,
-1966-12-31,RO,Romania,
-1966-12-31,RS,Serbia,
-1966-12-31,RU,Russia,
-1966-12-31,SE,Sweden,
-1966-12-31,SG,Singapore,
-1966-12-31,SI,Slovenia,
-1966-12-31,SK,Slovak Republic,
-1966-12-31,TH,Thailand,
-1966-12-31,TR,Türkiye,
-1966-12-31,US,United States,
-1966-12-31,XM,Euro area,
-1966-12-31,XW,World,
-1966-12-31,ZA,South Africa,
-1967-03-31,4T,Emerging market economies (aggregate),
-1967-03-31,5R,Advanced economies,
-1967-03-31,AE,United Arab Emirates,
-1967-03-31,AT,Austria,
-1967-03-31,AU,Australia,
-1967-03-31,BE,Belgium,
-1967-03-31,BG,Bulgaria,
-1967-03-31,BR,Brazil,
-1967-03-31,CA,Canada,
-1967-03-31,CH,Switzerland,
-1967-03-31,CL,Chile,
-1967-03-31,CN,China,
-1967-03-31,CO,Colombia,
-1967-03-31,CY,Cyprus,
-1967-03-31,CZ,Czechia,
-1967-03-31,DE,Germany,
-1967-03-31,DK,Denmark,
-1967-03-31,EE,Estonia,
-1967-03-31,ES,Spain,
-1967-03-31,FI,Finland,
-1967-03-31,FR,France,
-1967-03-31,GB,United Kingdom,
-1967-03-31,GR,Greece,
-1967-03-31,HK,Hong Kong SAR,
-1967-03-31,HR,Croatia,
-1967-03-31,HU,Hungary,
-1967-03-31,ID,Indonesia,
-1967-03-31,IE,Ireland,
-1967-03-31,IL,Israel,
-1967-03-31,IN,India,
-1967-03-31,IS,Iceland,
-1967-03-31,IT,Italy,-0.1446
+1966-12-31,NZ,New Zealand,6.001
+1967-03-31,IT,Italy,0.2039
 1967-03-31,JP,Japan,9.8266
-1967-03-31,KR,Korea,
-1967-03-31,LT,Lithuania,
-1967-03-31,LU,Luxembourg,
-1967-03-31,LV,Latvia,
-1967-03-31,MA,Morocco,
-1967-03-31,MK,North Macedonia,
-1967-03-31,MT,Malta,
-1967-03-31,MX,Mexico,
-1967-03-31,MY,Malaysia,
-1967-03-31,NL,Netherlands,
-1967-03-31,NO,Norway,
-1967-03-31,NZ,New Zealand,
-1967-03-31,PE,Peru,
-1967-03-31,PH,Philippines,
-1967-03-31,PL,Poland,
-1967-03-31,PT,Portugal,
-1967-03-31,RO,Romania,
-1967-03-31,RS,Serbia,
-1967-03-31,RU,Russia,
-1967-03-31,SE,Sweden,
-1967-03-31,SG,Singapore,
-1967-03-31,SI,Slovenia,
-1967-03-31,SK,Slovak Republic,
-1967-03-31,TH,Thailand,
-1967-03-31,TR,Türkiye,
-1967-03-31,US,United States,
-1967-03-31,XM,Euro area,
-1967-03-31,XW,World,
+1967-03-31,NZ,New Zealand,5.9597
 1967-03-31,ZA,South Africa,16.5049
-1967-06-30,4T,Emerging market economies (aggregate),
-1967-06-30,5R,Advanced economies,
-1967-06-30,AE,United Arab Emirates,
-1967-06-30,AT,Austria,
-1967-06-30,AU,Australia,
-1967-06-30,BE,Belgium,
-1967-06-30,BG,Bulgaria,
-1967-06-30,BR,Brazil,
-1967-06-30,CA,Canada,
-1967-06-30,CH,Switzerland,
-1967-06-30,CL,Chile,
-1967-06-30,CN,China,
-1967-06-30,CO,Colombia,
-1967-06-30,CY,Cyprus,
-1967-06-30,CZ,Czechia,
-1967-06-30,DE,Germany,
-1967-06-30,DK,Denmark,
-1967-06-30,EE,Estonia,
-1967-06-30,ES,Spain,
-1967-06-30,FI,Finland,
-1967-06-30,FR,France,
-1967-06-30,GB,United Kingdom,
-1967-06-30,GR,Greece,
-1967-06-30,HK,Hong Kong SAR,
-1967-06-30,HR,Croatia,
-1967-06-30,HU,Hungary,
-1967-06-30,ID,Indonesia,
-1967-06-30,IE,Ireland,
-1967-06-30,IL,Israel,
-1967-06-30,IN,India,
-1967-06-30,IS,Iceland,
-1967-06-30,IT,Italy,-0.5909
+1967-06-30,IT,Italy,-1.0528
 1967-06-30,JP,Japan,11.8868
-1967-06-30,KR,Korea,
-1967-06-30,LT,Lithuania,
-1967-06-30,LU,Luxembourg,
-1967-06-30,LV,Latvia,
-1967-06-30,MA,Morocco,
-1967-06-30,MK,North Macedonia,
-1967-06-30,MT,Malta,
-1967-06-30,MX,Mexico,
-1967-06-30,MY,Malaysia,
-1967-06-30,NL,Netherlands,
-1967-06-30,NO,Norway,
-1967-06-30,NZ,New Zealand,
-1967-06-30,PE,Peru,
-1967-06-30,PH,Philippines,
-1967-06-30,PL,Poland,
-1967-06-30,PT,Portugal,
-1967-06-30,RO,Romania,
-1967-06-30,RS,Serbia,
-1967-06-30,RU,Russia,
-1967-06-30,SE,Sweden,
-1967-06-30,SG,Singapore,
-1967-06-30,SI,Slovenia,
-1967-06-30,SK,Slovak Republic,
-1967-06-30,TH,Thailand,
-1967-06-30,TR,Türkiye,
-1967-06-30,US,United States,
-1967-06-30,XM,Euro area,
-1967-06-30,XW,World,
+1967-06-30,NZ,New Zealand,5.2286
 1967-06-30,ZA,South Africa,18.0952
-1967-09-30,4T,Emerging market economies (aggregate),
-1967-09-30,5R,Advanced economies,
-1967-09-30,AE,United Arab Emirates,
-1967-09-30,AT,Austria,
-1967-09-30,AU,Australia,
-1967-09-30,BE,Belgium,
-1967-09-30,BG,Bulgaria,
-1967-09-30,BR,Brazil,
-1967-09-30,CA,Canada,
-1967-09-30,CH,Switzerland,
-1967-09-30,CL,Chile,
-1967-09-30,CN,China,
-1967-09-30,CO,Colombia,
-1967-09-30,CY,Cyprus,
-1967-09-30,CZ,Czechia,
-1967-09-30,DE,Germany,
-1967-09-30,DK,Denmark,
-1967-09-30,EE,Estonia,
-1967-09-30,ES,Spain,
-1967-09-30,FI,Finland,
-1967-09-30,FR,France,
-1967-09-30,GB,United Kingdom,
-1967-09-30,GR,Greece,
-1967-09-30,HK,Hong Kong SAR,
-1967-09-30,HR,Croatia,
-1967-09-30,HU,Hungary,
-1967-09-30,ID,Indonesia,
-1967-09-30,IE,Ireland,
-1967-09-30,IL,Israel,
-1967-09-30,IN,India,
-1967-09-30,IS,Iceland,
-1967-09-30,IT,Italy,2.452
+1967-09-30,IT,Italy,2.204
 1967-09-30,JP,Japan,13.8889
-1967-09-30,KR,Korea,
-1967-09-30,LT,Lithuania,
-1967-09-30,LU,Luxembourg,
-1967-09-30,LV,Latvia,
-1967-09-30,MA,Morocco,
-1967-09-30,MK,North Macedonia,
-1967-09-30,MT,Malta,
-1967-09-30,MX,Mexico,
-1967-09-30,MY,Malaysia,
-1967-09-30,NL,Netherlands,
-1967-09-30,NO,Norway,
-1967-09-30,NZ,New Zealand,
-1967-09-30,PE,Peru,
-1967-09-30,PH,Philippines,
-1967-09-30,PL,Poland,
-1967-09-30,PT,Portugal,
-1967-09-30,RO,Romania,
-1967-09-30,RS,Serbia,
-1967-09-30,RU,Russia,
-1967-09-30,SE,Sweden,
-1967-09-30,SG,Singapore,
-1967-09-30,SI,Slovenia,
-1967-09-30,SK,Slovak Republic,
-1967-09-30,TH,Thailand,
-1967-09-30,TR,Türkiye,
-1967-09-30,US,United States,
-1967-09-30,XM,Euro area,
-1967-09-30,XW,World,
+1967-09-30,NZ,New Zealand,3.2047
 1967-09-30,ZA,South Africa,23.0769
-1967-12-31,4T,Emerging market economies (aggregate),
-1967-12-31,5R,Advanced economies,
-1967-12-31,AE,United Arab Emirates,
-1967-12-31,AT,Austria,
-1967-12-31,AU,Australia,
-1967-12-31,BE,Belgium,
-1967-12-31,BG,Bulgaria,
-1967-12-31,BR,Brazil,
-1967-12-31,CA,Canada,
-1967-12-31,CH,Switzerland,
-1967-12-31,CL,Chile,
-1967-12-31,CN,China,
-1967-12-31,CO,Colombia,
-1967-12-31,CY,Cyprus,
-1967-12-31,CZ,Czechia,
-1967-12-31,DE,Germany,
-1967-12-31,DK,Denmark,
-1967-12-31,EE,Estonia,
-1967-12-31,ES,Spain,
-1967-12-31,FI,Finland,
-1967-12-31,FR,France,
-1967-12-31,GB,United Kingdom,
-1967-12-31,GR,Greece,
-1967-12-31,HK,Hong Kong SAR,
-1967-12-31,HR,Croatia,
-1967-12-31,HU,Hungary,
-1967-12-31,ID,Indonesia,
-1967-12-31,IE,Ireland,
-1967-12-31,IL,Israel,
-1967-12-31,IN,India,
-1967-12-31,IS,Iceland,
-1967-12-31,IT,Italy,6.04
+1967-12-31,IT,Italy,6.4597
 1967-12-31,JP,Japan,15.4054
-1967-12-31,KR,Korea,
-1967-12-31,LT,Lithuania,
-1967-12-31,LU,Luxembourg,
-1967-12-31,LV,Latvia,
-1967-12-31,MA,Morocco,
-1967-12-31,MK,North Macedonia,
-1967-12-31,MT,Malta,
-1967-12-31,MX,Mexico,
-1967-12-31,MY,Malaysia,
-1967-12-31,NL,Netherlands,
-1967-12-31,NO,Norway,
-1967-12-31,NZ,New Zealand,
-1967-12-31,PE,Peru,
-1967-12-31,PH,Philippines,
-1967-12-31,PL,Poland,
-1967-12-31,PT,Portugal,
-1967-12-31,RO,Romania,
-1967-12-31,RS,Serbia,
-1967-12-31,RU,Russia,
-1967-12-31,SE,Sweden,
-1967-12-31,SG,Singapore,
-1967-12-31,SI,Slovenia,
-1967-12-31,SK,Slovak Republic,
-1967-12-31,TH,Thailand,
-1967-12-31,TR,Türkiye,
-1967-12-31,US,United States,
-1967-12-31,XM,Euro area,
-1967-12-31,XW,World,
+1967-12-31,NZ,New Zealand,1.2571
 1967-12-31,ZA,South Africa,18.5185
-1968-03-31,4T,Emerging market economies (aggregate),
-1968-03-31,5R,Advanced economies,
-1968-03-31,AE,United Arab Emirates,
-1968-03-31,AT,Austria,
-1968-03-31,AU,Australia,
-1968-03-31,BE,Belgium,
-1968-03-31,BG,Bulgaria,
-1968-03-31,BR,Brazil,
-1968-03-31,CA,Canada,
-1968-03-31,CH,Switzerland,
-1968-03-31,CL,Chile,
-1968-03-31,CN,China,
-1968-03-31,CO,Colombia,
-1968-03-31,CY,Cyprus,
-1968-03-31,CZ,Czechia,
-1968-03-31,DE,Germany,
-1968-03-31,DK,Denmark,
-1968-03-31,EE,Estonia,
-1968-03-31,ES,Spain,
-1968-03-31,FI,Finland,
-1968-03-31,FR,France,
-1968-03-31,GB,United Kingdom,
-1968-03-31,GR,Greece,
-1968-03-31,HK,Hong Kong SAR,
-1968-03-31,HR,Croatia,
-1968-03-31,HU,Hungary,
-1968-03-31,ID,Indonesia,
-1968-03-31,IE,Ireland,
-1968-03-31,IL,Israel,
-1968-03-31,IN,India,
-1968-03-31,IS,Iceland,
-1968-03-31,IT,Italy,9.1803
+1968-03-31,IT,Italy,7.4778
 1968-03-31,JP,Japan,16.8421
-1968-03-31,KR,Korea,
-1968-03-31,LT,Lithuania,
-1968-03-31,LU,Luxembourg,
-1968-03-31,LV,Latvia,
-1968-03-31,MA,Morocco,
-1968-03-31,MK,North Macedonia,
-1968-03-31,MT,Malta,
-1968-03-31,MX,Mexico,
-1968-03-31,MY,Malaysia,
-1968-03-31,NL,Netherlands,
-1968-03-31,NO,Norway,
-1968-03-31,NZ,New Zealand,
-1968-03-31,PE,Peru,
-1968-03-31,PH,Philippines,
-1968-03-31,PL,Poland,
-1968-03-31,PT,Portugal,
-1968-03-31,RO,Romania,
-1968-03-31,RS,Serbia,
-1968-03-31,RU,Russia,
-1968-03-31,SE,Sweden,
-1968-03-31,SG,Singapore,
-1968-03-31,SI,Slovenia,
-1968-03-31,SK,Slovak Republic,
-1968-03-31,TH,Thailand,
-1968-03-31,TR,Türkiye,
-1968-03-31,US,United States,
-1968-03-31,XM,Euro area,
-1968-03-31,XW,World,
+1968-03-31,NZ,New Zealand,1.2506
 1968-03-31,ZA,South Africa,5
-1968-06-30,4T,Emerging market economies (aggregate),
-1968-06-30,5R,Advanced economies,
-1968-06-30,AE,United Arab Emirates,
-1968-06-30,AT,Austria,
-1968-06-30,AU,Australia,
-1968-06-30,BE,Belgium,
-1968-06-30,BG,Bulgaria,
-1968-06-30,BR,Brazil,
-1968-06-30,CA,Canada,
-1968-06-30,CH,Switzerland,
-1968-06-30,CL,Chile,
-1968-06-30,CN,China,
-1968-06-30,CO,Colombia,
-1968-06-30,CY,Cyprus,
-1968-06-30,CZ,Czechia,
-1968-06-30,DE,Germany,
-1968-06-30,DK,Denmark,
-1968-06-30,EE,Estonia,
-1968-06-30,ES,Spain,
-1968-06-30,FI,Finland,
-1968-06-30,FR,France,
-1968-06-30,GB,United Kingdom,
-1968-06-30,GR,Greece,
-1968-06-30,HK,Hong Kong SAR,
-1968-06-30,HR,Croatia,
-1968-06-30,HU,Hungary,
-1968-06-30,ID,Indonesia,
-1968-06-30,IE,Ireland,
-1968-06-30,IL,Israel,
-1968-06-30,IN,India,
-1968-06-30,IS,Iceland,
-1968-06-30,IT,Italy,11.9676
+1968-06-30,IT,Italy,12.5634
 1968-06-30,JP,Japan,17.2398
-1968-06-30,KR,Korea,
-1968-06-30,LT,Lithuania,
-1968-06-30,LU,Luxembourg,
-1968-06-30,LV,Latvia,
-1968-06-30,MA,Morocco,
-1968-06-30,MK,North Macedonia,
-1968-06-30,MT,Malta,
-1968-06-30,MX,Mexico,
-1968-06-30,MY,Malaysia,
-1968-06-30,NL,Netherlands,
-1968-06-30,NO,Norway,
-1968-06-30,NZ,New Zealand,
-1968-06-30,PE,Peru,
-1968-06-30,PH,Philippines,
-1968-06-30,PL,Poland,
-1968-06-30,PT,Portugal,
-1968-06-30,RO,Romania,
-1968-06-30,RS,Serbia,
-1968-06-30,RU,Russia,
-1968-06-30,SE,Sweden,
-1968-06-30,SG,Singapore,
-1968-06-30,SI,Slovenia,
-1968-06-30,SK,Slovak Republic,
-1968-06-30,TH,Thailand,
-1968-06-30,TR,Türkiye,
-1968-06-30,US,United States,
-1968-06-30,XM,Euro area,
-1968-06-30,XW,World,
+1968-06-30,NZ,New Zealand,1.2429
 1968-06-30,ZA,South Africa,2.4194
-1968-09-30,4T,Emerging market economies (aggregate),
-1968-09-30,5R,Advanced economies,
-1968-09-30,AE,United Arab Emirates,
-1968-09-30,AT,Austria,
-1968-09-30,AU,Australia,
-1968-09-30,BE,Belgium,
-1968-09-30,BG,Bulgaria,
-1968-09-30,BR,Brazil,
-1968-09-30,CA,Canada,
-1968-09-30,CH,Switzerland,
-1968-09-30,CL,Chile,
-1968-09-30,CN,China,
-1968-09-30,CO,Colombia,
-1968-09-30,CY,Cyprus,
-1968-09-30,CZ,Czechia,
-1968-09-30,DE,Germany,
-1968-09-30,DK,Denmark,
-1968-09-30,EE,Estonia,
-1968-09-30,ES,Spain,
-1968-09-30,FI,Finland,
-1968-09-30,FR,France,
-1968-09-30,GB,United Kingdom,
-1968-09-30,GR,Greece,
-1968-09-30,HK,Hong Kong SAR,
-1968-09-30,HR,Croatia,
-1968-09-30,HU,Hungary,
-1968-09-30,ID,Indonesia,
-1968-09-30,IE,Ireland,
-1968-09-30,IL,Israel,
-1968-09-30,IN,India,
-1968-09-30,IS,Iceland,
-1968-09-30,IT,Italy,9.7313
+1968-09-30,IT,Italy,10.3331
 1968-09-30,JP,Japan,17.561
-1968-09-30,KR,Korea,
-1968-09-30,LT,Lithuania,
-1968-09-30,LU,Luxembourg,
-1968-09-30,LV,Latvia,
-1968-09-30,MA,Morocco,
-1968-09-30,MK,North Macedonia,
-1968-09-30,MT,Malta,
-1968-09-30,MX,Mexico,
-1968-09-30,MY,Malaysia,
-1968-09-30,NL,Netherlands,
-1968-09-30,NO,Norway,
-1968-09-30,NZ,New Zealand,
-1968-09-30,PE,Peru,
-1968-09-30,PH,Philippines,
-1968-09-30,PL,Poland,
-1968-09-30,PT,Portugal,
-1968-09-30,RO,Romania,
-1968-09-30,RS,Serbia,
-1968-09-30,RU,Russia,
-1968-09-30,SE,Sweden,
-1968-09-30,SG,Singapore,
-1968-09-30,SI,Slovenia,
-1968-09-30,SK,Slovak Republic,
-1968-09-30,TH,Thailand,
-1968-09-30,TR,Türkiye,
-1968-09-30,US,United States,
-1968-09-30,XM,Euro area,
-1968-09-30,XW,World,
+1968-09-30,NZ,New Zealand,1.8636
 1968-09-30,ZA,South Africa,3.125
-1968-12-31,4T,Emerging market economies (aggregate),
-1968-12-31,5R,Advanced economies,
-1968-12-31,AE,United Arab Emirates,
-1968-12-31,AT,Austria,
-1968-12-31,AU,Australia,
-1968-12-31,BE,Belgium,
-1968-12-31,BG,Bulgaria,
-1968-12-31,BR,Brazil,
-1968-12-31,CA,Canada,
-1968-12-31,CH,Switzerland,
-1968-12-31,CL,Chile,
-1968-12-31,CN,China,
-1968-12-31,CO,Colombia,
-1968-12-31,CY,Cyprus,
-1968-12-31,CZ,Czechia,
-1968-12-31,DE,Germany,
-1968-12-31,DK,Denmark,
-1968-12-31,EE,Estonia,
-1968-12-31,ES,Spain,
-1968-12-31,FI,Finland,
-1968-12-31,FR,France,
-1968-12-31,GB,United Kingdom,
-1968-12-31,GR,Greece,
-1968-12-31,HK,Hong Kong SAR,
-1968-12-31,HR,Croatia,
-1968-12-31,HU,Hungary,
-1968-12-31,ID,Indonesia,
-1968-12-31,IE,Ireland,
-1968-12-31,IL,Israel,
-1968-12-31,IN,India,
-1968-12-31,IS,Iceland,
-1968-12-31,IT,Italy,6.0109
+1968-12-31,IT,Italy,6.4717
 1968-12-31,JP,Japan,18.5012
-1968-12-31,KR,Korea,
-1968-12-31,LT,Lithuania,
-1968-12-31,LU,Luxembourg,
-1968-12-31,LV,Latvia,
-1968-12-31,MA,Morocco,
-1968-12-31,MK,North Macedonia,
-1968-12-31,MT,Malta,
-1968-12-31,MX,Mexico,
-1968-12-31,MY,Malaysia,
-1968-12-31,NL,Netherlands,
-1968-12-31,NO,Norway,
-1968-12-31,NZ,New Zealand,
-1968-12-31,PE,Peru,
-1968-12-31,PH,Philippines,
-1968-12-31,PL,Poland,
-1968-12-31,PT,Portugal,
-1968-12-31,RO,Romania,
-1968-12-31,RS,Serbia,
-1968-12-31,RU,Russia,
-1968-12-31,SE,Sweden,
-1968-12-31,SG,Singapore,
-1968-12-31,SI,Slovenia,
-1968-12-31,SK,Slovak Republic,
-1968-12-31,TH,Thailand,
-1968-12-31,TR,Türkiye,
-1968-12-31,US,United States,
-1968-12-31,XM,Euro area,
-1968-12-31,XW,World,
+1968-12-31,NZ,New Zealand,2.4844
 1968-12-31,ZA,South Africa,7.0313
-1969-03-31,4T,Emerging market economies (aggregate),
-1969-03-31,5R,Advanced economies,
-1969-03-31,AE,United Arab Emirates,
-1969-03-31,AT,Austria,
-1969-03-31,AU,Australia,
-1969-03-31,BE,Belgium,
-1969-03-31,BG,Bulgaria,
-1969-03-31,BR,Brazil,
-1969-03-31,CA,Canada,
-1969-03-31,CH,Switzerland,
-1969-03-31,CL,Chile,
-1969-03-31,CN,China,
-1969-03-31,CO,Colombia,
-1969-03-31,CY,Cyprus,
-1969-03-31,CZ,Czechia,
-1969-03-31,DE,Germany,
-1969-03-31,DK,Denmark,
-1969-03-31,EE,Estonia,
-1969-03-31,ES,Spain,
-1969-03-31,FI,Finland,
-1969-03-31,FR,France,
-1969-03-31,GB,United Kingdom,
-1969-03-31,GR,Greece,
-1969-03-31,HK,Hong Kong SAR,
-1969-03-31,HR,Croatia,
-1969-03-31,HU,Hungary,
-1969-03-31,ID,Indonesia,
-1969-03-31,IE,Ireland,
-1969-03-31,IL,Israel,
-1969-03-31,IN,India,
-1969-03-31,IS,Iceland,
-1969-03-31,IT,Italy,3.8403
+1969-03-31,IT,Italy,4.2803
 1969-03-31,JP,Japan,19.3694
-1969-03-31,KR,Korea,
-1969-03-31,LT,Lithuania,
-1969-03-31,LU,Luxembourg,
-1969-03-31,LV,Latvia,
-1969-03-31,MA,Morocco,
-1969-03-31,MK,North Macedonia,
-1969-03-31,MT,Malta,
-1969-03-31,MX,Mexico,
-1969-03-31,MY,Malaysia,
-1969-03-31,NL,Netherlands,
-1969-03-31,NO,Norway,
-1969-03-31,NZ,New Zealand,
-1969-03-31,PE,Peru,
-1969-03-31,PH,Philippines,
-1969-03-31,PL,Poland,
-1969-03-31,PT,Portugal,
-1969-03-31,RO,Romania,
-1969-03-31,RS,Serbia,
-1969-03-31,RU,Russia,
-1969-03-31,SE,Sweden,
-1969-03-31,SG,Singapore,
-1969-03-31,SI,Slovenia,
-1969-03-31,SK,Slovak Republic,
-1969-03-31,TH,Thailand,
-1969-03-31,TR,Türkiye,
-1969-03-31,US,United States,
-1969-03-31,XM,Euro area,
-1969-03-31,XW,World,
+1969-03-31,NZ,New Zealand,3.7029
 1969-03-31,ZA,South Africa,10.3175
-1969-06-30,4T,Emerging market economies (aggregate),
-1969-06-30,5R,Advanced economies,
-1969-06-30,AE,United Arab Emirates,
-1969-06-30,AT,Austria,
-1969-06-30,AU,Australia,
-1969-06-30,BE,Belgium,
-1969-06-30,BG,Bulgaria,
-1969-06-30,BR,Brazil,
-1969-06-30,CA,Canada,
-1969-06-30,CH,Switzerland,
-1969-06-30,CL,Chile,
-1969-06-30,CN,China,
-1969-06-30,CO,Colombia,
-1969-06-30,CY,Cyprus,
-1969-06-30,CZ,Czechia,
-1969-06-30,DE,Germany,
-1969-06-30,DK,Denmark,
-1969-06-30,EE,Estonia,
-1969-06-30,ES,Spain,
-1969-06-30,FI,Finland,
-1969-06-30,FR,France,
 1969-06-30,GB,United Kingdom,5.5556
-1969-06-30,GR,Greece,
-1969-06-30,HK,Hong Kong SAR,
-1969-06-30,HR,Croatia,
-1969-06-30,HU,Hungary,
-1969-06-30,ID,Indonesia,
-1969-06-30,IE,Ireland,
-1969-06-30,IL,Israel,
-1969-06-30,IN,India,
-1969-06-30,IS,Iceland,
-1969-06-30,IT,Italy,2.5868
+1969-06-30,IT,Italy,2.2176
 1969-06-30,JP,Japan,20.9145
-1969-06-30,KR,Korea,
-1969-06-30,LT,Lithuania,
-1969-06-30,LU,Luxembourg,
-1969-06-30,LV,Latvia,
-1969-06-30,MA,Morocco,
-1969-06-30,MK,North Macedonia,
-1969-06-30,MT,Malta,
-1969-06-30,MX,Mexico,
-1969-06-30,MY,Malaysia,
-1969-06-30,NL,Netherlands,
-1969-06-30,NO,Norway,
-1969-06-30,NZ,New Zealand,
-1969-06-30,PE,Peru,
-1969-06-30,PH,Philippines,
-1969-06-30,PL,Poland,
-1969-06-30,PT,Portugal,
-1969-06-30,RO,Romania,
-1969-06-30,RS,Serbia,
-1969-06-30,RU,Russia,
-1969-06-30,SE,Sweden,
-1969-06-30,SG,Singapore,
-1969-06-30,SI,Slovenia,
-1969-06-30,SK,Slovak Republic,
-1969-06-30,TH,Thailand,
-1969-06-30,TR,Türkiye,
-1969-06-30,US,United States,
-1969-06-30,XM,Euro area,
-1969-06-30,XW,World,
+1969-06-30,NZ,New Zealand,4.2947
 1969-06-30,ZA,South Africa,12.5984
-1969-09-30,4T,Emerging market economies (aggregate),
-1969-09-30,5R,Advanced economies,
-1969-09-30,AE,United Arab Emirates,
-1969-09-30,AT,Austria,
-1969-09-30,AU,Australia,
-1969-09-30,BE,Belgium,
-1969-09-30,BG,Bulgaria,
-1969-09-30,BR,Brazil,
-1969-09-30,CA,Canada,
-1969-09-30,CH,Switzerland,
-1969-09-30,CL,Chile,
-1969-09-30,CN,China,
-1969-09-30,CO,Colombia,
-1969-09-30,CY,Cyprus,
-1969-09-30,CZ,Czechia,
-1969-09-30,DE,Germany,
-1969-09-30,DK,Denmark,
-1969-09-30,EE,Estonia,
-1969-09-30,ES,Spain,
-1969-09-30,FI,Finland,
-1969-09-30,FR,France,
 1969-09-30,GB,United Kingdom,2.7027
-1969-09-30,GR,Greece,
-1969-09-30,HK,Hong Kong SAR,
-1969-09-30,HR,Croatia,
-1969-09-30,HU,Hungary,
-1969-09-30,ID,Indonesia,
-1969-09-30,IE,Ireland,
-1969-09-30,IL,Israel,
-1969-09-30,IN,India,
-1969-09-30,IS,Iceland,
-1969-09-30,IT,Italy,3.943
+1969-09-30,IT,Italy,3.7566
 1969-09-30,JP,Japan,22.4066
-1969-09-30,KR,Korea,
-1969-09-30,LT,Lithuania,
-1969-09-30,LU,Luxembourg,
-1969-09-30,LV,Latvia,
-1969-09-30,MA,Morocco,
-1969-09-30,MK,North Macedonia,
-1969-09-30,MT,Malta,
-1969-09-30,MX,Mexico,
-1969-09-30,MY,Malaysia,
-1969-09-30,NL,Netherlands,
-1969-09-30,NO,Norway,
-1969-09-30,NZ,New Zealand,
-1969-09-30,PE,Peru,
-1969-09-30,PH,Philippines,
-1969-09-30,PL,Poland,
-1969-09-30,PT,Portugal,
-1969-09-30,RO,Romania,
-1969-09-30,RS,Serbia,
-1969-09-30,RU,Russia,
-1969-09-30,SE,Sweden,
-1969-09-30,SG,Singapore,
-1969-09-30,SI,Slovenia,
-1969-09-30,SK,Slovak Republic,
-1969-09-30,TH,Thailand,
-1969-09-30,TR,Türkiye,
-1969-09-30,US,United States,
-1969-09-30,XM,Euro area,
-1969-09-30,XW,World,
+1969-09-30,NZ,New Zealand,4.8779
 1969-09-30,ZA,South Africa,11.3636
-1969-12-31,4T,Emerging market economies (aggregate),
-1969-12-31,5R,Advanced economies,
-1969-12-31,AE,United Arab Emirates,
-1969-12-31,AT,Austria,
-1969-12-31,AU,Australia,
-1969-12-31,BE,Belgium,
-1969-12-31,BG,Bulgaria,
-1969-12-31,BR,Brazil,
-1969-12-31,CA,Canada,
-1969-12-31,CH,Switzerland,
-1969-12-31,CL,Chile,
-1969-12-31,CN,China,
-1969-12-31,CO,Colombia,
-1969-12-31,CY,Cyprus,
-1969-12-31,CZ,Czechia,
-1969-12-31,DE,Germany,
-1969-12-31,DK,Denmark,
-1969-12-31,EE,Estonia,
-1969-12-31,ES,Spain,
-1969-12-31,FI,Finland,
-1969-12-31,FR,France,
 1969-12-31,GB,United Kingdom,5.4054
-1969-12-31,GR,Greece,
-1969-12-31,HK,Hong Kong SAR,
-1969-12-31,HR,Croatia,
-1969-12-31,HU,Hungary,
-1969-12-31,ID,Indonesia,
-1969-12-31,IE,Ireland,
-1969-12-31,IL,Israel,
-1969-12-31,IN,India,
-1969-12-31,IS,Iceland,
-1969-12-31,IT,Italy,5.0829
+1969-12-31,IT,Italy,5.2155
 1969-12-31,JP,Japan,22.5296
-1969-12-31,KR,Korea,
-1969-12-31,LT,Lithuania,
-1969-12-31,LU,Luxembourg,
-1969-12-31,LV,Latvia,
-1969-12-31,MA,Morocco,
-1969-12-31,MK,North Macedonia,
-1969-12-31,MT,Malta,
-1969-12-31,MX,Mexico,
-1969-12-31,MY,Malaysia,
-1969-12-31,NL,Netherlands,
-1969-12-31,NO,Norway,
-1969-12-31,NZ,New Zealand,
-1969-12-31,PE,Peru,
-1969-12-31,PH,Philippines,
-1969-12-31,PL,Poland,
-1969-12-31,PT,Portugal,
-1969-12-31,RO,Romania,
-1969-12-31,RS,Serbia,
-1969-12-31,RU,Russia,
-1969-12-31,SE,Sweden,
-1969-12-31,SG,Singapore,
-1969-12-31,SI,Slovenia,
-1969-12-31,SK,Slovak Republic,
-1969-12-31,TH,Thailand,
-1969-12-31,TR,Türkiye,
-1969-12-31,US,United States,
-1969-12-31,XM,Euro area,
-1969-12-31,XW,World,
+1969-12-31,NZ,New Zealand,5.4554
 1969-12-31,ZA,South Africa,10.219
-1970-03-31,4T,Emerging market economies (aggregate),
-1970-03-31,5R,Advanced economies,
-1970-03-31,AE,United Arab Emirates,
-1970-03-31,AT,Austria,
-1970-03-31,AU,Australia,
-1970-03-31,BE,Belgium,
-1970-03-31,BG,Bulgaria,
-1970-03-31,BR,Brazil,
-1970-03-31,CA,Canada,
-1970-03-31,CH,Switzerland,
-1970-03-31,CL,Chile,
-1970-03-31,CN,China,
-1970-03-31,CO,Colombia,
-1970-03-31,CY,Cyprus,
-1970-03-31,CZ,Czechia,
-1970-03-31,DE,Germany,
-1970-03-31,DK,Denmark,
-1970-03-31,EE,Estonia,
-1970-03-31,ES,Spain,
-1970-03-31,FI,Finland,
-1970-03-31,FR,France,
 1970-03-31,GB,United Kingdom,5.4054
-1970-03-31,GR,Greece,
-1970-03-31,HK,Hong Kong SAR,
-1970-03-31,HR,Croatia,
-1970-03-31,HU,Hungary,
-1970-03-31,ID,Indonesia,
-1970-03-31,IE,Ireland,
-1970-03-31,IL,Israel,
-1970-03-31,IN,India,
-1970-03-31,IS,Iceland,
-1970-03-31,IT,Italy,6.9396
+1970-03-31,IT,Italy,6.8066
 1970-03-31,JP,Japan,22.6415
-1970-03-31,KR,Korea,
-1970-03-31,LT,Lithuania,
-1970-03-31,LU,Luxembourg,
-1970-03-31,LV,Latvia,
-1970-03-31,MA,Morocco,
-1970-03-31,MK,North Macedonia,
-1970-03-31,MT,Malta,
-1970-03-31,MX,Mexico,
-1970-03-31,MY,Malaysia,
-1970-03-31,NL,Netherlands,
-1970-03-31,NO,Norway,
-1970-03-31,NZ,New Zealand,
-1970-03-31,PE,Peru,
-1970-03-31,PH,Philippines,
-1970-03-31,PL,Poland,
-1970-03-31,PT,Portugal,
-1970-03-31,RO,Romania,
-1970-03-31,RS,Serbia,
-1970-03-31,RU,Russia,
-1970-03-31,SE,Sweden,
-1970-03-31,SG,Singapore,
-1970-03-31,SI,Slovenia,
-1970-03-31,SK,Slovak Republic,
-1970-03-31,TH,Thailand,
-1970-03-31,TR,Türkiye,
-1970-03-31,US,United States,
-1970-03-31,XM,Euro area,
-1970-03-31,XW,World,
+1970-03-31,NZ,New Zealand,5.358
 1970-03-31,ZA,South Africa,14.3885
-1970-06-30,4T,Emerging market economies (aggregate),
-1970-06-30,5R,Advanced economies,
-1970-06-30,AE,United Arab Emirates,
-1970-06-30,AT,Austria,
-1970-06-30,AU,Australia,
-1970-06-30,BE,Belgium,
-1970-06-30,BG,Bulgaria,
-1970-06-30,BR,Brazil,
-1970-06-30,CA,Canada,
-1970-06-30,CH,Switzerland,
-1970-06-30,CL,Chile,
-1970-06-30,CN,China,
-1970-06-30,CO,Colombia,
-1970-06-30,CY,Cyprus,
-1970-06-30,CZ,Czechia,
-1970-06-30,DE,Germany,
-1970-06-30,DK,Denmark,
-1970-06-30,EE,Estonia,
-1970-06-30,ES,Spain,
-1970-06-30,FI,Finland,
-1970-06-30,FR,France,
 1970-06-30,GB,United Kingdom,2.6316
-1970-06-30,GR,Greece,
-1970-06-30,HK,Hong Kong SAR,
-1970-06-30,HR,Croatia,
-1970-06-30,HU,Hungary,
-1970-06-30,ID,Indonesia,
-1970-06-30,IE,Ireland,
-1970-06-30,IL,Israel,
-1970-06-30,IN,India,
-1970-06-30,IS,Iceland,
-1970-06-30,IT,Italy,7.3349
+1970-06-30,IT,Italy,7.3924
 1970-06-30,JP,Japan,21.4349
-1970-06-30,KR,Korea,
-1970-06-30,LT,Lithuania,
-1970-06-30,LU,Luxembourg,
-1970-06-30,LV,Latvia,
-1970-06-30,MA,Morocco,
-1970-06-30,MK,North Macedonia,
-1970-06-30,MT,Malta,
-1970-06-30,MX,Mexico,
-1970-06-30,MY,Malaysia,
-1970-06-30,NL,Netherlands,
-1970-06-30,NO,Norway,
-1970-06-30,NZ,New Zealand,
-1970-06-30,PE,Peru,
-1970-06-30,PH,Philippines,
-1970-06-30,PL,Poland,
-1970-06-30,PT,Portugal,
-1970-06-30,RO,Romania,
-1970-06-30,RS,Serbia,
-1970-06-30,RU,Russia,
-1970-06-30,SE,Sweden,
-1970-06-30,SG,Singapore,
-1970-06-30,SI,Slovenia,
-1970-06-30,SK,Slovak Republic,
-1970-06-30,TH,Thailand,
-1970-06-30,TR,Türkiye,
-1970-06-30,US,United States,
-1970-06-30,XM,Euro area,
-1970-06-30,XW,World,
+1970-06-30,NZ,New Zealand,6.4707
 1970-06-30,ZA,South Africa,16.0839
-1970-09-30,4T,Emerging market economies (aggregate),
-1970-09-30,5R,Advanced economies,
-1970-09-30,AE,United Arab Emirates,
-1970-09-30,AT,Austria,
-1970-09-30,AU,Australia,
-1970-09-30,BE,Belgium,
-1970-09-30,BG,Bulgaria,
-1970-09-30,BR,Brazil,
-1970-09-30,CA,Canada,
-1970-09-30,CH,Switzerland,
-1970-09-30,CL,Chile,
-1970-09-30,CN,China,
-1970-09-30,CO,Colombia,
-1970-09-30,CY,Cyprus,
-1970-09-30,CZ,Czechia,
-1970-09-30,DE,Germany,
-1970-09-30,DK,Denmark,
-1970-09-30,EE,Estonia,
-1970-09-30,ES,Spain,
-1970-09-30,FI,Finland,
-1970-09-30,FR,France,
 1970-09-30,GB,United Kingdom,7.8947
-1970-09-30,GR,Greece,
-1970-09-30,HK,Hong Kong SAR,
-1970-09-30,HR,Croatia,
-1970-09-30,HU,Hungary,
-1970-09-30,ID,Indonesia,
-1970-09-30,IE,Ireland,
-1970-09-30,IL,Israel,
-1970-09-30,IN,India,
-1970-09-30,IS,Iceland,
-1970-09-30,IT,Italy,5.5707
+1970-09-30,IT,Italy,5.6639
 1970-09-30,JP,Japan,20.339
-1970-09-30,KR,Korea,
-1970-09-30,LT,Lithuania,
-1970-09-30,LU,Luxembourg,
-1970-09-30,LV,Latvia,
-1970-09-30,MA,Morocco,
-1970-09-30,MK,North Macedonia,
-1970-09-30,MT,Malta,
-1970-09-30,MX,Mexico,
-1970-09-30,MY,Malaysia,
-1970-09-30,NL,Netherlands,
-1970-09-30,NO,Norway,
-1970-09-30,NZ,New Zealand,
-1970-09-30,PE,Peru,
-1970-09-30,PH,Philippines,
-1970-09-30,PL,Poland,
-1970-09-30,PT,Portugal,
-1970-09-30,RO,Romania,
-1970-09-30,RS,Serbia,
-1970-09-30,RU,Russia,
-1970-09-30,SE,Sweden,
-1970-09-30,SG,Singapore,
-1970-09-30,SI,Slovenia,
-1970-09-30,SK,Slovak Republic,
-1970-09-30,TH,Thailand,
-1970-09-30,TR,Türkiye,
-1970-09-30,US,United States,
-1970-09-30,XM,Euro area,
-1970-09-30,XW,World,
+1970-09-30,NZ,New Zealand,7.5589
 1970-09-30,ZA,South Africa,15.6463
-1970-12-31,4T,Emerging market economies (aggregate),
-1970-12-31,5R,Advanced economies,
-1970-12-31,AE,United Arab Emirates,
-1970-12-31,AT,Austria,
-1970-12-31,AU,Australia,
-1970-12-31,BE,Belgium,
-1970-12-31,BG,Bulgaria,
-1970-12-31,BR,Brazil,
-1970-12-31,CA,Canada,
-1970-12-31,CH,Switzerland,
-1970-12-31,CL,Chile,
-1970-12-31,CN,China,
-1970-12-31,CO,Colombia,
-1970-12-31,CY,Cyprus,
-1970-12-31,CZ,Czechia,
-1970-12-31,DE,Germany,
-1970-12-31,DK,Denmark,
-1970-12-31,EE,Estonia,
-1970-12-31,ES,Spain,
-1970-12-31,FI,Finland,
-1970-12-31,FR,France,
 1970-12-31,GB,United Kingdom,5.1282
-1970-12-31,GR,Greece,
-1970-12-31,HK,Hong Kong SAR,
-1970-12-31,HR,Croatia,
-1970-12-31,HU,Hungary,
-1970-12-31,ID,Indonesia,
-1970-12-31,IE,Ireland,
-1970-12-31,IL,Israel,
-1970-12-31,IN,India,
-1970-12-31,IS,Iceland,
-1970-12-31,IT,Italy,5.5406
+1970-12-31,IT,Italy,5.5208
 1970-12-31,JP,Japan,19.0323
-1970-12-31,KR,Korea,
-1970-12-31,LT,Lithuania,
-1970-12-31,LU,Luxembourg,
-1970-12-31,LV,Latvia,
-1970-12-31,MA,Morocco,
-1970-12-31,MK,North Macedonia,
-1970-12-31,MT,Malta,
-1970-12-31,MX,Mexico,
-1970-12-31,MY,Malaysia,
-1970-12-31,NL,Netherlands,
-1970-12-31,NO,Norway,
-1970-12-31,NZ,New Zealand,
-1970-12-31,PE,Peru,
-1970-12-31,PH,Philippines,
-1970-12-31,PL,Poland,
-1970-12-31,PT,Portugal,
-1970-12-31,RO,Romania,
-1970-12-31,RS,Serbia,
-1970-12-31,RU,Russia,
-1970-12-31,SE,Sweden,
-1970-12-31,SG,Singapore,
-1970-12-31,SI,Slovenia,
-1970-12-31,SK,Slovak Republic,
-1970-12-31,TH,Thailand,
-1970-12-31,TR,Türkiye,
-1970-12-31,US,United States,
-1970-12-31,XM,Euro area,
-1970-12-31,XW,World,
+1970-12-31,NZ,New Zealand,9.1951
 1970-12-31,ZA,South Africa,13.9073
-1971-03-31,4T,Emerging market economies (aggregate),
-1971-03-31,5R,Advanced economies,
-1971-03-31,AE,United Arab Emirates,
-1971-03-31,AT,Austria,
 1971-03-31,AU,Australia,10.9756
 1971-03-31,BE,Belgium,-3.1802
-1971-03-31,BG,Bulgaria,
-1971-03-31,BR,Brazil,
 1971-03-31,CA,Canada,4.5361
 1971-03-31,CH,Switzerland,9.999
-1971-03-31,CL,Chile,
-1971-03-31,CN,China,
-1971-03-31,CO,Colombia,
-1971-03-31,CY,Cyprus,
-1971-03-31,CZ,Czechia,
 1971-03-31,DE,Germany,10.3448
 1971-03-31,DK,Denmark,8.9506
-1971-03-31,EE,Estonia,
-1971-03-31,ES,Spain,
 1971-03-31,FI,Finland,6.0482
 1971-03-31,FR,France,3.9563
 1971-03-31,GB,United Kingdom,7.6923
-1971-03-31,GR,Greece,
-1971-03-31,HK,Hong Kong SAR,
-1971-03-31,HR,Croatia,
-1971-03-31,HU,Hungary,
-1971-03-31,ID,Indonesia,
 1971-03-31,IE,Ireland,9.724
-1971-03-31,IL,Israel,
-1971-03-31,IN,India,
-1971-03-31,IS,Iceland,
-1971-03-31,IT,Italy,1.502
+1971-03-31,IT,Italy,1.5887
 1971-03-31,JP,Japan,17.8462
-1971-03-31,KR,Korea,
-1971-03-31,LT,Lithuania,
-1971-03-31,LU,Luxembourg,
-1971-03-31,LV,Latvia,
-1971-03-31,MA,Morocco,
-1971-03-31,MK,North Macedonia,
-1971-03-31,MT,Malta,
-1971-03-31,MX,Mexico,
-1971-03-31,MY,Malaysia,
 1971-03-31,NL,Netherlands,12.8348
-1971-03-31,NO,Norway,
-1971-03-31,NZ,New Zealand,10.7891
-1971-03-31,PE,Peru,
-1971-03-31,PH,Philippines,
-1971-03-31,PL,Poland,
-1971-03-31,PT,Portugal,
-1971-03-31,RO,Romania,
-1971-03-31,RS,Serbia,
-1971-03-31,RU,Russia,
+1971-03-31,NZ,New Zealand,10.7344
 1971-03-31,SE,Sweden,5.317
-1971-03-31,SG,Singapore,
-1971-03-31,SI,Slovenia,
-1971-03-31,SK,Slovak Republic,
-1971-03-31,TH,Thailand,
-1971-03-31,TR,Türkiye,
 1971-03-31,US,United States,6.4516
-1971-03-31,XM,Euro area,
-1971-03-31,XW,World,
 1971-03-31,ZA,South Africa,9.434
-1971-06-30,4T,Emerging market economies (aggregate),
-1971-06-30,5R,Advanced economies,
-1971-06-30,AE,United Arab Emirates,
-1971-06-30,AT,Austria,
 1971-06-30,AU,Australia,11.477
 1971-06-30,BE,Belgium,-2.2602
-1971-06-30,BG,Bulgaria,
-1971-06-30,BR,Brazil,
 1971-06-30,CA,Canada,5.7732
 1971-06-30,CH,Switzerland,10.3258
-1971-06-30,CL,Chile,
-1971-06-30,CN,China,
-1971-06-30,CO,Colombia,
-1971-06-30,CY,Cyprus,
-1971-06-30,CZ,Czechia,
 1971-06-30,DE,Germany,10.6599
 1971-06-30,DK,Denmark,9.8765
-1971-06-30,EE,Estonia,
-1971-06-30,ES,Spain,
 1971-06-30,FI,Finland,2.8852
 1971-06-30,FR,France,5.0234
 1971-06-30,GB,United Kingdom,10.2564
-1971-06-30,GR,Greece,
-1971-06-30,HK,Hong Kong SAR,
-1971-06-30,HR,Croatia,
-1971-06-30,HU,Hungary,
-1971-06-30,ID,Indonesia,
 1971-06-30,IE,Ireland,8.9356
-1971-06-30,IL,Israel,
-1971-06-30,IN,India,
-1971-06-30,IS,Iceland,
-1971-06-30,IT,Italy,1.7639
+1971-06-30,IT,Italy,1.9053
 1971-06-30,JP,Japan,16.7704
-1971-06-30,KR,Korea,
-1971-06-30,LT,Lithuania,
-1971-06-30,LU,Luxembourg,
-1971-06-30,LV,Latvia,
-1971-06-30,MA,Morocco,
-1971-06-30,MK,North Macedonia,
-1971-06-30,MT,Malta,
-1971-06-30,MX,Mexico,
-1971-06-30,MY,Malaysia,
 1971-06-30,NL,Netherlands,11.5181
-1971-06-30,NO,Norway,
-1971-06-30,NZ,New Zealand,11.6535
-1971-06-30,PE,Peru,
-1971-06-30,PH,Philippines,
-1971-06-30,PL,Poland,
-1971-06-30,PT,Portugal,
-1971-06-30,RO,Romania,
-1971-06-30,RS,Serbia,
-1971-06-30,RU,Russia,
+1971-06-30,NZ,New Zealand,11.6015
 1971-06-30,SE,Sweden,5.187
-1971-06-30,SG,Singapore,
-1971-06-30,SI,Slovenia,
-1971-06-30,SK,Slovak Republic,
-1971-06-30,TH,Thailand,
-1971-06-30,TR,Türkiye,
 1971-06-30,US,United States,8.5393
-1971-06-30,XM,Euro area,
-1971-06-30,XW,World,
 1971-06-30,ZA,South Africa,7.2289
-1971-09-30,4T,Emerging market economies (aggregate),
-1971-09-30,5R,Advanced economies,
-1971-09-30,AE,United Arab Emirates,
-1971-09-30,AT,Austria,
 1971-09-30,AU,Australia,11.7476
 1971-09-30,BE,Belgium,-0.0508
-1971-09-30,BG,Bulgaria,
-1971-09-30,BR,Brazil,
 1971-09-30,CA,Canada,4.499
 1971-09-30,CH,Switzerland,11.6391
-1971-09-30,CL,Chile,
-1971-09-30,CN,China,
-1971-09-30,CO,Colombia,
-1971-09-30,CY,Cyprus,
-1971-09-30,CZ,Czechia,
 1971-09-30,DE,Germany,11.0553
 1971-09-30,DK,Denmark,13.0658
-1971-09-30,EE,Estonia,
-1971-09-30,ES,Spain,
 1971-09-30,FI,Finland,5.788
 1971-09-30,FR,France,6.7408
 1971-09-30,GB,United Kingdom,12.1951
-1971-09-30,GR,Greece,
-1971-09-30,HK,Hong Kong SAR,
-1971-09-30,HR,Croatia,
-1971-09-30,HU,Hungary,
-1971-09-30,ID,Indonesia,
 1971-09-30,IE,Ireland,14.2322
-1971-09-30,IL,Israel,
-1971-09-30,IN,India,
-1971-09-30,IS,Iceland,
-1971-09-30,IT,Italy,4.4547
+1971-09-30,IT,Italy,4.416
 1971-09-30,JP,Japan,15.7746
-1971-09-30,KR,Korea,
-1971-09-30,LT,Lithuania,
-1971-09-30,LU,Luxembourg,
-1971-09-30,LV,Latvia,
-1971-09-30,MA,Morocco,
-1971-09-30,MK,North Macedonia,
-1971-09-30,MT,Malta,
-1971-09-30,MX,Mexico,
-1971-09-30,MY,Malaysia,
 1971-09-30,NL,Netherlands,9.4702
-1971-09-30,NO,Norway,
-1971-09-30,NZ,New Zealand,11.4022
-1971-09-30,PE,Peru,
-1971-09-30,PH,Philippines,
-1971-09-30,PL,Poland,
-1971-09-30,PT,Portugal,
-1971-09-30,RO,Romania,
-1971-09-30,RS,Serbia,
-1971-09-30,RU,Russia,
+1971-09-30,NZ,New Zealand,11.3507
 1971-09-30,SE,Sweden,5.187
-1971-09-30,SG,Singapore,
-1971-09-30,SI,Slovenia,
-1971-09-30,SK,Slovak Republic,
-1971-09-30,TH,Thailand,
-1971-09-30,TR,Türkiye,
 1971-09-30,US,United States,8.0199
-1971-09-30,XM,Euro area,
-1971-09-30,XW,World,
 1971-09-30,ZA,South Africa,5.8824
-1971-12-31,4T,Emerging market economies (aggregate),
-1971-12-31,5R,Advanced economies,
-1971-12-31,AE,United Arab Emirates,
-1971-12-31,AT,Austria,
 1971-12-31,AU,Australia,12.5235
 1971-12-31,BE,Belgium,2.5383
-1971-12-31,BG,Bulgaria,
-1971-12-31,BR,Brazil,
 1971-12-31,CA,Canada,6.7594
 1971-12-31,CH,Switzerland,13.5217
-1971-12-31,CL,Chile,
-1971-12-31,CN,China,
-1971-12-31,CO,Colombia,
-1971-12-31,CY,Cyprus,
-1971-12-31,CZ,Czechia,
 1971-12-31,DE,Germany,9.9256
 1971-12-31,DK,Denmark,18.93
-1971-12-31,EE,Estonia,
-1971-12-31,ES,Spain,
 1971-12-31,FI,Finland,4.8876
 1971-12-31,FR,France,8.0052
 1971-12-31,GB,United Kingdom,17.0732
-1971-12-31,GR,Greece,
-1971-12-31,HK,Hong Kong SAR,
-1971-12-31,HR,Croatia,
-1971-12-31,HU,Hungary,
-1971-12-31,ID,Indonesia,
 1971-12-31,IE,Ireland,16.2928
-1971-12-31,IL,Israel,
-1971-12-31,IN,India,
-1971-12-31,IS,Iceland,
-1971-12-31,IT,Italy,4.7776
+1971-12-31,IT,Italy,4.5896
 1971-12-31,JP,Japan,15.0407
-1971-12-31,KR,Korea,
-1971-12-31,LT,Lithuania,
-1971-12-31,LU,Luxembourg,
-1971-12-31,LV,Latvia,
-1971-12-31,MA,Morocco,
-1971-12-31,MK,North Macedonia,
-1971-12-31,MT,Malta,
-1971-12-31,MX,Mexico,
-1971-12-31,MY,Malaysia,
 1971-12-31,NL,Netherlands,10.3687
-1971-12-31,NO,Norway,
-1971-12-31,NZ,New Zealand,10.9445
-1971-12-31,PE,Peru,
-1971-12-31,PH,Philippines,
-1971-12-31,PL,Poland,
-1971-12-31,PT,Portugal,
-1971-12-31,RO,Romania,
-1971-12-31,RS,Serbia,
-1971-12-31,RU,Russia,
+1971-12-31,NZ,New Zealand,11.0532
 1971-12-31,SE,Sweden,5.3197
-1971-12-31,SG,Singapore,
-1971-12-31,SI,Slovenia,
-1971-12-31,SK,Slovak Republic,
-1971-12-31,TH,Thailand,
-1971-12-31,TR,Türkiye,
 1971-12-31,US,United States,9.2299
-1971-12-31,XM,Euro area,
-1971-12-31,XW,World,
 1971-12-31,ZA,South Africa,5.814
-1972-03-31,4T,Emerging market economies (aggregate),
-1972-03-31,5R,Advanced economies,
-1972-03-31,AE,United Arab Emirates,
-1972-03-31,AT,Austria,
 1972-03-31,AU,Australia,11.8132
 1972-03-31,BE,Belgium,5.1616
-1972-03-31,BG,Bulgaria,
-1972-03-31,BR,Brazil,
 1972-03-31,CA,Canada,8.2183
 1972-03-31,CH,Switzerland,10.5153
-1972-03-31,CL,Chile,
-1972-03-31,CN,China,
-1972-03-31,CO,Colombia,
-1972-03-31,CY,Cyprus,
-1972-03-31,CZ,Czechia,
 1972-03-31,DE,Germany,8.6538
 1972-03-31,DK,Denmark,15.4391
-1972-03-31,EE,Estonia,
 1972-03-31,ES,Spain,4.2986
 1972-03-31,FI,Finland,7.5858
 1972-03-31,FR,France,8.5958
 1972-03-31,GB,United Kingdom,21.4286
-1972-03-31,GR,Greece,
-1972-03-31,HK,Hong Kong SAR,
-1972-03-31,HR,Croatia,
-1972-03-31,HU,Hungary,
-1972-03-31,ID,Indonesia,
 1972-03-31,IE,Ireland,13.8922
-1972-03-31,IL,Israel,
-1972-03-31,IN,India,
-1972-03-31,IS,Iceland,
 1972-03-31,IT,Italy,7.7273
 1972-03-31,JP,Japan,14.3603
-1972-03-31,KR,Korea,
-1972-03-31,LT,Lithuania,
-1972-03-31,LU,Luxembourg,
-1972-03-31,LV,Latvia,
-1972-03-31,MA,Morocco,
-1972-03-31,MK,North Macedonia,
-1972-03-31,MT,Malta,
-1972-03-31,MX,Mexico,
-1972-03-31,MY,Malaysia,
 1972-03-31,NL,Netherlands,11.4196
-1972-03-31,NO,Norway,
-1972-03-31,NZ,New Zealand,11.6279
-1972-03-31,PE,Peru,
-1972-03-31,PH,Philippines,
-1972-03-31,PL,Poland,
-1972-03-31,PT,Portugal,
-1972-03-31,RO,Romania,
-1972-03-31,RS,Serbia,
-1972-03-31,RU,Russia,
+1972-03-31,NZ,New Zealand,11.7346
 1972-03-31,SE,Sweden,7.4272
-1972-03-31,SG,Singapore,
-1972-03-31,SI,Slovenia,
-1972-03-31,SK,Slovak Republic,
-1972-03-31,TH,Thailand,
-1972-03-31,TR,Türkiye,
 1972-03-31,US,United States,6.6454
-1972-03-31,XM,Euro area,
-1972-03-31,XW,World,
 1972-03-31,ZA,South Africa,5.1724
-1972-06-30,4T,Emerging market economies (aggregate),
-1972-06-30,5R,Advanced economies,
-1972-06-30,AE,United Arab Emirates,
-1972-06-30,AT,Austria,
 1972-06-30,AU,Australia,11.1907
 1972-06-30,BE,Belgium,7.7595
-1972-06-30,BG,Bulgaria,
-1972-06-30,BR,Brazil,
 1972-06-30,CA,Canada,6.9526
 1972-06-30,CH,Switzerland,17.7387
-1972-06-30,CL,Chile,
-1972-06-30,CN,China,
-1972-06-30,CO,Colombia,
-1972-06-30,CY,Cyprus,
-1972-06-30,CZ,Czechia,
 1972-06-30,DE,Germany,6.1927
 1972-06-30,DK,Denmark,19.8502
-1972-06-30,EE,Estonia,
 1972-06-30,ES,Spain,4.3764
 1972-06-30,FI,Finland,10.544
 1972-06-30,FR,France,8.8648
 1972-06-30,GB,United Kingdom,30.2326
-1972-06-30,GR,Greece,
-1972-06-30,HK,Hong Kong SAR,
-1972-06-30,HR,Croatia,
-1972-06-30,HU,Hungary,
-1972-06-30,ID,Indonesia,
 1972-06-30,IE,Ireland,12.5452
-1972-06-30,IL,Israel,
-1972-06-30,IN,India,
-1972-06-30,IS,Iceland,
 1972-06-30,IT,Italy,8.6667
 1972-06-30,JP,Japan,15.2618
-1972-06-30,KR,Korea,
-1972-06-30,LT,Lithuania,
-1972-06-30,LU,Luxembourg,
-1972-06-30,LV,Latvia,
-1972-06-30,MA,Morocco,
-1972-06-30,MK,North Macedonia,
-1972-06-30,MT,Malta,
-1972-06-30,MX,Mexico,
-1972-06-30,MY,Malaysia,
 1972-06-30,NL,Netherlands,12.0138
-1972-06-30,NO,Norway,
-1972-06-30,NZ,New Zealand,12.835
-1972-06-30,PE,Peru,
-1972-06-30,PH,Philippines,
-1972-06-30,PL,Poland,
-1972-06-30,PT,Portugal,
-1972-06-30,RO,Romania,
-1972-06-30,RS,Serbia,
-1972-06-30,RU,Russia,
+1972-06-30,NZ,New Zealand,12.8715
 1972-06-30,SE,Sweden,7.4917
-1972-06-30,SG,Singapore,
-1972-06-30,SI,Slovenia,
-1972-06-30,SK,Slovak Republic,
-1972-06-30,TH,Thailand,
-1972-06-30,TR,Türkiye,
 1972-06-30,US,United States,6.7805
-1972-06-30,XM,Euro area,
-1972-06-30,XW,World,
 1972-06-30,ZA,South Africa,2.809
-1972-09-30,4T,Emerging market economies (aggregate),
-1972-09-30,5R,Advanced economies,
-1972-09-30,AE,United Arab Emirates,
-1972-09-30,AT,Austria,
 1972-09-30,AU,Australia,10.947
 1972-09-30,BE,Belgium,10.3203
-1972-09-30,BG,Bulgaria,
-1972-09-30,BR,Brazil,
 1972-09-30,CA,Canada,8.9367
 1972-09-30,CH,Switzerland,17.9446
-1972-09-30,CL,Chile,
-1972-09-30,CN,China,
-1972-09-30,CO,Colombia,
-1972-09-30,CY,Cyprus,
-1972-09-30,CZ,Czechia,
 1972-09-30,DE,Germany,5.8824
 1972-09-30,DK,Denmark,17.2429
-1972-09-30,EE,Estonia,
 1972-09-30,ES,Spain,6.2771
 1972-09-30,FI,Finland,7.2589
 1972-09-30,FR,France,9.1968
 1972-09-30,GB,United Kingdom,39.1304
-1972-09-30,GR,Greece,
-1972-09-30,HK,Hong Kong SAR,
-1972-09-30,HR,Croatia,
-1972-09-30,HU,Hungary,
-1972-09-30,ID,Indonesia,
 1972-09-30,IE,Ireland,7.6503
-1972-09-30,IL,Israel,
-1972-09-30,IN,India,
-1972-09-30,IS,Iceland,
 1972-09-30,IT,Italy,8.6768
 1972-09-30,JP,Japan,16.0584
-1972-09-30,KR,Korea,
-1972-09-30,LT,Lithuania,
-1972-09-30,LU,Luxembourg,
-1972-09-30,LV,Latvia,
-1972-09-30,MA,Morocco,
-1972-09-30,MK,North Macedonia,
-1972-09-30,MT,Malta,
-1972-09-30,MX,Mexico,
-1972-09-30,MY,Malaysia,
 1972-09-30,NL,Netherlands,11.9914
-1972-09-30,NO,Norway,
-1972-09-30,NZ,New Zealand,14.1079
-1972-09-30,PE,Peru,
-1972-09-30,PH,Philippines,
-1972-09-30,PL,Poland,
-1972-09-30,PT,Portugal,
-1972-09-30,RO,Romania,
-1972-09-30,RS,Serbia,
-1972-09-30,RU,Russia,
+1972-09-30,NZ,New Zealand,14.0781
 1972-09-30,SE,Sweden,7.4917
-1972-09-30,SG,Singapore,
-1972-09-30,SI,Slovenia,
-1972-09-30,SK,Slovak Republic,
-1972-09-30,TH,Thailand,
-1972-09-30,TR,Türkiye,
 1972-09-30,US,United States,7.7317
-1972-09-30,XM,Euro area,
-1972-09-30,XW,World,
 1972-09-30,ZA,South Africa,5
-1972-12-31,4T,Emerging market economies (aggregate),
-1972-12-31,5R,Advanced economies,
-1972-12-31,AE,United Arab Emirates,
-1972-12-31,AT,Austria,
 1972-12-31,AU,Australia,12.636
 1972-12-31,BE,Belgium,11.8102
-1972-12-31,BG,Bulgaria,
-1972-12-31,BR,Brazil,
 1972-12-31,CA,Canada,8.504
 1972-12-31,CH,Switzerland,21.6084
-1972-12-31,CL,Chile,
-1972-12-31,CN,China,
-1972-12-31,CO,Colombia,
-1972-12-31,CY,Cyprus,
-1972-12-31,CZ,Czechia,
 1972-12-31,DE,Germany,6.3205
 1972-12-31,DK,Denmark,16.436
-1972-12-31,EE,Estonia,
 1972-12-31,ES,Spain,7.9229
 1972-12-31,FI,Finland,11.3016
 1972-12-31,FR,France,9.5383
 1972-12-31,GB,United Kingdom,43.75
-1972-12-31,GR,Greece,
-1972-12-31,HK,Hong Kong SAR,
-1972-12-31,HR,Croatia,
-1972-12-31,HU,Hungary,
-1972-12-31,ID,Indonesia,
 1972-12-31,IE,Ireland,5.2792
-1972-12-31,IL,Israel,
-1972-12-31,IN,India,
-1972-12-31,IS,Iceland,
 1972-12-31,IT,Italy,7.9229
 1972-12-31,JP,Japan,22.7326
-1972-12-31,KR,Korea,
-1972-12-31,LT,Lithuania,
-1972-12-31,LU,Luxembourg,
-1972-12-31,LV,Latvia,
-1972-12-31,MA,Morocco,
-1972-12-31,MK,North Macedonia,
-1972-12-31,MT,Malta,
-1972-12-31,MX,Mexico,
-1972-12-31,MY,Malaysia,
 1972-12-31,NL,Netherlands,14.7808
-1972-12-31,NO,Norway,
-1972-12-31,NZ,New Zealand,16.2162
-1972-12-31,PE,Peru,
-1972-12-31,PH,Philippines,
-1972-12-31,PL,Poland,
-1972-12-31,PT,Portugal,
-1972-12-31,RO,Romania,
-1972-12-31,RS,Serbia,
-1972-12-31,RU,Russia,
+1972-12-31,NZ,New Zealand,16.1137
 1972-12-31,SE,Sweden,7.5996
-1972-12-31,SG,Singapore,
-1972-12-31,SI,Slovenia,
-1972-12-31,SK,Slovak Republic,
-1972-12-31,TH,Thailand,
-1972-12-31,TR,Türkiye,
 1972-12-31,US,United States,7.5
-1972-12-31,XM,Euro area,
-1972-12-31,XW,World,
 1972-12-31,ZA,South Africa,7.1429
-1973-03-31,4T,Emerging market economies (aggregate),
-1973-03-31,5R,Advanced economies,
-1973-03-31,AE,United Arab Emirates,
-1973-03-31,AT,Austria,
 1973-03-31,AU,Australia,13.3497
 1973-03-31,BE,Belgium,12.1963
-1973-03-31,BG,Bulgaria,
-1973-03-31,BR,Brazil,
 1973-03-31,CA,Canada,11.6646
 1973-03-31,CH,Switzerland,25.5428
-1973-03-31,CL,Chile,
-1973-03-31,CN,China,
-1973-03-31,CO,Colombia,
-1973-03-31,CY,Cyprus,
-1973-03-31,CZ,Czechia,
 1973-03-31,DE,Germany,5.7522
 1973-03-31,DK,Denmark,15.1738
-1973-03-31,EE,Estonia,
 1973-03-31,ES,Spain,20.1735
 1973-03-31,FI,Finland,14.668
 1973-03-31,FR,France,9.7281
 1973-03-31,GB,United Kingdom,50.9804
-1973-03-31,GR,Greece,
-1973-03-31,HK,Hong Kong SAR,
-1973-03-31,HR,Croatia,
-1973-03-31,HU,Hungary,
-1973-03-31,ID,Indonesia,
 1973-03-31,IE,Ireland,8.938
-1973-03-31,IL,Israel,
-1973-03-31,IN,India,
-1973-03-31,IS,Iceland,
 1973-03-31,IT,Italy,8.4388
 1973-03-31,JP,Japan,28.9954
-1973-03-31,KR,Korea,
-1973-03-31,LT,Lithuania,
-1973-03-31,LU,Luxembourg,
-1973-03-31,LV,Latvia,
-1973-03-31,MA,Morocco,
-1973-03-31,MK,North Macedonia,
-1973-03-31,MT,Malta,
-1973-03-31,MX,Mexico,
-1973-03-31,MY,Malaysia,
 1973-03-31,NL,Netherlands,14.3891
-1973-03-31,NO,Norway,
-1973-03-31,NZ,New Zealand,18.75
-1973-03-31,PE,Peru,
-1973-03-31,PH,Philippines,
-1973-03-31,PL,Poland,
-1973-03-31,PT,Portugal,
-1973-03-31,RO,Romania,
-1973-03-31,RS,Serbia,
-1973-03-31,RU,Russia,
+1973-03-31,NZ,New Zealand,18.7206
 1973-03-31,SE,Sweden,7.3656
-1973-03-31,SG,Singapore,
-1973-03-31,SI,Slovenia,
-1973-03-31,SK,Slovak Republic,
-1973-03-31,TH,Thailand,
-1973-03-31,TR,Türkiye,
 1973-03-31,US,United States,11.9143
-1973-03-31,XM,Euro area,
-1973-03-31,XW,World,
 1973-03-31,ZA,South Africa,11.4754
-1973-06-30,4T,Emerging market economies (aggregate),
-1973-06-30,5R,Advanced economies,
-1973-06-30,AE,United Arab Emirates,
-1973-06-30,AT,Austria,
 1973-06-30,AU,Australia,18.0354
 1973-06-30,BE,Belgium,12.5894
-1973-06-30,BG,Bulgaria,
-1973-06-30,BR,Brazil,
 1973-06-30,CA,Canada,17.497
 1973-06-30,CH,Switzerland,17.1956
-1973-06-30,CL,Chile,
-1973-06-30,CN,China,
-1973-06-30,CO,Colombia,
-1973-06-30,CY,Cyprus,
-1973-06-30,CZ,Czechia,
 1973-06-30,DE,Germany,7.9914
 1973-06-30,DK,Denmark,13.0859
-1973-06-30,EE,Estonia,
 1973-06-30,ES,Spain,15.304
 1973-06-30,FI,Finland,25.4186
 1973-06-30,FR,France,10.1347
 1973-06-30,GB,United Kingdom,44.6429
-1973-06-30,GR,Greece,
-1973-06-30,HK,Hong Kong SAR,
-1973-06-30,HR,Croatia,
-1973-06-30,HU,Hungary,
-1973-06-30,ID,Indonesia,
 1973-06-30,IE,Ireland,13.3976
-1973-06-30,IL,Israel,
-1973-06-30,IN,India,
-1973-06-30,IS,Iceland,
 1973-06-30,IT,Italy,12.6789
 1973-06-30,JP,Japan,33.605
-1973-06-30,KR,Korea,
-1973-06-30,LT,Lithuania,
-1973-06-30,LU,Luxembourg,
-1973-06-30,LV,Latvia,
-1973-06-30,MA,Morocco,
-1973-06-30,MK,North Macedonia,
-1973-06-30,MT,Malta,
-1973-06-30,MX,Mexico,
-1973-06-30,MY,Malaysia,
 1973-06-30,NL,Netherlands,16.5509
-1973-06-30,NO,Norway,
-1973-06-30,NZ,New Zealand,22.375
-1973-06-30,PE,Peru,
-1973-06-30,PH,Philippines,
-1973-06-30,PL,Poland,
-1973-06-30,PT,Portugal,
-1973-06-30,RO,Romania,
-1973-06-30,RS,Serbia,
-1973-06-30,RU,Russia,
+1973-06-30,NZ,New Zealand,22.368
 1973-06-30,SE,Sweden,7.2342
-1973-06-30,SG,Singapore,
-1973-06-30,SI,Slovenia,
-1973-06-30,SK,Slovak Republic,
-1973-06-30,TH,Thailand,
-1973-06-30,TR,Türkiye,
 1973-06-30,US,United States,11.4397
-1973-06-30,XM,Euro area,
-1973-06-30,XW,World,
 1973-06-30,ZA,South Africa,14.7541
-1973-09-30,4T,Emerging market economies (aggregate),
-1973-09-30,5R,Advanced economies,
-1973-09-30,AE,United Arab Emirates,
-1973-09-30,AT,Austria,
 1973-09-30,AU,Australia,24.119
 1973-09-30,BE,Belgium,12.8111
-1973-09-30,BG,Bulgaria,
-1973-09-30,BR,Brazil,
 1973-09-30,CA,Canada,24.4311
 1973-09-30,CH,Switzerland,14.3348
-1973-09-30,CL,Chile,
-1973-09-30,CN,China,
-1973-09-30,CO,Colombia,
-1973-09-30,CY,Cyprus,
-1973-09-30,CZ,Czechia,
 1973-09-30,DE,Germany,7.906
 1973-09-30,DK,Denmark,17.8114
-1973-09-30,EE,Estonia,
 1973-09-30,ES,Spain,21.5886
 1973-09-30,FI,Finland,32.3737
 1973-09-30,FR,France,10.7243
 1973-09-30,GB,United Kingdom,34.375
-1973-09-30,GR,Greece,
-1973-09-30,HK,Hong Kong SAR,
-1973-09-30,HR,Croatia,
-1973-09-30,HU,Hungary,
-1973-09-30,ID,Indonesia,
 1973-09-30,IE,Ireland,8.1218
-1973-09-30,IL,Israel,
-1973-09-30,IN,India,
-1973-09-30,IS,Iceland,
 1973-09-30,IT,Italy,22.3553
 1973-09-30,JP,Japan,37.9455
-1973-09-30,KR,Korea,
-1973-09-30,LT,Lithuania,
-1973-09-30,LU,Luxembourg,
-1973-09-30,LV,Latvia,
-1973-09-30,MA,Morocco,
-1973-09-30,MK,North Macedonia,
-1973-09-30,MT,Malta,
-1973-09-30,MX,Mexico,
-1973-09-30,MY,Malaysia,
 1973-09-30,NL,Netherlands,17.7438
-1973-09-30,NO,Norway,
-1973-09-30,NZ,New Zealand,27.6364
-1973-09-30,PE,Peru,
-1973-09-30,PH,Philippines,
-1973-09-30,PL,Poland,
-1973-09-30,PT,Portugal,
-1973-09-30,RO,Romania,
-1973-09-30,RS,Serbia,
-1973-09-30,RU,Russia,
+1973-09-30,NZ,New Zealand,27.6594
 1973-09-30,SE,Sweden,7.2342
-1973-09-30,SG,Singapore,
-1973-09-30,SI,Slovenia,
-1973-09-30,SK,Slovak Republic,
-1973-09-30,TH,Thailand,
-1973-09-30,TR,Türkiye,
 1973-09-30,US,United States,12.0722
-1973-09-30,XM,Euro area,
-1973-09-30,XW,World,
 1973-09-30,ZA,South Africa,17.4603
-1973-12-31,4T,Emerging market economies (aggregate),
-1973-12-31,5R,Advanced economies,
-1973-12-31,AE,United Arab Emirates,
-1973-12-31,AT,Austria,
 1973-12-31,AU,Australia,25.9287
 1973-12-31,BE,Belgium,14.2528
-1973-12-31,BG,Bulgaria,
-1973-12-31,BR,Brazil,
 1973-12-31,CA,Canada,30.1487
 1973-12-31,CH,Switzerland,7.2864
-1973-12-31,CL,Chile,
-1973-12-31,CN,China,
-1973-12-31,CO,Colombia,
-1973-12-31,CY,Cyprus,
-1973-12-31,CZ,Czechia,
 1973-12-31,DE,Germany,7.2187
 1973-12-31,DK,Denmark,15.7504
-1973-12-31,EE,Estonia,
 1973-12-31,ES,Spain,25.7937
 1973-12-31,FI,Finland,32.0019
 1973-12-31,FR,France,11.7582
 1973-12-31,GB,United Kingdom,26.087
-1973-12-31,GR,Greece,
-1973-12-31,HK,Hong Kong SAR,
-1973-12-31,HR,Croatia,
-1973-12-31,HU,Hungary,
-1973-12-31,ID,Indonesia,
 1973-12-31,IE,Ireland,4.4359
-1973-12-31,IL,Israel,
-1973-12-31,IN,India,
-1973-12-31,IS,Iceland,
 1973-12-31,IT,Italy,36.7063
 1973-12-31,JP,Japan,31.5739
-1973-12-31,KR,Korea,
-1973-12-31,LT,Lithuania,
-1973-12-31,LU,Luxembourg,
-1973-12-31,LV,Latvia,
-1973-12-31,MA,Morocco,
-1973-12-31,MK,North Macedonia,
-1973-12-31,MT,Malta,
-1973-12-31,MX,Mexico,
-1973-12-31,MY,Malaysia,
 1973-12-31,NL,Netherlands,18.1884
-1973-12-31,NO,Norway,
-1973-12-31,NZ,New Zealand,33.8372
-1973-12-31,PE,Peru,
-1973-12-31,PH,Philippines,
-1973-12-31,PL,Poland,
-1973-12-31,PT,Portugal,
-1973-12-31,RO,Romania,
-1973-12-31,RS,Serbia,
-1973-12-31,RU,Russia,
+1973-12-31,NZ,New Zealand,33.8766
 1973-12-31,SE,Sweden,7.0198
-1973-12-31,SG,Singapore,
-1973-12-31,SI,Slovenia,
-1973-12-31,SK,Slovak Republic,
-1973-12-31,TH,Thailand,
-1973-12-31,TR,Türkiye,
 1973-12-31,US,United States,12
-1973-12-31,XM,Euro area,
-1973-12-31,XW,World,
 1973-12-31,ZA,South Africa,18.4615
-1974-03-31,4T,Emerging market economies (aggregate),
-1974-03-31,5R,Advanced economies,
-1974-03-31,AE,United Arab Emirates,
-1974-03-31,AT,Austria,
 1974-03-31,AU,Australia,30.4191
 1974-03-31,BE,Belgium,12.2404
-1974-03-31,BG,Bulgaria,
-1974-03-31,BR,Brazil,
 1974-03-31,CA,Canada,36.8335
 1974-03-31,CH,Switzerland,-0.6184
-1974-03-31,CL,Chile,
-1974-03-31,CN,China,
-1974-03-31,CO,Colombia,
-1974-03-31,CY,Cyprus,
-1974-03-31,CZ,Czechia,
 1974-03-31,DE,Germany,7.9498
 1974-03-31,DK,Denmark,10.6534
-1974-03-31,EE,Estonia,
 1974-03-31,ES,Spain,26.3538
 1974-03-31,FI,Finland,29.8923
 1974-03-31,FR,France,13.8767
 1974-03-31,GB,United Kingdom,14.2857
-1974-03-31,GR,Greece,
-1974-03-31,HK,Hong Kong SAR,
-1974-03-31,HR,Croatia,
-1974-03-31,HU,Hungary,
-1974-03-31,ID,Indonesia,
 1974-03-31,IE,Ireland,11.7761
-1974-03-31,IL,Israel,
-1974-03-31,IN,India,
-1974-03-31,IS,Iceland,
 1974-03-31,IT,Italy,50.5837
 1974-03-31,JP,Japan,26.1947
-1974-03-31,KR,Korea,
-1974-03-31,LT,Lithuania,
-1974-03-31,LU,Luxembourg,
-1974-03-31,LV,Latvia,
-1974-03-31,MA,Morocco,
-1974-03-31,MK,North Macedonia,
-1974-03-31,MT,Malta,
-1974-03-31,MX,Mexico,
-1974-03-31,MY,Malaysia,
 1974-03-31,NL,Netherlands,20.4849
-1974-03-31,NO,Norway,
-1974-03-31,NZ,New Zealand,40.4605
-1974-03-31,PE,Peru,
-1974-03-31,PH,Philippines,
-1974-03-31,PL,Poland,
-1974-03-31,PT,Portugal,
-1974-03-31,RO,Romania,
-1974-03-31,RS,Serbia,
-1974-03-31,RU,Russia,
+1974-03-31,NZ,New Zealand,40.3851
 1974-03-31,SE,Sweden,6.9024
-1974-03-31,SG,Singapore,
-1974-03-31,SI,Slovenia,
-1974-03-31,SK,Slovak Republic,
-1974-03-31,TH,Thailand,
-1974-03-31,TR,Türkiye,
 1974-03-31,US,United States,9.8886
-1974-03-31,XM,Euro area,
-1974-03-31,XW,World,
 1974-03-31,ZA,South Africa,13.2353
-1974-06-30,4T,Emerging market economies (aggregate),
-1974-06-30,5R,Advanced economies,
-1974-06-30,AE,United Arab Emirates,
-1974-06-30,AT,Austria,
 1974-06-30,AU,Australia,27.2851
 1974-06-30,BE,Belgium,16.4761
-1974-06-30,BG,Bulgaria,
-1974-06-30,BR,Brazil,
 1974-06-30,CA,Canada,35.8842
 1974-06-30,CH,Switzerland,0.4188
-1974-06-30,CL,Chile,
-1974-06-30,CN,China,
-1974-06-30,CO,Colombia,
-1974-06-30,CY,Cyprus,
-1974-06-30,CZ,Czechia,
 1974-06-30,DE,Germany,7.4
 1974-06-30,DK,Denmark,3.9724
-1974-06-30,EE,Estonia,
 1974-06-30,ES,Spain,42.1818
 1974-06-30,FI,Finland,23.301
 1974-06-30,FR,France,14.8404
 1974-06-30,GB,United Kingdom,8.642
-1974-06-30,GR,Greece,
-1974-06-30,HK,Hong Kong SAR,
-1974-06-30,HR,Croatia,
-1974-06-30,HU,Hungary,
-1974-06-30,ID,Indonesia,
 1974-06-30,IE,Ireland,16.5406
-1974-06-30,IL,Israel,
-1974-06-30,IN,India,
-1974-06-30,IS,Iceland,
 1974-06-30,IT,Italy,56.8058
 1974-06-30,JP,Japan,17.6237
-1974-06-30,KR,Korea,
-1974-06-30,LT,Lithuania,
-1974-06-30,LU,Luxembourg,
-1974-06-30,LV,Latvia,
-1974-06-30,MA,Morocco,
-1974-06-30,MK,North Macedonia,
-1974-06-30,MT,Malta,
-1974-06-30,MX,Mexico,
-1974-06-30,MY,Malaysia,
 1974-06-30,NL,Netherlands,20.2582
-1974-06-30,NO,Norway,
-1974-06-30,NZ,New Zealand,43.7181
-1974-06-30,PE,Peru,
-1974-06-30,PH,Philippines,
-1974-06-30,PL,Poland,
-1974-06-30,PT,Portugal,
-1974-06-30,RO,Romania,
-1974-06-30,RS,Serbia,
-1974-06-30,RU,Russia,
+1974-06-30,NZ,New Zealand,43.7284
 1974-06-30,SE,Sweden,6.7051
-1974-06-30,SG,Singapore,
-1974-06-30,SI,Slovenia,
-1974-06-30,SK,Slovak Republic,
-1974-06-30,TH,Thailand,
-1974-06-30,TR,Türkiye,
 1974-06-30,US,United States,9.3954
-1974-06-30,XM,Euro area,
-1974-06-30,XW,World,
 1974-06-30,ZA,South Africa,11.9048
-1974-09-30,4T,Emerging market economies (aggregate),
-1974-09-30,5R,Advanced economies,
-1974-09-30,AE,United Arab Emirates,
-1974-09-30,AT,Austria,
 1974-09-30,AU,Australia,19.1167
 1974-09-30,BE,Belgium,16.9935
-1974-09-30,BG,Bulgaria,
-1974-09-30,BR,Brazil,
 1974-09-30,CA,Canada,25.3128
 1974-09-30,CH,Switzerland,-0.932
-1974-09-30,CL,Chile,
-1974-09-30,CN,China,
-1974-09-30,CO,Colombia,
-1974-09-30,CY,Cyprus,
-1974-09-30,CZ,Czechia,
 1974-09-30,DE,Germany,7.3267
 1974-09-30,DK,Denmark,0.2964
-1974-09-30,EE,Estonia,
 1974-09-30,ES,Spain,36.5159
 1974-09-30,FI,Finland,17.7032
 1974-09-30,FR,France,15.3651
 1974-09-30,GB,United Kingdom,3.4884
-1974-09-30,GR,Greece,
-1974-09-30,HK,Hong Kong SAR,
-1974-09-30,HR,Croatia,
-1974-09-30,HU,Hungary,
-1974-09-30,ID,Indonesia,
 1974-09-30,IE,Ireland,23.0047
-1974-09-30,IL,Israel,
-1974-09-30,IN,India,
-1974-09-30,IS,Iceland,
 1974-09-30,IT,Italy,54.1599
 1974-09-30,JP,Japan,10.1824
-1974-09-30,KR,Korea,
-1974-09-30,LT,Lithuania,
-1974-09-30,LU,Luxembourg,
-1974-09-30,LV,Latvia,
-1974-09-30,MA,Morocco,
-1974-09-30,MK,North Macedonia,
-1974-09-30,MT,Malta,
-1974-09-30,MX,Mexico,
-1974-09-30,MY,Malaysia,
 1974-09-30,NL,Netherlands,21.0458
-1974-09-30,NO,Norway,
-1974-09-30,NZ,New Zealand,41.9753
-1974-09-30,PE,Peru,
-1974-09-30,PH,Philippines,
-1974-09-30,PL,Poland,
-1974-09-30,PT,Portugal,
-1974-09-30,RO,Romania,
-1974-09-30,RS,Serbia,
-1974-09-30,RU,Russia,
+1974-09-30,NZ,New Zealand,41.9999
 1974-09-30,SE,Sweden,9.1732
-1974-09-30,SG,Singapore,
-1974-09-30,SI,Slovenia,
-1974-09-30,SK,Slovak Republic,
-1974-09-30,TH,Thailand,
-1974-09-30,TR,Türkiye,
 1974-09-30,US,United States,9.4996
-1974-09-30,XM,Euro area,
-1974-09-30,XW,World,
 1974-09-30,ZA,South Africa,6.3063
-1974-12-31,4T,Emerging market economies (aggregate),
-1974-12-31,5R,Advanced economies,
-1974-12-31,AE,United Arab Emirates,
-1974-12-31,AT,Austria,
 1974-12-31,AU,Australia,14.0413
 1974-12-31,BE,Belgium,14.1704
-1974-12-31,BG,Bulgaria,
-1974-12-31,BR,Brazil,
 1974-12-31,CA,Canada,14.7253
 1974-12-31,CH,Switzerland,-0.2259
-1974-12-31,CL,Chile,
-1974-12-31,CN,China,
-1974-12-31,CO,Colombia,
-1974-12-31,CY,Cyprus,
-1974-12-31,CZ,Czechia,
 1974-12-31,DE,Germany,6.7327
 1974-12-31,DK,Denmark,4.8139
-1974-12-31,EE,Estonia,
 1974-12-31,ES,Spain,28.8644
 1974-12-31,FI,Finland,14.2545
 1974-12-31,FR,France,15.0868
 1974-12-31,GB,United Kingdom,3.4483
-1974-12-31,GR,Greece,
-1974-12-31,HK,Hong Kong SAR,
-1974-12-31,HR,Croatia,
-1974-12-31,HU,Hungary,
-1974-12-31,ID,Indonesia,
 1974-12-31,IE,Ireland,32.41
-1974-12-31,IL,Israel,
-1974-12-31,IN,India,
-1974-12-31,IS,Iceland,
 1974-12-31,IT,Italy,44.8476
 1974-12-31,JP,Japan,2.6988
-1974-12-31,KR,Korea,
-1974-12-31,LT,Lithuania,
-1974-12-31,LU,Luxembourg,
-1974-12-31,LV,Latvia,
-1974-12-31,MA,Morocco,
-1974-12-31,MK,North Macedonia,
-1974-12-31,MT,Malta,
-1974-12-31,MX,Mexico,
-1974-12-31,MY,Malaysia,
 1974-12-31,NL,Netherlands,20.4063
-1974-12-31,NO,Norway,
-1974-12-31,NZ,New Zealand,33.5361
-1974-12-31,PE,Peru,
-1974-12-31,PH,Philippines,
-1974-12-31,PL,Poland,
-1974-12-31,PT,Portugal,
-1974-12-31,RO,Romania,
-1974-12-31,RS,Serbia,
-1974-12-31,RU,Russia,
+1974-12-31,NZ,New Zealand,33.5367
 1974-12-31,SE,Sweden,13.3602
-1974-12-31,SG,Singapore,
-1974-12-31,SI,Slovenia,
-1974-12-31,SK,Slovak Republic,
-1974-12-31,TH,Thailand,
-1974-12-31,TR,Türkiye,
 1974-12-31,US,United States,7.8904
-1974-12-31,XM,Euro area,
-1974-12-31,XW,World,
 1974-12-31,ZA,South Africa,2.5974
-1975-03-31,4T,Emerging market economies (aggregate),
-1975-03-31,5R,Advanced economies,
-1975-03-31,AE,United Arab Emirates,
-1975-03-31,AT,Austria,
 1975-03-31,AU,Australia,9.2521
 1975-03-31,BE,Belgium,18.8583
-1975-03-31,BG,Bulgaria,
-1975-03-31,BR,Brazil,
 1975-03-31,CA,Canada,9.2644
 1975-03-31,CH,Switzerland,-3.5266
-1975-03-31,CL,Chile,
-1975-03-31,CN,China,
-1975-03-31,CO,Colombia,
-1975-03-31,CY,Cyprus,
-1975-03-31,CZ,Czechia,
-1975-03-31,DE,Germany,4.854
+1975-03-31,DE,Germany,4.7614
 1975-03-31,DK,Denmark,11.8742
-1975-03-31,EE,Estonia,
 1975-03-31,ES,Spain,16.7143
 1975-03-31,FI,Finland,7.6365
 1975-03-31,FR,France,12.6209
 1975-03-31,GB,United Kingdom,3.4091
-1975-03-31,GR,Greece,
-1975-03-31,HK,Hong Kong SAR,
-1975-03-31,HR,Croatia,
-1975-03-31,HU,Hungary,
-1975-03-31,ID,Indonesia,
 1975-03-31,IE,Ireland,31.6062
-1975-03-31,IL,Israel,
-1975-03-31,IN,India,
-1975-03-31,IS,Iceland,
 1975-03-31,IT,Italy,32.8165
 1975-03-31,JP,Japan,-4.2076
-1975-03-31,KR,Korea,
-1975-03-31,LT,Lithuania,
-1975-03-31,LU,Luxembourg,
-1975-03-31,LV,Latvia,
-1975-03-31,MA,Morocco,
-1975-03-31,MK,North Macedonia,
-1975-03-31,MT,Malta,
-1975-03-31,MX,Mexico,
-1975-03-31,MY,Malaysia,
 1975-03-31,NL,Netherlands,16.5646
-1975-03-31,NO,Norway,
-1975-03-31,NZ,New Zealand,20.5308
-1975-03-31,PE,Peru,
-1975-03-31,PH,Philippines,
-1975-03-31,PL,Poland,
-1975-03-31,PT,Portugal,
-1975-03-31,RO,Romania,
-1975-03-31,RS,Serbia,
-1975-03-31,RU,Russia,
+1975-03-31,NZ,New Zealand,20.5481
 1975-03-31,SE,Sweden,15
-1975-03-31,SG,Singapore,
-1975-03-31,SI,Slovenia,
-1975-03-31,SK,Slovak Republic,
-1975-03-31,TH,Thailand,
-1975-03-31,TR,Türkiye,
 1975-03-31,US,United States,8.107
-1975-03-31,XM,Euro area,
-1975-03-31,XW,World,
 1975-03-31,ZA,South Africa,8.658
-1975-06-30,4T,Emerging market economies (aggregate),
-1975-06-30,5R,Advanced economies,
-1975-06-30,AE,United Arab Emirates,
-1975-06-30,AT,Austria,
 1975-06-30,AU,Australia,10.075
 1975-06-30,BE,Belgium,13.4909
-1975-06-30,BG,Bulgaria,
-1975-06-30,BR,Brazil,
 1975-06-30,CA,Canada,7.9909
 1975-06-30,CH,Switzerland,-4.9634
-1975-06-30,CL,Chile,
-1975-06-30,CN,China,
-1975-06-30,CO,Colombia,
-1975-06-30,CY,Cyprus,
-1975-06-30,CZ,Czechia,
-1975-06-30,DE,Germany,1.9787
+1975-06-30,DE,Germany,2.1058
 1975-06-30,DK,Denmark,19.9336
-1975-06-30,EE,Estonia,
 1975-06-30,ES,Spain,8.1841
 1975-06-30,FI,Finland,3.1168
 1975-06-30,FR,France,11.811
 1975-06-30,GB,United Kingdom,5.6818
-1975-06-30,GR,Greece,
-1975-06-30,HK,Hong Kong SAR,
-1975-06-30,HR,Croatia,
-1975-06-30,HU,Hungary,
-1975-06-30,ID,Indonesia,
 1975-06-30,IE,Ireland,30.4136
-1975-06-30,IL,Israel,
-1975-06-30,IN,India,
-1975-06-30,IS,Iceland,
 1975-06-30,IT,Italy,20.9491
 1975-06-30,JP,Japan,-4.7259
-1975-06-30,KR,Korea,
-1975-06-30,LT,Lithuania,
-1975-06-30,LU,Luxembourg,
-1975-06-30,LV,Latvia,
-1975-06-30,MA,Morocco,
-1975-06-30,MK,North Macedonia,
-1975-06-30,MT,Malta,
-1975-06-30,MX,Mexico,
-1975-06-30,MY,Malaysia,
 1975-06-30,NL,Netherlands,14.7536
-1975-06-30,NO,Norway,
-1975-06-30,NZ,New Zealand,9.737
-1975-06-30,PE,Peru,
-1975-06-30,PH,Philippines,
-1975-06-30,PL,Poland,
-1975-06-30,PT,Portugal,
-1975-06-30,RO,Romania,
-1975-06-30,RS,Serbia,
-1975-06-30,RU,Russia,
+1975-06-30,NZ,New Zealand,9.7255
 1975-06-30,SE,Sweden,18.8897
-1975-06-30,SG,Singapore,
-1975-06-30,SI,Slovenia,
-1975-06-30,SK,Slovak Republic,
-1975-06-30,TH,Thailand,
-1975-06-30,TR,Türkiye,
 1975-06-30,US,United States,9.0656
-1975-06-30,XM,Euro area,
-1975-06-30,XW,World,
 1975-06-30,ZA,South Africa,8.5106
-1975-09-30,4T,Emerging market economies (aggregate),
-1975-09-30,5R,Advanced economies,
-1975-09-30,AE,United Arab Emirates,
-1975-09-30,AT,Austria,
 1975-09-30,AU,Australia,11.8644
 1975-09-30,BE,Belgium,12.081
-1975-09-30,BG,Bulgaria,
-1975-09-30,BR,Brazil,
 1975-09-30,CA,Canada,12.4424
 1975-09-30,CH,Switzerland,-6.5798
-1975-09-30,CL,Chile,
-1975-09-30,CN,China,
-1975-09-30,CO,Colombia,
-1975-09-30,CY,Cyprus,
-1975-09-30,CZ,Czechia,
-1975-09-30,DE,Germany,1.1156
+1975-09-30,DE,Germany,1.1659
 1975-09-30,DK,Denmark,24.0722
-1975-09-30,EE,Estonia,
 1975-09-30,ES,Spain,5.1534
 1975-09-30,FI,Finland,2.658
 1975-09-30,FR,France,11.3846
 1975-09-30,GB,United Kingdom,7.8652
-1975-09-30,GR,Greece,
-1975-09-30,HK,Hong Kong SAR,
-1975-09-30,HR,Croatia,
-1975-09-30,HU,Hungary,
-1975-09-30,ID,Indonesia,
 1975-09-30,IE,Ireland,31.374
-1975-09-30,IL,Israel,
-1975-09-30,IN,India,
-1975-09-30,IS,Iceland,
 1975-09-30,IT,Italy,13.8624
 1975-09-30,JP,Japan,-5.2414
-1975-09-30,KR,Korea,
-1975-09-30,LT,Lithuania,
-1975-09-30,LU,Luxembourg,
-1975-09-30,LV,Latvia,
-1975-09-30,MA,Morocco,
-1975-09-30,MK,North Macedonia,
-1975-09-30,MT,Malta,
-1975-09-30,MX,Mexico,
-1975-09-30,MY,Malaysia,
 1975-09-30,NL,Netherlands,15.9914
-1975-09-30,NO,Norway,
-1975-09-30,NZ,New Zealand,4.6823
-1975-09-30,PE,Peru,
-1975-09-30,PH,Philippines,
-1975-09-30,PL,Poland,
-1975-09-30,PT,Portugal,
-1975-09-30,RO,Romania,
-1975-09-30,RS,Serbia,
-1975-09-30,RU,Russia,
+1975-09-30,NZ,New Zealand,4.6947
 1975-09-30,SE,Sweden,20.309
-1975-09-30,SG,Singapore,
-1975-09-30,SI,Slovenia,
-1975-09-30,SK,Slovak Republic,
-1975-09-30,TH,Thailand,
-1975-09-30,TR,Türkiye,
 1975-09-30,US,United States,8.1332
-1975-09-30,XM,Euro area,
-1975-09-30,XW,World,
 1975-09-30,ZA,South Africa,8.4746
-1975-12-31,4T,Emerging market economies (aggregate),
-1975-12-31,5R,Advanced economies,
-1975-12-31,AE,United Arab Emirates,
-1975-12-31,AT,Austria,
 1975-12-31,AU,Australia,12.4677
 1975-12-31,BE,Belgium,17.8218
-1975-12-31,BG,Bulgaria,
-1975-12-31,BR,Brazil,
 1975-12-31,CA,Canada,16.7816
 1975-12-31,CH,Switzerland,-6.3272
-1975-12-31,CL,Chile,
-1975-12-31,CN,China,
-1975-12-31,CO,Colombia,
-1975-12-31,CY,Cyprus,
-1975-12-31,CZ,Czechia,
-1975-12-31,DE,Germany,1.5441
+1975-12-31,DE,Germany,1.4547
 1975-12-31,DK,Denmark,15.9216
-1975-12-31,EE,Estonia,
 1975-12-31,ES,Spain,6.8543
 1975-12-31,FI,Finland,4.9138
 1975-12-31,FR,France,11.9448
 1975-12-31,GB,United Kingdom,7.7778
-1975-12-31,GR,Greece,
-1975-12-31,HK,Hong Kong SAR,
-1975-12-31,HR,Croatia,
-1975-12-31,HU,Hungary,
-1975-12-31,ID,Indonesia,
 1975-12-31,IE,Ireland,25.6625
-1975-12-31,IL,Israel,
-1975-12-31,IN,India,
-1975-12-31,IS,Iceland,
 1975-12-31,IT,Italy,11.8236
 1975-12-31,JP,Japan,-1.9886
-1975-12-31,KR,Korea,
-1975-12-31,LT,Lithuania,
-1975-12-31,LU,Luxembourg,
-1975-12-31,LV,Latvia,
-1975-12-31,MA,Morocco,
-1975-12-31,MK,North Macedonia,
-1975-12-31,MT,Malta,
-1975-12-31,MX,Mexico,
-1975-12-31,MY,Malaysia,
 1975-12-31,NL,Netherlands,16.1043
-1975-12-31,NO,Norway,
-1975-12-31,NZ,New Zealand,4.0989
-1975-12-31,PE,Peru,
-1975-12-31,PH,Philippines,
-1975-12-31,PL,Poland,
-1975-12-31,PT,Portugal,
-1975-12-31,RO,Romania,
-1975-12-31,RS,Serbia,
-1975-12-31,RU,Russia,
+1975-12-31,NZ,New Zealand,4.1097
 1975-12-31,SE,Sweden,17.4299
-1975-12-31,SG,Singapore,
-1975-12-31,SI,Slovenia,
-1975-12-31,SK,Slovak Republic,
-1975-12-31,TH,Thailand,
-1975-12-31,TR,Türkiye,
 1975-12-31,US,United States,9.4688
-1975-12-31,XM,Euro area,
-1975-12-31,XW,World,
 1975-12-31,ZA,South Africa,10.5485
-1976-03-31,4T,Emerging market economies (aggregate),
-1976-03-31,5R,Advanced economies,
-1976-03-31,AE,United Arab Emirates,
-1976-03-31,AT,Austria,
 1976-03-31,AU,Australia,14.503
 1976-03-31,BE,Belgium,21.5303
-1976-03-31,BG,Bulgaria,
-1976-03-31,BR,Brazil,
 1976-03-31,CA,Canada,15.6841
 1976-03-31,CH,Switzerland,-4.8653
-1976-03-31,CL,Chile,
-1976-03-31,CN,China,
-1976-03-31,CO,Colombia,
-1976-03-31,CY,Cyprus,
-1976-03-31,CZ,Czechia,
-1976-03-31,DE,Germany,1.3407
+1976-03-31,DE,Germany,1.3573
 1976-03-31,DK,Denmark,11.9048
-1976-03-31,EE,Estonia,
 1976-03-31,ES,Spain,9.3023
 1976-03-31,FI,Finland,7.191
 1976-03-31,FR,France,14.0404
 1976-03-31,GB,United Kingdom,8.7912
-1976-03-31,GR,Greece,
-1976-03-31,HK,Hong Kong SAR,
-1976-03-31,HR,Croatia,
-1976-03-31,HU,Hungary,
-1976-03-31,ID,Indonesia,
 1976-03-31,IE,Ireland,24.0157
-1976-03-31,IL,Israel,
-1976-03-31,IN,India,
-1976-03-31,IS,Iceland,
 1976-03-31,IT,Italy,12.7432
 1976-03-31,JP,Japan,1.4641
-1976-03-31,KR,Korea,35.3546
-1976-03-31,LT,Lithuania,
-1976-03-31,LU,Luxembourg,
-1976-03-31,LV,Latvia,
-1976-03-31,MA,Morocco,
-1976-03-31,MK,North Macedonia,
-1976-03-31,MT,Malta,
-1976-03-31,MX,Mexico,
-1976-03-31,MY,Malaysia,
+1976-03-31,KR,Korea,35.3547
 1976-03-31,NL,Netherlands,19.2394
-1976-03-31,NO,Norway,
-1976-03-31,NZ,New Zealand,5.8938
-1976-03-31,PE,Peru,
-1976-03-31,PH,Philippines,
-1976-03-31,PL,Poland,
-1976-03-31,PT,Portugal,
-1976-03-31,RO,Romania,
-1976-03-31,RS,Serbia,
-1976-03-31,RU,Russia,
+1976-03-31,NZ,New Zealand,5.9092
 1976-03-31,SE,Sweden,16.9805
-1976-03-31,SG,Singapore,
-1976-03-31,SI,Slovenia,
-1976-03-31,SK,Slovak Republic,
-1976-03-31,TH,Thailand,
-1976-03-31,TR,Türkiye,
-1976-03-31,US,United States,3.8557
-1976-03-31,XM,Euro area,7.7822
-1976-03-31,XW,World,
+1976-03-31,US,United States,3.7607
+1976-03-31,XM,Euro area,7.7429
 1976-03-31,ZA,South Africa,6.3745
-1976-06-30,4T,Emerging market economies (aggregate),
-1976-06-30,5R,Advanced economies,
-1976-06-30,AE,United Arab Emirates,
-1976-06-30,AT,Austria,
 1976-06-30,AU,Australia,12.5122
 1976-06-30,BE,Belgium,20.1218
-1976-06-30,BG,Bulgaria,
-1976-06-30,BR,Brazil,
 1976-06-30,CA,Canada,13.284
 1976-06-30,CH,Switzerland,-3.137
-1976-06-30,CL,Chile,
-1976-06-30,CN,China,
-1976-06-30,CO,Colombia,
-1976-06-30,CY,Cyprus,
-1976-06-30,CZ,Czechia,
-1976-06-30,DE,Germany,1.5426
+1976-06-30,DE,Germany,1.5099
 1976-06-30,DK,Denmark,9.2798
-1976-06-30,EE,Estonia,
 1976-06-30,ES,Spain,16.4303
 1976-06-30,FI,Finland,5.4407
 1976-06-30,FR,France,15.7829
 1976-06-30,GB,United Kingdom,9.6774
-1976-06-30,GR,Greece,
-1976-06-30,HK,Hong Kong SAR,
-1976-06-30,HR,Croatia,
-1976-06-30,HU,Hungary,
-1976-06-30,ID,Indonesia,
 1976-06-30,IE,Ireland,18.8433
-1976-06-30,IL,Israel,
-1976-06-30,IN,India,
-1976-06-30,IS,Iceland,
 1976-06-30,IT,Italy,15.5981
 1976-06-30,JP,Japan,2.0454
 1976-06-30,KR,Korea,27.711
-1976-06-30,LT,Lithuania,
-1976-06-30,LU,Luxembourg,
-1976-06-30,LV,Latvia,
-1976-06-30,MA,Morocco,
-1976-06-30,MK,North Macedonia,
-1976-06-30,MT,Malta,
-1976-06-30,MX,Mexico,
-1976-06-30,MY,Malaysia,
 1976-06-30,NL,Netherlands,26.721
-1976-06-30,NO,Norway,
-1976-06-30,NZ,New Zealand,7.9663
-1976-06-30,PE,Peru,
-1976-06-30,PH,Philippines,
-1976-06-30,PL,Poland,
-1976-06-30,PT,Portugal,
-1976-06-30,RO,Romania,
-1976-06-30,RS,Serbia,
-1976-06-30,RU,Russia,
+1976-06-30,NZ,New Zealand,7.9544
 1976-06-30,SE,Sweden,16.7964
-1976-06-30,SG,Singapore,
-1976-06-30,SI,Slovenia,
-1976-06-30,SK,Slovak Republic,
-1976-06-30,TH,Thailand,
-1976-06-30,TR,Türkiye,
-1976-06-30,US,United States,4.105
-1976-06-30,XM,Euro area,11.2576
-1976-06-30,XW,World,
+1976-06-30,US,United States,4.1602
+1976-06-30,XM,Euro area,11.2518
 1976-06-30,ZA,South Africa,7.0588
-1976-09-30,4T,Emerging market economies (aggregate),
-1976-09-30,5R,Advanced economies,
-1976-09-30,AE,United Arab Emirates,
-1976-09-30,AT,Austria,
 1976-09-30,AU,Australia,9.2803
 1976-09-30,BE,Belgium,21.838
-1976-09-30,BG,Bulgaria,
-1976-09-30,BR,Brazil,
 1976-09-30,CA,Canada,10.0068
 1976-09-30,CH,Switzerland,-3.2289
-1976-09-30,CL,Chile,
-1976-09-30,CN,China,
-1976-09-30,CO,Colombia,
-1976-09-30,CY,Cyprus,
-1976-09-30,CZ,Czechia,
-1976-09-30,DE,Germany,2.1753
+1976-09-30,DE,Germany,2.035
 1976-09-30,DK,Denmark,6.5379
-1976-09-30,EE,Estonia,
 1976-09-30,ES,Spain,20.7701
 1976-09-30,FI,Finland,7.2624
 1976-09-30,FR,France,16.7324
 1976-09-30,GB,United Kingdom,8.3333
-1976-09-30,GR,Greece,
-1976-09-30,HK,Hong Kong SAR,
-1976-09-30,HR,Croatia,
-1976-09-30,HU,Hungary,
-1976-09-30,ID,Indonesia,
 1976-09-30,IE,Ireland,17.1412
-1976-09-30,IL,Israel,
-1976-09-30,IN,India,
-1976-09-30,IS,Iceland,
 1976-09-30,IT,Italy,17.4721
 1976-09-30,JP,Japan,2.6201
 1976-09-30,KR,Korea,25.0624
-1976-09-30,LT,Lithuania,
-1976-09-30,LU,Luxembourg,
-1976-09-30,LV,Latvia,
-1976-09-30,MA,Morocco,
-1976-09-30,MK,North Macedonia,
-1976-09-30,MT,Malta,
-1976-09-30,MX,Mexico,
-1976-09-30,MY,Malaysia,
 1976-09-30,NL,Netherlands,30.2336
-1976-09-30,NO,Norway,
-1976-09-30,NZ,New Zealand,7.6038
-1976-09-30,PE,Peru,
-1976-09-30,PH,Philippines,
-1976-09-30,PL,Poland,
-1976-09-30,PT,Portugal,
-1976-09-30,RO,Romania,
-1976-09-30,RS,Serbia,
-1976-09-30,RU,Russia,
+1976-09-30,NZ,New Zealand,7.6234
 1976-09-30,SE,Sweden,19.1356
-1976-09-30,SG,Singapore,
-1976-09-30,SI,Slovenia,
-1976-09-30,SK,Slovak Republic,
-1976-09-30,TH,Thailand,
-1976-09-30,TR,Türkiye,
-1976-09-30,US,United States,4.9035
-1976-09-30,XM,Euro area,13.5622
-1976-09-30,XW,World,
+1976-09-30,US,United States,4.9195
+1976-09-30,XM,Euro area,13.5801
 1976-09-30,ZA,South Africa,6.6406
-1976-12-31,4T,Emerging market economies (aggregate),
-1976-12-31,5R,Advanced economies,
-1976-12-31,AE,United Arab Emirates,
-1976-12-31,AT,Austria,
 1976-12-31,AU,Australia,9.6136
 1976-12-31,BE,Belgium,21.1885
-1976-12-31,BG,Bulgaria,
-1976-12-31,BR,Brazil,
 1976-12-31,CA,Canada,9.6129
 1976-12-31,CH,Switzerland,0.1823
-1976-12-31,CL,Chile,
-1976-12-31,CN,China,
-1976-12-31,CO,Colombia,
-1976-12-31,CY,Cyprus,
-1976-12-31,CZ,Czechia,
-1976-12-31,DE,Germany,3.7329
+1976-12-31,DE,Germany,3.8923
 1976-12-31,DK,Denmark,10.7237
-1976-12-31,EE,Estonia,
 1976-12-31,ES,Spain,22.795
 1976-12-31,FI,Finland,4.5316
 1976-12-31,FR,France,16.7951
 1976-12-31,GB,United Kingdom,9.2784
-1976-12-31,GR,Greece,
-1976-12-31,HK,Hong Kong SAR,
-1976-12-31,HR,Croatia,
-1976-12-31,HU,Hungary,
-1976-12-31,ID,Indonesia,
 1976-12-31,IE,Ireland,23.3074
-1976-12-31,IL,Israel,
-1976-12-31,IN,India,
-1976-12-31,IS,Iceland,
 1976-12-31,IT,Italy,17.6523
 1976-12-31,JP,Japan,3.2609
 1976-12-31,KR,Korea,20.6956
-1976-12-31,LT,Lithuania,
-1976-12-31,LU,Luxembourg,
-1976-12-31,LV,Latvia,
-1976-12-31,MA,Morocco,
-1976-12-31,MK,North Macedonia,
-1976-12-31,MT,Malta,
-1976-12-31,MX,Mexico,
-1976-12-31,MY,Malaysia,
 1976-12-31,NL,Netherlands,33.1352
-1976-12-31,NO,Norway,
-1976-12-31,NZ,New Zealand,7
-1976-12-31,PE,Peru,
-1976-12-31,PH,Philippines,
-1976-12-31,PL,Poland,
-1976-12-31,PT,Portugal,
-1976-12-31,RO,Romania,
-1976-12-31,RS,Serbia,
-1976-12-31,RU,Russia,
+1976-12-31,NZ,New Zealand,7.0173
 1976-12-31,SE,Sweden,15.1451
-1976-12-31,SG,Singapore,
-1976-12-31,SI,Slovenia,
-1976-12-31,SK,Slovak Republic,
-1976-12-31,TH,Thailand,
-1976-12-31,TR,Türkiye,
-1976-12-31,US,United States,7.1709
-1976-12-31,XM,Euro area,14.931
-1976-12-31,XW,World,
+1976-12-31,US,United States,7.1906
+1976-12-31,XM,Euro area,14.9285
 1976-12-31,ZA,South Africa,3.8168
-1977-03-31,4T,Emerging market economies (aggregate),
-1977-03-31,5R,Advanced economies,
-1977-03-31,AE,United Arab Emirates,
-1977-03-31,AT,Austria,
 1977-03-31,AU,Australia,8.2817
 1977-03-31,BE,Belgium,15.2085
-1977-03-31,BG,Bulgaria,
-1977-03-31,BR,Brazil,
 1977-03-31,CA,Canada,6.0396
 1977-03-31,CH,Switzerland,2.4277
-1977-03-31,CL,Chile,
-1977-03-31,CN,China,
-1977-03-31,CO,Colombia,
-1977-03-31,CY,Cyprus,
-1977-03-31,CZ,Czechia,
-1977-03-31,DE,Germany,4.6479
+1977-03-31,DE,Germany,4.5649
 1977-03-31,DK,Denmark,7.921
-1977-03-31,EE,Estonia,
 1977-03-31,ES,Spain,32.5868
 1977-03-31,FI,Finland,2.6655
 1977-03-31,FR,France,16.3027
 1977-03-31,GB,United Kingdom,7.0707
-1977-03-31,GR,Greece,
-1977-03-31,HK,Hong Kong SAR,
-1977-03-31,HR,Croatia,
-1977-03-31,HU,Hungary,
-1977-03-31,ID,Indonesia,
 1977-03-31,IE,Ireland,16.3492
-1977-03-31,IL,Israel,
-1977-03-31,IN,India,
-1977-03-31,IS,Iceland,
 1977-03-31,IT,Italy,15.7032
 1977-03-31,JP,Japan,3.8961
 1977-03-31,KR,Korea,27.1152
-1977-03-31,LT,Lithuania,
-1977-03-31,LU,Luxembourg,
-1977-03-31,LV,Latvia,
-1977-03-31,MA,Morocco,
-1977-03-31,MK,North Macedonia,
-1977-03-31,MT,Malta,
-1977-03-31,MX,Mexico,
-1977-03-31,MY,Malaysia,
 1977-03-31,NL,Netherlands,41.3554
-1977-03-31,NO,Norway,
-1977-03-31,NZ,New Zealand,7.0948
-1977-03-31,PE,Peru,
-1977-03-31,PH,Philippines,
-1977-03-31,PL,Poland,
-1977-03-31,PT,Portugal,
-1977-03-31,RO,Romania,
-1977-03-31,RS,Serbia,
-1977-03-31,RU,Russia,
+1977-03-31,NZ,New Zealand,7.0812
 1977-03-31,SE,Sweden,15.9497
-1977-03-31,SG,Singapore,
-1977-03-31,SI,Slovenia,
-1977-03-31,SK,Slovak Republic,
-1977-03-31,TH,Thailand,
-1977-03-31,TR,Türkiye,
-1977-03-31,US,United States,14.5827
-1977-03-31,XM,Euro area,14.9236
-1977-03-31,XW,World,
+1977-03-31,US,United States,14.7563
+1977-03-31,XM,Euro area,14.9717
 1977-03-31,ZA,South Africa,2.2472
-1977-06-30,4T,Emerging market economies (aggregate),
-1977-06-30,5R,Advanced economies,
-1977-06-30,AE,United Arab Emirates,
-1977-06-30,AT,Austria,
 1977-06-30,AU,Australia,8.3081
 1977-06-30,BE,Belgium,16.191
-1977-06-30,BG,Bulgaria,
-1977-06-30,BR,Brazil,
 1977-06-30,CA,Canada,5.2255
 1977-06-30,CH,Switzerland,2.8469
-1977-06-30,CL,Chile,
-1977-06-30,CN,China,
-1977-06-30,CO,Colombia,
-1977-06-30,CY,Cyprus,
-1977-06-30,CZ,Czechia,
-1977-06-30,DE,Germany,5.3332
+1977-06-30,DE,Germany,5.3849
 1977-06-30,DK,Denmark,13.4347
-1977-06-30,EE,Estonia,
 1977-06-30,ES,Spain,32.8934
 1977-06-30,FI,Finland,5.5522
 1977-06-30,FR,France,15.4562
 1977-06-30,GB,United Kingdom,5.8824
-1977-06-30,GR,Greece,
-1977-06-30,HK,Hong Kong SAR,
-1977-06-30,HR,Croatia,
-1977-06-30,HU,Hungary,
-1977-06-30,ID,Indonesia,
 1977-06-30,IE,Ireland,19.0999
-1977-06-30,IL,Israel,
-1977-06-30,IN,India,
-1977-06-30,IS,Iceland,
 1977-06-30,IT,Italy,12.9139
 1977-06-30,JP,Japan,4.1425
 1977-06-30,KR,Korea,29.5576
-1977-06-30,LT,Lithuania,
-1977-06-30,LU,Luxembourg,
-1977-06-30,LV,Latvia,
-1977-06-30,MA,Morocco,
-1977-06-30,MK,North Macedonia,
-1977-06-30,MT,Malta,
-1977-06-30,MX,Mexico,
-1977-06-30,MY,Malaysia,
 1977-06-30,NL,Netherlands,45.6748
-1977-06-30,NO,Norway,
-1977-06-30,NZ,New Zealand,7.3785
-1977-06-30,PE,Peru,
-1977-06-30,PH,Philippines,
-1977-06-30,PL,Poland,
-1977-06-30,PT,Portugal,
-1977-06-30,RO,Romania,
-1977-06-30,RS,Serbia,
-1977-06-30,RU,Russia,
+1977-06-30,NZ,New Zealand,7.3683
 1977-06-30,SE,Sweden,16.4908
-1977-06-30,SG,Singapore,
-1977-06-30,SI,Slovenia,
-1977-06-30,SK,Slovak Republic,
-1977-06-30,TH,Thailand,
-1977-06-30,TR,Türkiye,
-1977-06-30,US,United States,16.3009
-1977-06-30,XM,Euro area,13.5197
-1977-06-30,XW,World,
+1977-06-30,US,United States,16.3457
+1977-06-30,XM,Euro area,13.5487
 1977-06-30,ZA,South Africa,1.4652
-1977-09-30,4T,Emerging market economies (aggregate),
-1977-09-30,5R,Advanced economies,
-1977-09-30,AE,United Arab Emirates,
-1977-09-30,AT,Austria,
 1977-09-30,AU,Australia,8.7955
 1977-09-30,BE,Belgium,16.1084
-1977-09-30,BG,Bulgaria,
-1977-09-30,BR,Brazil,
 1977-09-30,CA,Canada,4.6569
 1977-09-30,CH,Switzerland,6.1942
-1977-09-30,CL,Chile,
-1977-09-30,CN,China,
-1977-09-30,CO,Colombia,
-1977-09-30,CY,Cyprus,
-1977-09-30,CZ,Czechia,
-1977-09-30,DE,Germany,6.1798
+1977-09-30,DE,Germany,6.3871
 1977-09-30,DK,Denmark,15.354
-1977-09-30,EE,Estonia,
 1977-09-30,ES,Spain,36.715
 1977-09-30,FI,Finland,2.1195
 1977-09-30,FR,France,14.9087
 1977-09-30,GB,United Kingdom,6.7308
-1977-09-30,GR,Greece,
-1977-09-30,HK,Hong Kong SAR,
-1977-09-30,HR,Croatia,
-1977-09-30,HU,Hungary,
-1977-09-30,ID,Indonesia,
 1977-09-30,IE,Ireland,25
-1977-09-30,IL,Israel,
-1977-09-30,IN,India,
-1977-09-30,IS,Iceland,
 1977-09-30,IT,Italy,9.6519
 1977-09-30,JP,Japan,4.3972
 1977-09-30,KR,Korea,33.3468
-1977-09-30,LT,Lithuania,
-1977-09-30,LU,Luxembourg,
-1977-09-30,LV,Latvia,
-1977-09-30,MA,Morocco,
-1977-09-30,MK,North Macedonia,
-1977-09-30,MT,Malta,
-1977-09-30,MX,Mexico,
-1977-09-30,MY,Malaysia,
 1977-09-30,NL,Netherlands,37.8153
-1977-09-30,NO,Norway,
-1977-09-30,NZ,New Zealand,6.8884
-1977-09-30,PE,Peru,
-1977-09-30,PH,Philippines,
-1977-09-30,PL,Poland,
-1977-09-30,PT,Portugal,
-1977-09-30,RO,Romania,
-1977-09-30,RS,Serbia,
-1977-09-30,RU,Russia,
+1977-09-30,NZ,New Zealand,6.8752
 1977-09-30,SE,Sweden,13.3281
-1977-09-30,SG,Singapore,
-1977-09-30,SI,Slovenia,
-1977-09-30,SK,Slovak Republic,
-1977-09-30,TH,Thailand,
-1977-09-30,TR,Türkiye,
-1977-09-30,US,United States,17.4046
-1977-09-30,XM,Euro area,13.3816
-1977-09-30,XW,World,
+1977-09-30,US,United States,17.5439
+1977-09-30,XM,Euro area,13.3946
 1977-09-30,ZA,South Africa,1.4652
-1977-12-31,4T,Emerging market economies (aggregate),
-1977-12-31,5R,Advanced economies,
-1977-12-31,AE,United Arab Emirates,
-1977-12-31,AT,Austria,
 1977-12-31,AU,Australia,7.3017
 1977-12-31,BE,Belgium,18.0535
-1977-12-31,BG,Bulgaria,
-1977-12-31,BR,Brazil,
 1977-12-31,CA,Canada,3.7713
 1977-12-31,CH,Switzerland,2.7144
-1977-12-31,CL,Chile,
-1977-12-31,CN,China,
-1977-12-31,CO,Colombia,
-1977-12-31,CY,Cyprus,
-1977-12-31,CZ,Czechia,
-1977-12-31,DE,Germany,6.032
+1977-12-31,DE,Germany,5.855
 1977-12-31,DK,Denmark,16.4361
-1977-12-31,EE,Estonia,
 1977-12-31,ES,Spain,43.8433
 1977-12-31,FI,Finland,0.931
 1977-12-31,FR,France,14.4129
 1977-12-31,GB,United Kingdom,8.4906
-1977-12-31,GR,Greece,
-1977-12-31,HK,Hong Kong SAR,
-1977-12-31,HR,Croatia,
-1977-12-31,HU,Hungary,
-1977-12-31,ID,Indonesia,
 1977-12-31,IE,Ireland,16.9667
-1977-12-31,IL,Israel,
-1977-12-31,IN,India,
-1977-12-31,IS,Iceland,
 1977-12-31,IT,Italy,7.3115
 1977-12-31,JP,Japan,4.5614
 1977-12-31,KR,Korea,42.6236
-1977-12-31,LT,Lithuania,
-1977-12-31,LU,Luxembourg,
-1977-12-31,LV,Latvia,
-1977-12-31,MA,Morocco,
-1977-12-31,MK,North Macedonia,
-1977-12-31,MT,Malta,
-1977-12-31,MX,Mexico,
-1977-12-31,MY,Malaysia,
 1977-12-31,NL,Netherlands,30.7094
-1977-12-31,NO,Norway,
-1977-12-31,NZ,New Zealand,4.965
-1977-12-31,PE,Peru,
-1977-12-31,PH,Philippines,
-1977-12-31,PL,Poland,
-1977-12-31,PT,Portugal,
-1977-12-31,RO,Romania,
-1977-12-31,RS,Serbia,
-1977-12-31,RU,Russia,
+1977-12-31,NZ,New Zealand,4.9183
 1977-12-31,SE,Sweden,16.041
-1977-12-31,SG,Singapore,
-1977-12-31,SI,Slovenia,
-1977-12-31,SK,Slovak Republic,
-1977-12-31,TH,Thailand,
-1977-12-31,TR,Türkiye,
-1977-12-31,US,United States,15.9986
-1977-12-31,XM,Euro area,13.5668
-1977-12-31,XW,World,
+1977-12-31,US,United States,16.1345
+1977-12-31,XM,Euro area,13.6181
 1977-12-31,ZA,South Africa,2.5735
-1978-03-31,4T,Emerging market economies (aggregate),
-1978-03-31,5R,Advanced economies,
-1978-03-31,AE,United Arab Emirates,
-1978-03-31,AT,Austria,
 1978-03-31,AU,Australia,7.362
 1978-03-31,BE,Belgium,14.2418
-1978-03-31,BG,Bulgaria,
-1978-03-31,BR,Brazil,
 1978-03-31,CA,Canada,2.4918
 1978-03-31,CH,Switzerland,1.6621
-1978-03-31,CL,Chile,
-1978-03-31,CN,China,
-1978-03-31,CO,Colombia,
-1978-03-31,CY,Cyprus,
-1978-03-31,CZ,Czechia,
-1978-03-31,DE,Germany,6.7929
+1978-03-31,DE,Germany,6.9238
 1978-03-31,DK,Denmark,19.9287
-1978-03-31,EE,Estonia,
 1978-03-31,ES,Spain,41.5541
 1978-03-31,FI,Finland,3.909
 1978-03-31,FR,France,13.4024
 1978-03-31,GB,United Kingdom,10.3774
-1978-03-31,GR,Greece,
-1978-03-31,HK,Hong Kong SAR,
-1978-03-31,HR,Croatia,
-1978-03-31,HU,Hungary,
-1978-03-31,ID,Indonesia,
 1978-03-31,IE,Ireland,30.5593
-1978-03-31,IL,Israel,
-1978-03-31,IN,India,
-1978-03-31,IS,Iceland,
 1978-03-31,IT,Italy,7.9791
 1978-03-31,JP,Japan,4.7222
 1978-03-31,KR,Korea,51.4907
-1978-03-31,LT,Lithuania,
-1978-03-31,LU,Luxembourg,
-1978-03-31,LV,Latvia,
-1978-03-31,MA,Morocco,
-1978-03-31,MK,North Macedonia,
-1978-03-31,MT,Malta,
-1978-03-31,MX,Mexico,
-1978-03-31,MY,Malaysia,
 1978-03-31,NL,Netherlands,20.1722
-1978-03-31,NO,Norway,
-1978-03-31,NZ,New Zealand,2.7984
-1978-03-31,PE,Peru,
-1978-03-31,PH,Philippines,
-1978-03-31,PL,Poland,
-1978-03-31,PT,Portugal,
-1978-03-31,RO,Romania,
-1978-03-31,RS,Serbia,
-1978-03-31,RU,Russia,
+1978-03-31,NZ,New Zealand,2.8058
 1978-03-31,SE,Sweden,12.5189
-1978-03-31,SG,Singapore,
-1978-03-31,SI,Slovenia,
-1978-03-31,SK,Slovak Republic,
-1978-03-31,TH,Thailand,
-1978-03-31,TR,Türkiye,
-1978-03-31,US,United States,16.1839
-1978-03-31,XM,Euro area,13.9072
-1978-03-31,XW,World,
+1978-03-31,US,United States,16.2748
+1978-03-31,XM,Euro area,13.9182
 1978-03-31,ZA,South Africa,3.2967
-1978-06-30,4T,Emerging market economies (aggregate),
-1978-06-30,5R,Advanced economies,
-1978-06-30,AE,United Arab Emirates,
-1978-06-30,AT,Austria,
 1978-06-30,AU,Australia,4.5545
 1978-06-30,BE,Belgium,12.3508
-1978-06-30,BG,Bulgaria,
-1978-06-30,BR,Brazil,
 1978-06-30,CA,Canada,5.1138
 1978-06-30,CH,Switzerland,3.2262
-1978-06-30,CL,Chile,
-1978-06-30,CN,China,
-1978-06-30,CO,Colombia,
-1978-06-30,CY,Cyprus,
-1978-06-30,CZ,Czechia,
-1978-06-30,DE,Germany,7.0265
+1978-06-30,DE,Germany,6.9898
 1978-06-30,DK,Denmark,17.3631
-1978-06-30,EE,Estonia,
 1978-06-30,ES,Spain,37.8151
 1978-06-30,FI,Finland,3.7736
 1978-06-30,FR,France,12.0545
 1978-06-30,GB,United Kingdom,13.8889
-1978-06-30,GR,Greece,
-1978-06-30,HK,Hong Kong SAR,
-1978-06-30,HR,Croatia,
-1978-06-30,HU,Hungary,
-1978-06-30,ID,Indonesia,
 1978-06-30,IE,Ireland,33.5677
-1978-06-30,IL,Israel,
-1978-06-30,IN,India,
-1978-06-30,IS,Iceland,
 1978-06-30,IT,Italy,12.1701
 1978-06-30,JP,Japan,5.2854
 1978-06-30,KR,Korea,56.0117
-1978-06-30,LT,Lithuania,
-1978-06-30,LU,Luxembourg,
-1978-06-30,LV,Latvia,
-1978-06-30,MA,Morocco,
-1978-06-30,MK,North Macedonia,
-1978-06-30,MT,Malta,
-1978-06-30,MX,Mexico,
-1978-06-30,MY,Malaysia,
 1978-06-30,NL,Netherlands,11.4345
-1978-06-30,NO,Norway,
-1978-06-30,NZ,New Zealand,1.1732
-1978-06-30,PE,Peru,
-1978-06-30,PH,Philippines,
-1978-06-30,PL,Poland,
-1978-06-30,PT,Portugal,
-1978-06-30,RO,Romania,
-1978-06-30,RS,Serbia,
-1978-06-30,RU,Russia,
+1978-06-30,NZ,New Zealand,1.1767
 1978-06-30,SE,Sweden,13.1316
-1978-06-30,SG,Singapore,
-1978-06-30,SI,Slovenia,
-1978-06-30,SK,Slovak Republic,
-1978-06-30,TH,Thailand,
-1978-06-30,TR,Türkiye,
-1978-06-30,US,United States,14.792
-1978-06-30,XM,Euro area,12.8679
-1978-06-30,XW,World,
+1978-06-30,US,United States,14.8624
+1978-06-30,XM,Euro area,12.8612
 1978-06-30,ZA,South Africa,2.1661
-1978-09-30,4T,Emerging market economies (aggregate),
-1978-09-30,5R,Advanced economies,
-1978-09-30,AE,United Arab Emirates,
-1978-09-30,AT,Austria,
 1978-09-30,AU,Australia,4.7391
 1978-09-30,BE,Belgium,12.3982
-1978-09-30,BG,Bulgaria,
-1978-09-30,BR,Brazil,
 1978-09-30,CA,Canada,5.31
 1978-09-30,CH,Switzerland,2.8203
-1978-09-30,CL,Chile,
-1978-09-30,CN,China,
-1978-09-30,CO,Colombia,
-1978-09-30,CY,Cyprus,
-1978-09-30,CZ,Czechia,
-1978-09-30,DE,Germany,7.5652
+1978-09-30,DE,Germany,7.4502
 1978-09-30,DK,Denmark,15.9595
-1978-09-30,EE,Estonia,
 1978-09-30,ES,Spain,31.8728
 1978-09-30,FI,Finland,3.0556
 1978-09-30,FR,France,10.8267
 1978-09-30,GB,United Kingdom,18.018
-1978-09-30,GR,Greece,
-1978-09-30,HK,Hong Kong SAR,
-1978-09-30,HR,Croatia,
-1978-09-30,HU,Hungary,
-1978-09-30,ID,Indonesia,
 1978-09-30,IE,Ireland,29.127
-1978-09-30,IL,Israel,
-1978-09-30,IN,India,
-1978-09-30,IS,Iceland,
 1978-09-30,IT,Italy,17.3882
 1978-09-30,JP,Japan,5.8424
 1978-09-30,KR,Korea,51.022
-1978-09-30,LT,Lithuania,
-1978-09-30,LU,Luxembourg,
-1978-09-30,LV,Latvia,
-1978-09-30,MA,Morocco,
-1978-09-30,MK,North Macedonia,
-1978-09-30,MT,Malta,
-1978-09-30,MX,Mexico,
-1978-09-30,MY,Malaysia,
 1978-09-30,NL,Netherlands,2.5777
-1978-09-30,NO,Norway,
-1978-09-30,NZ,New Zealand,1.5556
-1978-09-30,PE,Peru,
-1978-09-30,PH,Philippines,
-1978-09-30,PL,Poland,
-1978-09-30,PT,Portugal,
-1978-09-30,RO,Romania,
-1978-09-30,RS,Serbia,
-1978-09-30,RU,Russia,
+1978-09-30,NZ,New Zealand,1.5594
 1978-09-30,SE,Sweden,15.4025
-1978-09-30,SG,Singapore,
-1978-09-30,SI,Slovenia,
-1978-09-30,SK,Slovak Republic,
-1978-09-30,TH,Thailand,
-1978-09-30,TR,Türkiye,
-1978-09-30,US,United States,15.419
-1978-09-30,XM,Euro area,12.1517
-1978-09-30,XW,World,
+1978-09-30,US,United States,15.4358
+1978-09-30,XM,Euro area,12.17
 1978-09-30,ZA,South Africa,4.3321
-1978-12-31,4T,Emerging market economies (aggregate),
-1978-12-31,5R,Advanced economies,
-1978-12-31,AE,United Arab Emirates,
-1978-12-31,AT,Austria,
 1978-12-31,AU,Australia,3.989
 1978-12-31,BE,Belgium,8.1183
-1978-12-31,BG,Bulgaria,
-1978-12-31,BR,Brazil,
 1978-12-31,CA,Canada,7.2397
 1978-12-31,CH,Switzerland,6.3047
-1978-12-31,CL,Chile,
-1978-12-31,CN,China,
-1978-12-31,CO,Colombia,
-1978-12-31,CY,Cyprus,
-1978-12-31,CZ,Czechia,
-1978-12-31,DE,Germany,7.8243
+1978-12-31,DE,Germany,7.8515
 1978-12-31,DK,Denmark,11.3911
-1978-12-31,EE,Estonia,
 1978-12-31,ES,Spain,22.3087
 1978-12-31,FI,Finland,4.2087
 1978-12-31,FR,France,10.4929
 1978-12-31,GB,United Kingdom,22.6087
-1978-12-31,GR,Greece,
-1978-12-31,HK,Hong Kong SAR,
-1978-12-31,HR,Croatia,
-1978-12-31,HU,Hungary,
-1978-12-31,ID,Indonesia,
 1978-12-31,IE,Ireland,24.8942
-1978-12-31,IL,Israel,
-1978-12-31,IN,India,
-1978-12-31,IS,Iceland,
 1978-12-31,IT,Italy,21.3627
 1978-12-31,JP,Japan,6.7114
 1978-12-31,KR,Korea,39.5368
-1978-12-31,LT,Lithuania,
-1978-12-31,LU,Luxembourg,
-1978-12-31,LV,Latvia,
-1978-12-31,MA,Morocco,
-1978-12-31,MK,North Macedonia,
-1978-12-31,MT,Malta,
-1978-12-31,MX,Mexico,
-1978-12-31,MY,Malaysia,
 1978-12-31,NL,Netherlands,0.8224
-1978-12-31,NO,Norway,
-1978-12-31,NZ,New Zealand,2.8937
-1978-12-31,PE,Peru,
-1978-12-31,PH,Philippines,
-1978-12-31,PL,Poland,
-1978-12-31,PT,Portugal,
-1978-12-31,RO,Romania,
-1978-12-31,RS,Serbia,
-1978-12-31,RU,Russia,
+1978-12-31,NZ,New Zealand,2.9297
 1978-12-31,SE,Sweden,12.3303
-1978-12-31,SG,Singapore,
-1978-12-31,SI,Slovenia,
-1978-12-31,SK,Slovak Republic,
-1978-12-31,TH,Thailand,
-1978-12-31,TR,Türkiye,
-1978-12-31,US,United States,15.5165
-1978-12-31,XM,Euro area,12.454
-1978-12-31,XW,World,
+1978-12-31,US,United States,15.485
+1978-12-31,XM,Euro area,12.4513
 1978-12-31,ZA,South Africa,7.1685
-1979-03-31,4T,Emerging market economies (aggregate),
-1979-03-31,5R,Advanced economies,
-1979-03-31,AE,United Arab Emirates,
-1979-03-31,AT,Austria,
 1979-03-31,AU,Australia,6.7429
 1979-03-31,BE,Belgium,10.0435
-1979-03-31,BG,Bulgaria,
-1979-03-31,BR,Brazil,
 1979-03-31,CA,Canada,11.259
 1979-03-31,CH,Switzerland,8.8385
-1979-03-31,CL,Chile,
-1979-03-31,CN,China,
-1979-03-31,CO,Colombia,
-1979-03-31,CY,Cyprus,
-1979-03-31,CZ,Czechia,
-1979-03-31,DE,Germany,8.0295
+1979-03-31,DE,Germany,7.9672
 1979-03-31,DK,Denmark,10.2991
-1979-03-31,EE,Estonia,
 1979-03-31,ES,Spain,12.8878
 1979-03-31,FI,Finland,2.7232
 1979-03-31,FR,France,10.9335
 1979-03-31,GB,United Kingdom,26.4957
-1979-03-31,GR,Greece,
-1979-03-31,HK,Hong Kong SAR,
-1979-03-31,HR,Croatia,
-1979-03-31,HU,Hungary,
-1979-03-31,ID,Indonesia,
 1979-03-31,IE,Ireland,21.3863
-1979-03-31,IL,Israel,
-1979-03-31,IN,India,
-1979-03-31,IS,Iceland,
 1979-03-31,IT,Italy,23.0663
 1979-03-31,JP,Japan,7.5597
 1979-03-31,KR,Korea,25.4853
-1979-03-31,LT,Lithuania,
-1979-03-31,LU,Luxembourg,
-1979-03-31,LV,Latvia,
-1979-03-31,MA,Morocco,
-1979-03-31,MK,North Macedonia,
-1979-03-31,MT,Malta,
-1979-03-31,MX,Mexico,
-1979-03-31,MY,Malaysia,
 1979-03-31,NL,Netherlands,-3.1497
-1979-03-31,NO,Norway,
-1979-03-31,NZ,New Zealand,4.6667
-1979-03-31,PE,Peru,
-1979-03-31,PH,Philippines,
-1979-03-31,PL,Poland,
-1979-03-31,PT,Portugal,
-1979-03-31,RO,Romania,
-1979-03-31,RS,Serbia,
-1979-03-31,RU,Russia,
+1979-03-31,NZ,New Zealand,4.6782
 1979-03-31,SE,Sweden,12.5841
-1979-03-31,SG,Singapore,
-1979-03-31,SI,Slovenia,
-1979-03-31,SK,Slovak Republic,
-1979-03-31,TH,Thailand,
-1979-03-31,TR,Türkiye,
-1979-03-31,US,United States,15.6748
-1979-03-31,XM,Euro area,14.2625
-1979-03-31,XW,World,
+1979-03-31,US,United States,15.6874
+1979-03-31,XM,Euro area,14.2663
 1979-03-31,ZA,South Africa,8.5106
-1979-06-30,4T,Emerging market economies (aggregate),
-1979-06-30,5R,Advanced economies,
-1979-06-30,AE,United Arab Emirates,
-1979-06-30,AT,Austria,
 1979-06-30,AU,Australia,13.7944
 1979-06-30,BE,Belgium,9.4197
-1979-06-30,BG,Bulgaria,
-1979-06-30,BR,Brazil,
 1979-06-30,CA,Canada,10.4612
 1979-06-30,CH,Switzerland,6.2161
-1979-06-30,CL,Chile,
-1979-06-30,CN,China,
-1979-06-30,CO,Colombia,
-1979-06-30,CY,Cyprus,
-1979-06-30,CZ,Czechia,
-1979-06-30,DE,Germany,9.4003
+1979-06-30,DE,Germany,9.4431
 1979-06-30,DK,Denmark,10.9101
-1979-06-30,EE,Estonia,
 1979-06-30,ES,Spain,4.7672
 1979-06-30,FI,Finland,2.1212
 1979-06-30,FR,France,11.9192
 1979-06-30,GB,United Kingdom,30.0813
-1979-06-30,GR,Greece,
-1979-06-30,HK,Hong Kong SAR,
-1979-06-30,HR,Croatia,
-1979-06-30,HU,Hungary,
-1979-06-30,ID,Indonesia,
 1979-06-30,IE,Ireland,24.9342
-1979-06-30,IL,Israel,
-1979-06-30,IN,India,
-1979-06-30,IS,Iceland,
 1979-06-30,IT,Italy,20.5229
 1979-06-30,JP,Japan,8.7995
 1979-06-30,KR,Korea,21.4236
-1979-06-30,LT,Lithuania,
-1979-06-30,LU,Luxembourg,
-1979-06-30,LV,Latvia,
-1979-06-30,MA,Morocco,
-1979-06-30,MK,North Macedonia,
-1979-06-30,MT,Malta,
-1979-06-30,MX,Mexico,
-1979-06-30,MY,Malaysia,
 1979-06-30,NL,Netherlands,-7.9641
-1979-06-30,NO,Norway,
-1979-06-30,NZ,New Zealand,5.4114
-1979-06-30,PE,Peru,
-1979-06-30,PH,Philippines,
-1979-06-30,PL,Poland,
-1979-06-30,PT,Portugal,
-1979-06-30,RO,Romania,
-1979-06-30,RS,Serbia,
-1979-06-30,RU,Russia,
+1979-06-30,NZ,New Zealand,5.4262
 1979-06-30,SE,Sweden,11.4809
-1979-06-30,SG,Singapore,
-1979-06-30,SI,Slovenia,
-1979-06-30,SK,Slovak Republic,
-1979-06-30,TH,Thailand,
-1979-06-30,TR,Türkiye,
-1979-06-30,US,United States,16.8935
-1979-06-30,XM,Euro area,14.8202
-1979-06-30,XW,World,
+1979-06-30,US,United States,16.8915
+1979-06-30,XM,Euro area,14.8053
 1979-06-30,ZA,South Africa,11.6608
-1979-09-30,4T,Emerging market economies (aggregate),
-1979-09-30,5R,Advanced economies,
-1979-09-30,AE,United Arab Emirates,
-1979-09-30,AT,Austria,
 1979-09-30,AU,Australia,15.7414
 1979-09-30,BE,Belgium,8.1309
-1979-09-30,BG,Bulgaria,
-1979-09-30,BR,Brazil,
 1979-09-30,CA,Canada,10.1408
 1979-09-30,CH,Switzerland,8.5746
-1979-09-30,CL,Chile,
-1979-09-30,CN,China,
-1979-09-30,CO,Colombia,
-1979-09-30,CY,Cyprus,
-1979-09-30,CZ,Czechia,
-1979-09-30,DE,Germany,9.4074
+1979-09-30,DE,Germany,9.4478
 1979-09-30,DK,Denmark,9.844
-1979-09-30,EE,Estonia,
 1979-09-30,ES,Spain,3.1083
 1979-09-30,FI,Finland,5.5944
 1979-09-30,FR,France,13.7244
 1979-09-30,GB,United Kingdom,31.2977
-1979-09-30,GR,Greece,
-1979-09-30,HK,Hong Kong SAR,
-1979-09-30,HR,Croatia,
-1979-09-30,HU,Hungary,
-1979-09-30,ID,Indonesia,
 1979-09-30,IE,Ireland,20.4978
-1979-09-30,IL,Israel,
-1979-09-30,IN,India,
-1979-09-30,IS,Iceland,
 1979-09-30,IT,Italy,17.5169
 1979-09-30,JP,Japan,10.0128
 1979-09-30,KR,Korea,12.7368
-1979-09-30,LT,Lithuania,
-1979-09-30,LU,Luxembourg,
-1979-09-30,LV,Latvia,
-1979-09-30,MA,Morocco,
-1979-09-30,MK,North Macedonia,
-1979-09-30,MT,Malta,
-1979-09-30,MX,Mexico,
-1979-09-30,MY,Malaysia,
 1979-09-30,NL,Netherlands,-3.4175
-1979-09-30,NO,Norway,
-1979-09-30,NZ,New Zealand,5.5799
-1979-09-30,PE,Peru,
-1979-09-30,PH,Philippines,
-1979-09-30,PL,Poland,
-1979-09-30,PT,Portugal,
-1979-09-30,RO,Romania,
-1979-09-30,RS,Serbia,
-1979-09-30,RU,Russia,
+1979-09-30,NZ,New Zealand,5.5664
 1979-09-30,SE,Sweden,10.3116
-1979-09-30,SG,Singapore,
-1979-09-30,SI,Slovenia,
-1979-09-30,SK,Slovak Republic,
-1979-09-30,TH,Thailand,
-1979-09-30,TR,Türkiye,
-1979-09-30,US,United States,16.4132
-1979-09-30,XM,Euro area,14.0042
-1979-09-30,XW,World,
+1979-09-30,US,United States,16.4029
+1979-09-30,XM,Euro area,13.9706
 1979-09-30,ZA,South Africa,13.8408
-1979-12-31,4T,Emerging market economies (aggregate),
-1979-12-31,5R,Advanced economies,
-1979-12-31,AE,United Arab Emirates,
-1979-12-31,AT,Austria,
 1979-12-31,AU,Australia,16.4724
 1979-12-31,BE,Belgium,6.2864
-1979-12-31,BG,Bulgaria,
-1979-12-31,BR,Brazil,
 1979-12-31,CA,Canada,9.8171
 1979-12-31,CH,Switzerland,8.5298
-1979-12-31,CL,Chile,
-1979-12-31,CN,China,
-1979-12-31,CO,Colombia,
-1979-12-31,CY,Cyprus,
-1979-12-31,CZ,Czechia,
-1979-12-31,DE,Germany,8.6287
+1979-12-31,DE,Germany,8.6044
 1979-12-31,DK,Denmark,8.6077
-1979-12-31,EE,Estonia,
 1979-12-31,ES,Spain,1.0074
 1979-12-31,FI,Finland,8.603
 1979-12-31,FR,France,15.7318
 1979-12-31,GB,United Kingdom,29.7872
-1979-12-31,GR,Greece,
-1979-12-31,HK,Hong Kong SAR,
-1979-12-31,HR,Croatia,
-1979-12-31,HU,Hungary,
-1979-12-31,ID,Indonesia,
 1979-12-31,IE,Ireland,20.1787
-1979-12-31,IL,Israel,
-1979-12-31,IN,India,
-1979-12-31,IS,Iceland,
 1979-12-31,IT,Italy,16.8421
 1979-12-31,JP,Japan,11.3836
 1979-12-31,KR,Korea,8.9914
-1979-12-31,LT,Lithuania,
-1979-12-31,LU,Luxembourg,
-1979-12-31,LV,Latvia,
-1979-12-31,MA,Morocco,
-1979-12-31,MK,North Macedonia,
-1979-12-31,MT,Malta,
-1979-12-31,MX,Mexico,
-1979-12-31,MY,Malaysia,
 1979-12-31,NL,Netherlands,-6.1363
-1979-12-31,NO,Norway,
-1979-12-31,NZ,New Zealand,5.6787
-1979-12-31,PE,Peru,
-1979-12-31,PH,Philippines,
-1979-12-31,PL,Poland,
-1979-12-31,PT,Portugal,
-1979-12-31,RO,Romania,
-1979-12-31,RS,Serbia,
-1979-12-31,RU,Russia,
+1979-12-31,NZ,New Zealand,5.6926
 1979-12-31,SE,Sweden,9.6475
-1979-12-31,SG,Singapore,
-1979-12-31,SI,Slovenia,
-1979-12-31,SK,Slovak Republic,
-1979-12-31,TH,Thailand,
-1979-12-31,TR,Türkiye,
-1979-12-31,US,United States,17.1554
-1979-12-31,XM,Euro area,11.3853
-1979-12-31,XW,World,
+1979-12-31,US,United States,17.1677
+1979-12-31,XM,Euro area,11.3429
 1979-12-31,ZA,South Africa,14.3813
-1980-03-31,4T,Emerging market economies (aggregate),
-1980-03-31,5R,Advanced economies,
-1980-03-31,AE,United Arab Emirates,
-1980-03-31,AT,Austria,
 1980-03-31,AU,Australia,12.9907
 1980-03-31,BE,Belgium,5.9654
-1980-03-31,BG,Bulgaria,
-1980-03-31,BR,Brazil,
 1980-03-31,CA,Canada,7.7784
 1980-03-31,CH,Switzerland,11.5469
-1980-03-31,CL,Chile,
-1980-03-31,CN,China,
-1980-03-31,CO,Colombia,
-1980-03-31,CY,Cyprus,
-1980-03-31,CZ,Czechia,
-1980-03-31,DE,Germany,8.4862
+1980-03-31,DE,Germany,8.5182
 1980-03-31,DK,Denmark,4.13
-1980-03-31,EE,Estonia,
 1980-03-31,ES,Spain,4.9154
 1980-03-31,FI,Finland,13.009
 1980-03-31,FR,France,18.7597
 1980-03-31,GB,United Kingdom,29.0541
-1980-03-31,GR,Greece,
-1980-03-31,HK,Hong Kong SAR,
-1980-03-31,HR,Croatia,
-1980-03-31,HU,Hungary,
-1980-03-31,ID,Indonesia,
 1980-03-31,IE,Ireland,19.6557
-1980-03-31,IL,Israel,
-1980-03-31,IN,India,
-1980-03-31,IS,Iceland,
 1980-03-31,IT,Italy,20.0898
 1980-03-31,JP,Japan,12.7004
 1980-03-31,KR,Korea,12.9624
-1980-03-31,LT,Lithuania,
-1980-03-31,LU,Luxembourg,
-1980-03-31,LV,Latvia,
-1980-03-31,MA,Morocco,
-1980-03-31,MK,North Macedonia,
-1980-03-31,MT,Malta,
-1980-03-31,MX,Mexico,
-1980-03-31,MY,Malaysia,
 1980-03-31,NL,Netherlands,-5.7136
-1980-03-31,NO,Norway,
-1980-03-31,NZ,New Zealand,6.0158
-1980-03-31,PE,Peru,
-1980-03-31,PH,Philippines,
-1980-03-31,PL,Poland,
-1980-03-31,PT,Portugal,
-1980-03-31,RO,Romania,
-1980-03-31,RS,Serbia,
-1980-03-31,RU,Russia,
+1980-03-31,NZ,New Zealand,5.9977
 1980-03-31,SE,Sweden,7.2724
-1980-03-31,SG,Singapore,
-1980-03-31,SI,Slovenia,
-1980-03-31,SK,Slovak Republic,
-1980-03-31,TH,Thailand,
-1980-03-31,TR,Türkiye,
-1980-03-31,US,United States,14.6398
-1980-03-31,XM,Euro area,8.9119
-1980-03-31,XW,World,
+1980-03-31,US,United States,14.6809
+1980-03-31,XM,Euro area,8.8547
 1980-03-31,ZA,South Africa,16.0131
-1980-06-30,4T,Emerging market economies (aggregate),
-1980-06-30,5R,Advanced economies,
-1980-06-30,AE,United Arab Emirates,
-1980-06-30,AT,Austria,
 1980-06-30,AU,Australia,11.7529
 1980-06-30,BE,Belgium,2.5023
-1980-06-30,BG,Bulgaria,
-1980-06-30,BR,Brazil,
 1980-06-30,CA,Canada,9.7505
 1980-06-30,CH,Switzerland,9.6902
-1980-06-30,CL,Chile,
-1980-06-30,CN,China,
-1980-06-30,CO,Colombia,
-1980-06-30,CY,Cyprus,
-1980-06-30,CZ,Czechia,
-1980-06-30,DE,Germany,7.2303
+1980-06-30,DE,Germany,7.178
 1980-06-30,DK,Denmark,-3.485
-1980-06-30,EE,Estonia,
 1980-06-30,ES,Spain,6.6138
 1980-06-30,FI,Finland,14.8907
 1980-06-30,FR,France,20.7808
 1980-06-30,GB,United Kingdom,23.75
-1980-06-30,GR,Greece,
-1980-06-30,HK,Hong Kong SAR,
-1980-06-30,HR,Croatia,
-1980-06-30,HU,Hungary,
-1980-06-30,ID,Indonesia,
 1980-06-30,IE,Ireland,12.5592
-1980-06-30,IL,Israel,
-1980-06-30,IN,India,
-1980-06-30,IS,Iceland,
 1980-06-30,IT,Italy,28.6876
 1980-06-30,JP,Japan,13.2067
 1980-06-30,KR,Korea,9.5077
-1980-06-30,LT,Lithuania,
-1980-06-30,LU,Luxembourg,
-1980-06-30,LV,Latvia,
-1980-06-30,MA,Morocco,
-1980-06-30,MK,North Macedonia,
-1980-06-30,MT,Malta,
-1980-06-30,MX,Mexico,
-1980-06-30,MY,Malaysia,
 1980-06-30,NL,Netherlands,-7.1709
-1980-06-30,NO,Norway,
-1980-06-30,NZ,New Zealand,7.9447
-1980-06-30,PE,Peru,
-1980-06-30,PH,Philippines,
-1980-06-30,PL,Poland,
-1980-06-30,PT,Portugal,
-1980-06-30,RO,Romania,
-1980-06-30,RS,Serbia,
-1980-06-30,RU,Russia,
+1980-06-30,NZ,New Zealand,7.9511
 1980-06-30,SE,Sweden,3.3825
-1980-06-30,SG,Singapore,
-1980-06-30,SI,Slovenia,
-1980-06-30,SK,Slovak Republic,
-1980-06-30,TH,Thailand,
-1980-06-30,TR,Türkiye,
-1980-06-30,US,United States,11.1458
-1980-06-30,XM,Euro area,9.4878
-1980-06-30,XW,World,
+1980-06-30,US,United States,11.1591
+1980-06-30,XM,Euro area,9.4546
 1980-06-30,ZA,South Africa,19.9367
-1980-09-30,4T,Emerging market economies (aggregate),
-1980-09-30,5R,Advanced economies,
-1980-09-30,AE,United Arab Emirates,
-1980-09-30,AT,Austria,
 1980-09-30,AU,Australia,12.8121
 1980-09-30,BE,Belgium,-0.9966
-1980-09-30,BG,Bulgaria,
-1980-09-30,BR,Brazil,
 1980-09-30,CA,Canada,14.7826
 1980-09-30,CH,Switzerland,7.8045
-1980-09-30,CL,Chile,
-1980-09-30,CN,China,
-1980-09-30,CO,Colombia,
-1980-09-30,CY,Cyprus,
-1980-09-30,CZ,Czechia,
-1980-09-30,DE,Germany,6.4935
+1980-09-30,DE,Germany,6.4747
 1980-09-30,DK,Denmark,-3.2973
-1980-09-30,EE,Estonia,
 1980-09-30,ES,Spain,4.4699
 1980-09-30,FI,Finland,17.2185
 1980-09-30,FR,France,21.1251
 1980-09-30,GB,United Kingdom,19.7674
-1980-09-30,GR,Greece,
-1980-09-30,HK,Hong Kong SAR,
-1980-09-30,HR,Croatia,
-1980-09-30,HU,Hungary,
-1980-09-30,ID,Indonesia,
 1980-09-30,IE,Ireland,18.7962
-1980-09-30,IL,Israel,
-1980-09-30,IN,India,
-1980-09-30,IS,Iceland,
 1980-09-30,IT,Italy,38.2845
 1980-09-30,JP,Japan,13.6523
 1980-09-30,KR,Korea,9.9943
-1980-09-30,LT,Lithuania,
-1980-09-30,LU,Luxembourg,
-1980-09-30,LV,Latvia,
-1980-09-30,MA,Morocco,
-1980-09-30,MK,North Macedonia,
-1980-09-30,MT,Malta,
-1980-09-30,MX,Mexico,
-1980-09-30,MY,Malaysia,
 1980-09-30,NL,Netherlands,-11.1747
-1980-09-30,NO,Norway,
-1980-09-30,NZ,New Zealand,10.3173
-1980-09-30,PE,Peru,
-1980-09-30,PH,Philippines,
-1980-09-30,PL,Poland,
-1980-09-30,PT,Portugal,
-1980-09-30,RO,Romania,
-1980-09-30,RS,Serbia,
-1980-09-30,RU,Russia,
+1980-09-30,NZ,New Zealand,10.3205
 1980-09-30,SE,Sweden,1.1844
-1980-09-30,SG,Singapore,
-1980-09-30,SI,Slovenia,
-1980-09-30,SK,Slovak Republic,
-1980-09-30,TH,Thailand,
-1980-09-30,TR,Türkiye,
-1980-09-30,US,United States,10.6116
-1980-09-30,XM,Euro area,13.1845
-1980-09-30,XW,World,
+1980-09-30,US,United States,10.6544
+1980-09-30,XM,Euro area,13.1554
 1980-09-30,ZA,South Africa,25.8359
-1980-12-31,4T,Emerging market economies (aggregate),
-1980-12-31,5R,Advanced economies,
-1980-12-31,AE,United Arab Emirates,
-1980-12-31,AT,Austria,
 1980-12-31,AU,Australia,14.6271
 1980-12-31,BE,Belgium,-4.0343
-1980-12-31,BG,Bulgaria,
-1980-12-31,BR,Brazil,
 1980-12-31,CA,Canada,16.8748
 1980-12-31,CH,Switzerland,6.6208
-1980-12-31,CL,Chile,
-1980-12-31,CN,China,
-1980-12-31,CO,Colombia,
-1980-12-31,CY,Cyprus,
-1980-12-31,CZ,Czechia,
-1980-12-31,DE,Germany,7.5893
+1980-12-31,DE,Germany,7.6313
 1980-12-31,DK,Denmark,-2.9975
-1980-12-31,EE,Estonia,
 1980-12-31,ES,Spain,4.0945
 1980-12-31,FI,Finland,13.729
 1980-12-31,FR,France,18.688
 1980-12-31,GB,United Kingdom,13.1148
-1980-12-31,GR,Greece,
 1980-12-31,HK,Hong Kong SAR,35.757
-1980-12-31,HR,Croatia,
-1980-12-31,HU,Hungary,
-1980-12-31,ID,Indonesia,
 1980-12-31,IE,Ireland,25.1474
-1980-12-31,IL,Israel,
-1980-12-31,IN,India,
-1980-12-31,IS,Iceland,
 1980-12-31,IT,Italy,44.8949
 1980-12-31,JP,Japan,12.9305
 1980-12-31,KR,Korea,14.403
-1980-12-31,LT,Lithuania,
-1980-12-31,LU,Luxembourg,
-1980-12-31,LV,Latvia,
-1980-12-31,MA,Morocco,
-1980-12-31,MK,North Macedonia,
-1980-12-31,MT,Malta,
-1980-12-31,MX,Mexico,
-1980-12-31,MY,Malaysia,
 1980-12-31,NL,Netherlands,-9.0374
-1980-12-31,NO,Norway,
-1980-12-31,NZ,New Zealand,12.3784
-1980-12-31,PE,Peru,
-1980-12-31,PH,Philippines,
-1980-12-31,PL,Poland,
-1980-12-31,PT,Portugal,
-1980-12-31,RO,Romania,
-1980-12-31,RS,Serbia,
-1980-12-31,RU,Russia,
+1980-12-31,NZ,New Zealand,12.3492
 1980-12-31,SE,Sweden,-0.7899
-1980-12-31,SG,Singapore,
-1980-12-31,SI,Slovenia,
-1980-12-31,SK,Slovak Republic,
-1980-12-31,TH,Thailand,
-1980-12-31,TR,Türkiye,
-1980-12-31,US,United States,9.0282
-1980-12-31,XM,Euro area,17.1782
-1980-12-31,XW,World,
+1980-12-31,US,United States,9.1162
+1980-12-31,XM,Euro area,17.1748
 1980-12-31,ZA,South Africa,32.4561
-1981-03-31,4T,Emerging market economies (aggregate),
-1981-03-31,5R,Advanced economies,
-1981-03-31,AE,United Arab Emirates,
-1981-03-31,AT,Austria,
 1981-03-31,AU,Australia,19.2672
 1981-03-31,BE,Belgium,-7.0325
-1981-03-31,BG,Bulgaria,
-1981-03-31,BR,Brazil,
 1981-03-31,CA,Canada,19.5752
 1981-03-31,CH,Switzerland,6.6863
-1981-03-31,CL,Chile,
-1981-03-31,CN,China,
-1981-03-31,CO,Colombia,
-1981-03-31,CY,Cyprus,
-1981-03-31,CZ,Czechia,
-1981-03-31,DE,Germany,7.4983
+1981-03-31,DE,Germany,7.4143
 1981-03-31,DK,Denmark,-1.8279
-1981-03-31,EE,Estonia,
 1981-03-31,ES,Spain,3.1234
 1981-03-31,FI,Finland,14.8972
 1981-03-31,FR,France,15.1896
 1981-03-31,GB,United Kingdom,8.377
-1981-03-31,GR,Greece,
 1981-03-31,HK,Hong Kong SAR,32.0656
-1981-03-31,HR,Croatia,
-1981-03-31,HU,Hungary,
-1981-03-31,ID,Indonesia,
 1981-03-31,IE,Ireland,18.6091
-1981-03-31,IL,Israel,
-1981-03-31,IN,India,
-1981-03-31,IS,Iceland,
 1981-03-31,IT,Italy,46.028
 1981-03-31,JP,Japan,12.2538
 1981-03-31,KR,Korea,8.336
-1981-03-31,LT,Lithuania,
-1981-03-31,LU,Luxembourg,
-1981-03-31,LV,Latvia,
-1981-03-31,MA,Morocco,
-1981-03-31,MK,North Macedonia,
-1981-03-31,MT,Malta,
-1981-03-31,MX,Mexico,
-1981-03-31,MY,Malaysia,
 1981-03-31,NL,Netherlands,-7.5883
-1981-03-31,NO,Norway,
 1981-03-31,NZ,New Zealand,14.4816
-1981-03-31,PE,Peru,
-1981-03-31,PH,Philippines,
-1981-03-31,PL,Poland,
-1981-03-31,PT,Portugal,
-1981-03-31,RO,Romania,
-1981-03-31,RS,Serbia,
-1981-03-31,RU,Russia,
 1981-03-31,SE,Sweden,0.9101
-1981-03-31,SG,Singapore,
-1981-03-31,SI,Slovenia,
-1981-03-31,SK,Slovak Republic,
-1981-03-31,TH,Thailand,
-1981-03-31,TR,Türkiye,
-1981-03-31,US,United States,8.7106
-1981-03-31,XM,Euro area,19.8393
-1981-03-31,XW,World,
+1981-03-31,US,United States,8.6721
+1981-03-31,XM,Euro area,19.8869
 1981-03-31,ZA,South Africa,38.5915
-1981-06-30,4T,Emerging market economies (aggregate),
-1981-06-30,5R,Advanced economies,
-1981-06-30,AE,United Arab Emirates,
-1981-06-30,AT,Austria,
 1981-06-30,AU,Australia,17.1875
 1981-06-30,BE,Belgium,-5.8116
-1981-06-30,BG,Bulgaria,
-1981-06-30,BR,Brazil,
 1981-06-30,CA,Canada,15.7968
 1981-06-30,CH,Switzerland,11.5585
-1981-06-30,CL,Chile,
-1981-06-30,CN,China,
-1981-06-30,CO,Colombia,
-1981-06-30,CY,Cyprus,
-1981-06-30,CZ,Czechia,
-1981-06-30,DE,Germany,8.0538
+1981-06-30,DE,Germany,8.0096
 1981-06-30,DK,Denmark,-2.8282
-1981-06-30,EE,Estonia,
 1981-06-30,ES,Spain,4.5658
 1981-06-30,FI,Finland,13.8765
 1981-06-30,FR,France,12.009
 1981-06-30,GB,United Kingdom,7.5758
-1981-06-30,GR,Greece,
 1981-06-30,HK,Hong Kong SAR,32.6094
-1981-06-30,HR,Croatia,
-1981-06-30,HU,Hungary,
-1981-06-30,ID,Indonesia,
 1981-06-30,IE,Ireland,16.5848
-1981-06-30,IL,Israel,
-1981-06-30,IN,India,
-1981-06-30,IS,Iceland,
 1981-06-30,IT,Italy,40.118
 1981-06-30,JP,Japan,11.2674
 1981-06-30,KR,Korea,6.2059
-1981-06-30,LT,Lithuania,
-1981-06-30,LU,Luxembourg,
-1981-06-30,LV,Latvia,
-1981-06-30,MA,Morocco,
-1981-06-30,MK,North Macedonia,
-1981-06-30,MT,Malta,
-1981-06-30,MX,Mexico,
-1981-06-30,MY,Malaysia,
 1981-06-30,NL,Netherlands,-10.55
-1981-06-30,NO,Norway,
 1981-06-30,NZ,New Zealand,20.515
-1981-06-30,PE,Peru,
-1981-06-30,PH,Philippines,
-1981-06-30,PL,Poland,
-1981-06-30,PT,Portugal,
-1981-06-30,RO,Romania,
-1981-06-30,RS,Serbia,
-1981-06-30,RU,Russia,
 1981-06-30,SE,Sweden,0
-1981-06-30,SG,Singapore,
-1981-06-30,SI,Slovenia,
-1981-06-30,SK,Slovak Republic,
-1981-06-30,TH,Thailand,
-1981-06-30,TR,Türkiye,
-1981-06-30,US,United States,8.6311
-1981-06-30,XM,Euro area,18.4831
-1981-06-30,XW,World,
+1981-06-30,US,United States,8.656
+1981-06-30,XM,Euro area,18.5336
 1981-06-30,ZA,South Africa,40.8971
-1981-09-30,4T,Emerging market economies (aggregate),
-1981-09-30,5R,Advanced economies,
-1981-09-30,AE,United Arab Emirates,
-1981-09-30,AT,Austria,
 1981-09-30,AU,Australia,11.4444
 1981-09-30,BE,Belgium,-5.5271
-1981-09-30,BG,Bulgaria,
-1981-09-30,BR,Brazil,
 1981-09-30,CA,Canada,14.0597
 1981-09-30,CH,Switzerland,9.9849
-1981-09-30,CL,Chile,
-1981-09-30,CN,China,
-1981-09-30,CO,Colombia,
-1981-09-30,CY,Cyprus,
-1981-09-30,CZ,Czechia,
-1981-09-30,DE,Germany,7.4569
+1981-09-30,DE,Germany,7.5638
 1981-09-30,DK,Denmark,-7.8685
-1981-09-30,EE,Estonia,
 1981-09-30,ES,Spain,3.6318
 1981-09-30,FI,Finland,14.2147
 1981-09-30,FR,France,9.3467
 1981-09-30,GB,United Kingdom,4.8544
-1981-09-30,GR,Greece,
 1981-09-30,HK,Hong Kong SAR,21.1821
-1981-09-30,HR,Croatia,
-1981-09-30,HU,Hungary,
-1981-09-30,ID,Indonesia,
 1981-09-30,IE,Ireland,14.62
-1981-09-30,IL,Israel,
-1981-09-30,IN,India,
-1981-09-30,IS,Iceland,
 1981-09-30,IT,Italy,31.2405
 1981-09-30,JP,Japan,10.3696
 1981-09-30,KR,Korea,9.4189
-1981-09-30,LT,Lithuania,
-1981-09-30,LU,Luxembourg,
-1981-09-30,LV,Latvia,
-1981-09-30,MA,Morocco,
-1981-09-30,MK,North Macedonia,
-1981-09-30,MT,Malta,
-1981-09-30,MX,Mexico,
-1981-09-30,MY,Malaysia,
 1981-09-30,NL,Netherlands,-8.5237
-1981-09-30,NO,Norway,
 1981-09-30,NZ,New Zealand,25.4823
-1981-09-30,PE,Peru,
-1981-09-30,PH,Philippines,
-1981-09-30,PL,Poland,
-1981-09-30,PT,Portugal,
-1981-09-30,RO,Romania,
-1981-09-30,RS,Serbia,
-1981-09-30,RU,Russia,
 1981-09-30,SE,Sweden,-2.5572
-1981-09-30,SG,Singapore,
-1981-09-30,SI,Slovenia,
-1981-09-30,SK,Slovak Republic,
-1981-09-30,TH,Thailand,
-1981-09-30,TR,Türkiye,
-1981-09-30,US,United States,6.2987
-1981-09-30,XM,Euro area,12.6669
-1981-09-30,XW,World,
+1981-09-30,US,United States,6.2644
+1981-09-30,XM,Euro area,12.6842
 1981-09-30,ZA,South Africa,39.1304
-1981-12-31,4T,Emerging market economies (aggregate),
-1981-12-31,5R,Advanced economies,
-1981-12-31,AE,United Arab Emirates,
-1981-12-31,AT,Austria,
 1981-12-31,AU,Australia,12.9014
 1981-12-31,BE,Belgium,-3.2148
-1981-12-31,BG,Bulgaria,
-1981-12-31,BR,Brazil,
 1981-12-31,CA,Canada,8.8013
 1981-12-31,CH,Switzerland,9.7296
-1981-12-31,CL,Chile,
-1981-12-31,CN,China,
-1981-12-31,CO,Colombia,
-1981-12-31,CY,Cyprus,
-1981-12-31,CZ,Czechia,
-1981-12-31,DE,Germany,5.2248
+1981-12-31,DE,Germany,5.2375
 1981-12-31,DK,Denmark,-6.3198
-1981-12-31,EE,Estonia,
 1981-12-31,ES,Spain,2.3701
 1981-12-31,FI,Finland,15.7895
 1981-12-31,FR,France,7.9392
 1981-12-31,GB,United Kingdom,2.4155
-1981-12-31,GR,Greece,
 1981-12-31,HK,Hong Kong SAR,7.5899
-1981-12-31,HR,Croatia,
-1981-12-31,HU,Hungary,
-1981-12-31,ID,Indonesia,
 1981-12-31,IE,Ireland,12.331
-1981-12-31,IL,Israel,
-1981-12-31,IN,India,
-1981-12-31,IS,Iceland,
 1981-12-31,IT,Italy,22.3834
 1981-12-31,JP,Japan,9.7
 1981-12-31,KR,Korea,6.0566
-1981-12-31,LT,Lithuania,
-1981-12-31,LU,Luxembourg,
-1981-12-31,LV,Latvia,
-1981-12-31,MA,Morocco,
-1981-12-31,MK,North Macedonia,
-1981-12-31,MT,Malta,
-1981-12-31,MX,Mexico,
-1981-12-31,MY,Malaysia,
 1981-12-31,NL,Netherlands,-13.6978
-1981-12-31,NO,Norway,
 1981-12-31,NZ,New Zealand,31.5666
-1981-12-31,PE,Peru,
-1981-12-31,PH,Philippines,
-1981-12-31,PL,Poland,
-1981-12-31,PT,Portugal,
-1981-12-31,RO,Romania,
-1981-12-31,RS,Serbia,
-1981-12-31,RU,Russia,
 1981-12-31,SE,Sweden,-2.0181
-1981-12-31,SG,Singapore,
-1981-12-31,SI,Slovenia,
-1981-12-31,SK,Slovak Republic,
-1981-12-31,TH,Thailand,
-1981-12-31,TR,Türkiye,
-1981-12-31,US,United States,5.3357
-1981-12-31,XM,Euro area,8.2229
-1981-12-31,XW,World,
+1981-12-31,US,United States,5.3378
+1981-12-31,XM,Euro area,8.2183
 1981-12-31,ZA,South Africa,34.8786
-1982-03-31,4T,Emerging market economies (aggregate),
-1982-03-31,5R,Advanced economies,
-1982-03-31,AE,United Arab Emirates,
-1982-03-31,AT,Austria,
 1982-03-31,AU,Australia,5.0053
 1982-03-31,BE,Belgium,-5.9217
-1982-03-31,BG,Bulgaria,
-1982-03-31,BR,Brazil,
 1982-03-31,CA,Canada,0.545
 1982-03-31,CH,Switzerland,8.008
-1982-03-31,CL,Chile,
-1982-03-31,CN,China,
-1982-03-31,CO,Colombia,
-1982-03-31,CY,Cyprus,
-1982-03-31,CZ,Czechia,
-1982-03-31,DE,Germany,3.4194
+1982-03-31,DE,Germany,3.665
 1982-03-31,DK,Denmark,-6.5168
-1982-03-31,EE,Estonia,
 1982-03-31,ES,Spain,1.661
 1982-03-31,FI,Finland,17.8489
 1982-03-31,FR,France,6.471
 1982-03-31,GB,United Kingdom,0
-1982-03-31,GR,Greece,
 1982-03-31,HK,Hong Kong SAR,-7.4075
-1982-03-31,HR,Croatia,
-1982-03-31,HU,Hungary,
-1982-03-31,ID,Indonesia,
 1982-03-31,IE,Ireland,11.8075
-1982-03-31,IL,Israel,
-1982-03-31,IN,India,
-1982-03-31,IS,Iceland,
+1982-03-31,IS,Iceland,73.7111
 1982-03-31,IT,Italy,15.296
 1982-03-31,JP,Japan,9.0643
 1982-03-31,KR,Korea,4.6187
-1982-03-31,LT,Lithuania,
-1982-03-31,LU,Luxembourg,
-1982-03-31,LV,Latvia,
-1982-03-31,MA,Morocco,
-1982-03-31,MK,North Macedonia,
-1982-03-31,MT,Malta,
-1982-03-31,MX,Mexico,
-1982-03-31,MY,Malaysia,
 1982-03-31,NL,Netherlands,-16.4666
-1982-03-31,NO,Norway,
 1982-03-31,NZ,New Zealand,37.1257
-1982-03-31,PE,Peru,
-1982-03-31,PH,Philippines,
-1982-03-31,PL,Poland,
-1982-03-31,PT,Portugal,
-1982-03-31,RO,Romania,
-1982-03-31,RS,Serbia,
-1982-03-31,RU,Russia,
 1982-03-31,SE,Sweden,-1.4909
-1982-03-31,SG,Singapore,
-1982-03-31,SI,Slovenia,
-1982-03-31,SK,Slovak Republic,
-1982-03-31,TH,Thailand,
-1982-03-31,TR,Türkiye,
-1982-03-31,US,United States,3.8345
-1982-03-31,XM,Euro area,4.7285
-1982-03-31,XW,World,
+1982-03-31,US,United States,3.8341
+1982-03-31,XM,Euro area,4.7051
 1982-03-31,ZA,South Africa,29.2683
-1982-06-30,4T,Emerging market economies (aggregate),
-1982-06-30,5R,Advanced economies,
-1982-06-30,AE,United Arab Emirates,
-1982-06-30,AT,Austria,
 1982-06-30,AU,Australia,4.7949
 1982-06-30,BE,Belgium,-5.4352
-1982-06-30,BG,Bulgaria,
-1982-06-30,BR,Brazil,
 1982-06-30,CA,Canada,-4.4071
 1982-06-30,CH,Switzerland,4.0728
-1982-06-30,CL,Chile,
-1982-06-30,CN,China,
-1982-06-30,CO,Colombia,
-1982-06-30,CY,Cyprus,
-1982-06-30,CZ,Czechia,
-1982-06-30,DE,Germany,0.5968
+1982-06-30,DE,Germany,0.5271
 1982-06-30,DK,Denmark,-1.7756
-1982-06-30,EE,Estonia,
 1982-06-30,ES,Spain,0.4746
 1982-06-30,FI,Finland,18.9072
 1982-06-30,FR,France,5.6986
 1982-06-30,GB,United Kingdom,1.4085
-1982-06-30,GR,Greece,
 1982-06-30,HK,Hong Kong SAR,-11.0658
-1982-06-30,HR,Croatia,
-1982-06-30,HU,Hungary,
-1982-06-30,ID,Indonesia,
 1982-06-30,IE,Ireland,11.2159
-1982-06-30,IL,Israel,
-1982-06-30,IN,India,
-1982-06-30,IS,Iceland,
+1982-06-30,IS,Iceland,81.8588
 1982-06-30,IT,Italy,11.609
 1982-06-30,JP,Japan,8.2387
 1982-06-30,KR,Korea,3.9732
-1982-06-30,LT,Lithuania,
-1982-06-30,LU,Luxembourg,
-1982-06-30,LV,Latvia,
-1982-06-30,MA,Morocco,
-1982-06-30,MK,North Macedonia,
-1982-06-30,MT,Malta,
-1982-06-30,MX,Mexico,
-1982-06-30,MY,Malaysia,
 1982-06-30,NL,Netherlands,-13.4422
-1982-06-30,NO,Norway,
 1982-06-30,NZ,New Zealand,36.8711
-1982-06-30,PE,Peru,
-1982-06-30,PH,Philippines,
-1982-06-30,PL,Poland,
-1982-06-30,PT,Portugal,
-1982-06-30,RO,Romania,
-1982-06-30,RS,Serbia,
-1982-06-30,RU,Russia,
 1982-06-30,SE,Sweden,0.3107
-1982-06-30,SG,Singapore,
-1982-06-30,SI,Slovenia,
-1982-06-30,SK,Slovak Republic,
-1982-06-30,TH,Thailand,
-1982-06-30,TR,Türkiye,
-1982-06-30,US,United States,2.7564
-1982-06-30,XM,Euro area,2.8862
-1982-06-30,XW,World,
+1982-06-30,US,United States,2.7634
+1982-06-30,XM,Euro area,2.8661
 1982-06-30,ZA,South Africa,23.0337
-1982-09-30,4T,Emerging market economies (aggregate),
-1982-09-30,5R,Advanced economies,
-1982-09-30,AE,United Arab Emirates,
-1982-09-30,AT,Austria,
 1982-09-30,AU,Australia,4.9125
 1982-09-30,BE,Belgium,-1.4723
-1982-09-30,BG,Bulgaria,
-1982-09-30,BR,Brazil,
 1982-09-30,CA,Canada,-8.5368
 1982-09-30,CH,Switzerland,4.0161
-1982-09-30,CL,Chile,
-1982-09-30,CN,China,
-1982-09-30,CO,Colombia,
-1982-09-30,CY,Cyprus,
-1982-09-30,CZ,Czechia,
-1982-09-30,DE,Germany,-0.1911
+1982-09-30,DE,Germany,-0.2748
 1982-09-30,DK,Denmark,-0.4935
-1982-09-30,EE,Estonia,
 1982-09-30,ES,Spain,2.8325
 1982-09-30,FI,Finland,17.313
 1982-09-30,FR,France,5.3049
 1982-09-30,GB,United Kingdom,2.3148
-1982-09-30,GR,Greece,
 1982-09-30,HK,Hong Kong SAR,-16.2601
-1982-09-30,HR,Croatia,
-1982-09-30,HU,Hungary,
-1982-09-30,ID,Indonesia,
 1982-09-30,IE,Ireland,7.0425
-1982-09-30,IL,Israel,
-1982-09-30,IN,India,
-1982-09-30,IS,Iceland,
+1982-09-30,IS,Iceland,76.5553
 1982-09-30,IT,Italy,9.9424
 1982-09-30,JP,Japan,7.4419
 1982-09-30,KR,Korea,3.8047
-1982-09-30,LT,Lithuania,
-1982-09-30,LU,Luxembourg,
-1982-09-30,LV,Latvia,
-1982-09-30,MA,Morocco,
-1982-09-30,MK,North Macedonia,
-1982-09-30,MT,Malta,
-1982-09-30,MX,Mexico,
-1982-09-30,MY,Malaysia,
 1982-09-30,NL,Netherlands,-8.2933
-1982-09-30,NO,Norway,
 1982-09-30,NZ,New Zealand,30.1089
-1982-09-30,PE,Peru,
-1982-09-30,PH,Philippines,
-1982-09-30,PL,Poland,
-1982-09-30,PT,Portugal,
-1982-09-30,RO,Romania,
-1982-09-30,RS,Serbia,
-1982-09-30,RU,Russia,
 1982-09-30,SE,Sweden,2.3286
-1982-09-30,SG,Singapore,
-1982-09-30,SI,Slovenia,
-1982-09-30,SK,Slovak Republic,
-1982-09-30,TH,Thailand,
-1982-09-30,TR,Türkiye,
-1982-09-30,US,United States,1.8482
-1982-09-30,XM,Euro area,4.0692
-1982-09-30,XW,World,
+1982-09-30,US,United States,1.8982
+1982-09-30,XM,Euro area,4.0865
 1982-09-30,ZA,South Africa,17.1875
-1982-12-31,4T,Emerging market economies (aggregate),
-1982-12-31,5R,Advanced economies,
-1982-12-31,AE,United Arab Emirates,
-1982-12-31,AT,Austria,
 1982-12-31,AU,Australia,-0.2495
 1982-12-31,BE,Belgium,-1.7885
-1982-12-31,BG,Bulgaria,
-1982-12-31,BR,Brazil,
 1982-12-31,CA,Canada,-7.8775
 1982-12-31,CH,Switzerland,3.8493
-1982-12-31,CL,Chile,
-1982-12-31,CN,China,
-1982-12-31,CO,Colombia,
-1982-12-31,CY,Cyprus,
-1982-12-31,CZ,Czechia,
-1982-12-31,DE,Germany,-0.1453
+1982-12-31,DE,Germany,-0.2204
 1982-12-31,DK,Denmark,0
-1982-12-31,EE,Estonia,
 1982-12-31,ES,Spain,8.4729
 1982-12-31,FI,Finland,20.058
 1982-12-31,FR,France,5.0326
 1982-12-31,GB,United Kingdom,5.6604
-1982-12-31,GR,Greece,
 1982-12-31,HK,Hong Kong SAR,-19.087
-1982-12-31,HR,Croatia,
-1982-12-31,HU,Hungary,
-1982-12-31,ID,Indonesia,
 1982-12-31,IE,Ireland,5.7075
-1982-12-31,IL,Israel,
-1982-12-31,IN,India,
-1982-12-31,IS,Iceland,
+1982-12-31,IS,Iceland,69.5999
 1982-12-31,IT,Italy,10.1327
 1982-12-31,JP,Japan,6.6089
 1982-12-31,KR,Korea,9.1734
-1982-12-31,LT,Lithuania,
-1982-12-31,LU,Luxembourg,
-1982-12-31,LV,Latvia,
-1982-12-31,MA,Morocco,
-1982-12-31,MK,North Macedonia,
-1982-12-31,MT,Malta,
-1982-12-31,MX,Mexico,
-1982-12-31,MY,Malaysia,
 1982-12-31,NL,Netherlands,-4.9387
-1982-12-31,NO,Norway,
 1982-12-31,NZ,New Zealand,22.9858
-1982-12-31,PE,Peru,
-1982-12-31,PH,Philippines,
-1982-12-31,PL,Poland,
-1982-12-31,PT,Portugal,
-1982-12-31,RO,Romania,
-1982-12-31,RS,Serbia,
-1982-12-31,RU,Russia,
 1982-12-31,SE,Sweden,3.3825
-1982-12-31,SG,Singapore,
-1982-12-31,SI,Slovenia,
-1982-12-31,SK,Slovak Republic,
-1982-12-31,TH,Thailand,
-1982-12-31,TR,Türkiye,
-1982-12-31,US,United States,1.3715
-1982-12-31,XM,Euro area,4.7913
-1982-12-31,XW,World,
+1982-12-31,US,United States,1.3626
+1982-12-31,XM,Euro area,4.8231
 1982-12-31,ZA,South Africa,13.5843
-1983-03-31,4T,Emerging market economies (aggregate),
-1983-03-31,5R,Advanced economies,
-1983-03-31,AE,United Arab Emirates,
-1983-03-31,AT,Austria,
 1983-03-31,AU,Australia,3.4805
 1983-03-31,BE,Belgium,-0.4467
-1983-03-31,BG,Bulgaria,
-1983-03-31,BR,Brazil,
 1983-03-31,CA,Canada,2.5898
 1983-03-31,CH,Switzerland,1.6327
-1983-03-31,CL,Chile,
-1983-03-31,CN,China,
-1983-03-31,CO,Colombia,
-1983-03-31,CY,Cyprus,
-1983-03-31,CZ,Czechia,
-1983-03-31,DE,Germany,-0.1026
+1983-03-31,DE,Germany,-0.3268
 1983-03-31,DK,Denmark,9.4513
-1983-03-31,EE,Estonia,
 1983-03-31,ES,Spain,17.3955
 1983-03-31,FI,Finland,20.7716
 1983-03-31,FR,France,4.9823
 1983-03-31,GB,United Kingdom,11.5942
-1983-03-31,GR,Greece,
 1983-03-31,HK,Hong Kong SAR,-17.7777
-1983-03-31,HR,Croatia,
-1983-03-31,HU,Hungary,
-1983-03-31,ID,Indonesia,
 1983-03-31,IE,Ireland,3.472
-1983-03-31,IL,Israel,
-1983-03-31,IN,India,
-1983-03-31,IS,Iceland,
+1983-03-31,IS,Iceland,55.8017
 1983-03-31,IT,Italy,10.2692
 1983-03-31,JP,Japan,5.8088
 1983-03-31,KR,Korea,16.1714
-1983-03-31,LT,Lithuania,
-1983-03-31,LU,Luxembourg,
-1983-03-31,LV,Latvia,
-1983-03-31,MA,Morocco,
-1983-03-31,MK,North Macedonia,
-1983-03-31,MT,Malta,
-1983-03-31,MX,Mexico,
-1983-03-31,MY,Malaysia,
 1983-03-31,NL,Netherlands,-0.9462
-1983-03-31,NO,Norway,
 1983-03-31,NZ,New Zealand,14.9017
-1983-03-31,PE,Peru,
-1983-03-31,PH,Philippines,
-1983-03-31,PL,Poland,
-1983-03-31,PT,Portugal,
-1983-03-31,RO,Romania,
-1983-03-31,RS,Serbia,
-1983-03-31,RU,Russia,
 1983-03-31,SE,Sweden,1.5135
-1983-03-31,SG,Singapore,
-1983-03-31,SI,Slovenia,
-1983-03-31,SK,Slovak Republic,
-1983-03-31,TH,Thailand,
-1983-03-31,TR,Türkiye,
-1983-03-31,US,United States,1.9878
-1983-03-31,XM,Euro area,5.3626
-1983-03-31,XW,World,
+1983-03-31,US,United States,2.0436
+1983-03-31,XM,Euro area,5.4159
 1983-03-31,ZA,South Africa,15.566
-1983-06-30,4T,Emerging market economies (aggregate),
-1983-06-30,5R,Advanced economies,
-1983-06-30,AE,United Arab Emirates,
-1983-06-30,AT,Austria,
 1983-06-30,AU,Australia,3.9149
 1983-06-30,BE,Belgium,-0.3477
-1983-06-30,BG,Bulgaria,
-1983-06-30,BR,Brazil,
 1983-06-30,CA,Canada,7.0201
 1983-06-30,CH,Switzerland,4.1268
-1983-06-30,CL,Chile,
-1983-06-30,CN,China,
-1983-06-30,CO,Colombia,
-1983-06-30,CY,Cyprus,
-1983-06-30,CZ,Czechia,
-1983-06-30,DE,Germany,0.4692
+1983-06-30,DE,Germany,0.5162
 1983-06-30,DK,Denmark,22.2139
-1983-06-30,EE,Estonia,
 1983-06-30,ES,Spain,20.6897
 1983-06-30,FI,Finland,20.0798
 1983-06-30,FR,France,5.0631
 1983-06-30,GB,United Kingdom,10.6481
-1983-06-30,GR,Greece,
 1983-06-30,HK,Hong Kong SAR,-14.2855
-1983-06-30,HR,Croatia,
-1983-06-30,HU,Hungary,
-1983-06-30,ID,Indonesia,
 1983-06-30,IE,Ireland,0.2165
-1983-06-30,IL,Israel,
-1983-06-30,IN,India,
-1983-06-30,IS,Iceland,
+1983-06-30,IS,Iceland,47.739
 1983-06-30,IT,Italy,8.7577
 1983-06-30,JP,Japan,5.1487
 1983-06-30,KR,Korea,19.8435
-1983-06-30,LT,Lithuania,
-1983-06-30,LU,Luxembourg,
-1983-06-30,LV,Latvia,
-1983-06-30,MA,Morocco,
-1983-06-30,MK,North Macedonia,
-1983-06-30,MT,Malta,
-1983-06-30,MX,Mexico,
-1983-06-30,MY,Malaysia,
 1983-06-30,NL,Netherlands,3.4021
-1983-06-30,NO,Norway,
 1983-06-30,NZ,New Zealand,7.9557
-1983-06-30,PE,Peru,
-1983-06-30,PH,Philippines,
-1983-06-30,PL,Poland,
-1983-06-30,PT,Portugal,
-1983-06-30,RO,Romania,
-1983-06-30,RS,Serbia,
-1983-06-30,RU,Russia,
 1983-06-30,SE,Sweden,0.2004
-1983-06-30,SG,Singapore,
-1983-06-30,SI,Slovenia,
-1983-06-30,SK,Slovak Republic,
-1983-06-30,TH,Thailand,
-1983-06-30,TR,Türkiye,
-1983-06-30,US,United States,3.1572
-1983-06-30,XM,Euro area,5.4964
-1983-06-30,XW,World,
+1983-06-30,US,United States,3.1595
+1983-06-30,XM,Euro area,5.5564
 1983-06-30,ZA,South Africa,18.7215
-1983-09-30,4T,Emerging market economies (aggregate),
-1983-09-30,5R,Advanced economies,
-1983-09-30,AE,United Arab Emirates,
-1983-09-30,AT,Austria,
 1983-09-30,AU,Australia,5.1059
 1983-09-30,BE,Belgium,-3.2049
-1983-09-30,BG,Bulgaria,
-1983-09-30,BR,Brazil,
 1983-09-30,CA,Canada,7.689
 1983-09-30,CH,Switzerland,6.1533
-1983-09-30,CL,Chile,
-1983-09-30,CN,China,
-1983-09-30,CO,Colombia,
-1983-09-30,CY,Cyprus,
-1983-09-30,CZ,Czechia,
-1983-09-30,DE,Germany,0.6538
+1983-09-30,DE,Germany,0.6425
 1983-09-30,DK,Denmark,26.7595
-1983-09-30,EE,Estonia,
 1983-09-30,ES,Spain,20.9617
 1983-09-30,FI,Finland,21.8081
 1983-09-30,FR,France,5.1883
 1983-09-30,GB,United Kingdom,12.6697
-1983-09-30,GR,Greece,
 1983-09-30,HK,Hong Kong SAR,-13.107
-1983-09-30,HR,Croatia,
-1983-09-30,HU,Hungary,
-1983-09-30,ID,Indonesia,
 1983-09-30,IE,Ireland,2.2397
-1983-09-30,IL,Israel,
-1983-09-30,IN,India,
-1983-09-30,IS,Iceland,
+1983-09-30,IS,Iceland,40.7098
 1983-09-30,IT,Italy,7.1035
 1983-09-30,JP,Japan,4.5022
 1983-09-30,KR,Korea,20.0058
-1983-09-30,LT,Lithuania,
-1983-09-30,LU,Luxembourg,
-1983-09-30,LV,Latvia,
-1983-09-30,MA,Morocco,
-1983-09-30,MK,North Macedonia,
-1983-09-30,MT,Malta,
-1983-09-30,MX,Mexico,
-1983-09-30,MY,Malaysia,
 1983-09-30,NL,Netherlands,2.5838
-1983-09-30,NO,Norway,
 1983-09-30,NZ,New Zealand,8.1733
-1983-09-30,PE,Peru,
-1983-09-30,PH,Philippines,
-1983-09-30,PL,Poland,
-1983-09-30,PT,Portugal,
-1983-09-30,RO,Romania,
-1983-09-30,RS,Serbia,
-1983-09-30,RU,Russia,
 1983-09-30,SE,Sweden,-0.4876
-1983-09-30,SG,Singapore,
-1983-09-30,SI,Slovenia,
-1983-09-30,SK,Slovak Republic,
-1983-09-30,TH,Thailand,
-1983-09-30,TR,Türkiye,
-1983-09-30,US,United States,4.4755
-1983-09-30,XM,Euro area,5.6016
-1983-09-30,XW,World,
+1983-09-30,US,United States,4.4909
+1983-09-30,XM,Euro area,5.6459
 1983-09-30,ZA,South Africa,21.3333
-1983-12-31,4T,Emerging market economies (aggregate),
-1983-12-31,5R,Advanced economies,
-1983-12-31,AE,United Arab Emirates,
-1983-12-31,AT,Austria,
 1983-12-31,AU,Australia,10.4052
 1983-12-31,BE,Belgium,-2.4215
-1983-12-31,BG,Bulgaria,
-1983-12-31,BR,Brazil,
 1983-12-31,CA,Canada,5.7913
 1983-12-31,CH,Switzerland,6.0542
-1983-12-31,CL,Chile,
-1983-12-31,CN,China,
-1983-12-31,CO,Colombia,
-1983-12-31,CY,Cyprus,
-1983-12-31,CZ,Czechia,
-1983-12-31,DE,Germany,-0.0232
+1983-12-31,DE,Germany,0.1618
 1983-12-31,DK,Denmark,27.4693
-1983-12-31,EE,Estonia,
 1983-12-31,ES,Spain,18.3015
 1983-12-31,FI,Finland,21.0246
 1983-12-31,FR,France,5.1935
 1983-12-31,GB,United Kingdom,12.0536
-1983-12-31,GR,Greece,
 1983-12-31,HK,Hong Kong SAR,-12.821
-1983-12-31,HR,Croatia,
-1983-12-31,HU,Hungary,
-1983-12-31,ID,Indonesia,
 1983-12-31,IE,Ireland,-2.0528
-1983-12-31,IL,Israel,
-1983-12-31,IN,India,
-1983-12-31,IS,Iceland,
+1983-12-31,IS,Iceland,47.3507
 1983-12-31,IT,Italy,5.5613
 1983-12-31,JP,Japan,4.0616
 1983-12-31,KR,Korea,17.9349
-1983-12-31,LT,Lithuania,
-1983-12-31,LU,Luxembourg,
-1983-12-31,LV,Latvia,
-1983-12-31,MA,Morocco,
-1983-12-31,MK,North Macedonia,
-1983-12-31,MT,Malta,
-1983-12-31,MX,Mexico,
-1983-12-31,MY,Malaysia,
 1983-12-31,NL,Netherlands,2.1139
-1983-12-31,NO,Norway,
 1983-12-31,NZ,New Zealand,9.2967
-1983-12-31,PE,Peru,
-1983-12-31,PH,Philippines,
-1983-12-31,PL,Poland,
-1983-12-31,PT,Portugal,
-1983-12-31,RO,Romania,
-1983-12-31,RS,Serbia,
-1983-12-31,RU,Russia,
 1983-12-31,SE,Sweden,1.4988
-1983-12-31,SG,Singapore,
-1983-12-31,SI,Slovenia,
-1983-12-31,SK,Slovak Republic,
-1983-12-31,TH,Thailand,
-1983-12-31,TR,Türkiye,
-1983-12-31,US,United States,5.0772
-1983-12-31,XM,Euro area,4.4054
-1983-12-31,XW,World,
+1983-12-31,US,United States,5.1013
+1983-12-31,XM,Euro area,4.4579
 1983-12-31,ZA,South Africa,24.7839
-1984-03-31,4T,Emerging market economies (aggregate),
-1984-03-31,5R,Advanced economies,
-1984-03-31,AE,United Arab Emirates,
-1984-03-31,AT,Austria,
 1984-03-31,AU,Australia,11.1138
 1984-03-31,BE,Belgium,0.7138
-1984-03-31,BG,Bulgaria,
-1984-03-31,BR,Brazil,
 1984-03-31,CA,Canada,-1.0763
 1984-03-31,CH,Switzerland,7.2819
-1984-03-31,CL,Chile,
-1984-03-31,CN,China,
-1984-03-31,CO,Colombia,
-1984-03-31,CY,Cyprus,
-1984-03-31,CZ,Czechia,
-1984-03-31,DE,Germany,-1.0152
+1984-03-31,DE,Germany,-0.9528
 1984-03-31,DK,Denmark,24.103
-1984-03-31,EE,Estonia,
 1984-03-31,ES,Spain,10.4789
 1984-03-31,FI,Finland,15.8977
 1984-03-31,FR,France,4.8469
 1984-03-31,GB,United Kingdom,9.5238
-1984-03-31,GR,Greece,
 1984-03-31,HK,Hong Kong SAR,-5.4058
-1984-03-31,HR,Croatia,
-1984-03-31,HU,Hungary,
-1984-03-31,ID,Indonesia,
 1984-03-31,IE,Ireland,0.8913
-1984-03-31,IL,Israel,
-1984-03-31,IN,India,
-1984-03-31,IS,Iceland,
+1984-03-31,IS,Iceland,44.8795
 1984-03-31,IT,Italy,4.2537
 1984-03-31,JP,Japan,3.6318
 1984-03-31,KR,Korea,15.3215
-1984-03-31,LT,Lithuania,
-1984-03-31,LU,Luxembourg,
-1984-03-31,LV,Latvia,
-1984-03-31,MA,Morocco,
-1984-03-31,MK,North Macedonia,
-1984-03-31,MT,Malta,
-1984-03-31,MX,Mexico,
-1984-03-31,MY,Malaysia,
 1984-03-31,NL,Netherlands,1.4682
-1984-03-31,NO,Norway,
 1984-03-31,NZ,New Zealand,11.5914
-1984-03-31,PE,Peru,
-1984-03-31,PH,Philippines,
-1984-03-31,PL,Poland,
-1984-03-31,PT,Portugal,
-1984-03-31,RO,Romania,
-1984-03-31,RS,Serbia,
-1984-03-31,RU,Russia,
 1984-03-31,SE,Sweden,2.1167
-1984-03-31,SG,Singapore,
-1984-03-31,SI,Slovenia,
-1984-03-31,SK,Slovak Republic,
-1984-03-31,TH,Thailand,
-1984-03-31,TR,Türkiye,
-1984-03-31,US,United States,5.2326
-1984-03-31,XM,Euro area,2.8693
-1984-03-31,XW,World,
+1984-03-31,US,United States,5.2129
+1984-03-31,XM,Euro area,2.8964
 1984-03-31,ZA,South Africa,20.5442
-1984-06-30,4T,Emerging market economies (aggregate),
-1984-06-30,5R,Advanced economies,
-1984-06-30,AE,United Arab Emirates,
-1984-06-30,AT,Austria,
 1984-06-30,AU,Australia,9.8658
 1984-06-30,BE,Belgium,1.991
-1984-06-30,BG,Bulgaria,
-1984-06-30,BR,Brazil,
 1984-06-30,CA,Canada,-0.4504
 1984-06-30,CH,Switzerland,7.9851
-1984-06-30,CL,Chile,
-1984-06-30,CN,China,
-1984-06-30,CO,Colombia,
-1984-06-30,CY,Cyprus,
-1984-06-30,CZ,Czechia,
-1984-06-30,DE,Germany,-2.1988
+1984-06-30,DE,Germany,-2.2015
 1984-06-30,DK,Denmark,12.5191
-1984-06-30,EE,Estonia,
 1984-06-30,ES,Spain,7.3581
 1984-06-30,FI,Finland,13.6895
 1984-06-30,FR,France,4.1612
 1984-06-30,GB,United Kingdom,9.205
-1984-06-30,GR,Greece,
 1984-06-30,HK,Hong Kong SAR,-5.3767
-1984-06-30,HR,Croatia,
-1984-06-30,HU,Hungary,
-1984-06-30,ID,Indonesia,
 1984-06-30,IE,Ireland,2.6103
-1984-06-30,IL,Israel,
-1984-06-30,IN,India,
-1984-06-30,IS,Iceland,
+1984-06-30,IS,Iceland,41.0267
 1984-06-30,IT,Italy,2.9732
 1984-06-30,JP,Japan,3.3514
 1984-06-30,KR,Korea,14.1158
-1984-06-30,LT,Lithuania,
-1984-06-30,LU,Luxembourg,
-1984-06-30,LV,Latvia,
-1984-06-30,MA,Morocco,
-1984-06-30,MK,North Macedonia,
-1984-06-30,MT,Malta,
-1984-06-30,MX,Mexico,
-1984-06-30,MY,Malaysia,
 1984-06-30,NL,Netherlands,-2.1821
-1984-06-30,NO,Norway,
 1984-06-30,NZ,New Zealand,13.1996
-1984-06-30,PE,Peru,
-1984-06-30,PH,Philippines,
-1984-06-30,PL,Poland,
-1984-06-30,PT,Portugal,
-1984-06-30,RO,Romania,
-1984-06-30,RS,Serbia,
-1984-06-30,RU,Russia,
 1984-06-30,SE,Sweden,4.0553
-1984-06-30,SG,Singapore,
-1984-06-30,SI,Slovenia,
-1984-06-30,SK,Slovak Republic,
-1984-06-30,TH,Thailand,
-1984-06-30,TR,Türkiye,
-1984-06-30,US,United States,5.224
-1984-06-30,XM,Euro area,1.9387
-1984-06-30,XW,World,
+1984-06-30,US,United States,5.2177
+1984-06-30,XM,Euro area,1.9615
 1984-06-30,ZA,South Africa,13.3333
-1984-09-30,4T,Emerging market economies (aggregate),
-1984-09-30,5R,Advanced economies,
-1984-09-30,AE,United Arab Emirates,
-1984-09-30,AT,Austria,
 1984-09-30,AU,Australia,15.1659
 1984-09-30,BE,Belgium,2.8235
-1984-09-30,BG,Bulgaria,
-1984-09-30,BR,Brazil,
 1984-09-30,CA,Canada,-1.0313
 1984-09-30,CH,Switzerland,5.1898
-1984-09-30,CL,Chile,
-1984-09-30,CN,China,
-1984-09-30,CO,Colombia,
-1984-09-30,CY,Cyprus,
-1984-09-30,CZ,Czechia,
-1984-09-30,DE,Germany,-2.9327
+1984-09-30,DE,Germany,-2.9117
 1984-09-30,DK,Denmark,12.2179
-1984-09-30,EE,Estonia,
 1984-09-30,ES,Spain,6.2138
 1984-09-30,FI,Finland,11.3542
 1984-09-30,FR,France,3.3731
 1984-09-30,GB,United Kingdom,8.8353
-1984-09-30,GR,Greece,
 1984-09-30,HK,Hong Kong SAR,-6.704
-1984-09-30,HR,Croatia,
-1984-09-30,HU,Hungary,
-1984-09-30,ID,Indonesia,
 1984-09-30,IE,Ireland,1.7457
-1984-09-30,IL,Israel,
-1984-09-30,IN,India,
-1984-09-30,IS,Iceland,
+1984-09-30,IS,Iceland,32.1831
 1984-09-30,IT,Italy,2.0558
 1984-09-30,JP,Japan,3.0655
 1984-09-30,KR,Korea,12.629
-1984-09-30,LT,Lithuania,
-1984-09-30,LU,Luxembourg,
-1984-09-30,LV,Latvia,
-1984-09-30,MA,Morocco,
-1984-09-30,MK,North Macedonia,
-1984-09-30,MT,Malta,
-1984-09-30,MX,Mexico,
-1984-09-30,MY,Malaysia,
 1984-09-30,NL,Netherlands,-1.8039
-1984-09-30,NO,Norway,
 1984-09-30,NZ,New Zealand,13.564
-1984-09-30,PE,Peru,
-1984-09-30,PH,Philippines,
-1984-09-30,PL,Poland,
-1984-09-30,PT,Portugal,
-1984-09-30,RO,Romania,
-1984-09-30,RS,Serbia,
-1984-09-30,RU,Russia,
 1984-09-30,SE,Sweden,4.9365
-1984-09-30,SG,Singapore,
-1984-09-30,SI,Slovenia,
-1984-09-30,SK,Slovak Republic,
-1984-09-30,TH,Thailand,
-1984-09-30,TR,Türkiye,
-1984-09-30,US,United States,5.3511
-1984-09-30,XM,Euro area,1.0511
-1984-09-30,XW,World,
+1984-09-30,US,United States,5.3504
+1984-09-30,XM,Euro area,1.0619
 1984-09-30,ZA,South Africa,6.5934
-1984-12-31,4T,Emerging market economies (aggregate),
-1984-12-31,5R,Advanced economies,
-1984-12-31,AE,United Arab Emirates,
-1984-12-31,AT,Austria,
 1984-12-31,AU,Australia,9.9683
 1984-12-31,BE,Belgium,2.5636
-1984-12-31,BG,Bulgaria,
-1984-12-31,BR,Brazil,
 1984-12-31,CA,Canada,-0.1581
 1984-12-31,CH,Switzerland,4.4648
-1984-12-31,CL,Chile,
-1984-12-31,CN,China,
-1984-12-31,CO,Colombia,
-1984-12-31,CY,Cyprus,
-1984-12-31,CZ,Czechia,
-1984-12-31,DE,Germany,-2.3414
+1984-12-31,DE,Germany,-2.4186
 1984-12-31,DK,Denmark,13.9327
-1984-12-31,EE,Estonia,
 1984-12-31,ES,Spain,6.4491
 1984-12-31,FI,Finland,7.6278
 1984-12-31,FR,France,3.2649
 1984-12-31,GB,United Kingdom,9.5618
-1984-12-31,GR,Greece,
 1984-12-31,HK,Hong Kong SAR,-0.5877
-1984-12-31,HR,Croatia,
-1984-12-31,HU,Hungary,
-1984-12-31,ID,Indonesia,
 1984-12-31,IE,Ireland,3.8218
-1984-12-31,IL,Israel,
-1984-12-31,IN,India,
-1984-12-31,IS,Iceland,
+1984-12-31,IS,Iceland,20.6794
 1984-12-31,IT,Italy,1.6023
 1984-12-31,JP,Japan,2.917
 1984-12-31,KR,Korea,11.0161
-1984-12-31,LT,Lithuania,
-1984-12-31,LU,Luxembourg,
-1984-12-31,LV,Latvia,
-1984-12-31,MA,Morocco,
-1984-12-31,MK,North Macedonia,
-1984-12-31,MT,Malta,
-1984-12-31,MX,Mexico,
-1984-12-31,MY,Malaysia,
 1984-12-31,NL,Netherlands,-0.193
-1984-12-31,NO,Norway,
 1984-12-31,NZ,New Zealand,13.0454
-1984-12-31,PE,Peru,
-1984-12-31,PH,Philippines,
-1984-12-31,PL,Poland,
-1984-12-31,PT,Portugal,
-1984-12-31,RO,Romania,
-1984-12-31,RS,Serbia,
-1984-12-31,RU,Russia,
 1984-12-31,SE,Sweden,4.2139
-1984-12-31,SG,Singapore,
-1984-12-31,SI,Slovenia,
-1984-12-31,SK,Slovak Republic,
-1984-12-31,TH,Thailand,
-1984-12-31,TR,Türkiye,
-1984-12-31,US,United States,4.7947
-1984-12-31,XM,Euro area,1.2429
-1984-12-31,XW,World,
+1984-12-31,US,United States,4.7545
+1984-12-31,XM,Euro area,1.2471
 1984-12-31,ZA,South Africa,-2.0785
-1985-03-31,4T,Emerging market economies (aggregate),
-1985-03-31,5R,Advanced economies,
-1985-03-31,AE,United Arab Emirates,
-1985-03-31,AT,Austria,
 1985-03-31,AU,Australia,11.8886
 1985-03-31,BE,Belgium,1.4378
-1985-03-31,BG,Bulgaria,
-1985-03-31,BR,Brazil,
 1985-03-31,CA,Canada,2.0376
-1985-03-31,CH,Switzerland,8.4034
-1985-03-31,CL,Chile,
-1985-03-31,CN,China,
-1985-03-31,CO,Colombia,
-1985-03-31,CY,Cyprus,
-1985-03-31,CZ,Czechia,
-1985-03-31,DE,Germany,-1.6349
+1985-03-31,CH,Switzerland,8.5008
+1985-03-31,DE,Germany,-1.6021
 1985-03-31,DK,Denmark,12.0764
-1985-03-31,EE,Estonia,
 1985-03-31,ES,Spain,8.8922
 1985-03-31,FI,Finland,6.1376
 1985-03-31,FR,France,3.1461
 1985-03-31,GB,United Kingdom,8.6957
-1985-03-31,GR,Greece,
 1985-03-31,HK,Hong Kong SAR,0.5717
-1985-03-31,HR,Croatia,
-1985-03-31,HU,Hungary,
-1985-03-31,ID,Indonesia,
 1985-03-31,IE,Ireland,1.455
-1985-03-31,IL,Israel,
-1985-03-31,IN,India,
-1985-03-31,IS,Iceland,
+1985-03-31,IS,Iceland,17.48
 1985-03-31,IT,Italy,1.5934
 1985-03-31,JP,Japan,2.771
 1985-03-31,KR,Korea,8.1389
-1985-03-31,LT,Lithuania,
-1985-03-31,LU,Luxembourg,
-1985-03-31,LV,Latvia,
-1985-03-31,MA,Morocco,
-1985-03-31,MK,North Macedonia,
-1985-03-31,MT,Malta,
-1985-03-31,MX,Mexico,
-1985-03-31,MY,Malaysia,
 1985-03-31,NL,Netherlands,-0.7497
-1985-03-31,NO,Norway,
 1985-03-31,NZ,New Zealand,13.0268
-1985-03-31,PE,Peru,
-1985-03-31,PH,Philippines,
-1985-03-31,PL,Poland,
-1985-03-31,PT,Portugal,
-1985-03-31,RO,Romania,
-1985-03-31,RS,Serbia,
-1985-03-31,RU,Russia,
 1985-03-31,SE,Sweden,5.2992
-1985-03-31,SG,Singapore,
-1985-03-31,SI,Slovenia,
-1985-03-31,SK,Slovak Republic,
-1985-03-31,TH,Thailand,
-1985-03-31,TR,Türkiye,
-1985-03-31,US,United States,4.7723
-1985-03-31,XM,Euro area,1.6288
-1985-03-31,XW,World,
+1985-03-31,US,United States,4.779
+1985-03-31,XM,Euro area,1.6551
 1985-03-31,ZA,South Africa,-7.1106
-1985-06-30,4T,Emerging market economies (aggregate),
-1985-06-30,5R,Advanced economies,
-1985-06-30,AE,United Arab Emirates,
-1985-06-30,AT,Austria,
 1985-06-30,AU,Australia,10.4158
 1985-06-30,BE,Belgium,-0.1006
-1985-06-30,BG,Bulgaria,
-1985-06-30,BR,Brazil,
 1985-06-30,CA,Canada,3.8159
-1985-06-30,CH,Switzerland,3.8519
-1985-06-30,CL,Chile,
-1985-06-30,CN,China,
-1985-06-30,CO,Colombia,
-1985-06-30,CY,Cyprus,
-1985-06-30,CZ,Czechia,
-1985-06-30,DE,Germany,-1.4566
+1985-06-30,CH,Switzerland,3.8092
+1985-06-30,DE,Germany,-1.5754
 1985-06-30,DK,Denmark,14.8259
-1985-06-30,EE,Estonia,
 1985-06-30,ES,Spain,9.7703
 1985-06-30,FI,Finland,5.5633
 1985-06-30,FR,France,3.2212
 1985-06-30,GB,United Kingdom,9.1954
-1985-06-30,GR,Greece,
 1985-06-30,HK,Hong Kong SAR,5.1137
-1985-06-30,HR,Croatia,
-1985-06-30,HU,Hungary,
-1985-06-30,ID,Indonesia,
 1985-06-30,IE,Ireland,2
-1985-06-30,IL,Israel,
-1985-06-30,IN,India,
-1985-06-30,IS,Iceland,
+1985-06-30,IS,Iceland,16.7662
 1985-06-30,IT,Italy,1.7565
 1985-06-30,JP,Japan,2.5871
 1985-06-30,KR,Korea,6.7983
-1985-06-30,LT,Lithuania,
-1985-06-30,LU,Luxembourg,
-1985-06-30,LV,Latvia,
-1985-06-30,MA,Morocco,
-1985-06-30,MK,North Macedonia,
-1985-06-30,MT,Malta,
-1985-06-30,MX,Mexico,
-1985-06-30,MY,Malaysia,
 1985-06-30,NL,Netherlands,1.1851
-1985-06-30,NO,Norway,
 1985-06-30,NZ,New Zealand,13.597
-1985-06-30,PE,Peru,
-1985-06-30,PH,Philippines,
-1985-06-30,PL,Poland,
-1985-06-30,PT,Portugal,
-1985-06-30,RO,Romania,
-1985-06-30,RS,Serbia,
-1985-06-30,RU,Russia,
 1985-06-30,SE,Sweden,4.6662
-1985-06-30,SG,Singapore,
-1985-06-30,SI,Slovenia,
-1985-06-30,SK,Slovak Republic,
-1985-06-30,TH,Thailand,
-1985-06-30,TR,Türkiye,
-1985-06-30,US,United States,5.7024
-1985-06-30,XM,Euro area,1.7292
-1985-06-30,XW,World,
+1985-06-30,US,United States,5.7129
+1985-06-30,XM,Euro area,1.7395
 1985-06-30,ZA,South Africa,-8.5973
-1985-09-30,4T,Emerging market economies (aggregate),
-1985-09-30,5R,Advanced economies,
-1985-09-30,AE,United Arab Emirates,
-1985-09-30,AT,Austria,
 1985-09-30,AU,Australia,8.4362
 1985-09-30,BE,Belgium,1.9557
-1985-09-30,BG,Bulgaria,
-1985-09-30,BR,Brazil,
 1985-09-30,CA,Canada,6.2926
-1985-09-30,CH,Switzerland,4.7089
-1985-09-30,CL,Chile,
-1985-09-30,CN,China,
-1985-09-30,CO,Colombia,
-1985-09-30,CY,Cyprus,
-1985-09-30,CZ,Czechia,
-1985-09-30,DE,Germany,-0.6602
+1985-09-30,CH,Switzerland,4.6971
+1985-09-30,DE,Germany,-0.6434
 1985-09-30,DK,Denmark,21.6546
-1985-09-30,EE,Estonia,
 1985-09-30,ES,Spain,10.5741
 1985-09-30,FI,Finland,2.6486
 1985-09-30,FR,France,3.34
 1985-09-30,GB,United Kingdom,7.3801
-1985-09-30,GR,Greece,
 1985-09-30,HK,Hong Kong SAR,17.3653
-1985-09-30,HR,Croatia,
-1985-09-30,HU,Hungary,
-1985-09-30,ID,Indonesia,
 1985-09-30,IE,Ireland,1.7325
-1985-09-30,IL,Israel,
-1985-09-30,IN,India,
-1985-09-30,IS,Iceland,
+1985-09-30,IS,Iceland,11.8979
 1985-09-30,IT,Italy,2.1103
 1985-09-30,JP,Japan,2.4116
 1985-09-30,KR,Korea,6.4543
-1985-09-30,LT,Lithuania,
-1985-09-30,LU,Luxembourg,
-1985-09-30,LV,Latvia,
-1985-09-30,MA,Morocco,
-1985-09-30,MK,North Macedonia,
-1985-09-30,MT,Malta,
-1985-09-30,MX,Mexico,
-1985-09-30,MY,Malaysia,
 1985-09-30,NL,Netherlands,-0.7279
-1985-09-30,NO,Norway,
 1985-09-30,NZ,New Zealand,14.7896
-1985-09-30,PE,Peru,
-1985-09-30,PH,Philippines,
-1985-09-30,PL,Poland,
-1985-09-30,PT,Portugal,
-1985-09-30,RO,Romania,
-1985-09-30,RS,Serbia,
-1985-09-30,RU,Russia,
 1985-09-30,SE,Sweden,3.7703
-1985-09-30,SG,Singapore,
-1985-09-30,SI,Slovenia,
-1985-09-30,SK,Slovak Republic,
-1985-09-30,TH,Thailand,
-1985-09-30,TR,Türkiye,
-1985-09-30,US,United States,5.0614
-1985-09-30,XM,Euro area,2.2567
-1985-09-30,XW,World,
+1985-09-30,US,United States,5.0469
+1985-09-30,XM,Euro area,2.2782
 1985-09-30,ZA,South Africa,-8.8202
-1985-12-31,4T,Emerging market economies (aggregate),
-1985-12-31,5R,Advanced economies,
-1985-12-31,AE,United Arab Emirates,
-1985-12-31,AT,Austria,
 1985-12-31,AU,Australia,10.1566
 1985-12-31,BE,Belgium,2.6195
-1985-12-31,BG,Bulgaria,
-1985-12-31,BR,Brazil,
 1985-12-31,CA,Canada,9.4418
-1985-12-31,CH,Switzerland,3.8109
-1985-12-31,CL,Chile,
-1985-12-31,CN,China,
-1985-12-31,CO,Colombia,
-1985-12-31,CY,Cyprus,
-1985-12-31,CZ,Czechia,
-1985-12-31,DE,Germany,-0.3388
+1985-12-31,CH,Switzerland,3.7725
+1985-12-31,DE,Germany,-0.2704
 1985-12-31,DK,Denmark,19.2609
-1985-12-31,EE,Estonia,
 1985-12-31,ES,Spain,10.9268
 1985-12-31,FI,Finland,2.9685
 1985-12-31,FR,France,3.4701
 1985-12-31,GB,United Kingdom,9.4545
-1985-12-31,GR,Greece,
 1985-12-31,HK,Hong Kong SAR,20.118
-1985-12-31,HR,Croatia,
-1985-12-31,HU,Hungary,
-1985-12-31,ID,Indonesia,
 1985-12-31,IE,Ireland,4.9194
-1985-12-31,IL,Israel,
-1985-12-31,IN,India,
-1985-12-31,IS,Iceland,
+1985-12-31,IS,Iceland,18.1359
 1985-12-31,IT,Italy,2.1983
 1985-12-31,JP,Japan,2.2754
 1985-12-31,KR,Korea,6.6386
-1985-12-31,LT,Lithuania,
-1985-12-31,LU,Luxembourg,
-1985-12-31,LV,Latvia,
-1985-12-31,MA,Morocco,
-1985-12-31,MK,North Macedonia,
-1985-12-31,MT,Malta,
-1985-12-31,MX,Mexico,
-1985-12-31,MY,Malaysia,
 1985-12-31,NL,Netherlands,1.0019
-1985-12-31,NO,Norway,
 1985-12-31,NZ,New Zealand,15.1657
-1985-12-31,PE,Peru,
-1985-12-31,PH,Philippines,
-1985-12-31,PL,Poland,
-1985-12-31,PT,Portugal,
-1985-12-31,RO,Romania,
-1985-12-31,RS,Serbia,
-1985-12-31,RU,Russia,
 1985-12-31,SE,Sweden,2.9203
-1985-12-31,SG,Singapore,
-1985-12-31,SI,Slovenia,
-1985-12-31,SK,Slovak Republic,
-1985-12-31,TH,Thailand,
-1985-12-31,TR,Türkiye,
-1985-12-31,US,United States,6.3542
-1985-12-31,XM,Euro area,3.0172
-1985-12-31,XW,World,
+1985-12-31,US,United States,6.3396
+1985-12-31,XM,Euro area,3.0337
 1985-12-31,ZA,South Africa,-6.3679
-1986-03-31,4T,Emerging market economies (aggregate),
-1986-03-31,5R,Advanced economies,
-1986-03-31,AE,United Arab Emirates,
-1986-03-31,AT,Austria,
 1986-03-31,AU,Australia,7.1359
 1986-03-31,BE,Belgium,2.5754
-1986-03-31,BG,Bulgaria,
-1986-03-31,BR,Brazil,
 1986-03-31,CA,Canada,13.4354
-1986-03-31,CH,Switzerland,2.0819
-1986-03-31,CL,Chile,
-1986-03-31,CN,China,
-1986-03-31,CO,Colombia,
-1986-03-31,CY,Cyprus,
-1986-03-31,CZ,Czechia,
-1986-03-31,DE,Germany,-0.0176
+1986-03-31,CH,Switzerland,2.1312
+1986-03-31,DE,Germany,-0.0603
 1986-03-31,DK,Denmark,21.254
-1986-03-31,EE,Estonia,
 1986-03-31,ES,Spain,8.2341
 1986-03-31,FI,Finland,3.4023
 1986-03-31,FR,France,4.1394
 1986-03-31,GB,United Kingdom,11.6364
-1986-03-31,GR,Greece,
 1986-03-31,HK,Hong Kong SAR,15.9088
-1986-03-31,HR,Croatia,
-1986-03-31,HU,Hungary,
-1986-03-31,ID,Indonesia,
 1986-03-31,IE,Ireland,3.3464
-1986-03-31,IL,Israel,
-1986-03-31,IN,India,
-1986-03-31,IS,Iceland,
+1986-03-31,IS,Iceland,10.5589
 1986-03-31,IT,Italy,2.4002
 1986-03-31,JP,Japan,2.1412
-1986-03-31,KR,Korea,11.5935
-1986-03-31,LT,Lithuania,
-1986-03-31,LU,Luxembourg,
-1986-03-31,LV,Latvia,
-1986-03-31,MA,Morocco,
-1986-03-31,MK,North Macedonia,
-1986-03-31,MT,Malta,
-1986-03-31,MX,Mexico,
-1986-03-31,MY,Malaysia,
+1986-03-31,KR,Korea,11.5911
 1986-03-31,NL,Netherlands,3.4955
-1986-03-31,NO,Norway,
 1986-03-31,NZ,New Zealand,13.5217
-1986-03-31,PE,Peru,
-1986-03-31,PH,Philippines,
-1986-03-31,PL,Poland,
-1986-03-31,PT,Portugal,
-1986-03-31,RO,Romania,
-1986-03-31,RS,Serbia,
-1986-03-31,RU,Russia,
 1986-03-31,SE,Sweden,3.5457
-1986-03-31,SG,Singapore,
-1986-03-31,SI,Slovenia,
-1986-03-31,SK,Slovak Republic,
-1986-03-31,TH,Thailand,
-1986-03-31,TR,Türkiye,
-1986-03-31,US,United States,7.2329
-1986-03-31,XM,Euro area,2.7841
-1986-03-31,XW,World,
+1986-03-31,US,United States,7.2061
+1986-03-31,XM,Euro area,2.7887
 1986-03-31,ZA,South Africa,-4.6173
-1986-06-30,4T,Emerging market economies (aggregate),
-1986-06-30,5R,Advanced economies,
-1986-06-30,AE,United Arab Emirates,
-1986-06-30,AT,Austria,
 1986-06-30,AU,Australia,8.948
 1986-06-30,BE,Belgium,4.7744
-1986-06-30,BG,Bulgaria,
-1986-06-30,BR,Brazil,
 1986-06-30,CA,Canada,16.4456
-1986-06-30,CH,Switzerland,0.9022
-1986-06-30,CL,Chile,
-1986-06-30,CN,China,
-1986-06-30,CO,Colombia,
-1986-06-30,CY,Cyprus,
-1986-06-30,CZ,Czechia,
-1986-06-30,DE,Germany,0.8525
+1986-06-30,CH,Switzerland,0.8876
+1986-06-30,DE,Germany,0.9696
 1986-06-30,DK,Denmark,16.3578
-1986-06-30,EE,Estonia,
 1986-06-30,ES,Spain,10.5945
 1986-06-30,FI,Finland,2.7313
 1986-06-30,FR,France,4.4516
 1986-06-30,GB,United Kingdom,12.6316
-1986-06-30,GR,Greece,
 1986-06-30,HK,Hong Kong SAR,11.3516
-1986-06-30,HR,Croatia,
-1986-06-30,HU,Hungary,
-1986-06-30,ID,Indonesia,
 1986-06-30,IE,Ireland,4.2484
-1986-06-30,IL,Israel,
-1986-06-30,IN,India,
-1986-06-30,IS,Iceland,
+1986-06-30,IS,Iceland,7.5086
 1986-06-30,IT,Italy,2.8612
 1986-06-30,JP,Japan,2.3264
-1986-06-30,KR,Korea,8.4032
-1986-06-30,LT,Lithuania,
-1986-06-30,LU,Luxembourg,
-1986-06-30,LV,Latvia,
-1986-06-30,MA,Morocco,
-1986-06-30,MK,North Macedonia,
-1986-06-30,MT,Malta,
-1986-06-30,MX,Mexico,
-1986-06-30,MY,Malaysia,
+1986-06-30,KR,Korea,8.3853
 1986-06-30,NL,Netherlands,3.2553
-1986-06-30,NO,Norway,
 1986-06-30,NZ,New Zealand,10.8451
-1986-06-30,PE,Peru,
-1986-06-30,PH,Philippines,
-1986-06-30,PL,Poland,
-1986-06-30,PT,Portugal,
-1986-06-30,RO,Romania,
-1986-06-30,RS,Serbia,
-1986-06-30,RU,Russia,
 1986-06-30,SE,Sweden,2.824
-1986-06-30,SG,Singapore,
-1986-06-30,SI,Slovenia,
-1986-06-30,SK,Slovak Republic,
-1986-06-30,TH,Thailand,
-1986-06-30,TR,Türkiye,
-1986-06-30,US,United States,6.9298
-1986-06-30,XM,Euro area,3.7078
-1986-06-30,XW,World,
+1986-06-30,US,United States,6.924
+1986-06-30,XM,Euro area,3.708
 1986-06-30,ZA,South Africa,-4.5792
-1986-09-30,4T,Emerging market economies (aggregate),
-1986-09-30,5R,Advanced economies,
-1986-09-30,AE,United Arab Emirates,
-1986-09-30,AT,Austria,
 1986-09-30,AU,Australia,3.5863
 1986-09-30,BE,Belgium,6.0066
-1986-09-30,BG,Bulgaria,
-1986-09-30,BR,Brazil,
 1986-09-30,CA,Canada,17.8544
-1986-09-30,CH,Switzerland,1.4756
-1986-09-30,CL,Chile,
-1986-09-30,CN,China,
-1986-09-30,CO,Colombia,
-1986-09-30,CY,Cyprus,
-1986-09-30,CZ,Czechia,
-1986-09-30,DE,Germany,0.3994
+1986-09-30,CH,Switzerland,1.4832
+1986-09-30,DE,Germany,0.3714
 1986-09-30,DK,Denmark,5.8415
-1986-09-30,EE,Estonia,
 1986-09-30,ES,Spain,16.6283
 1986-09-30,FI,Finland,4.361
 1986-09-30,FR,France,4.6917
 1986-09-30,GB,United Kingdom,15.1203
-1986-09-30,GR,Greece,
 1986-09-30,HK,Hong Kong SAR,10.204
-1986-09-30,HR,Croatia,
-1986-09-30,HU,Hungary,
-1986-09-30,ID,Indonesia,
 1986-09-30,IE,Ireland,5.1257
-1986-09-30,IL,Israel,
-1986-09-30,IN,India,
-1986-09-30,IS,Iceland,
+1986-09-30,IS,Iceland,14.9313
 1986-09-30,IT,Italy,2.9826
 1986-09-30,JP,Japan,2.5118
-1986-09-30,KR,Korea,5.8207
-1986-09-30,LT,Lithuania,
-1986-09-30,LU,Luxembourg,
-1986-09-30,LV,Latvia,
-1986-09-30,MA,Morocco,
-1986-09-30,MK,North Macedonia,
-1986-09-30,MT,Malta,
-1986-09-30,MX,Mexico,
-1986-09-30,MY,Malaysia,
+1986-09-30,KR,Korea,5.775
 1986-09-30,NL,Netherlands,6.5293
-1986-09-30,NO,Norway,
 1986-09-30,NZ,New Zealand,9.0782
-1986-09-30,PE,Peru,
-1986-09-30,PH,Philippines,
-1986-09-30,PL,Poland,
-1986-09-30,PT,Portugal,
-1986-09-30,RO,Romania,
-1986-09-30,RS,Serbia,
-1986-09-30,RU,Russia,
 1986-09-30,SE,Sweden,5.3604
-1986-09-30,SG,Singapore,
-1986-09-30,SI,Slovenia,
-1986-09-30,SK,Slovak Republic,
-1986-09-30,TH,Thailand,
-1986-09-30,TR,Türkiye,
-1986-09-30,US,United States,8.5234
-1986-09-30,XM,Euro area,4.1293
-1986-09-30,XW,World,
+1986-09-30,US,United States,8.4479
+1986-09-30,XM,Euro area,4.1535
 1986-09-30,ZA,South Africa,-3.7688
-1986-12-31,4T,Emerging market economies (aggregate),
-1986-12-31,5R,Advanced economies,
-1986-12-31,AE,United Arab Emirates,
-1986-12-31,AT,Austria,
 1986-12-31,AU,Australia,3.2729
 1986-12-31,BE,Belgium,5.2416
-1986-12-31,BG,Bulgaria,
-1986-12-31,BR,Brazil,
 1986-12-31,CA,Canada,20.8537
-1986-12-31,CH,Switzerland,0.9133
-1986-12-31,CL,Chile,
-1986-12-31,CN,China,
-1986-12-31,CO,Colombia,
-1986-12-31,CY,Cyprus,
-1986-12-31,CZ,Czechia,
-1986-12-31,DE,Germany,-0.1988
+1986-12-31,CH,Switzerland,0.8699
+1986-12-31,DE,Germany,-0.2437
 1986-12-31,DK,Denmark,4.8418
-1986-12-31,EE,Estonia,
 1986-12-31,ES,Spain,25.5202
 1986-12-31,FI,Finland,5.958
 1986-12-31,FR,France,5.2914
 1986-12-31,GB,United Kingdom,14.6179
-1986-12-31,GR,Greece,
 1986-12-31,HK,Hong Kong SAR,11.8221
-1986-12-31,HR,Croatia,
-1986-12-31,HU,Hungary,
-1986-12-31,ID,Indonesia,
 1986-12-31,IE,Ireland,1.3905
-1986-12-31,IL,Israel,
-1986-12-31,IN,India,
-1986-12-31,IS,Iceland,
+1986-12-31,IS,Iceland,17.8565
 1986-12-31,IT,Italy,3.1097
 1986-12-31,JP,Japan,3.5129
-1986-12-31,KR,Korea,3.7745
-1986-12-31,LT,Lithuania,
-1986-12-31,LU,Luxembourg,
-1986-12-31,LV,Latvia,
-1986-12-31,MA,Morocco,
-1986-12-31,MK,North Macedonia,
-1986-12-31,MT,Malta,
-1986-12-31,MX,Mexico,
-1986-12-31,MY,Malaysia,
+1986-12-31,KR,Korea,3.8388
 1986-12-31,NL,Netherlands,5.7257
-1986-12-31,NO,Norway,
 1986-12-31,NZ,New Zealand,7.9215
-1986-12-31,PE,Peru,
-1986-12-31,PH,Philippines,
-1986-12-31,PL,Poland,
-1986-12-31,PT,Portugal,
-1986-12-31,RO,Romania,
-1986-12-31,RS,Serbia,
-1986-12-31,RU,Russia,
 1986-12-31,SE,Sweden,8.8837
-1986-12-31,SG,Singapore,
-1986-12-31,SI,Slovenia,
-1986-12-31,SK,Slovak Republic,
-1986-12-31,TH,Thailand,
-1986-12-31,TR,Türkiye,
-1986-12-31,US,United States,8.0884
-1986-12-31,XM,Euro area,4.623
-1986-12-31,XW,World,
+1986-12-31,US,United States,8.0689
+1986-12-31,XM,Euro area,4.678
 1986-12-31,ZA,South Africa,-2.8967
-1987-03-31,4T,Emerging market economies (aggregate),
-1987-03-31,5R,Advanced economies,
-1987-03-31,AE,United Arab Emirates,
-1987-03-31,AT,Austria,
 1987-03-31,AU,Australia,2.1775
 1987-03-31,BE,Belgium,7.9019
-1987-03-31,BG,Bulgaria,
-1987-03-31,BR,Brazil,
 1987-03-31,CA,Canada,23.825
-1987-03-31,CH,Switzerland,-0.2293
-1987-03-31,CL,Chile,
-1987-03-31,CN,China,
-1987-03-31,CO,Colombia,
-1987-03-31,CY,Cyprus,
-1987-03-31,CZ,Czechia,
-1987-03-31,DE,Germany,-0.7885
+1987-03-31,CH,Switzerland,-0.3511
+1987-03-31,DE,Germany,-0.6873
 1987-03-31,DK,Denmark,-7.3697
-1987-03-31,EE,Estonia,
 1987-03-31,ES,Spain,37.724
 1987-03-31,FI,Finland,5.6738
 1987-03-31,FR,France,5.7083
 1987-03-31,GB,United Kingdom,15.6352
-1987-03-31,GR,Greece,
 1987-03-31,HK,Hong Kong SAR,20.5887
-1987-03-31,HR,Croatia,
-1987-03-31,HU,Hungary,
-1987-03-31,ID,Indonesia,
 1987-03-31,IE,Ireland,1.6851
-1987-03-31,IL,Israel,
-1987-03-31,IN,India,
-1987-03-31,IS,Iceland,
+1987-03-31,IS,Iceland,31.7062
 1987-03-31,IT,Italy,3.7596
 1987-03-31,JP,Japan,4.5031
-1987-03-31,KR,Korea,-3.0084
-1987-03-31,LT,Lithuania,
-1987-03-31,LU,Luxembourg,
-1987-03-31,LV,Latvia,
-1987-03-31,MA,Morocco,
-1987-03-31,MK,North Macedonia,
-1987-03-31,MT,Malta,
-1987-03-31,MX,Mexico,
-1987-03-31,MY,Malaysia,
+1987-03-31,KR,Korea,-3.0424
 1987-03-31,NL,Netherlands,5.3293
-1987-03-31,NO,Norway,
 1987-03-31,NZ,New Zealand,11.8115
-1987-03-31,PE,Peru,
-1987-03-31,PH,Philippines,
-1987-03-31,PL,Poland,
-1987-03-31,PT,Portugal,
-1987-03-31,RO,Romania,
-1987-03-31,RS,Serbia,
-1987-03-31,RU,Russia,
 1987-03-31,SE,Sweden,11.7117
-1987-03-31,SG,Singapore,
-1987-03-31,SI,Slovenia,
-1987-03-31,SK,Slovak Republic,
-1987-03-31,TH,Thailand,
-1987-03-31,TR,Türkiye,
-1987-03-31,US,United States,9.4478
-1987-03-31,XM,Euro area,6.4978
-1987-03-31,XW,World,
+1987-03-31,US,United States,9.4144
+1987-03-31,XM,Euro area,6.5798
 1987-03-31,ZA,South Africa,1.6561
-1987-06-30,4T,Emerging market economies (aggregate),
-1987-06-30,5R,Advanced economies,
-1987-06-30,AE,United Arab Emirates,
-1987-06-30,AT,Austria,
 1987-06-30,AU,Australia,0.5879
 1987-06-30,BE,Belgium,6.6333
-1987-06-30,BG,Bulgaria,
-1987-06-30,BR,Brazil,
 1987-06-30,CA,Canada,16.466
-1987-06-30,CH,Switzerland,4.5738
-1987-06-30,CL,Chile,
-1987-06-30,CN,China,
-1987-06-30,CO,Colombia,
-1987-06-30,CY,Cyprus,
-1987-06-30,CZ,Czechia,
-1987-06-30,DE,Germany,-1.3673
+1987-06-30,CH,Switzerland,4.6945
+1987-06-30,DE,Germany,-1.4442
 1987-06-30,DK,Denmark,-7.8811
-1987-06-30,EE,Estonia,
 1987-06-30,ES,Spain,40.0601
 1987-06-30,FI,Finland,10.0141
 1987-06-30,FR,France,6.5612
 1987-06-30,GB,United Kingdom,15.5763
-1987-06-30,GR,Greece,
 1987-06-30,HK,Hong Kong SAR,27.184
-1987-06-30,HR,Croatia,
-1987-06-30,HU,Hungary,
-1987-06-30,ID,Indonesia,
 1987-06-30,IE,Ireland,-1.8479
-1987-06-30,IL,Israel,
-1987-06-30,IN,India,
-1987-06-30,IS,Iceland,
+1987-06-30,IS,Iceland,34.9436
 1987-06-30,IT,Italy,4.9195
 1987-06-30,JP,Japan,6.9641
-1987-06-30,KR,Korea,-1.8248
-1987-06-30,LT,Lithuania,
-1987-06-30,LU,Luxembourg,
-1987-06-30,LV,Latvia,
-1987-06-30,MA,Morocco,
-1987-06-30,MK,North Macedonia,
-1987-06-30,MT,Malta,
-1987-06-30,MX,Mexico,
-1987-06-30,MY,Malaysia,
+1987-06-30,KR,Korea,-1.9667
 1987-06-30,NL,Netherlands,5.8549
-1987-06-30,NO,Norway,
 1987-06-30,NZ,New Zealand,15.7723
-1987-06-30,PE,Peru,
-1987-06-30,PH,Philippines,
-1987-06-30,PL,Poland,
-1987-06-30,PT,Portugal,
-1987-06-30,RO,Romania,
-1987-06-30,RS,Serbia,
-1987-06-30,RU,Russia,
 1987-06-30,SE,Sweden,12.3894
-1987-06-30,SG,Singapore,
-1987-06-30,SI,Slovenia,
-1987-06-30,SK,Slovak Republic,
-1987-06-30,TH,Thailand,
-1987-06-30,TR,Türkiye,
-1987-06-30,US,United States,9.7996
-1987-06-30,XM,Euro area,6.8577
-1987-06-30,XW,World,
+1987-06-30,US,United States,9.7
+1987-06-30,XM,Euro area,6.9718
 1987-06-30,ZA,South Africa,7.9118
-1987-09-30,4T,Emerging market economies (aggregate),
-1987-09-30,5R,Advanced economies,
-1987-09-30,AE,United Arab Emirates,
-1987-09-30,AT,Austria,
+1987-09-30,AT,Austria,-0.4587
 1987-09-30,AU,Australia,5.2024
 1987-09-30,BE,Belgium,5.0082
-1987-09-30,BG,Bulgaria,
-1987-09-30,BR,Brazil,
 1987-09-30,CA,Canada,14.5097
-1987-09-30,CH,Switzerland,3.2506
-1987-09-30,CL,Chile,
-1987-09-30,CN,China,
-1987-09-30,CO,Colombia,
-1987-09-30,CY,Cyprus,
-1987-09-30,CZ,Czechia,
-1987-09-30,DE,Germany,-1.1801
+1987-09-30,CH,Switzerland,3.2673
+1987-09-30,DE,Germany,-1.2157
 1987-09-30,DK,Denmark,-6.071
-1987-09-30,EE,Estonia,
 1987-09-30,ES,Spain,38.377
 1987-09-30,FI,Finland,12.7336
 1987-09-30,FR,France,7.7678
 1987-09-30,GB,United Kingdom,16.1194
-1987-09-30,GR,Greece,
 1987-09-30,HK,Hong Kong SAR,25.463
-1987-09-30,HR,Croatia,
-1987-09-30,HU,Hungary,
-1987-09-30,ID,Indonesia,
 1987-09-30,IE,Ireland,-0.173
-1987-09-30,IL,Israel,
-1987-09-30,IN,India,
-1987-09-30,IS,Iceland,
+1987-09-30,IS,Iceland,36.7821
 1987-09-30,IT,Italy,6.3854
 1987-09-30,JP,Japan,9.4181
-1987-09-30,KR,Korea,0.4902
-1987-09-30,LT,Lithuania,
-1987-09-30,LU,Luxembourg,
-1987-09-30,LV,Latvia,
-1987-09-30,MA,Morocco,
-1987-09-30,MK,North Macedonia,
-1987-09-30,MT,Malta,
-1987-09-30,MX,Mexico,
-1987-09-30,MY,Malaysia,
+1987-09-30,KR,Korea,0.5081
 1987-09-30,NL,Netherlands,3.5726
-1987-09-30,NO,Norway,
 1987-09-30,NZ,New Zealand,18.758
-1987-09-30,PE,Peru,
-1987-09-30,PH,Philippines,
-1987-09-30,PL,Poland,
-1987-09-30,PT,Portugal,
-1987-09-30,RO,Romania,
-1987-09-30,RS,Serbia,
-1987-09-30,RU,Russia,
 1987-09-30,SE,Sweden,12.931
-1987-09-30,SG,Singapore,
-1987-09-30,SI,Slovenia,
-1987-09-30,SK,Slovak Republic,
-1987-09-30,TH,Thailand,
-1987-09-30,TR,Türkiye,
-1987-09-30,US,United States,9.6014
-1987-09-30,XM,Euro area,6.4321
-1987-09-30,XW,World,
+1987-09-30,US,United States,9.5995
+1987-09-30,XM,Euro area,6.5202
 1987-09-30,ZA,South Africa,12.5326
-1987-12-31,4T,Emerging market economies (aggregate),
-1987-12-31,5R,Advanced economies,
-1987-12-31,AE,United Arab Emirates,
-1987-12-31,AT,Austria,
+1987-12-31,AT,Austria,14.8058
 1987-12-31,AU,Australia,9.0004
 1987-12-31,BE,Belgium,6.1655
-1987-12-31,BG,Bulgaria,
-1987-12-31,BR,Brazil,
 1987-12-31,CA,Canada,12.9901
-1987-12-31,CH,Switzerland,3.5646
-1987-12-31,CL,Chile,
-1987-12-31,CN,China,
-1987-12-31,CO,Colombia,
-1987-12-31,CY,Cyprus,
-1987-12-31,CZ,Czechia,
-1987-12-31,DE,Germany,-0.2697
+1987-12-31,CH,Switzerland,3.5573
+1987-12-31,DE,Germany,-0.2561
 1987-12-31,DK,Denmark,-8.3333
-1987-12-31,EE,Estonia,
 1987-12-31,ES,Spain,35.2499
 1987-12-31,FI,Finland,17.311
 1987-12-31,FR,France,8.3239
 1987-12-31,GB,United Kingdom,19.7101
-1987-12-31,GR,Greece,
 1987-12-31,HK,Hong Kong SAR,20.265
-1987-12-31,HR,Croatia,
-1987-12-31,HU,Hungary,
-1987-12-31,ID,Indonesia,
 1987-12-31,IE,Ireland,6.538
-1987-12-31,IL,Israel,
-1987-12-31,IN,India,
-1987-12-31,IS,Iceland,
+1987-12-31,IS,Iceland,39.2501
 1987-12-31,IT,Italy,7.9592
 1987-12-31,JP,Japan,8.8612
-1987-12-31,KR,Korea,6.1652
-1987-12-31,LT,Lithuania,
-1987-12-31,LU,Luxembourg,
-1987-12-31,LV,Latvia,
-1987-12-31,MA,Morocco,
-1987-12-31,MK,North Macedonia,
-1987-12-31,MT,Malta,
-1987-12-31,MX,Mexico,
-1987-12-31,MY,Malaysia,
+1987-12-31,KR,Korea,6.1287
 1987-12-31,NL,Netherlands,4.1811
-1987-12-31,NO,Norway,
 1987-12-31,NZ,New Zealand,21.7064
-1987-12-31,PE,Peru,
-1987-12-31,PH,Philippines,
-1987-12-31,PL,Poland,
-1987-12-31,PT,Portugal,
-1987-12-31,RO,Romania,
-1987-12-31,RS,Serbia,
-1987-12-31,RU,Russia,
 1987-12-31,SE,Sweden,14.2857
-1987-12-31,SG,Singapore,
-1987-12-31,SI,Slovenia,
-1987-12-31,SK,Slovak Republic,
-1987-12-31,TH,Thailand,
-1987-12-31,TR,Türkiye,
-1987-12-31,US,United States,10.1148
-1987-12-31,XM,Euro area,8.2174
-1987-12-31,XW,World,
+1987-12-31,US,United States,10.0702
+1987-12-31,XM,Euro area,8.2862
 1987-12-31,ZA,South Africa,16.9909
-1988-03-31,4T,Emerging market economies (aggregate),
-1988-03-31,5R,Advanced economies,
-1988-03-31,AE,United Arab Emirates,
-1988-03-31,AT,Austria,
+1988-03-31,AT,Austria,1.1211
 1988-03-31,AU,Australia,12.5537
 1988-03-31,BE,Belgium,5.1768
-1988-03-31,BG,Bulgaria,
-1988-03-31,BR,Brazil,
 1988-03-31,CA,Canada,13.8578
-1988-03-31,CH,Switzerland,3.2639
-1988-03-31,CL,Chile,
-1988-03-31,CN,China,
-1988-03-31,CO,Colombia,
-1988-03-31,CY,Cyprus,
-1988-03-31,CZ,Czechia,
-1988-03-31,DE,Germany,0.5323
+1988-03-31,CH,Switzerland,3.1997
+1988-03-31,DE,Germany,0.3761
 1988-03-31,DK,Denmark,-0.4835
-1988-03-31,EE,Estonia,
 1988-03-31,ES,Spain,27.3225
 1988-03-31,FI,Finland,27.9459
 1988-03-31,FR,France,9.3158
 1988-03-31,GB,United Kingdom,21.1268
-1988-03-31,GR,Greece,
 1988-03-31,HK,Hong Kong SAR,15.0405
-1988-03-31,HR,Croatia,
-1988-03-31,HU,Hungary,
-1988-03-31,ID,Indonesia,
 1988-03-31,IE,Ireland,6.3038
-1988-03-31,IL,Israel,
-1988-03-31,IN,India,
-1988-03-31,IS,Iceland,
+1988-03-31,IS,Iceland,40.0148
 1988-03-31,IT,Italy,9.5281
 1988-03-31,JP,Japan,8.321
-1988-03-31,KR,Korea,11.4144
-1988-03-31,LT,Lithuania,
-1988-03-31,LU,Luxembourg,
-1988-03-31,LV,Latvia,
-1988-03-31,MA,Morocco,
-1988-03-31,MK,North Macedonia,
-1988-03-31,MT,Malta,
-1988-03-31,MX,Mexico,
-1988-03-31,MY,Malaysia,
+1988-03-31,KR,Korea,11.4712
 1988-03-31,NL,Netherlands,2.6909
-1988-03-31,NO,Norway,
 1988-03-31,NZ,New Zealand,18.457
-1988-03-31,PE,Peru,
-1988-03-31,PH,Philippines,
-1988-03-31,PL,Poland,
-1988-03-31,PT,Portugal,
-1988-03-31,RO,Romania,
-1988-03-31,RS,Serbia,
-1988-03-31,RU,Russia,
 1988-03-31,SE,Sweden,15.3226
-1988-03-31,SG,Singapore,
-1988-03-31,SI,Slovenia,
-1988-03-31,SK,Slovak Republic,
-1988-03-31,TH,Thailand,
-1988-03-31,TR,Türkiye,
-1988-03-31,US,United States,8.2603
-1988-03-31,XM,Euro area,7.5902
-1988-03-31,XW,World,
+1988-03-31,US,United States,8.2205
+1988-03-31,XM,Euro area,7.6419
 1988-03-31,ZA,South Africa,17.1679
-1988-06-30,4T,Emerging market economies (aggregate),
-1988-06-30,5R,Advanced economies,
-1988-06-30,AE,United Arab Emirates,
-1988-06-30,AT,Austria,
+1988-06-30,AT,Austria,-1.0225
 1988-06-30,AU,Australia,17.2866
 1988-06-30,BE,Belgium,8.4746
-1988-06-30,BG,Bulgaria,
-1988-06-30,BR,Brazil,
 1988-06-30,CA,Canada,17.7005
-1988-06-30,CH,Switzerland,2.6487
-1988-06-30,CL,Chile,
-1988-06-30,CN,China,
-1988-06-30,CO,Colombia,
-1988-06-30,CY,Cyprus,
-1988-06-30,CZ,Czechia,
-1988-06-30,DE,Germany,1.5516
+1988-06-30,CH,Switzerland,2.5124
+1988-06-30,DE,Germany,1.6645
 1988-06-30,DK,Denmark,-0.5836
-1988-06-30,EE,Estonia,
 1988-06-30,ES,Spain,26.3079
 1988-06-30,FI,Finland,30.7995
 1988-06-30,FR,France,10.3216
 1988-06-30,GB,United Kingdom,22.9111
-1988-06-30,GR,Greece,
 1988-06-30,HK,Hong Kong SAR,17.5572
-1988-06-30,HR,Croatia,
-1988-06-30,HU,Hungary,
-1988-06-30,ID,Indonesia,
 1988-06-30,IE,Ireland,7.4634
-1988-06-30,IL,Israel,
-1988-06-30,IN,India,
-1988-06-30,IS,Iceland,
+1988-06-30,IS,Iceland,37.7406
 1988-06-30,IT,Italy,11.9632
 1988-06-30,JP,Japan,6.1797
-1988-06-30,KR,Korea,17.3482
-1988-06-30,LT,Lithuania,
-1988-06-30,LU,Luxembourg,
-1988-06-30,LV,Latvia,
-1988-06-30,MA,Morocco,
-1988-06-30,MK,North Macedonia,
-1988-06-30,MT,Malta,
-1988-06-30,MX,Mexico,
-1988-06-30,MY,Malaysia,
+1988-06-30,KR,Korea,17.5412
 1988-06-30,NL,Netherlands,4.3177
-1988-06-30,NO,Norway,
 1988-06-30,NZ,New Zealand,16.0825
-1988-06-30,PE,Peru,
-1988-06-30,PH,Philippines,
-1988-06-30,PL,Poland,
-1988-06-30,PT,Portugal,
-1988-06-30,RO,Romania,
-1988-06-30,RS,Serbia,
-1988-06-30,RU,Russia,
 1988-06-30,SE,Sweden,17.3228
-1988-06-30,SG,Singapore,
-1988-06-30,SI,Slovenia,
-1988-06-30,SK,Slovak Republic,
-1988-06-30,TH,Thailand,
-1988-06-30,TR,Türkiye,
-1988-06-30,US,United States,8.54
-1988-06-30,XM,Euro area,8.5449
-1988-06-30,XW,World,
+1988-06-30,US,United States,8.5253
+1988-06-30,XM,Euro area,8.5915
 1988-06-30,ZA,South Africa,14.7837
-1988-09-30,4T,Emerging market economies (aggregate),
-1988-09-30,5R,Advanced economies,
-1988-09-30,AE,United Arab Emirates,
-1988-09-30,AT,Austria,
+1988-09-30,AT,Austria,33.4101
 1988-09-30,AU,Australia,26.5889
 1988-09-30,BE,Belgium,8.564
-1988-09-30,BG,Bulgaria,
-1988-09-30,BR,Brazil,
 1988-09-30,CA,Canada,18.874
-1988-09-30,CH,Switzerland,5.7168
-1988-09-30,CL,Chile,
-1988-09-30,CN,China,
-1988-09-30,CO,Colombia,
-1988-09-30,CY,Cyprus,
-1988-09-30,CZ,Czechia,
-1988-09-30,DE,Germany,2.3179
+1988-09-30,CH,Switzerland,5.7029
+1988-09-30,DE,Germany,2.4248
 1988-09-30,DK,Denmark,1.9623
-1988-09-30,EE,Estonia,
 1988-09-30,ES,Spain,24.4349
 1988-09-30,FI,Finland,37.4279
 1988-09-30,FR,France,11.3531
 1988-09-30,GB,United Kingdom,32.6478
-1988-09-30,GR,Greece,
 1988-09-30,HK,Hong Kong SAR,21.7715
-1988-09-30,HR,Croatia,
-1988-09-30,HU,Hungary,
-1988-09-30,ID,Indonesia,
 1988-09-30,IE,Ireland,7.5941
-1988-09-30,IL,Israel,
-1988-09-30,IN,India,
-1988-09-30,IS,Iceland,
+1988-09-30,IS,Iceland,27.8278
 1988-09-30,IT,Italy,14.0407
 1988-09-30,JP,Japan,4.1288
-1988-09-30,KR,Korea,19.5122
-1988-09-30,LT,Lithuania,
-1988-09-30,LU,Luxembourg,
-1988-09-30,LV,Latvia,
-1988-09-30,MA,Morocco,
-1988-09-30,MK,North Macedonia,
-1988-09-30,MT,Malta,
-1988-09-30,MX,Mexico,
-1988-09-30,MY,Malaysia,
+1988-09-30,KR,Korea,19.5147
 1988-09-30,NL,Netherlands,5.7437
-1988-09-30,NO,Norway,
 1988-09-30,NZ,New Zealand,11.4286
-1988-09-30,PE,Peru,
-1988-09-30,PH,Philippines,
-1988-09-30,PL,Poland,
-1988-09-30,PT,Portugal,
-1988-09-30,RO,Romania,
-1988-09-30,RS,Serbia,
-1988-09-30,RU,Russia,
 1988-09-30,SE,Sweden,20.6107
-1988-09-30,SG,Singapore,
-1988-09-30,SI,Slovenia,
-1988-09-30,SK,Slovak Republic,
-1988-09-30,TH,Thailand,
-1988-09-30,TR,Türkiye,
-1988-09-30,US,United States,9.1736
-1988-09-30,XM,Euro area,10.5795
-1988-09-30,XW,World,
+1988-09-30,US,United States,9.1485
+1988-09-30,XM,Euro area,10.6281
 1988-09-30,ZA,South Africa,14.9652
-1988-12-31,4T,Emerging market economies (aggregate),
-1988-12-31,5R,Advanced economies,
-1988-12-31,AE,United Arab Emirates,
-1988-12-31,AT,Austria,
+1988-12-31,AT,Austria,13.9535
 1988-12-31,AU,Australia,32.8792
 1988-12-31,BE,Belgium,9.8709
-1988-12-31,BG,Bulgaria,
-1988-12-31,BR,Brazil,
 1988-12-31,CA,Canada,21.8675
-1988-12-31,CH,Switzerland,10.78
-1988-12-31,CL,Chile,
-1988-12-31,CN,China,
-1988-12-31,CO,Colombia,
-1988-12-31,CY,Cyprus,
-1988-12-31,CZ,Czechia,
-1988-12-31,DE,Germany,2.3455
+1988-12-31,CH,Switzerland,10.9993
+1988-12-31,DE,Germany,2.2817
 1988-12-31,DK,Denmark,3.7506
-1988-12-31,EE,Estonia,
 1988-12-31,ES,Spain,22.4435
 1988-12-31,FI,Finland,41.7665
 1988-12-31,FR,France,12.1014
 1988-12-31,GB,United Kingdom,32.6877
-1988-12-31,GR,Greece,
 1988-12-31,HK,Hong Kong SAR,29.3038
-1988-12-31,HR,Croatia,
-1988-12-31,HU,Hungary,
-1988-12-31,ID,Indonesia,
 1988-12-31,IE,Ireland,5.6578
-1988-12-31,IL,Israel,
-1988-12-31,IN,India,
-1988-12-31,IS,Iceland,
+1988-12-31,IS,Iceland,28.8639
 1988-12-31,IT,Italy,15.774
 1988-12-31,JP,Japan,4.78
-1988-12-31,KR,Korea,13.9373
-1988-12-31,LT,Lithuania,
-1988-12-31,LU,Luxembourg,
-1988-12-31,LV,Latvia,
-1988-12-31,MA,Morocco,
-1988-12-31,MK,North Macedonia,
-1988-12-31,MT,Malta,
-1988-12-31,MX,Mexico,
-1988-12-31,MY,Malaysia,
+1988-12-31,KR,Korea,13.8595
 1988-12-31,NL,Netherlands,5.5933
-1988-12-31,NO,Norway,
 1988-12-31,NZ,New Zealand,7.1907
-1988-12-31,PE,Peru,
-1988-12-31,PH,Philippines,
-1988-12-31,PL,Poland,
-1988-12-31,PT,Portugal,
-1988-12-31,RO,Romania,
-1988-12-31,RS,Serbia,
-1988-12-31,RU,Russia,
 1988-12-31,SE,Sweden,19.1176
-1988-12-31,SG,Singapore,
-1988-12-31,SI,Slovenia,
-1988-12-31,SK,Slovak Republic,
-1988-12-31,TH,Thailand,
-1988-12-31,TR,Türkiye,
-1988-12-31,US,United States,9.7169
-1988-12-31,XM,Euro area,9.8329
-1988-12-31,XW,World,
+1988-12-31,US,United States,9.7025
+1988-12-31,XM,Euro area,9.8918
 1988-12-31,ZA,South Africa,13.6364
-1989-03-31,4T,Emerging market economies (aggregate),
-1989-03-31,5R,Advanced economies,
-1989-03-31,AE,United Arab Emirates,
-1989-03-31,AT,Austria,
+1989-03-31,AT,Austria,22.8381
 1989-03-31,AU,Australia,37.5656
 1989-03-31,BE,Belgium,13.4111
-1989-03-31,BG,Bulgaria,
-1989-03-31,BR,Brazil,
 1989-03-31,CA,Canada,22.7422
-1989-03-31,CH,Switzerland,10.3938
-1989-03-31,CL,Chile,
-1989-03-31,CN,China,
-1989-03-31,CO,Colombia,31.1413
-1989-03-31,CY,Cyprus,
-1989-03-31,CZ,Czechia,
-1989-03-31,DE,Germany,2.7015
+1989-03-31,CH,Switzerland,10.5435
+1989-03-31,CO,Colombia,31.0206
+1989-03-31,DE,Germany,2.7992
 1989-03-31,DK,Denmark,1.3582
-1989-03-31,EE,Estonia,
 1989-03-31,ES,Spain,23.7003
 1989-03-31,FI,Finland,36.1252
 1989-03-31,FR,France,12.6859
 1989-03-31,GB,United Kingdom,30.2326
-1989-03-31,GR,Greece,
 1989-03-31,HK,Hong Kong SAR,39.2228
-1989-03-31,HR,Croatia,
-1989-03-31,HU,Hungary,
-1989-03-31,ID,Indonesia,
 1989-03-31,IE,Ireland,11.4168
-1989-03-31,IL,Israel,
-1989-03-31,IN,India,
-1989-03-31,IS,Iceland,
+1989-03-31,IS,Iceland,17.2175
 1989-03-31,IT,Italy,16.847
 1989-03-31,JP,Japan,5.4184
-1989-03-31,KR,Korea,13.6971
-1989-03-31,LT,Lithuania,
-1989-03-31,LU,Luxembourg,
-1989-03-31,LV,Latvia,
-1989-03-31,MA,Morocco,
-1989-03-31,MK,North Macedonia,
-1989-03-31,MT,Malta,
-1989-03-31,MX,Mexico,
+1989-03-31,KR,Korea,13.7056
 1989-03-31,MY,Malaysia,6.3732
 1989-03-31,NL,Netherlands,6.7001
-1989-03-31,NO,Norway,
 1989-03-31,NZ,New Zealand,6.8387
-1989-03-31,PE,Peru,
-1989-03-31,PH,Philippines,
-1989-03-31,PL,Poland,
-1989-03-31,PT,Portugal,
-1989-03-31,RO,Romania,
-1989-03-31,RS,Serbia,
-1989-03-31,RU,Russia,
+1989-03-31,PT,Portugal,18.483
 1989-03-31,SE,Sweden,20.2797
-1989-03-31,SG,Singapore,
-1989-03-31,SI,Slovenia,
-1989-03-31,SK,Slovak Republic,
-1989-03-31,TH,Thailand,
-1989-03-31,TR,Türkiye,
-1989-03-31,US,United States,10.3482
-1989-03-31,XM,Euro area,11.7801
-1989-03-31,XW,World,
+1989-03-31,US,United States,10.32
+1989-03-31,XM,Euro area,11.8112
 1989-03-31,ZA,South Africa,13.0481
-1989-06-30,4T,Emerging market economies (aggregate),
-1989-06-30,5R,Advanced economies,
-1989-06-30,AE,United Arab Emirates,
-1989-06-30,AT,Austria,
+1989-06-30,AT,Austria,19.6281
 1989-06-30,AU,Australia,33.1169
 1989-06-30,BE,Belgium,12.8158
-1989-06-30,BG,Bulgaria,
-1989-06-30,BR,Brazil,
 1989-06-30,CA,Canada,9.816
-1989-06-30,CH,Switzerland,8.424
-1989-06-30,CL,Chile,
-1989-06-30,CN,China,
-1989-06-30,CO,Colombia,44.3238
-1989-06-30,CY,Cyprus,
-1989-06-30,CZ,Czechia,
-1989-06-30,DE,Germany,2.6015
+1989-06-30,CH,Switzerland,8.4197
+1989-06-30,CO,Colombia,44.1836
+1989-06-30,DE,Germany,2.6352
 1989-06-30,DK,Denmark,1.8607
-1989-06-30,EE,Estonia,
 1989-06-30,ES,Spain,23.1709
 1989-06-30,FI,Finland,31.3772
 1989-06-30,FR,France,12.5452
 1989-06-30,GB,United Kingdom,27.193
-1989-06-30,GR,Greece,
 1989-06-30,HK,Hong Kong SAR,32.4679
-1989-06-30,HR,Croatia,
-1989-06-30,HU,Hungary,
-1989-06-30,ID,Indonesia,
 1989-06-30,IE,Ireland,9.6512
-1989-06-30,IL,Israel,
-1989-06-30,IN,India,
-1989-06-30,IS,Iceland,
+1989-06-30,IS,Iceland,19.2626
 1989-06-30,IT,Italy,17.5538
 1989-06-30,JP,Japan,6.8091
-1989-06-30,KR,Korea,16.2619
-1989-06-30,LT,Lithuania,
-1989-06-30,LU,Luxembourg,
-1989-06-30,LV,Latvia,
-1989-06-30,MA,Morocco,
-1989-06-30,MK,North Macedonia,
-1989-06-30,MT,Malta,
-1989-06-30,MX,Mexico,
+1989-06-30,KR,Korea,16.2363
 1989-06-30,MY,Malaysia,6.1204
 1989-06-30,NL,Netherlands,6.3293
-1989-06-30,NO,Norway,
 1989-06-30,NZ,New Zealand,4.7967
-1989-06-30,PE,Peru,
-1989-06-30,PH,Philippines,
-1989-06-30,PL,Poland,
-1989-06-30,PT,Portugal,
-1989-06-30,RO,Romania,
-1989-06-30,RS,Serbia,
-1989-06-30,RU,Russia,
+1989-06-30,PT,Portugal,17.2124
 1989-06-30,SE,Sweden,20.8054
-1989-06-30,SG,Singapore,
-1989-06-30,SI,Slovenia,
-1989-06-30,SK,Slovak Republic,
-1989-06-30,TH,Thailand,
-1989-06-30,TR,Türkiye,
-1989-06-30,US,United States,9.2672
-1989-06-30,XM,Euro area,11.6535
-1989-06-30,XW,World,
+1989-06-30,US,United States,9.2502
+1989-06-30,XM,Euro area,11.6974
 1989-06-30,ZA,South Africa,15.8115
-1989-09-30,4T,Emerging market economies (aggregate),
-1989-09-30,5R,Advanced economies,
-1989-09-30,AE,United Arab Emirates,
-1989-09-30,AT,Austria,
+1989-09-30,AT,Austria,10.8808
 1989-09-30,AU,Australia,21.2517
 1989-09-30,BE,Belgium,13.0511
-1989-09-30,BG,Bulgaria,
-1989-09-30,BR,Brazil,
 1989-09-30,CA,Canada,11.2939
-1989-09-30,CH,Switzerland,6.7878
-1989-09-30,CL,Chile,
-1989-09-30,CN,China,
-1989-09-30,CO,Colombia,25.2344
-1989-09-30,CY,Cyprus,
-1989-09-30,CZ,Czechia,
-1989-09-30,DE,Germany,3.3339
+1989-09-30,CH,Switzerland,6.6814
+1989-09-30,CO,Colombia,25.2848
+1989-09-30,DE,Germany,3.2217
 1989-09-30,DK,Denmark,-1.9245
-1989-09-30,EE,Estonia,
 1989-09-30,ES,Spain,24.3168
 1989-09-30,FI,Finland,19.8771
 1989-09-30,FR,France,11.8317
 1989-09-30,GB,United Kingdom,16.2791
-1989-09-30,GR,Greece,
 1989-09-30,HK,Hong Kong SAR,18.7876
-1989-09-30,HR,Croatia,
-1989-09-30,HU,Hungary,
-1989-09-30,ID,Indonesia,
 1989-09-30,IE,Ireland,11.2315
-1989-09-30,IL,Israel,
-1989-09-30,IN,India,
-1989-09-30,IS,Iceland,
+1989-09-30,IS,Iceland,19.1432
 1989-09-30,IT,Italy,18.2707
 1989-09-30,JP,Japan,8.1989
-1989-09-30,KR,Korea,12.6531
-1989-09-30,LT,Lithuania,
-1989-09-30,LU,Luxembourg,
-1989-09-30,LV,Latvia,
-1989-09-30,MA,Morocco,
-1989-09-30,MK,North Macedonia,
-1989-09-30,MT,Malta,
-1989-09-30,MX,Mexico,
+1989-09-30,KR,Korea,12.6481
 1989-09-30,MY,Malaysia,2.9814
 1989-09-30,NL,Netherlands,6.8083
-1989-09-30,NO,Norway,
 1989-09-30,NZ,New Zealand,6.0958
-1989-09-30,PE,Peru,
-1989-09-30,PH,Philippines,
-1989-09-30,PL,Poland,
-1989-09-30,PT,Portugal,
-1989-09-30,RO,Romania,
-1989-09-30,RS,Serbia,
-1989-09-30,RU,Russia,
+1989-09-30,PT,Portugal,19.567
 1989-09-30,SE,Sweden,18.3544
-1989-09-30,SG,Singapore,
-1989-09-30,SI,Slovenia,
-1989-09-30,SK,Slovak Republic,
-1989-09-30,TH,Thailand,
-1989-09-30,TR,Türkiye,
-1989-09-30,US,United States,7.7563
-1989-09-30,XM,Euro area,11.5907
-1989-09-30,XW,World,
+1989-09-30,US,United States,7.7287
+1989-09-30,XM,Euro area,11.6327
 1989-09-30,ZA,South Africa,15.6408
-1989-12-31,4T,Emerging market economies (aggregate),
-1989-12-31,5R,Advanced economies,
-1989-12-31,AE,United Arab Emirates,
-1989-12-31,AT,Austria,
+1989-12-31,AT,Austria,20.7792
 1989-12-31,AU,Australia,10.5526
 1989-12-31,BE,Belgium,16.0794
-1989-12-31,BG,Bulgaria,
-1989-12-31,BR,Brazil,
 1989-12-31,CA,Canada,8.8143
-1989-12-31,CH,Switzerland,7.8279
-1989-12-31,CL,Chile,
-1989-12-31,CN,China,
-1989-12-31,CO,Colombia,33.2232
-1989-12-31,CY,Cyprus,
-1989-12-31,CZ,Czechia,
-1989-12-31,DE,Germany,4.6085
+1989-12-31,CH,Switzerland,7.7996
+1989-12-31,CO,Colombia,33.0801
+1989-12-31,DE,Germany,4.5928
 1989-12-31,DK,Denmark,-4.0898
-1989-12-31,EE,Estonia,
 1989-12-31,ES,Spain,22.0519
 1989-12-31,FI,Finland,6.3667
 1989-12-31,FR,France,11.2497
 1989-12-31,GB,United Kingdom,7.2993
-1989-12-31,GR,Greece,
 1989-12-31,HK,Hong Kong SAR,17.2805
-1989-12-31,HR,Croatia,
-1989-12-31,HU,Hungary,
-1989-12-31,ID,Indonesia,
 1989-12-31,IE,Ireland,14.7471
-1989-12-31,IL,Israel,
-1989-12-31,IN,India,
-1989-12-31,IS,Iceland,
+1989-12-31,IS,Iceland,12.6802
 1989-12-31,IT,Italy,18.7228
 1989-12-31,JP,Japan,10.5455
-1989-12-31,KR,Korea,13.8634
-1989-12-31,LT,Lithuania,
-1989-12-31,LU,Luxembourg,
-1989-12-31,LV,Latvia,
-1989-12-31,MA,Morocco,
-1989-12-31,MK,North Macedonia,
-1989-12-31,MT,Malta,
-1989-12-31,MX,Mexico,
+1989-12-31,KR,Korea,13.9476
 1989-12-31,MY,Malaysia,1.6536
 1989-12-31,NL,Netherlands,6.7934
-1989-12-31,NO,Norway,
 1989-12-31,NZ,New Zealand,7.3094
-1989-12-31,PE,Peru,
-1989-12-31,PH,Philippines,
-1989-12-31,PL,Poland,
-1989-12-31,PT,Portugal,
-1989-12-31,RO,Romania,
-1989-12-31,RS,Serbia,
-1989-12-31,RU,Russia,
+1989-12-31,PT,Portugal,17.1625
 1989-12-31,SE,Sweden,16.0494
-1989-12-31,SG,Singapore,
-1989-12-31,SI,Slovenia,
-1989-12-31,SK,Slovak Republic,
-1989-12-31,TH,Thailand,
-1989-12-31,TR,Türkiye,
-1989-12-31,US,United States,6.3856
-1989-12-31,XM,Euro area,12.0336
-1989-12-31,XW,World,
+1989-12-31,US,United States,6.4094
+1989-12-31,XM,Euro area,12.0457
 1989-12-31,ZA,South Africa,14.2439
-1990-03-31,4T,Emerging market economies (aggregate),
-1990-03-31,5R,Advanced economies,
-1990-03-31,AE,United Arab Emirates,
-1990-03-31,AT,Austria,
+1990-03-31,AT,Austria,19.1336
 1990-03-31,AU,Australia,2.7759
 1990-03-31,BE,Belgium,14.29
-1990-03-31,BG,Bulgaria,
-1990-03-31,BR,Brazil,
 1990-03-31,CA,Canada,-2.884
-1990-03-31,CH,Switzerland,7.9692
-1990-03-31,CL,Chile,
-1990-03-31,CN,China,
-1990-03-31,CO,Colombia,29.4455
-1990-03-31,CY,Cyprus,
-1990-03-31,CZ,Czechia,
-1990-03-31,DE,Germany,6.6971
+1990-03-31,CH,Switzerland,7.9674
+1990-03-31,CO,Colombia,29.2877
+1990-03-31,DE,Germany,6.7162
 1990-03-31,DK,Denmark,-7.5934
-1990-03-31,EE,Estonia,
 1990-03-31,ES,Spain,20.5507
 1990-03-31,FI,Finland,-3.6639
 1990-03-31,FR,France,10.0069
 1990-03-31,GB,United Kingdom,2.8571
-1990-03-31,GR,Greece,
 1990-03-31,HK,Hong Kong SAR,8.6293
-1990-03-31,HR,Croatia,
-1990-03-31,HU,Hungary,
-1990-03-31,ID,Indonesia,
 1990-03-31,IE,Ireland,14.9931
-1990-03-31,IL,Israel,
-1990-03-31,IN,India,
-1990-03-31,IS,Iceland,
+1990-03-31,IS,Iceland,17.3823
 1990-03-31,IT,Italy,19
 1990-03-31,JP,Japan,12.8172
-1990-03-31,KR,Korea,15.475
-1990-03-31,LT,Lithuania,
-1990-03-31,LU,Luxembourg,
-1990-03-31,LV,Latvia,
-1990-03-31,MA,Morocco,
-1990-03-31,MK,North Macedonia,
-1990-03-31,MT,Malta,
-1990-03-31,MX,Mexico,
+1990-03-31,KR,Korea,15.4627
 1990-03-31,MY,Malaysia,1.5731
 1990-03-31,NL,Netherlands,4.7353
-1990-03-31,NO,Norway,
 1990-03-31,NZ,New Zealand,6.8933
-1990-03-31,PE,Peru,
-1990-03-31,PH,Philippines,
-1990-03-31,PL,Poland,
-1990-03-31,PT,Portugal,
-1990-03-31,RO,Romania,
-1990-03-31,RS,Serbia,
-1990-03-31,RU,Russia,
+1990-03-31,PT,Portugal,16.262
 1990-03-31,SE,Sweden,15.6977
-1990-03-31,SG,Singapore,
-1990-03-31,SI,Slovenia,
-1990-03-31,SK,Slovak Republic,
-1990-03-31,TH,Thailand,
-1990-03-31,TR,Türkiye,
-1990-03-31,US,United States,5.5966
-1990-03-31,XM,Euro area,12.2457
-1990-03-31,XW,World,
+1990-03-31,US,United States,5.6453
+1990-03-31,XM,Euro area,12.2754
 1990-03-31,ZA,South Africa,15.5156
-1990-06-30,4T,Emerging market economies (aggregate),
-1990-06-30,5R,Advanced economies,
-1990-06-30,AE,United Arab Emirates,
-1990-06-30,AT,Austria,
+1990-06-30,AT,Austria,28.3247
 1990-06-30,AU,Australia,1.713
 1990-06-30,BE,Belgium,11.0947
-1990-06-30,BG,Bulgaria,
-1990-06-30,BR,Brazil,
 1990-06-30,CA,Canada,-0.8323
-1990-06-30,CH,Switzerland,10.5549
-1990-06-30,CL,Chile,
-1990-06-30,CN,China,
-1990-06-30,CO,Colombia,21.2853
-1990-06-30,CY,Cyprus,
-1990-06-30,CZ,Czechia,
-1990-06-30,DE,Germany,8.6279
+1990-06-30,CH,Switzerland,10.7157
+1990-06-30,CO,Colombia,21.2403
+1990-06-30,DE,Germany,8.6199
 1990-06-30,DK,Denmark,-7.3937
-1990-06-30,EE,Estonia,
 1990-06-30,ES,Spain,16.5794
 1990-06-30,FI,Finland,-5.2971
 1990-06-30,FR,France,9.2318
 1990-06-30,GB,United Kingdom,-1.5517
-1990-06-30,GR,Greece,
 1990-06-30,HK,Hong Kong SAR,7.1079
-1990-06-30,HR,Croatia,
-1990-06-30,HU,Hungary,
-1990-06-30,ID,Indonesia,
 1990-06-30,IE,Ireland,15.6348
-1990-06-30,IL,Israel,
-1990-06-30,IN,India,
-1990-06-30,IS,Iceland,
+1990-06-30,IS,Iceland,12.4663
 1990-06-30,IT,Italy,17.972
 1990-06-30,JP,Japan,14.0385
-1990-06-30,KR,Korea,14.8955
-1990-06-30,LT,Lithuania,
-1990-06-30,LU,Luxembourg,
-1990-06-30,LV,Latvia,
-1990-06-30,MA,Morocco,
-1990-06-30,MK,North Macedonia,
-1990-06-30,MT,Malta,
-1990-06-30,MX,Mexico,
+1990-06-30,KR,Korea,14.9096
 1990-06-30,MY,Malaysia,1.1699
 1990-06-30,NL,Netherlands,4.4751
-1990-06-30,NO,Norway,
 1990-06-30,NZ,New Zealand,7.0167
-1990-06-30,PE,Peru,
-1990-06-30,PH,Philippines,
-1990-06-30,PL,Poland,
-1990-06-30,PT,Portugal,
-1990-06-30,RO,Romania,
-1990-06-30,RS,Serbia,
-1990-06-30,RU,Russia,
+1990-06-30,PT,Portugal,16.7622
 1990-06-30,SE,Sweden,12.7778
-1990-06-30,SG,Singapore,
-1990-06-30,SI,Slovenia,
-1990-06-30,SK,Slovak Republic,
-1990-06-30,TH,Thailand,
-1990-06-30,TR,Türkiye,
-1990-06-30,US,United States,4.1331
-1990-06-30,XM,Euro area,12.5497
-1990-06-30,XW,World,
+1990-06-30,US,United States,4.1931
+1990-06-30,XM,Euro area,12.563
 1990-06-30,ZA,South Africa,15.4611
-1990-09-30,4T,Emerging market economies (aggregate),
-1990-09-30,5R,Advanced economies,
-1990-09-30,AE,United Arab Emirates,
-1990-09-30,AT,Austria,
+1990-09-30,AT,Austria,28.5047
 1990-09-30,AU,Australia,0.8054
 1990-09-30,BE,Belgium,10.0837
-1990-09-30,BG,Bulgaria,
-1990-09-30,BR,Brazil,
 1990-09-30,CA,Canada,-2.5977
-1990-09-30,CH,Switzerland,8.6606
-1990-09-30,CL,Chile,
-1990-09-30,CN,China,
-1990-09-30,CO,Colombia,28.3904
-1990-09-30,CY,Cyprus,
-1990-09-30,CZ,Czechia,
-1990-09-30,DE,Germany,8.5461
+1990-09-30,CH,Switzerland,8.766
+1990-09-30,CO,Colombia,28.2823
+1990-09-30,DE,Germany,8.5507
 1990-09-30,DK,Denmark,-7.9268
-1990-09-30,EE,Estonia,
 1990-09-30,ES,Spain,13.5317
 1990-09-30,FI,Finland,-6.0125
 1990-09-30,FR,France,8.4703
 1990-09-30,GB,United Kingdom,-3.1667
-1990-09-30,GR,Greece,
 1990-09-30,HK,Hong Kong SAR,15.5613
-1990-09-30,HR,Croatia,
-1990-09-30,HU,Hungary,
-1990-09-30,ID,Indonesia,
 1990-09-30,IE,Ireland,13.9942
-1990-09-30,IL,Israel,
-1990-09-30,IN,India,
-1990-09-30,IS,Iceland,
+1990-09-30,IS,Iceland,13.3679
 1990-09-30,IT,Italy,16.0115
 1990-09-30,JP,Japan,15.2174
-1990-09-30,KR,Korea,17.1196
-1990-09-30,LT,Lithuania,
-1990-09-30,LU,Luxembourg,
-1990-09-30,LV,Latvia,
-1990-09-30,MA,Morocco,
-1990-09-30,MK,North Macedonia,
-1990-09-30,MT,Malta,
-1990-09-30,MX,Mexico,
+1990-09-30,KR,Korea,17.1986
 1990-09-30,MY,Malaysia,1.6943
 1990-09-30,NL,Netherlands,0
-1990-09-30,NO,Norway,
 1990-09-30,NZ,New Zealand,5.2212
-1990-09-30,PE,Peru,
-1990-09-30,PH,Philippines,
-1990-09-30,PL,Poland,
-1990-09-30,PT,Portugal,
-1990-09-30,RO,Romania,
-1990-09-30,RS,Serbia,
-1990-09-30,RU,Russia,
+1990-09-30,PT,Portugal,13.4809
 1990-09-30,SE,Sweden,10.6952
-1990-09-30,SG,Singapore,
-1990-09-30,SI,Slovenia,
-1990-09-30,SK,Slovak Republic,
-1990-09-30,TH,Thailand,
-1990-09-30,TR,Türkiye,
-1990-09-30,US,United States,2.4998
-1990-09-30,XM,Euro area,12.226
-1990-09-30,XW,World,
+1990-09-30,US,United States,2.5461
+1990-09-30,XM,Euro area,12.2386
 1990-09-30,ZA,South Africa,14.0489
-1990-12-31,4T,Emerging market economies (aggregate),
-1990-12-31,5R,Advanced economies,
-1990-12-31,AE,United Arab Emirates,
-1990-12-31,AT,Austria,
+1990-12-31,AT,Austria,27.957
 1990-12-31,AU,Australia,1.097
 1990-12-31,BE,Belgium,7.3431
-1990-12-31,BG,Bulgaria,
-1990-12-31,BR,Brazil,
 1990-12-31,CA,Canada,-7.1314
-1990-12-31,CH,Switzerland,0.9204
-1990-12-31,CL,Chile,
-1990-12-31,CN,China,
-1990-12-31,CO,Colombia,26.8002
-1990-12-31,CY,Cyprus,
-1990-12-31,CZ,Czechia,
-1990-12-31,DE,Germany,7.2973
+1990-12-31,CH,Switzerland,0.6823
+1990-12-31,CO,Colombia,26.8308
+1990-12-31,DE,Germany,7.2812
 1990-12-31,DK,Denmark,-7.1557
-1990-12-31,EE,Estonia,
 1990-12-31,ES,Spain,12.4295
 1990-12-31,FI,Finland,-6.8893
 1990-12-31,FR,France,7.6181
 1990-12-31,GB,United Kingdom,-2.7211
-1990-12-31,GR,Greece,
 1990-12-31,HK,Hong Kong SAR,14.251
-1990-12-31,HR,Croatia,
-1990-12-31,HU,Hungary,
-1990-12-31,ID,Indonesia,
 1990-12-31,IE,Ireland,4.7654
-1990-12-31,IL,Israel,
-1990-12-31,IN,India,
-1990-12-31,IS,Iceland,
+1990-12-31,IS,Iceland,11.8881
 1990-12-31,IT,Italy,16.2867
 1990-12-31,JP,Japan,12.3206
-1990-12-31,KR,Korea,20.7699
-1990-12-31,LT,Lithuania,
-1990-12-31,LU,Luxembourg,
-1990-12-31,LV,Latvia,
-1990-12-31,MA,Morocco,
-1990-12-31,MK,North Macedonia,
-1990-12-31,MT,Malta,
-1990-12-31,MX,Mexico,
+1990-12-31,KR,Korea,20.8086
 1990-12-31,MY,Malaysia,11.7119
 1990-12-31,NL,Netherlands,-1.0509
-1990-12-31,NO,Norway,
 1990-12-31,NZ,New Zealand,2.8008
-1990-12-31,PE,Peru,
-1990-12-31,PH,Philippines,
-1990-12-31,PL,Poland,
-1990-12-31,PT,Portugal,
-1990-12-31,RO,Romania,
-1990-12-31,RS,Serbia,
-1990-12-31,RU,Russia,
+1990-12-31,PT,Portugal,13.8672
 1990-12-31,SE,Sweden,8.5106
-1990-12-31,SG,Singapore,
-1990-12-31,SI,Slovenia,
-1990-12-31,SK,Slovak Republic,
-1990-12-31,TH,Thailand,
-1990-12-31,TR,Türkiye,
-1990-12-31,US,United States,0.7555
-1990-12-31,XM,Euro area,10.9438
-1990-12-31,XW,World,
+1990-12-31,US,United States,0.7868
+1990-12-31,XM,Euro area,10.9817
 1990-12-31,ZA,South Africa,13.8343
-1991-03-31,4T,Emerging market economies (aggregate),
-1991-03-31,5R,Advanced economies,
-1991-03-31,AE,United Arab Emirates,
-1991-03-31,AT,Austria,
+1991-03-31,AT,Austria,29.5455
 1991-03-31,AU,Australia,0.4952
 1991-03-31,BE,Belgium,4.4721
-1991-03-31,BG,Bulgaria,
-1991-03-31,BR,Brazil,
 1991-03-31,CA,Canada,-0.8746
-1991-03-31,CH,Switzerland,-0.7496
-1991-03-31,CL,Chile,
-1991-03-31,CN,China,
-1991-03-31,CO,Colombia,16.1914
-1991-03-31,CY,Cyprus,
-1991-03-31,CZ,Czechia,
-1991-03-31,DE,Germany,5.5341
+1991-03-31,CH,Switzerland,-1.0032
+1991-03-31,CO,Colombia,16.3051
+1991-03-31,DE,Germany,5.3934
 1991-03-31,DK,Denmark,-0.731
-1991-03-31,EE,Estonia,
 1991-03-31,ES,Spain,11.4451
 1991-03-31,FI,Finland,-11.082
 1991-03-31,FR,France,7.1458
 1991-03-31,GB,United Kingdom,-2.0833
-1991-03-31,GR,Greece,
 1991-03-31,HK,Hong Kong SAR,15.8877
-1991-03-31,HR,Croatia,
-1991-03-31,HU,Hungary,
-1991-03-31,ID,Indonesia,
+1991-03-31,HU,Hungary,14.5965
 1991-03-31,IE,Ireland,2.5051
-1991-03-31,IL,Israel,
-1991-03-31,IN,India,
-1991-03-31,IS,Iceland,
+1991-03-31,IS,Iceland,10.465
 1991-03-31,IT,Italy,17.6167
 1991-03-31,JP,Japan,9.6309
-1991-03-31,KR,Korea,17.4724
-1991-03-31,LT,Lithuania,
-1991-03-31,LU,Luxembourg,
-1991-03-31,LV,Latvia,
-1991-03-31,MA,Morocco,
-1991-03-31,MK,North Macedonia,
-1991-03-31,MT,Malta,
-1991-03-31,MX,Mexico,
+1991-03-31,KR,Korea,17.5044
 1991-03-31,MY,Malaysia,19.3622
 1991-03-31,NL,Netherlands,0.3931
-1991-03-31,NO,Norway,
 1991-03-31,NZ,New Zealand,-1.1406
-1991-03-31,PE,Peru,
-1991-03-31,PH,Philippines,
-1991-03-31,PL,Poland,
-1991-03-31,PT,Portugal,
-1991-03-31,RO,Romania,
-1991-03-31,RS,Serbia,
-1991-03-31,RU,Russia,
+1991-03-31,PT,Portugal,18.3544
 1991-03-31,SE,Sweden,9.5477
-1991-03-31,SG,Singapore,
-1991-03-31,SI,Slovenia,
-1991-03-31,SK,Slovak Republic,
-1991-03-31,TH,Thailand,
-1991-03-31,TR,Türkiye,
-1991-03-31,US,United States,-1.3678
-1991-03-31,XM,Euro area,9.3816
-1991-03-31,XW,World,
+1991-03-31,US,United States,-1.3254
+1991-03-31,XM,Euro area,9.4212
 1991-03-31,ZA,South Africa,12.6126
-1991-06-30,4T,Emerging market economies (aggregate),
-1991-06-30,5R,Advanced economies,
-1991-06-30,AE,United Arab Emirates,
-1991-06-30,AT,Austria,
+1991-06-30,AT,Austria,22.2073
 1991-06-30,AU,Australia,0.7919
 1991-06-30,BE,Belgium,3.1565
-1991-06-30,BG,Bulgaria,
-1991-06-30,BR,Brazil,
 1991-06-30,CA,Canada,10.0054
-1991-06-30,CH,Switzerland,-0.1254
-1991-06-30,CL,Chile,
-1991-06-30,CN,China,
-1991-06-30,CO,Colombia,27.7151
-1991-06-30,CY,Cyprus,
-1991-06-30,CZ,Czechia,
-1991-06-30,DE,Germany,4.7403
+1991-06-30,CH,Switzerland,-0.2743
+1991-06-30,CO,Colombia,27.5534
+1991-06-30,DE,Germany,4.7676
 1991-06-30,DK,Denmark,0.1057
-1991-06-30,EE,Estonia,
 1991-06-30,ES,Spain,13.9615
 1991-06-30,FI,Finland,-12.5867
 1991-06-30,FR,France,6.2525
 1991-06-30,GB,United Kingdom,-1.5762
-1991-06-30,GR,Greece,
 1991-06-30,HK,Hong Kong SAR,28.1463
-1991-06-30,HR,Croatia,
-1991-06-30,HU,Hungary,
-1991-06-30,ID,Indonesia,
+1991-06-30,HU,Hungary,15.5223
 1991-06-30,IE,Ireland,0.4194
-1991-06-30,IL,Israel,
-1991-06-30,IN,India,
-1991-06-30,IS,Iceland,
+1991-06-30,IS,Iceland,12.1264
 1991-06-30,IT,Italy,17.1814
 1991-06-30,JP,Japan,5.816
-1991-06-30,KR,Korea,13.4387
-1991-06-30,LT,Lithuania,
-1991-06-30,LU,Luxembourg,
-1991-06-30,LV,Latvia,
-1991-06-30,MA,Morocco,
-1991-06-30,MK,North Macedonia,
-1991-06-30,MT,Malta,
-1991-06-30,MX,Mexico,
+1991-06-30,KR,Korea,13.4011
 1991-06-30,MY,Malaysia,28.9426
 1991-06-30,NL,Netherlands,-0.0544
-1991-06-30,NO,Norway,
 1991-06-30,NZ,New Zealand,-3.1698
-1991-06-30,PE,Peru,
-1991-06-30,PH,Philippines,
-1991-06-30,PL,Poland,
-1991-06-30,PT,Portugal,
-1991-06-30,RO,Romania,
-1991-06-30,RS,Serbia,
-1991-06-30,RU,Russia,
+1991-06-30,PT,Portugal,20.2454
 1991-06-30,SE,Sweden,6.8966
-1991-06-30,SG,Singapore,
-1991-06-30,SI,Slovenia,
-1991-06-30,SK,Slovak Republic,
-1991-06-30,TH,Thailand,
-1991-06-30,TR,Türkiye,
-1991-06-30,US,United States,-0.7509
-1991-06-30,XM,Euro area,8.6726
-1991-06-30,XW,World,
+1991-06-30,US,United States,-0.7462
+1991-06-30,XM,Euro area,8.7242
 1991-06-30,ZA,South Africa,12.2161
-1991-09-30,4T,Emerging market economies (aggregate),
-1991-09-30,5R,Advanced economies,
-1991-09-30,AE,United Arab Emirates,
-1991-09-30,AT,Austria,
+1991-09-30,AT,Austria,15.1515
 1991-09-30,AU,Australia,4.7941
 1991-09-30,BE,Belgium,4.5864
-1991-09-30,BG,Bulgaria,
-1991-09-30,BR,Brazil,
 1991-09-30,CA,Canada,3.2632
-1991-09-30,CH,Switzerland,4.8823
-1991-09-30,CL,Chile,
-1991-09-30,CN,China,
-1991-09-30,CO,Colombia,17.7269
-1991-09-30,CY,Cyprus,
-1991-09-30,CZ,Czechia,
-1991-09-30,DE,Germany,4.2638
+1991-09-30,CH,Switzerland,5.0652
+1991-09-30,CO,Colombia,17.7302
+1991-09-30,DE,Germany,4.2997
 1991-09-30,DK,Denmark,2.2396
-1991-09-30,EE,Estonia,
 1991-09-30,ES,Spain,14.3768
 1991-09-30,FI,Finland,-15.1948
 1991-09-30,FR,France,4.74
 1991-09-30,GB,United Kingdom,-1.3769
-1991-09-30,GR,Greece,
 1991-09-30,HK,Hong Kong SAR,44.5916
-1991-09-30,HR,Croatia,
-1991-09-30,HU,Hungary,
-1991-09-30,ID,Indonesia,
+1991-09-30,HU,Hungary,9.203
 1991-09-30,IE,Ireland,-0.1155
-1991-09-30,IL,Israel,
-1991-09-30,IN,India,
-1991-09-30,IS,Iceland,
+1991-09-30,IS,Iceland,11.9214
 1991-09-30,IT,Italy,15.4565
 1991-09-30,JP,Japan,2.2102
-1991-09-30,KR,Korea,9.5901
-1991-09-30,LT,Lithuania,
-1991-09-30,LU,Luxembourg,
-1991-09-30,LV,Latvia,
-1991-09-30,MA,Morocco,
-1991-09-30,MK,North Macedonia,
-1991-09-30,MT,Malta,
-1991-09-30,MX,Mexico,
+1991-09-30,KR,Korea,9.6123
 1991-09-30,MY,Malaysia,31.4069
 1991-09-30,NL,Netherlands,3.3203
-1991-09-30,NO,Norway,
 1991-09-30,NZ,New Zealand,-2.5352
-1991-09-30,PE,Peru,
-1991-09-30,PH,Philippines,
-1991-09-30,PL,Poland,
-1991-09-30,PT,Portugal,
-1991-09-30,RO,Romania,
-1991-09-30,RS,Serbia,
-1991-09-30,RU,Russia,
+1991-09-30,PT,Portugal,19.4444
 1991-09-30,SE,Sweden,5.314
-1991-09-30,SG,Singapore,
-1991-09-30,SI,Slovenia,
-1991-09-30,SK,Slovak Republic,
-1991-09-30,TH,Thailand,
-1991-09-30,TR,Türkiye,
-1991-09-30,US,United States,-0.8569
-1991-09-30,XM,Euro area,7.7048
-1991-09-30,XW,World,
+1991-09-30,US,United States,-0.8127
+1991-09-30,XM,Euro area,7.7566
 1991-09-30,ZA,South Africa,13.8485
-1991-12-31,4T,Emerging market economies (aggregate),
-1991-12-31,5R,Advanced economies,
-1991-12-31,AE,United Arab Emirates,
-1991-12-31,AT,Austria,
+1991-12-31,AT,Austria,17.2869
 1991-12-31,AU,Australia,4.1727
 1991-12-31,BE,Belgium,4.7516
-1991-12-31,BG,Bulgaria,
-1991-12-31,BR,Brazil,
 1991-12-31,CA,Canada,3.6782
-1991-12-31,CH,Switzerland,4.6806
-1991-12-31,CL,Chile,
-1991-12-31,CN,China,
-1991-12-31,CO,Colombia,20.754
-1991-12-31,CY,Cyprus,
-1991-12-31,CZ,Czechia,
-1991-12-31,DE,Germany,4.7909
+1991-12-31,CH,Switzerland,4.904
+1991-12-31,CO,Colombia,20.6572
+1991-12-31,DE,Germany,4.8605
 1991-12-31,DK,Denmark,3.6476
-1991-12-31,EE,Estonia,
 1991-12-31,ES,Spain,17.3353
 1991-12-31,FI,Finland,-16.8972
 1991-12-31,FR,France,2.814
 1991-12-31,GB,United Kingdom,-0.6993
-1991-12-31,GR,Greece,
 1991-12-31,HK,Hong Kong SAR,54.7571
-1991-12-31,HR,Croatia,
-1991-12-31,HU,Hungary,
-1991-12-31,ID,Indonesia,
+1991-12-31,HU,Hungary,10.8912
 1991-12-31,IE,Ireland,5.5621
-1991-12-31,IL,Israel,
-1991-12-31,IN,India,
-1991-12-31,IS,Iceland,
+1991-12-31,IS,Iceland,8.3435
 1991-12-31,IT,Italy,13.4194
 1991-12-31,JP,Japan,-0.1597
-1991-12-31,KR,Korea,1.9274
-1991-12-31,LT,Lithuania,
-1991-12-31,LU,Luxembourg,
-1991-12-31,LV,Latvia,
-1991-12-31,MA,Morocco,
-1991-12-31,MK,North Macedonia,
-1991-12-31,MT,Malta,
-1991-12-31,MX,Mexico,
+1991-12-31,KR,Korea,1.9343
 1991-12-31,MY,Malaysia,22.4483
 1991-12-31,NL,Netherlands,6.712
-1991-12-31,NO,Norway,
 1991-12-31,NZ,New Zealand,-2.4847
-1991-12-31,PE,Peru,
-1991-12-31,PH,Philippines,
-1991-12-31,PL,Poland,
-1991-12-31,PT,Portugal,
-1991-12-31,RO,Romania,
-1991-12-31,RS,Serbia,
-1991-12-31,RU,Russia,
+1991-12-31,PT,Portugal,19.4397
 1991-12-31,SE,Sweden,5.8824
-1991-12-31,SG,Singapore,
-1991-12-31,SI,Slovenia,
-1991-12-31,SK,Slovak Republic,
-1991-12-31,TH,Thailand,
-1991-12-31,TR,Türkiye,
-1991-12-31,US,United States,-0.6266
-1991-12-31,XM,Euro area,7.7823
-1991-12-31,XW,World,
+1991-12-31,US,United States,-0.6097
+1991-12-31,XM,Euro area,7.8223
 1991-12-31,ZA,South Africa,14.8537
-1992-03-31,4T,Emerging market economies (aggregate),
-1992-03-31,5R,Advanced economies,
-1992-03-31,AE,United Arab Emirates,
-1992-03-31,AT,Austria,
+1992-03-31,AT,Austria,22.4561
 1992-03-31,AU,Australia,3.5834
 1992-03-31,BE,Belgium,5.6231
-1992-03-31,BG,Bulgaria,
-1992-03-31,BR,Brazil,
 1992-03-31,CA,Canada,0.5438
-1992-03-31,CH,Switzerland,4.0326
-1992-03-31,CL,Chile,
-1992-03-31,CN,China,
-1992-03-31,CO,Colombia,23.6231
-1992-03-31,CY,Cyprus,
-1992-03-31,CZ,Czechia,
-1992-03-31,DE,Germany,5.3758
+1992-03-31,CH,Switzerland,4.2659
+1992-03-31,CO,Colombia,21.9253
+1992-03-31,DE,Germany,5.5251
 1992-03-31,DK,Denmark,0.8907
-1992-03-31,EE,Estonia,
 1992-03-31,ES,Spain,6.041
 1992-03-31,FI,Finland,-13.4587
 1992-03-31,FR,France,-0.0584
 1992-03-31,GB,United Kingdom,-0.8865
-1992-03-31,GR,Greece,
 1992-03-31,HK,Hong Kong SAR,60.4842
-1992-03-31,HR,Croatia,
-1992-03-31,HU,Hungary,
-1992-03-31,ID,Indonesia,
+1992-03-31,HU,Hungary,1.599
 1992-03-31,IE,Ireland,4.0033
-1992-03-31,IL,Israel,
-1992-03-31,IN,India,
-1992-03-31,IS,Iceland,
+1992-03-31,IS,Iceland,7.0907
 1992-03-31,IT,Italy,14.6954
 1992-03-31,JP,Japan,-2.4724
-1992-03-31,KR,Korea,-3.1047
-1992-03-31,LT,Lithuania,
-1992-03-31,LU,Luxembourg,
-1992-03-31,LV,Latvia,
-1992-03-31,MA,Morocco,
-1992-03-31,MK,North Macedonia,
-1992-03-31,MT,Malta,
-1992-03-31,MX,Mexico,
+1992-03-31,KR,Korea,-3.111
 1992-03-31,MY,Malaysia,17.0118
 1992-03-31,NL,Netherlands,9.7483
-1992-03-31,NO,Norway,
 1992-03-31,NZ,New Zealand,-1.2203
-1992-03-31,PE,Peru,
-1992-03-31,PH,Philippines,
-1992-03-31,PL,Poland,
-1992-03-31,PT,Portugal,
-1992-03-31,RO,Romania,
-1992-03-31,RS,Serbia,
-1992-03-31,RU,Russia,
+1992-03-31,PT,Portugal,16.5775
 1992-03-31,SE,Sweden,-5.5046
-1992-03-31,SG,Singapore,
-1992-03-31,SI,Slovenia,
-1992-03-31,SK,Slovak Republic,
 1992-03-31,TH,Thailand,23.4114
-1992-03-31,TR,Türkiye,
-1992-03-31,US,United States,0.351
-1992-03-31,XM,Euro area,6.3854
-1992-03-31,XW,World,
+1992-03-31,US,United States,0.3458
+1992-03-31,XM,Euro area,6.4081
 1992-03-31,ZA,South Africa,11.8545
-1992-06-30,4T,Emerging market economies (aggregate),
-1992-06-30,5R,Advanced economies,
-1992-06-30,AE,United Arab Emirates,
-1992-06-30,AT,Austria,
+1992-06-30,AT,Austria,20.9251
 1992-06-30,AU,Australia,2.6557
 1992-06-30,BE,Belgium,9.8483
-1992-06-30,BG,Bulgaria,
-1992-06-30,BR,Brazil,
 1992-06-30,CA,Canada,-2.15
-1992-06-30,CH,Switzerland,1.4997
-1992-06-30,CL,Chile,
-1992-06-30,CN,China,
-1992-06-30,CO,Colombia,17.7374
-1992-06-30,CY,Cyprus,
-1992-06-30,CZ,Czechia,
-1992-06-30,DE,Germany,5.0547
+1992-06-30,CH,Switzerland,1.6325
+1992-06-30,CO,Colombia,17.3406
+1992-06-30,DE,Germany,4.9883
 1992-06-30,DK,Denmark,-0.3636
-1992-06-30,EE,Estonia,
 1992-06-30,ES,Spain,-0.3423
 1992-06-30,FI,Finland,-16.7864
 1992-06-30,FR,France,-2.3653
 1992-06-30,GB,United Kingdom,-3.0249
-1992-06-30,GR,Greece,
 1992-06-30,HK,Hong Kong SAR,55.0002
-1992-06-30,HR,Croatia,
-1992-06-30,HU,Hungary,
-1992-06-30,ID,Indonesia,
+1992-06-30,HU,Hungary,-0.1612
 1992-06-30,IE,Ireland,5.8354
-1992-06-30,IL,Israel,
-1992-06-30,IN,India,
-1992-06-30,IS,Iceland,
+1992-06-30,IS,Iceland,2.9987
 1992-06-30,IT,Italy,15.1445
 1992-06-30,JP,Japan,-3.5561
-1992-06-30,KR,Korea,-8.223
-1992-06-30,LT,Lithuania,
-1992-06-30,LU,Luxembourg,
-1992-06-30,LV,Latvia,
-1992-06-30,MA,Morocco,
-1992-06-30,MK,North Macedonia,
-1992-06-30,MT,Malta,
-1992-06-30,MX,Mexico,
+1992-06-30,KR,Korea,-8.2057
 1992-06-30,MY,Malaysia,12.2725
 1992-06-30,NL,Netherlands,4.6803
-1992-06-30,NO,Norway,
 1992-06-30,NZ,New Zealand,1.278
-1992-06-30,PE,Peru,
-1992-06-30,PH,Philippines,
-1992-06-30,PL,Poland,
-1992-06-30,PT,Portugal,
-1992-06-30,RO,Romania,
-1992-06-30,RS,Serbia,
-1992-06-30,RU,Russia,
+1992-06-30,PT,Portugal,15.1531
 1992-06-30,SE,Sweden,-6.9124
-1992-06-30,SG,Singapore,
-1992-06-30,SI,Slovenia,
-1992-06-30,SK,Slovak Republic,
 1992-06-30,TH,Thailand,11.8526
-1992-06-30,TR,Türkiye,
-1992-06-30,US,United States,-0.5632
-1992-06-30,XM,Euro area,5.2324
-1992-06-30,XW,World,
+1992-06-30,US,United States,-0.5423
+1992-06-30,XM,Euro area,5.2307
 1992-06-30,ZA,South Africa,5.3733
-1992-09-30,4T,Emerging market economies (aggregate),
-1992-09-30,5R,Advanced economies,
-1992-09-30,AE,United Arab Emirates,
-1992-09-30,AT,Austria,
+1992-09-30,AT,Austria,11.6842
 1992-09-30,AU,Australia,-0.2899
 1992-09-30,BE,Belgium,6.2823
-1992-09-30,BG,Bulgaria,
-1992-09-30,BR,Brazil,
 1992-09-30,CA,Canada,3.937
-1992-09-30,CH,Switzerland,-5.4149
-1992-09-30,CL,Chile,
-1992-09-30,CN,China,
-1992-09-30,CO,Colombia,21.5294
-1992-09-30,CY,Cyprus,
-1992-09-30,CZ,Czechia,
-1992-09-30,DE,Germany,5.3374
+1992-09-30,CH,Switzerland,-5.6356
+1992-09-30,CO,Colombia,21.3857
+1992-09-30,DE,Germany,5.3622
 1992-09-30,DK,Denmark,-1.8608
-1992-09-30,EE,Estonia,
 1992-09-30,ES,Spain,-2.9093
 1992-09-30,FI,Finland,-18.9681
 1992-09-30,FR,France,-3.4618
 1992-09-30,GB,United Kingdom,-4.5375
-1992-09-30,GR,Greece,
 1992-09-30,HK,Hong Kong SAR,35.4199
-1992-09-30,HR,Croatia,
-1992-09-30,HU,Hungary,
-1992-09-30,ID,Indonesia,
+1992-09-30,HU,Hungary,-2.0139
 1992-09-30,IE,Ireland,3.8617
-1992-09-30,IL,Israel,
-1992-09-30,IN,India,
-1992-09-30,IS,Iceland,
+1992-09-30,IS,Iceland,3.2159
 1992-09-30,IT,Italy,15.6682
 1992-09-30,JP,Japan,-4.6414
-1992-09-30,KR,Korea,-8.5392
-1992-09-30,LT,Lithuania,
-1992-09-30,LU,Luxembourg,
-1992-09-30,LV,Latvia,
-1992-09-30,MA,Morocco,
-1992-09-30,MK,North Macedonia,
-1992-09-30,MT,Malta,
-1992-09-30,MX,Mexico,
+1992-09-30,KR,Korea,-8.594
 1992-09-30,MY,Malaysia,10.5491
 1992-09-30,NL,Netherlands,10.739
-1992-09-30,NO,Norway,
 1992-09-30,NZ,New Zealand,1.0671
-1992-09-30,PE,Peru,
-1992-09-30,PH,Philippines,
-1992-09-30,PL,Poland,
-1992-09-30,PT,Portugal,
-1992-09-30,RO,Romania,
-1992-09-30,RS,Serbia,
-1992-09-30,RU,Russia,
+1992-09-30,PT,Portugal,11.2321
 1992-09-30,SE,Sweden,-10.0917
-1992-09-30,SG,Singapore,
-1992-09-30,SI,Slovenia,
-1992-09-30,SK,Slovak Republic,
 1992-09-30,TH,Thailand,11.0784
-1992-09-30,TR,Türkiye,
-1992-09-30,US,United States,-0.367
-1992-09-30,XM,Euro area,4.2165
-1992-09-30,XW,World,
+1992-09-30,US,United States,-0.3591
+1992-09-30,XM,Euro area,4.2152
 1992-09-30,ZA,South Africa,0.7392
-1992-12-31,4T,Emerging market economies (aggregate),
-1992-12-31,5R,Advanced economies,
-1992-12-31,AE,United Arab Emirates,
-1992-12-31,AT,Austria,
+1992-12-31,AT,Austria,9.9284
 1992-12-31,AU,Australia,0.6658
 1992-12-31,BE,Belgium,5.0468
-1992-12-31,BG,Bulgaria,
-1992-12-31,BR,Brazil,
 1992-12-31,CA,Canada,4.917
-1992-12-31,CH,Switzerland,-3.0553
-1992-12-31,CL,Chile,
-1992-12-31,CN,China,
-1992-12-31,CO,Colombia,16.1946
-1992-12-31,CY,Cyprus,
-1992-12-31,CZ,Czechia,
-1992-12-31,DE,Germany,4.8568
+1992-12-31,CH,Switzerland,-3.1568
+1992-12-31,CO,Colombia,16.7267
+1992-12-31,DE,Germany,4.7566
 1992-12-31,DK,Denmark,-5.0859
-1992-12-31,EE,Estonia,
 1992-12-31,ES,Spain,-7.4211
 1992-12-31,FI,Finland,-19.0989
 1992-12-31,FR,France,-3.5609
 1992-12-31,GB,United Kingdom,-7.3944
-1992-12-31,GR,Greece,
 1992-12-31,HK,Hong Kong SAR,17.0763
-1992-12-31,HR,Croatia,
-1992-12-31,HU,Hungary,
-1992-12-31,ID,Indonesia,
+1992-12-31,HU,Hungary,-4.4224
 1992-12-31,IE,Ireland,0.4354
-1992-12-31,IL,Israel,
-1992-12-31,IN,India,
-1992-12-31,IS,Iceland,
+1992-12-31,IS,Iceland,3.2599
 1992-12-31,IT,Italy,14.1802
 1992-12-31,JP,Japan,-4.8
-1992-12-31,KR,Korea,-6.0364
-1992-12-31,LT,Lithuania,
-1992-12-31,LU,Luxembourg,
-1992-12-31,LV,Latvia,
-1992-12-31,MA,Morocco,
-1992-12-31,MK,North Macedonia,
-1992-12-31,MT,Malta,
-1992-12-31,MX,Mexico,
+1992-12-31,KR,Korea,-6.0542
 1992-12-31,MY,Malaysia,9.3043
 1992-12-31,NL,Netherlands,8.3599
-1992-12-31,NO,Norway,
 1992-12-31,NZ,New Zealand,1.7211
-1992-12-31,PE,Peru,
-1992-12-31,PH,Philippines,
-1992-12-31,PL,Poland,
-1992-12-31,PT,Portugal,
-1992-12-31,RO,Romania,
-1992-12-31,RS,Serbia,
-1992-12-31,RU,Russia,
+1992-12-31,PT,Portugal,7.3241
 1992-12-31,SE,Sweden,-15.2778
-1992-12-31,SG,Singapore,
-1992-12-31,SI,Slovenia,
-1992-12-31,SK,Slovak Republic,
 1992-12-31,TH,Thailand,8.9898
-1992-12-31,TR,Türkiye,
-1992-12-31,US,United States,0.1866
-1992-12-31,XM,Euro area,2.9228
-1992-12-31,XW,World,
+1992-12-31,US,United States,0.1934
+1992-12-31,XM,Euro area,2.9181
 1992-12-31,ZA,South Africa,0.3266
-1993-03-31,4T,Emerging market economies (aggregate),
-1993-03-31,5R,Advanced economies,
-1993-03-31,AE,United Arab Emirates,
-1993-03-31,AT,Austria,
+1993-03-31,AT,Austria,-0.382
 1993-03-31,AU,Australia,2.3027
 1993-03-31,BE,Belgium,4.1607
-1993-03-31,BG,Bulgaria,
-1993-03-31,BR,Brazil,
 1993-03-31,CA,Canada,4.0918
-1993-03-31,CH,Switzerland,-2.7997
-1993-03-31,CL,Chile,
-1993-03-31,CN,China,
-1993-03-31,CO,Colombia,18.4672
-1993-03-31,CY,Cyprus,
-1993-03-31,CZ,Czechia,
-1993-03-31,DE,Germany,4.6269
+1993-03-31,CH,Switzerland,-2.8915
+1993-03-31,CO,Colombia,20.1605
+1993-03-31,DE,Germany,4.6716
 1993-03-31,DK,Denmark,-5.6975
-1993-03-31,EE,Estonia,
 1993-03-31,ES,Spain,-3.8454
 1993-03-31,FI,Finland,-17.9634
 1993-03-31,FR,France,-2.3965
 1993-03-31,GB,United Kingdom,-5.3667
-1993-03-31,GR,Greece,
 1993-03-31,HK,Hong Kong SAR,6.9094
-1993-03-31,HR,Croatia,
-1993-03-31,HU,Hungary,
-1993-03-31,ID,Indonesia,
+1993-03-31,HU,Hungary,6.5936
 1993-03-31,IE,Ireland,-2.4505
-1993-03-31,IL,Israel,
-1993-03-31,IN,India,
-1993-03-31,IS,Iceland,
+1993-03-31,IS,Iceland,0.9115
 1993-03-31,IT,Italy,8.4729
 1993-03-31,JP,Japan,-4.9622
-1993-03-31,KR,Korea,-4.2474
-1993-03-31,LT,Lithuania,
-1993-03-31,LU,Luxembourg,
-1993-03-31,LV,Latvia,
-1993-03-31,MA,Morocco,
-1993-03-31,MK,North Macedonia,
-1993-03-31,MT,Malta,
-1993-03-31,MX,Mexico,
+1993-03-31,KR,Korea,-4.2606
 1993-03-31,MY,Malaysia,7.0325
 1993-03-31,NL,Netherlands,5.9003
 1993-03-31,NO,Norway,-5.3191
 1993-03-31,NZ,New Zealand,3.3019
-1993-03-31,PE,Peru,
-1993-03-31,PH,Philippines,
-1993-03-31,PL,Poland,
-1993-03-31,PT,Portugal,
-1993-03-31,RO,Romania,
-1993-03-31,RS,Serbia,
-1993-03-31,RU,Russia,
+1993-03-31,PT,Portugal,3.0275
 1993-03-31,SE,Sweden,-15.0485
-1993-03-31,SG,Singapore,
-1993-03-31,SI,Slovenia,
-1993-03-31,SK,Slovak Republic,
 1993-03-31,TH,Thailand,8.0397
-1993-03-31,TR,Türkiye,
-1993-03-31,US,United States,0.25
-1993-03-31,XM,Euro area,2.0649
-1993-03-31,XW,World,
+1993-03-31,US,United States,0.2741
+1993-03-31,XM,Euro area,2.0701
 1993-03-31,ZA,South Africa,1.4954
-1993-06-30,4T,Emerging market economies (aggregate),
-1993-06-30,5R,Advanced economies,
-1993-06-30,AE,United Arab Emirates,
-1993-06-30,AT,Austria,
+1993-06-30,AT,Austria,-1.184
 1993-06-30,AU,Australia,2.6733
 1993-06-30,BE,Belgium,4.5529
-1993-06-30,BG,Bulgaria,
-1993-06-30,BR,Brazil,
 1993-06-30,CA,Canada,3.2908
-1993-06-30,CH,Switzerland,-0.1332
-1993-06-30,CL,Chile,
-1993-06-30,CN,China,
-1993-06-30,CO,Colombia,20.4378
-1993-06-30,CY,Cyprus,
-1993-06-30,CZ,Czechia,
-1993-06-30,DE,Germany,4.2239
+1993-06-30,CH,Switzerland,-0.0843
+1993-06-30,CO,Colombia,20.9823
+1993-06-30,DE,Germany,4.1873
 1993-06-30,DK,Denmark,-6.3331
-1993-06-30,EE,Estonia,
 1993-06-30,ES,Spain,-0.1353
 1993-06-30,FI,Finland,-12.8429
 1993-06-30,FR,France,-1.6411
 1993-06-30,GB,United Kingdom,-2.2018
-1993-06-30,GR,Greece,
 1993-06-30,HK,Hong Kong SAR,4.877
-1993-06-30,HR,Croatia,
-1993-06-30,HU,Hungary,
-1993-06-30,ID,Indonesia,
+1993-06-30,HU,Hungary,9.5725
 1993-06-30,IE,Ireland,1.7411
-1993-06-30,IL,Israel,
-1993-06-30,IN,India,
-1993-06-30,IS,Iceland,
+1993-06-30,IS,Iceland,1.8084
 1993-06-30,IT,Italy,5.0613
 1993-06-30,JP,Japan,-4.5831
-1993-06-30,KR,Korea,-3.265
-1993-06-30,LT,Lithuania,
-1993-06-30,LU,Luxembourg,
-1993-06-30,LV,Latvia,
-1993-06-30,MA,Morocco,
-1993-06-30,MK,North Macedonia,
-1993-06-30,MT,Malta,
-1993-06-30,MX,Mexico,
+1993-06-30,KR,Korea,-3.2106
 1993-06-30,MY,Malaysia,4.2882
 1993-06-30,NL,Netherlands,10.7226
 1993-06-30,NO,Norway,-1.0582
 1993-06-30,NZ,New Zealand,2.7673
-1993-06-30,PE,Peru,
-1993-06-30,PH,Philippines,
-1993-06-30,PL,Poland,
-1993-06-30,PT,Portugal,
-1993-06-30,RO,Romania,
-1993-06-30,RS,Serbia,
-1993-06-30,RU,Russia,
+1993-06-30,PT,Portugal,0.4874
 1993-06-30,SE,Sweden,-13.3663
-1993-06-30,SG,Singapore,
-1993-06-30,SI,Slovenia,
-1993-06-30,SK,Slovak Republic,
 1993-06-30,TH,Thailand,12.1995
-1993-06-30,TR,Türkiye,
-1993-06-30,US,United States,0.9328
-1993-06-30,XM,Euro area,2.17
-1993-06-30,XW,World,
+1993-06-30,US,United States,0.9612
+1993-06-30,XM,Euro area,2.1677
 1993-06-30,ZA,South Africa,4.2384
-1993-09-30,4T,Emerging market economies (aggregate),
-1993-09-30,5R,Advanced economies,
-1993-09-30,AE,United Arab Emirates,
-1993-09-30,AT,Austria,
+1993-09-30,AT,Austria,1.131
 1993-09-30,AU,Australia,2.6817
 1993-09-30,BE,Belgium,4.5665
-1993-09-30,BG,Bulgaria,
-1993-09-30,BR,Brazil,
 1993-09-30,CA,Canada,0.7677
-1993-09-30,CH,Switzerland,-0.2081
-1993-09-30,CL,Chile,
-1993-09-30,CN,China,
-1993-09-30,CO,Colombia,25.6256
-1993-09-30,CY,Cyprus,
-1993-09-30,CZ,Czechia,
-1993-09-30,DE,Germany,3.9532
+1993-09-30,CH,Switzerland,-0.1686
+1993-09-30,CO,Colombia,25.6014
+1993-09-30,DE,Germany,3.89
 1993-09-30,DK,Denmark,0
-1993-09-30,EE,Estonia,
 1993-09-30,ES,Spain,0.9292
 1993-09-30,FI,Finland,-5.5448
 1993-09-30,FR,France,-1.0246
 1993-09-30,GB,United Kingdom,-0.5484
-1993-09-30,GR,Greece,
 1993-09-30,HK,Hong Kong SAR,10.372
-1993-09-30,HR,Croatia,
-1993-09-30,HU,Hungary,
-1993-09-30,ID,Indonesia,
+1993-09-30,HU,Hungary,6.0113
 1993-09-30,IE,Ireland,2.4268
-1993-09-30,IL,Israel,
-1993-09-30,IN,India,
-1993-09-30,IS,Iceland,
+1993-09-30,IS,Iceland,-2.9097
 1993-09-30,IT,Italy,4.0481
 1993-09-30,JP,Japan,-4.2035
-1993-09-30,KR,Korea,-3.0093
-1993-09-30,LT,Lithuania,
-1993-09-30,LU,Luxembourg,
-1993-09-30,LV,Latvia,
-1993-09-30,MA,Morocco,
-1993-09-30,MK,North Macedonia,
-1993-09-30,MT,Malta,
-1993-09-30,MX,Mexico,
+1993-09-30,KR,Korea,-2.9741
 1993-09-30,MY,Malaysia,3.8207
 1993-09-30,NL,Netherlands,7.163
 1993-09-30,NO,Norway,2.1053
 1993-09-30,NZ,New Zealand,4.0695
-1993-09-30,PE,Peru,
-1993-09-30,PH,Philippines,
-1993-09-30,PL,Poland,
-1993-09-30,PT,Portugal,
-1993-09-30,RO,Romania,
-1993-09-30,RS,Serbia,
-1993-09-30,RU,Russia,
+1993-09-30,PT,Portugal,0.6228
 1993-09-30,SE,Sweden,-11.2245
-1993-09-30,SG,Singapore,
-1993-09-30,SI,Slovenia,
-1993-09-30,SK,Slovak Republic,
 1993-09-30,TH,Thailand,11.5622
-1993-09-30,TR,Türkiye,
-1993-09-30,US,United States,1.7977
-1993-09-30,XM,Euro area,2.301
-1993-09-30,XW,World,
+1993-09-30,US,United States,1.8034
+1993-09-30,XM,Euro area,2.2983
 1993-09-30,ZA,South Africa,7.3382
-1993-12-31,4T,Emerging market economies (aggregate),
-1993-12-31,5R,Advanced economies,
-1993-12-31,AE,United Arab Emirates,
-1993-12-31,AT,Austria,
+1993-12-31,AT,Austria,1.9553
 1993-12-31,AU,Australia,2.6563
 1993-12-31,BE,Belgium,7.9185
-1993-12-31,BG,Bulgaria,
-1993-12-31,BR,Brazil,
 1993-12-31,CA,Canada,-0.1483
-1993-12-31,CH,Switzerland,-0.6763
-1993-12-31,CL,Chile,
-1993-12-31,CN,China,
-1993-12-31,CO,Colombia,30.4446
-1993-12-31,CY,Cyprus,
-1993-12-31,CZ,Czechia,
-1993-12-31,DE,Germany,4.2742
+1993-12-31,CH,Switzerland,-0.6716
+1993-12-31,CO,Colombia,29.2671
+1993-12-31,DE,Germany,4.3308
 1993-12-31,DK,Denmark,8.6105
-1993-12-31,EE,Estonia,
 1993-12-31,ES,Spain,1.5738
 1993-12-31,FI,Finland,3.2658
 1993-12-31,FR,France,-0.6776
 1993-12-31,GB,United Kingdom,1.5209
-1993-12-31,GR,Greece,
 1993-12-31,HK,Hong Kong SAR,14.3914
-1993-12-31,HR,Croatia,
-1993-12-31,HU,Hungary,
-1993-12-31,ID,Indonesia,
+1993-12-31,HU,Hungary,15.8755
 1993-12-31,IE,Ireland,0.5557
-1993-12-31,IL,Israel,
-1993-12-31,IN,India,
-1993-12-31,IS,Iceland,
+1993-12-31,IS,Iceland,-2.2382
 1993-12-31,IT,Italy,1.8114
 1993-12-31,JP,Japan,-3.5854
-1993-12-31,KR,Korea,-3.2508
-1993-12-31,LT,Lithuania,
-1993-12-31,LU,Luxembourg,
-1993-12-31,LV,Latvia,
-1993-12-31,MA,Morocco,
-1993-12-31,MK,North Macedonia,
-1993-12-31,MT,Malta,
-1993-12-31,MX,Mexico,
+1993-12-31,KR,Korea,-3.3023
 1993-12-31,MY,Malaysia,4.2936
 1993-12-31,NL,Netherlands,9.2212
 1993-12-31,NO,Norway,8.1081
 1993-12-31,NZ,New Zealand,6.3063
-1993-12-31,PE,Peru,
-1993-12-31,PH,Philippines,
-1993-12-31,PL,Poland,
-1993-12-31,PT,Portugal,
-1993-12-31,RO,Romania,
-1993-12-31,RS,Serbia,
-1993-12-31,RU,Russia,
+1993-12-31,PT,Portugal,0.9813
 1993-12-31,SE,Sweden,-3.8251
-1993-12-31,SG,Singapore,
-1993-12-31,SI,Slovenia,
-1993-12-31,SK,Slovak Republic,
 1993-12-31,TH,Thailand,7.9082
-1993-12-31,TR,Türkiye,
-1993-12-31,US,United States,2.4177
-1993-12-31,XM,Euro area,2.3004
-1993-12-31,XW,World,
+1993-12-31,US,United States,2.4423
+1993-12-31,XM,Euro area,2.3002
 1993-12-31,ZA,South Africa,6.901
-1994-03-31,4T,Emerging market economies (aggregate),
-1994-03-31,5R,Advanced economies,
-1994-03-31,AE,United Arab Emirates,
-1994-03-31,AT,Austria,
+1994-03-31,AT,Austria,5.3691
 1994-03-31,AU,Australia,2.8109
 1994-03-31,BE,Belgium,7.4709
-1994-03-31,BG,Bulgaria,
-1994-03-31,BR,Brazil,
 1994-03-31,CA,Canada,3.4506
-1994-03-31,CH,Switzerland,1.1754
-1994-03-31,CL,Chile,
-1994-03-31,CN,China,
-1994-03-31,CO,Colombia,33.5448
-1994-03-31,CY,Cyprus,
-1994-03-31,CZ,Czechia,
-1994-03-31,DE,Germany,4.0307
+1994-03-31,CH,Switzerland,1.2738
+1994-03-31,CO,Colombia,33.881
+1994-03-31,DE,Germany,3.9361
 1994-03-31,DK,Denmark,16.4399
-1994-03-31,EE,Estonia,
 1994-03-31,ES,Spain,1.4812
 1994-03-31,FI,Finland,7.3439
 1994-03-31,FR,France,-0.5689
 1994-03-31,GB,United Kingdom,2.0794
-1994-03-31,GR,Greece,
 1994-03-31,HK,Hong Kong SAR,32.6675
-1994-03-31,HR,Croatia,
-1994-03-31,HU,Hungary,
-1994-03-31,ID,Indonesia,
+1994-03-31,HU,Hungary,14.4244
 1994-03-31,IE,Ireland,7.41
-1994-03-31,IL,Israel,
-1994-03-31,IN,India,
-1994-03-31,IS,Iceland,
+1994-03-31,IS,Iceland,-0.3751
 1994-03-31,IT,Italy,-0.0294
 1994-03-31,JP,Japan,-2.9512
-1994-03-31,KR,Korea,-2.8794
-1994-03-31,LT,Lithuania,
-1994-03-31,LU,Luxembourg,
-1994-03-31,LV,Latvia,
-1994-03-31,MA,Morocco,
-1994-03-31,MK,North Macedonia,
-1994-03-31,MT,Malta,
-1994-03-31,MX,Mexico,
+1994-03-31,KR,Korea,-2.9023
 1994-03-31,MY,Malaysia,6.3307
 1994-03-31,NL,Netherlands,11.3598
 1994-03-31,NO,Norway,15.7303
 1994-03-31,NZ,New Zealand,11.1329
-1994-03-31,PE,Peru,
-1994-03-31,PH,Philippines,
-1994-03-31,PL,Poland,
-1994-03-31,PT,Portugal,
-1994-03-31,RO,Romania,
-1994-03-31,RS,Serbia,
-1994-03-31,RU,Russia,
+1994-03-31,PT,Portugal,1.959
 1994-03-31,SE,Sweden,2.2857
-1994-03-31,SG,Singapore,
-1994-03-31,SI,Slovenia,
-1994-03-31,SK,Slovak Republic,
 1994-03-31,TH,Thailand,0.5853
-1994-03-31,TR,Türkiye,
-1994-03-31,US,United States,2.4425
-1994-03-31,XM,Euro area,2.375
-1994-03-31,XW,World,
+1994-03-31,US,United States,2.4442
+1994-03-31,XM,Euro area,2.3514
 1994-03-31,ZA,South Africa,8.0077
-1994-06-30,4T,Emerging market economies (aggregate),
-1994-06-30,5R,Advanced economies,
-1994-06-30,AE,United Arab Emirates,
-1994-06-30,AT,Austria,
+1994-06-30,AT,Austria,-0.553
 1994-06-30,AU,Australia,3.3596
 1994-06-30,BE,Belgium,6.1234
-1994-06-30,BG,Bulgaria,
-1994-06-30,BR,Brazil,
 1994-06-30,CA,Canada,2.588
-1994-06-30,CH,Switzerland,-2.166
-1994-06-30,CL,Chile,
-1994-06-30,CN,China,
-1994-06-30,CO,Colombia,30.5844
-1994-06-30,CY,Cyprus,
-1994-06-30,CZ,Czechia,
-1994-06-30,DE,Germany,4.2182
+1994-06-30,CH,Switzerland,-2.2585
+1994-06-30,CO,Colombia,30.4177
+1994-06-30,DE,Germany,4.1922
 1994-06-30,DK,Denmark,17.2301
-1994-06-30,EE,Estonia,
 1994-06-30,ES,Spain,0.3023
 1994-06-30,FI,Finland,8.3892
 1994-06-30,FR,France,-0.0894
 1994-06-30,GB,United Kingdom,2.6266
-1994-06-30,GR,Greece,
 1994-06-30,HK,Hong Kong SAR,28.268
-1994-06-30,HR,Croatia,
-1994-06-30,HU,Hungary,
-1994-06-30,ID,Indonesia,
+1994-06-30,HU,Hungary,18.4783
 1994-06-30,IE,Ireland,3.0348
-1994-06-30,IL,Israel,
-1994-06-30,IN,India,
-1994-06-30,IS,Iceland,
+1994-06-30,IS,Iceland,-0.7463
 1994-06-30,IT,Italy,-1.7019
 1994-06-30,JP,Japan,-2.521
-1994-06-30,KR,Korea,-2.1978
-1994-06-30,LT,Lithuania,
-1994-06-30,LU,Luxembourg,
-1994-06-30,LV,Latvia,
-1994-06-30,MA,Morocco,
-1994-06-30,MK,North Macedonia,
-1994-06-30,MT,Malta,
-1994-06-30,MX,Mexico,
+1994-06-30,KR,Korea,-2.2439
 1994-06-30,MY,Malaysia,5.0594
 1994-06-30,NL,Netherlands,10.0599
 1994-06-30,NO,Norway,13.369
 1994-06-30,NZ,New Zealand,13.7872
-1994-06-30,PE,Peru,
-1994-06-30,PH,Philippines,
-1994-06-30,PL,Poland,
-1994-06-30,PT,Portugal,
-1994-06-30,RO,Romania,
-1994-06-30,RS,Serbia,
-1994-06-30,RU,Russia,
+1994-06-30,PT,Portugal,1.1464
 1994-06-30,SE,Sweden,5.1429
-1994-06-30,SG,Singapore,
-1994-06-30,SI,Slovenia,
-1994-06-30,SK,Slovak Republic,
 1994-06-30,TH,Thailand,-1.1905
-1994-06-30,TR,Türkiye,
-1994-06-30,US,United States,2.5389
-1994-06-30,XM,Euro area,1.7327
-1994-06-30,XW,World,
+1994-06-30,US,United States,2.5326
+1994-06-30,XM,Euro area,1.7183
 1994-06-30,ZA,South Africa,11.2452
-1994-09-30,4T,Emerging market economies (aggregate),
-1994-09-30,5R,Advanced economies,
-1994-09-30,AE,United Arab Emirates,
-1994-09-30,AT,Austria,
+1994-09-30,AT,Austria,0.932
 1994-09-30,AU,Australia,4.8458
 1994-09-30,BE,Belgium,7.9251
-1994-09-30,BG,Bulgaria,
-1994-09-30,BR,Brazil,
 1994-09-30,CA,Canada,3.2478
-1994-09-30,CH,Switzerland,-0.145
-1994-09-30,CL,Chile,
-1994-09-30,CN,China,
-1994-09-30,CO,Colombia,31.2633
-1994-09-30,CY,Cyprus,
-1994-09-30,CZ,Czechia,
-1994-09-30,DE,Germany,3.9082
+1994-09-30,CH,Switzerland,-0.1321
+1994-09-30,CO,Colombia,31.5112
+1994-09-30,DE,Germany,4.0049
 1994-09-30,DK,Denmark,10.3324
-1994-09-30,EE,Estonia,
 1994-09-30,ES,Spain,0.7345
 1994-09-30,FI,Finland,6.526
 1994-09-30,FR,France,-0.0098
 1994-09-30,GB,United Kingdom,2.3897
-1994-09-30,GR,Greece,
 1994-09-30,HK,Hong Kong SAR,18.4202
-1994-09-30,HR,Croatia,
-1994-09-30,HU,Hungary,
-1994-09-30,ID,Indonesia,
+1994-09-30,HU,Hungary,30.3539
 1994-09-30,IE,Ireland,-0.0326
-1994-09-30,IL,Israel,
-1994-09-30,IN,India,
-1994-09-30,IS,Iceland,
+1994-09-30,IS,Iceland,-0.1991
 1994-09-30,IT,Italy,-1.8132
 1994-09-30,JP,Japan,-2.0785
-1994-09-30,KR,Korea,-0.9547
-1994-09-30,LT,Lithuania,
-1994-09-30,LU,Luxembourg,
-1994-09-30,LV,Latvia,
-1994-09-30,MA,Morocco,
-1994-09-30,MK,North Macedonia,
-1994-09-30,MT,Malta,
-1994-09-30,MX,Mexico,
+1994-09-30,KR,Korea,-0.9888
 1994-09-30,MY,Malaysia,7.9128
 1994-09-30,NL,Netherlands,11.1974
 1994-09-30,NO,Norway,13.9175
 1994-09-30,NZ,New Zealand,15.0074
-1994-09-30,PE,Peru,
-1994-09-30,PH,Philippines,
-1994-09-30,PL,Poland,
-1994-09-30,PT,Portugal,
-1994-09-30,RO,Romania,
-1994-09-30,RS,Serbia,
-1994-09-30,RU,Russia,
+1994-09-30,PT,Portugal,2.4757
 1994-09-30,SE,Sweden,6.8966
-1994-09-30,SG,Singapore,
-1994-09-30,SI,Slovenia,
-1994-09-30,SK,Slovak Republic,
 1994-09-30,TH,Thailand,-1.7405
-1994-09-30,TR,Türkiye,
-1994-09-30,US,United States,2.2995
-1994-09-30,XM,Euro area,1.6662
-1994-09-30,XW,World,
+1994-09-30,US,United States,2.3091
+1994-09-30,XM,Euro area,1.6612
 1994-09-30,ZA,South Africa,11.9329
-1994-12-31,4T,Emerging market economies (aggregate),
-1994-12-31,5R,Advanced economies,
-1994-12-31,AE,United Arab Emirates,
-1994-12-31,AT,Austria,
+1994-12-31,AT,Austria,-3.9269
 1994-12-31,AU,Australia,3.4085
 1994-12-31,BE,Belgium,4.2266
-1994-12-31,BG,Bulgaria,
-1994-12-31,BR,Brazil,
 1994-12-31,CA,Canada,3.2082
-1994-12-31,CH,Switzerland,-0.6339
-1994-12-31,CL,Chile,
-1994-12-31,CN,China,
-1994-12-31,CO,Colombia,34.1203
-1994-12-31,CY,Cyprus,
-1994-12-31,CZ,Czechia,
-1994-12-31,DE,Germany,3.0515
+1994-12-31,CH,Switzerland,-0.647
+1994-12-31,CO,Colombia,34.5278
+1994-12-31,DE,Germany,3.0705
 1994-12-31,DK,Denmark,5.7956
-1994-12-31,EE,Estonia,
 1994-12-31,ES,Spain,0.3099
 1994-12-31,FI,Finland,1.8241
 1994-12-31,FR,France,-0.0593
 1994-12-31,GB,United Kingdom,3.5581
-1994-12-31,GR,Greece,
 1994-12-31,HK,Hong Kong SAR,16.3209
-1994-12-31,HR,Croatia,
-1994-12-31,HU,Hungary,
-1994-12-31,ID,Indonesia,
+1994-12-31,HU,Hungary,19.3541
 1994-12-31,IE,Ireland,7.5163
-1994-12-31,IL,Israel,
-1994-12-31,IN,India,
-1994-12-31,IS,Iceland,
+1994-12-31,IS,Iceland,-0.6006
 1994-12-31,IT,Italy,-1.3862
 1994-12-31,JP,Japan,-1.8013
-1994-12-31,KR,Korea,-0.32
-1994-12-31,LT,Lithuania,
-1994-12-31,LU,Luxembourg,
-1994-12-31,LV,Latvia,
-1994-12-31,MA,Morocco,
-1994-12-31,MK,North Macedonia,
-1994-12-31,MT,Malta,
-1994-12-31,MX,Mexico,
+1994-12-31,KR,Korea,-0.2984
 1994-12-31,MY,Malaysia,12.5198
 1994-12-31,NL,Netherlands,7.7027
 1994-12-31,NO,Norway,10
 1994-12-31,NZ,New Zealand,14.5721
-1994-12-31,PE,Peru,
-1994-12-31,PH,Philippines,
-1994-12-31,PL,Poland,
-1994-12-31,PT,Portugal,
-1994-12-31,RO,Romania,
-1994-12-31,RS,Serbia,
-1994-12-31,RU,Russia,
+1994-12-31,PT,Portugal,3.5336
 1994-12-31,SE,Sweden,3.9773
-1994-12-31,SG,Singapore,
-1994-12-31,SI,Slovenia,
-1994-12-31,SK,Slovak Republic,
 1994-12-31,TH,Thailand,1.4972
-1994-12-31,TR,Türkiye,
-1994-12-31,US,United States,1.8228
-1994-12-31,XM,Euro area,1.3822
-1994-12-31,XW,World,
+1994-12-31,US,United States,1.8202
+1994-12-31,XM,Euro area,1.3568
 1994-12-31,ZA,South Africa,11.5104
-1995-03-31,4T,Emerging market economies (aggregate),
-1995-03-31,5R,Advanced economies,
-1995-03-31,AE,United Arab Emirates,
-1995-03-31,AT,Austria,
+1995-03-31,AT,Austria,-2.3658
 1995-03-31,AU,Australia,3.2891
 1995-03-31,BE,Belgium,4.9807
-1995-03-31,BG,Bulgaria,
-1995-03-31,BR,Brazil,
 1995-03-31,CA,Canada,-3.8946
-1995-03-31,CH,Switzerland,-1.7822
-1995-03-31,CL,Chile,
-1995-03-31,CN,China,
-1995-03-31,CO,Colombia,28.2569
-1995-03-31,CY,Cyprus,
-1995-03-31,CZ,Czechia,
-1995-03-31,DE,Germany,2.2111
+1995-03-31,CH,Switzerland,-1.8562
+1995-03-31,CO,Colombia,27.3836
+1995-03-31,DE,Germany,2.2759
 1995-03-31,DK,Denmark,2.3049
-1995-03-31,EE,Estonia,
 1995-03-31,ES,Spain,2.867
 1995-03-31,FI,Finland,-1.3644
 1995-03-31,FR,France,-0.793
 1995-03-31,GB,United Kingdom,1.4815
-1995-03-31,GR,Greece,
 1995-03-31,HK,Hong Kong SAR,-0.8857
-1995-03-31,HR,Croatia,
-1995-03-31,HU,Hungary,
-1995-03-31,ID,Indonesia,
+1995-03-31,HU,Hungary,17.6614
 1995-03-31,IE,Ireland,6.4609
 1995-03-31,IL,Israel,17.7208
-1995-03-31,IN,India,
-1995-03-31,IS,Iceland,
+1995-03-31,IS,Iceland,-4.5098
 1995-03-31,IT,Italy,-1.2463
 1995-03-31,JP,Japan,-1.5205
-1995-03-31,KR,Korea,-0.2404
-1995-03-31,LT,Lithuania,
-1995-03-31,LU,Luxembourg,
-1995-03-31,LV,Latvia,
-1995-03-31,MA,Morocco,
-1995-03-31,MK,North Macedonia,
-1995-03-31,MT,Malta,
-1995-03-31,MX,Mexico,
+1995-03-31,KR,Korea,-0.2325
 1995-03-31,MY,Malaysia,15.2738
-1995-03-31,NL,Netherlands,5.2645
+1995-03-31,NL,Netherlands,5.328
 1995-03-31,NO,Norway,7.2816
 1995-03-31,NZ,New Zealand,10.5654
-1995-03-31,PE,Peru,
-1995-03-31,PH,Philippines,
-1995-03-31,PL,Poland,
-1995-03-31,PT,Portugal,
-1995-03-31,RO,Romania,
-1995-03-31,RS,Serbia,
-1995-03-31,RU,Russia,
+1995-03-31,PT,Portugal,2.4891
 1995-03-31,SE,Sweden,2.2346
-1995-03-31,SG,Singapore,
-1995-03-31,SI,Slovenia,
-1995-03-31,SK,Slovak Republic,
 1995-03-31,TH,Thailand,6.7332
-1995-03-31,TR,Türkiye,
-1995-03-31,US,United States,1.8559
-1995-03-31,XM,Euro area,1.3899
-1995-03-31,XW,World,
+1995-03-31,US,United States,1.8613
+1995-03-31,XM,Euro area,1.3754
 1995-03-31,ZA,South Africa,10.8541
-1995-06-30,4T,Emerging market economies (aggregate),
-1995-06-30,5R,Advanced economies,
-1995-06-30,AE,United Arab Emirates,
-1995-06-30,AT,Austria,
+1995-06-30,AT,Austria,-2.1316
 1995-06-30,AU,Australia,1.3509
 1995-06-30,BE,Belgium,4.0295
-1995-06-30,BG,Bulgaria,
-1995-06-30,BR,Brazil,
 1995-06-30,CA,Canada,-5.5518
-1995-06-30,CH,Switzerland,-0.1768
-1995-06-30,CL,Chile,
-1995-06-30,CN,China,
-1995-06-30,CO,Colombia,33.79
-1995-06-30,CY,Cyprus,
-1995-06-30,CZ,Czechia,
-1995-06-30,DE,Germany,1.2264
+1995-06-30,CH,Switzerland,-0.1624
+1995-06-30,CO,Colombia,34.0677
+1995-06-30,DE,Germany,1.2548
 1995-06-30,DK,Denmark,6.0463
-1995-06-30,EE,Estonia,
 1995-06-30,ES,Spain,3.8138
 1995-06-30,FI,Finland,-3.9699
 1995-06-30,FR,France,-1.004
 1995-06-30,GB,United Kingdom,1.2797
-1995-06-30,GR,Greece,
 1995-06-30,HK,Hong Kong SAR,-5.5096
-1995-06-30,HR,Croatia,
-1995-06-30,HU,Hungary,
-1995-06-30,ID,Indonesia,
+1995-06-30,HU,Hungary,11.124
 1995-06-30,IE,Ireland,6.3448
 1995-06-30,IL,Israel,13.6329
-1995-06-30,IN,India,
-1995-06-30,IS,Iceland,
+1995-06-30,IS,Iceland,-4.6121
 1995-06-30,IT,Italy,0.6847
 1995-06-30,JP,Japan,-1.4975
-1995-06-30,KR,Korea,-0.0803
-1995-06-30,LT,Lithuania,
-1995-06-30,LU,Luxembourg,
-1995-06-30,LV,Latvia,
-1995-06-30,MA,Morocco,
-1995-06-30,MK,North Macedonia,
-1995-06-30,MT,Malta,
-1995-06-30,MX,Mexico,
+1995-06-30,KR,Korea,-0.0665
 1995-06-30,MY,Malaysia,20.2204
-1995-06-30,NL,Netherlands,5.1496
+1995-06-30,NL,Netherlands,5.3963
 1995-06-30,NO,Norway,8.4906
 1995-06-30,NZ,New Zealand,8.8603
-1995-06-30,PE,Peru,
-1995-06-30,PH,Philippines,
-1995-06-30,PL,Poland,
-1995-06-30,PT,Portugal,
-1995-06-30,RO,Romania,
-1995-06-30,RS,Serbia,
-1995-06-30,RU,Russia,
+1995-06-30,PT,Portugal,2.0924
 1995-06-30,SE,Sweden,1.087
-1995-06-30,SG,Singapore,
-1995-06-30,SI,Slovenia,
-1995-06-30,SK,Slovak Republic,
 1995-06-30,TH,Thailand,4.739
-1995-06-30,TR,Türkiye,
-1995-06-30,US,United States,1.9056
-1995-06-30,XM,Euro area,1.3747
-1995-06-30,XW,World,
+1995-06-30,US,United States,1.9266
+1995-06-30,XM,Euro area,1.3654
 1995-06-30,ZA,South Africa,8.6808
-1995-09-30,4T,Emerging market economies (aggregate),
-1995-09-30,5R,Advanced economies,
-1995-09-30,AE,United Arab Emirates,
-1995-09-30,AT,Austria,
+1995-09-30,AT,Austria,3.0471
 1995-09-30,AU,Australia,0
 1995-09-30,BE,Belgium,4.1594
-1995-09-30,BG,Bulgaria,
-1995-09-30,BR,Brazil,
 1995-09-30,CA,Canada,-3.1165
-1995-09-30,CH,Switzerland,-0.1163
-1995-09-30,CL,Chile,
-1995-09-30,CN,China,
-1995-09-30,CO,Colombia,29.5251
-1995-09-30,CY,Cyprus,
-1995-09-30,CZ,Czechia,
-1995-09-30,DE,Germany,0.3594
+1995-09-30,CH,Switzerland,-0.0818
+1995-09-30,CO,Colombia,29.1548
+1995-09-30,DE,Germany,0.2512
 1995-09-30,DK,Denmark,10.2241
-1995-09-30,EE,Estonia,
 1995-09-30,ES,Spain,3.2656
 1995-09-30,FI,Finland,-4.8952
 1995-09-30,FR,France,-0.9474
 1995-09-30,GB,United Kingdom,0.3591
-1995-09-30,GR,Greece,
 1995-09-30,HK,Hong Kong SAR,-10.0058
-1995-09-30,HR,Croatia,
-1995-09-30,HU,Hungary,
-1995-09-30,ID,Indonesia,
+1995-09-30,HU,Hungary,4.1441
 1995-09-30,IE,Ireland,8.8498
 1995-09-30,IL,Israel,13.8972
-1995-09-30,IN,India,
-1995-09-30,IS,Iceland,
+1995-09-30,IS,Iceland,-1.8179
 1995-09-30,IT,Italy,1.0548
 1995-09-30,JP,Japan,-1.4741
-1995-09-30,KR,Korea,-0.1606
-1995-09-30,LT,Lithuania,
-1995-09-30,LU,Luxembourg,
-1995-09-30,LV,Latvia,
-1995-09-30,MA,Morocco,
-1995-09-30,MK,North Macedonia,
-1995-09-30,MT,Malta,
-1995-09-30,MX,Mexico,
+1995-09-30,KR,Korea,-0.0999
 1995-09-30,MY,Malaysia,20.2012
-1995-09-30,NL,Netherlands,4.2044
+1995-09-30,NL,Netherlands,3.9667
 1995-09-30,NO,Norway,5.8824
 1995-09-30,NZ,New Zealand,8.6381
-1995-09-30,PE,Peru,
-1995-09-30,PH,Philippines,
-1995-09-30,PL,Poland,
-1995-09-30,PT,Portugal,
-1995-09-30,RO,Romania,
-1995-09-30,RS,Serbia,
-1995-09-30,RU,Russia,
+1995-09-30,PT,Portugal,1.1648
 1995-09-30,SE,Sweden,-1.0753
-1995-09-30,SG,Singapore,
-1995-09-30,SI,Slovenia,
-1995-09-30,SK,Slovak Republic,
 1995-09-30,TH,Thailand,8.4541
-1995-09-30,TR,Türkiye,
-1995-09-30,US,United States,2.3516
-1995-09-30,XM,Euro area,1.6013
-1995-09-30,XW,World,
+1995-09-30,US,United States,2.3428
+1995-09-30,XM,Euro area,1.5875
 1995-09-30,ZA,South Africa,6.1077
-1995-12-31,4T,Emerging market economies (aggregate),
-1995-12-31,5R,Advanced economies,
-1995-12-31,AE,United Arab Emirates,
-1995-12-31,AT,Austria,
+1995-12-31,AT,Austria,-2.2814
 1995-12-31,AU,Australia,0.2713
 1995-12-31,BE,Belgium,4.93
-1995-12-31,BG,Bulgaria,
-1995-12-31,BR,Brazil,
 1995-12-31,CA,Canada,-4.1063
-1995-12-31,CH,Switzerland,-0.8873
-1995-12-31,CL,Chile,
-1995-12-31,CN,China,
-1995-12-31,CO,Colombia,25.0158
-1995-12-31,CY,Cyprus,
-1995-12-31,CZ,Czechia,
-1995-12-31,DE,Germany,0.108
+1995-12-31,CH,Switzerland,-0.8617
+1995-12-31,CO,Colombia,25.2261
+1995-12-31,DE,Germany,0.1272
 1995-12-31,DK,Denmark,11.8139
-1995-12-31,EE,Estonia,
 1995-12-31,ES,Spain,3.8719
 1995-12-31,FI,Finland,-4.2742
 1995-12-31,FR,France,-0.9102
 1995-12-31,GB,United Kingdom,-0.3617
-1995-12-31,GR,Greece,
 1995-12-31,HK,Hong Kong SAR,-9.997
-1995-12-31,HR,Croatia,
-1995-12-31,HU,Hungary,
-1995-12-31,ID,Indonesia,
+1995-12-31,HU,Hungary,7.4122
 1995-12-31,IE,Ireland,7.0731
 1995-12-31,IL,Israel,15.3246
-1995-12-31,IN,India,
-1995-12-31,IS,Iceland,
+1995-12-31,IS,Iceland,-5.6333
 1995-12-31,IT,Italy,2.6557
 1995-12-31,JP,Japan,-1.6272
-1995-12-31,KR,Korea,-0.2408
-1995-12-31,LT,Lithuania,
-1995-12-31,LU,Luxembourg,
-1995-12-31,LV,Latvia,
-1995-12-31,MA,Morocco,
-1995-12-31,MK,North Macedonia,
-1995-12-31,MT,Malta,
-1995-12-31,MX,Mexico,
+1995-12-31,KR,Korea,-0.1995
 1995-12-31,MY,Malaysia,17.5855
-1995-12-31,NL,Netherlands,6.796
+1995-12-31,NL,Netherlands,6.7349
 1995-12-31,NO,Norway,7.7273
 1995-12-31,NZ,New Zealand,8.8941
-1995-12-31,PE,Peru,
-1995-12-31,PH,Philippines,
-1995-12-31,PL,Poland,
-1995-12-31,PT,Portugal,
-1995-12-31,RO,Romania,
-1995-12-31,RS,Serbia,
-1995-12-31,RU,Russia,
+1995-12-31,PT,Portugal,0.4266
 1995-12-31,SE,Sweden,-1.0929
-1995-12-31,SG,Singapore,
-1995-12-31,SI,Slovenia,
-1995-12-31,SK,Slovak Republic,
 1995-12-31,TH,Thailand,5.6677
-1995-12-31,TR,Türkiye,
-1995-12-31,US,United States,2.4153
-1995-12-31,XM,Euro area,1.7675
-1995-12-31,XW,World,
+1995-12-31,US,United States,2.427
+1995-12-31,XM,Euro area,1.7634
 1995-12-31,ZA,South Africa,4.9153
-1996-03-31,4T,Emerging market economies (aggregate),
-1996-03-31,5R,Advanced economies,
-1996-03-31,AE,United Arab Emirates,
-1996-03-31,AT,Austria,
+1996-03-31,AT,Austria,1.4911
 1996-03-31,AU,Australia,-0.8857
 1996-03-31,BE,Belgium,1.9284
-1996-03-31,BG,Bulgaria,
-1996-03-31,BR,Brazil,
 1996-03-31,CA,Canada,-2.6425
-1996-03-31,CH,Switzerland,-2.5254
-1996-03-31,CL,Chile,
-1996-03-31,CN,China,
-1996-03-31,CO,Colombia,26.1665
-1996-03-31,CY,Cyprus,
-1996-03-31,CZ,Czechia,
-1996-03-31,DE,Germany,-0.629
+1996-03-31,CH,Switzerland,-2.5568
+1996-03-31,CO,Colombia,26.1311
+1996-03-31,DE,Germany,-0.6025
 1996-03-31,DK,Denmark,10.9819
-1996-03-31,EE,Estonia,
 1996-03-31,ES,Spain,2.6148
 1996-03-31,FI,Finland,-1.8052
 1996-03-31,FR,France,0.8442
 1996-03-31,GB,United Kingdom,2.0073
-1996-03-31,GR,Greece,
 1996-03-31,HK,Hong Kong SAR,-2.7406
-1996-03-31,HR,Croatia,
-1996-03-31,HU,Hungary,
-1996-03-31,ID,Indonesia,
+1996-03-31,HU,Hungary,10.183
 1996-03-31,IE,Ireland,4.9353
 1996-03-31,IL,Israel,17.4912
-1996-03-31,IN,India,
-1996-03-31,IS,Iceland,
+1996-03-31,IS,Iceland,-2.2584
 1996-03-31,IT,Italy,4.2919
 1996-03-31,JP,Japan,-1.7815
-1996-03-31,KR,Korea,0.241
-1996-03-31,LT,Lithuania,
-1996-03-31,LU,Luxembourg,
-1996-03-31,LV,Latvia,
-1996-03-31,MA,Morocco,
-1996-03-31,MK,North Macedonia,
-1996-03-31,MT,Malta,
-1996-03-31,MX,Mexico,
-1996-03-31,MY,Malaysia,15.5735
-1996-03-31,NL,Netherlands,8.2126
+1996-03-31,KR,Korea,0.1997
+1996-03-31,MY,Malaysia,15.5736
+1996-03-31,NL,Netherlands,7.9585
 1996-03-31,NO,Norway,8.1448
 1996-03-31,NZ,New Zealand,11.8032
-1996-03-31,PE,Peru,
-1996-03-31,PH,Philippines,
-1996-03-31,PL,Poland,
-1996-03-31,PT,Portugal,
-1996-03-31,RO,Romania,
-1996-03-31,RS,Serbia,
-1996-03-31,RU,Russia,
+1996-03-31,PT,Portugal,0.7243
 1996-03-31,SE,Sweden,-0.5464
-1996-03-31,SG,Singapore,
-1996-03-31,SI,Slovenia,
-1996-03-31,SK,Slovak Republic,
 1996-03-31,TH,Thailand,4.9844
-1996-03-31,TR,Türkiye,
-1996-03-31,US,United States,2.9232
-1996-03-31,XM,Euro area,2.1129
-1996-03-31,XW,World,
+1996-03-31,US,United States,2.9399
+1996-03-31,XM,Euro area,2.1162
 1996-03-31,ZA,South Africa,4.1199
-1996-06-30,4T,Emerging market economies (aggregate),
-1996-06-30,5R,Advanced economies,
-1996-06-30,AE,United Arab Emirates,
-1996-06-30,AT,Austria,
+1996-06-30,AT,Austria,4.3561
 1996-06-30,AU,Australia,1.0623
 1996-06-30,BE,Belgium,2.6567
-1996-06-30,BG,Bulgaria,
-1996-06-30,BR,Brazil,
 1996-06-30,CA,Canada,2.0437
-1996-06-30,CH,Switzerland,-2.658
-1996-06-30,CL,Chile,
-1996-06-30,CN,China,
-1996-06-30,CO,Colombia,20.9025
-1996-06-30,CY,Cyprus,
-1996-06-30,CZ,Czechia,
-1996-06-30,DE,Germany,-1.44
+1996-06-30,CH,Switzerland,-2.6634
+1996-06-30,CO,Colombia,20.1884
+1996-06-30,DE,Germany,-1.4463
 1996-06-30,DK,Denmark,9.7857
-1996-06-30,EE,Estonia,
 1996-06-30,ES,Spain,2.0721
 1996-06-30,FI,Finland,2.7362
 1996-06-30,FR,France,0.0746
 1996-06-30,GB,United Kingdom,1.083
-1996-06-30,GR,Greece,
 1996-06-30,HK,Hong Kong SAR,2.9003
-1996-06-30,HR,Croatia,
-1996-06-30,HU,Hungary,
-1996-06-30,ID,Indonesia,
+1996-06-30,HU,Hungary,10.2806
 1996-06-30,IE,Ireland,10.4956
 1996-06-30,IL,Israel,20.5964
-1996-06-30,IN,India,
-1996-06-30,IS,Iceland,
+1996-06-30,IS,Iceland,-0.2063
 1996-06-30,IT,Italy,3.6747
 1996-06-30,JP,Japan,-1.8501
-1996-06-30,KR,Korea,0.4819
-1996-06-30,LT,Lithuania,
-1996-06-30,LU,Luxembourg,
-1996-06-30,LV,Latvia,
-1996-06-30,MA,Morocco,
-1996-06-30,MK,North Macedonia,
-1996-06-30,MT,Malta,
-1996-06-30,MX,Mexico,
-1996-06-30,MY,Malaysia,14.2765
-1996-06-30,NL,Netherlands,10.7399
+1996-06-30,KR,Korea,0.5326
+1996-06-30,MY,Malaysia,14.2766
+1996-06-30,NL,Netherlands,9.5563
 1996-06-30,NO,Norway,8.6957
 1996-06-30,NZ,New Zealand,11.5826
-1996-06-30,PE,Peru,
-1996-06-30,PH,Philippines,
-1996-06-30,PL,Poland,
-1996-06-30,PT,Portugal,
-1996-06-30,RO,Romania,
-1996-06-30,RS,Serbia,
-1996-06-30,RU,Russia,
+1996-06-30,PT,Portugal,1.7933
 1996-06-30,SE,Sweden,-1.0753
-1996-06-30,SG,Singapore,
-1996-06-30,SI,Slovenia,
-1996-06-30,SK,Slovak Republic,
 1996-06-30,TH,Thailand,6.7485
-1996-06-30,TR,Türkiye,
-1996-06-30,US,United States,3.0033
-1996-06-30,XM,Euro area,2.0698
-1996-06-30,XW,World,
+1996-06-30,US,United States,3.0007
+1996-06-30,XM,Euro area,2.0606
 1996-06-30,ZA,South Africa,3.1529
-1996-09-30,4T,Emerging market economies (aggregate),
-1996-09-30,5R,Advanced economies,
-1996-09-30,AE,United Arab Emirates,
-1996-09-30,AT,Austria,
+1996-09-30,AT,Austria,-5.4659
 1996-09-30,AU,Australia,1.2405
 1996-09-30,BE,Belgium,1.9128
-1996-09-30,BG,Bulgaria,
-1996-09-30,BR,Brazil,
 1996-09-30,CA,Canada,-0.3207
-1996-09-30,CH,Switzerland,-1.7331
-1996-09-30,CL,Chile,
-1996-09-30,CN,China,
-1996-09-30,CO,Colombia,16.2971
-1996-09-30,CY,Cyprus,
-1996-09-30,CZ,Czechia,
-1996-09-30,DE,Germany,-1.498
+1996-09-30,CH,Switzerland,-1.6752
+1996-09-30,CO,Colombia,16.5372
+1996-09-30,DE,Germany,-1.4548
 1996-09-30,DK,Denmark,10.3513
-1996-09-30,EE,Estonia,
 1996-09-30,ES,Spain,1.4618
 1996-09-30,FI,Finland,8.2213
 1996-09-30,FR,France,0.6657
 1996-09-30,GB,United Kingdom,4.1145
-1996-09-30,GR,Greece,
 1996-09-30,HK,Hong Kong SAR,11.885
-1996-09-30,HR,Croatia,
-1996-09-30,HU,Hungary,
-1996-09-30,ID,Indonesia,
+1996-09-30,HU,Hungary,18.8682
 1996-09-30,IE,Ireland,17.7387
 1996-09-30,IL,Israel,14.0362
-1996-09-30,IN,India,
-1996-09-30,IS,Iceland,
+1996-09-30,IS,Iceland,-1.0294
 1996-09-30,IT,Italy,3.6533
 1996-09-30,JP,Japan,-1.915
-1996-09-30,KR,Korea,0.8045
-1996-09-30,LT,Lithuania,
-1996-09-30,LU,Luxembourg,
-1996-09-30,LV,Latvia,
-1996-09-30,MA,Morocco,
-1996-09-30,MK,North Macedonia,
-1996-09-30,MT,Malta,
-1996-09-30,MX,Mexico,
+1996-09-30,KR,Korea,0.7664
 1996-09-30,MY,Malaysia,12.3923
-1996-09-30,NL,Netherlands,11.3689
+1996-09-30,NL,Netherlands,10.3333
 1996-09-30,NO,Norway,8.9744
 1996-09-30,NZ,New Zealand,8.6787
-1996-09-30,PE,Peru,
-1996-09-30,PH,Philippines,
-1996-09-30,PL,Poland,
-1996-09-30,PT,Portugal,
-1996-09-30,RO,Romania,
-1996-09-30,RS,Serbia,
-1996-09-30,RU,Russia,
+1996-09-30,PT,Portugal,1.8763
 1996-09-30,SE,Sweden,1.6304
-1996-09-30,SG,Singapore,
-1996-09-30,SI,Slovenia,
-1996-09-30,SK,Slovak Republic,
 1996-09-30,TH,Thailand,-1.4105
-1996-09-30,TR,Türkiye,
-1996-09-30,US,United States,2.6431
-1996-09-30,XM,Euro area,2.0422
-1996-09-30,XW,World,
+1996-09-30,US,United States,2.6636
+1996-09-30,XM,Euro area,2.0138
 1996-09-30,ZA,South Africa,3.2967
-1996-12-31,4T,Emerging market economies (aggregate),
-1996-12-31,5R,Advanced economies,
-1996-12-31,AE,United Arab Emirates,
-1996-12-31,AT,Austria,
+1996-12-31,AT,Austria,0.6809
 1996-12-31,AU,Australia,1.6837
 1996-12-31,BE,Belgium,2.1677
-1996-12-31,BG,Bulgaria,
-1996-12-31,BR,Brazil,
 1996-12-31,CA,Canada,0.09
-1996-12-31,CH,Switzerland,-3.0426
-1996-12-31,CL,Chile,
-1996-12-31,CN,China,
-1996-12-31,CO,Colombia,12.6298
-1996-12-31,CY,Cyprus,
-1996-12-31,CZ,Czechia,
-1996-12-31,DE,Germany,-1.7637
+1996-12-31,CH,Switzerland,-3.0651
+1996-12-31,CO,Colombia,11.9933
+1996-12-31,DE,Germany,-1.8273
 1996-12-31,DK,Denmark,11.6012
-1996-12-31,EE,Estonia,
 1996-12-31,ES,Spain,1.3384
 1996-12-31,FI,Finland,13.0899
 1996-12-31,FR,France,1.9321
 1996-12-31,GB,United Kingdom,7.441
-1996-12-31,GR,Greece,
 1996-12-31,HK,Hong Kong SAR,25.2354
-1996-12-31,HR,Croatia,
-1996-12-31,HU,Hungary,
-1996-12-31,ID,Indonesia,
+1996-12-31,HU,Hungary,20.446
 1996-12-31,IE,Ireland,14.5079
 1996-12-31,IL,Israel,12.1916
-1996-12-31,IN,India,
-1996-12-31,IS,Iceland,
+1996-12-31,IS,Iceland,4.6902
 1996-12-31,IT,Italy,3.7486
 1996-12-31,JP,Japan,-1.7143
-1996-12-31,KR,Korea,1.4481
-1996-12-31,LT,Lithuania,
-1996-12-31,LU,Luxembourg,
-1996-12-31,LV,Latvia,
-1996-12-31,MA,Morocco,
-1996-12-31,MK,North Macedonia,
-1996-12-31,MT,Malta,
-1996-12-31,MX,Mexico,
+1996-12-31,KR,Korea,1.3662
 1996-12-31,MY,Malaysia,9.7745
-1996-12-31,NL,Netherlands,12.3853
+1996-12-31,NL,Netherlands,11.8421
 1996-12-31,NO,Norway,10.1266
 1996-12-31,NZ,New Zealand,8.0848
-1996-12-31,PE,Peru,
-1996-12-31,PH,Philippines,
-1996-12-31,PL,Poland,
-1996-12-31,PT,Portugal,
-1996-12-31,RO,Romania,
-1996-12-31,RS,Serbia,
-1996-12-31,RU,Russia,
+1996-12-31,PT,Portugal,2.124
 1996-12-31,SE,Sweden,3.3149
-1996-12-31,SG,Singapore,
-1996-12-31,SI,Slovenia,
-1996-12-31,SK,Slovak Republic,
 1996-12-31,TH,Thailand,-1.6899
-1996-12-31,TR,Türkiye,
-1996-12-31,US,United States,2.7732
-1996-12-31,XM,Euro area,2.3428
-1996-12-31,XW,World,
+1996-12-31,US,United States,2.7768
+1996-12-31,XM,Euro area,2.3223
 1996-12-31,ZA,South Africa,3.8522
-1997-03-31,4T,Emerging market economies (aggregate),
-1997-03-31,5R,Advanced economies,
-1997-03-31,AE,United Arab Emirates,
-1997-03-31,AT,Austria,
+1997-03-31,AT,Austria,-0.8264
 1997-03-31,AU,Australia,2.761
 1997-03-31,BE,Belgium,0.2402
-1997-03-31,BG,Bulgaria,
-1997-03-31,BR,Brazil,
 1997-03-31,CA,Canada,2.5116
-1997-03-31,CH,Switzerland,-1.8146
-1997-03-31,CL,Chile,
-1997-03-31,CN,China,
-1997-03-31,CO,Colombia,8.9677
-1997-03-31,CY,Cyprus,
-1997-03-31,CZ,Czechia,
-1997-03-31,DE,Germany,-1.7068
+1997-03-31,CH,Switzerland,-1.7784
+1997-03-31,CO,Colombia,8.9753
+1997-03-31,DE,Germany,-1.7171
 1997-03-31,DK,Denmark,12.69
-1997-03-31,EE,Estonia,
 1997-03-31,ES,Spain,1.1556
 1997-03-31,FI,Finland,19.0828
 1997-03-31,FR,France,-2.439
 1997-03-31,GB,United Kingdom,7.3345
-1997-03-31,GR,Greece,
 1997-03-31,HK,Hong Kong SAR,40.6432
-1997-03-31,HR,Croatia,
-1997-03-31,HU,Hungary,
-1997-03-31,ID,Indonesia,
+1997-03-31,HU,Hungary,16.425
 1997-03-31,IE,Ireland,14.4441
 1997-03-31,IL,Israel,10.3948
-1997-03-31,IN,India,
-1997-03-31,IS,Iceland,
+1997-03-31,IS,Iceland,2.2058
 1997-03-31,IT,Italy,4.366
 1997-03-31,JP,Japan,-1.5115
-1997-03-31,KR,Korea,2.9647
-1997-03-31,LT,Lithuania,
-1997-03-31,LU,Luxembourg,
-1997-03-31,LV,Latvia,
-1997-03-31,MA,Morocco,
-1997-03-31,MK,North Macedonia,
-1997-03-31,MT,Malta,
-1997-03-31,MX,Mexico,
+1997-03-31,KR,Korea,2.99
 1997-03-31,MY,Malaysia,7.4398
-1997-03-31,NL,Netherlands,12.9464
+1997-03-31,NL,Netherlands,11.859
 1997-03-31,NO,Norway,10.8787
 1997-03-31,NZ,New Zealand,6.8218
-1997-03-31,PE,Peru,
-1997-03-31,PH,Philippines,
-1997-03-31,PL,Poland,
-1997-03-31,PT,Portugal,
-1997-03-31,RO,Romania,
-1997-03-31,RS,Serbia,
-1997-03-31,RU,Russia,
+1997-03-31,PT,Portugal,2.665
 1997-03-31,SE,Sweden,4.3956
-1997-03-31,SG,Singapore,
-1997-03-31,SI,Slovenia,
-1997-03-31,SK,Slovak Republic,
 1997-03-31,TH,Thailand,2.5223
-1997-03-31,TR,Türkiye,
-1997-03-31,US,United States,2.7499
-1997-03-31,XM,Euro area,1.4002
-1997-03-31,XW,World,
+1997-03-31,US,United States,2.7423
+1997-03-31,XM,Euro area,1.3921
 1997-03-31,ZA,South Africa,3.6999
-1997-06-30,4T,Emerging market economies (aggregate),
-1997-06-30,5R,Advanced economies,
-1997-06-30,AE,United Arab Emirates,
-1997-06-30,AT,Austria,
+1997-06-30,AT,Austria,-3.902
 1997-06-30,AU,Australia,2.8163
 1997-06-30,BE,Belgium,2.5583
-1997-06-30,BG,Bulgaria,
-1997-06-30,BR,Brazil,
 1997-06-30,CA,Canada,2.8852
-1997-06-30,CH,Switzerland,-2.7831
-1997-06-30,CL,Chile,
-1997-06-30,CN,China,
-1997-06-30,CO,Colombia,8.3011
-1997-06-30,CY,Cyprus,
-1997-06-30,CZ,Czechia,
-1997-06-30,DE,Germany,-1.8114
+1997-06-30,CH,Switzerland,-2.8094
+1997-06-30,CO,Colombia,8.6553
+1997-06-30,DE,Germany,-1.8499
 1997-06-30,DK,Denmark,12.8729
-1997-06-30,EE,Estonia,
 1997-06-30,ES,Spain,1.2259
 1997-06-30,FI,Finland,18.9713
 1997-06-30,FR,France,2.439
 1997-06-30,GB,United Kingdom,9.2857
-1997-06-30,GR,Greece,
 1997-06-30,HK,Hong Kong SAR,47.1815
-1997-06-30,HR,Croatia,
-1997-06-30,HU,Hungary,
-1997-06-30,ID,Indonesia,
+1997-06-30,HU,Hungary,18.6267
 1997-06-30,IE,Ireland,18.7712
 1997-06-30,IL,Israel,7.9738
-1997-06-30,IN,India,
-1997-06-30,IS,Iceland,
+1997-06-30,IS,Iceland,2.1649
 1997-06-30,IT,Italy,4.0749
 1997-06-30,JP,Japan,-1.3347
-1997-06-30,KR,Korea,3.3573
-1997-06-30,LT,Lithuania,
-1997-06-30,LU,Luxembourg,
-1997-06-30,LV,Latvia,
-1997-06-30,MA,Morocco,
-1997-06-30,MK,North Macedonia,
-1997-06-30,MT,Malta,
-1997-06-30,MX,Mexico,
+1997-06-30,KR,Korea,3.245
 1997-06-30,MY,Malaysia,4.5326
-1997-06-30,NL,Netherlands,12.069
+1997-06-30,NL,Netherlands,11.838
 1997-06-30,NO,Norway,13.6
 1997-06-30,NZ,New Zealand,6.2032
-1997-06-30,PE,Peru,
-1997-06-30,PH,Philippines,
-1997-06-30,PL,Poland,
-1997-06-30,PT,Portugal,
-1997-06-30,RO,Romania,
-1997-06-30,RS,Serbia,
-1997-06-30,RU,Russia,
+1997-06-30,PT,Portugal,2.8943
 1997-06-30,SE,Sweden,7.0652
-1997-06-30,SG,Singapore,
-1997-06-30,SI,Slovenia,
-1997-06-30,SK,Slovak Republic,
 1997-06-30,TH,Thailand,5.1724
-1997-06-30,TR,Türkiye,
-1997-06-30,US,United States,3.047
-1997-06-30,XM,Euro area,2.4894
-1997-06-30,XW,World,
+1997-06-30,US,United States,3.0593
+1997-06-30,XM,Euro area,2.4579
 1997-06-30,ZA,South Africa,5.8584
-1997-09-30,4T,Emerging market economies (aggregate),
-1997-09-30,5R,Advanced economies,
-1997-09-30,AE,United Arab Emirates,
-1997-09-30,AT,Austria,
+1997-09-30,AT,Austria,4.9289
 1997-09-30,AU,Australia,4.2984
 1997-09-30,BE,Belgium,3.6087
-1997-09-30,BG,Bulgaria,
-1997-09-30,BR,Brazil,
 1997-09-30,CA,Canada,2.5033
-1997-09-30,CH,Switzerland,-2.6951
-1997-09-30,CL,Chile,
-1997-09-30,CN,China,
-1997-09-30,CO,Colombia,10.3192
-1997-09-30,CY,Cyprus,
-1997-09-30,CZ,Czechia,
-1997-09-30,DE,Germany,-1.7696
+1997-09-30,CH,Switzerland,-2.7307
+1997-09-30,CO,Colombia,10.0393
+1997-09-30,DE,Germany,-1.8035
 1997-09-30,DK,Denmark,12.0182
-1997-09-30,EE,Estonia,
 1997-09-30,ES,Spain,1.6956
 1997-09-30,FI,Finland,16.9875
 1997-09-30,FR,France,0
 1997-09-30,GB,United Kingdom,10.4811
-1997-09-30,GR,Greece,
 1997-09-30,HK,Hong Kong SAR,45.2313
-1997-09-30,HR,Croatia,
-1997-09-30,HU,Hungary,
-1997-09-30,ID,Indonesia,
+1997-09-30,HU,Hungary,11.5686
 1997-09-30,IE,Ireland,14.5657
 1997-09-30,IL,Israel,11.3006
-1997-09-30,IN,India,
-1997-09-30,IS,Iceland,
+1997-09-30,IS,Iceland,1.9755
 1997-09-30,IT,Italy,2.8896
 1997-09-30,JP,Japan,-1.1592
-1997-09-30,KR,Korea,3.1923
-1997-09-30,LT,Lithuania,
-1997-09-30,LU,Luxembourg,
-1997-09-30,LV,Latvia,
-1997-09-30,MA,Morocco,
-1997-09-30,MK,North Macedonia,
-1997-09-30,MT,Malta,
-1997-09-30,MX,Mexico,
+1997-09-30,KR,Korea,3.1415
 1997-09-30,MY,Malaysia,0.5021
-1997-09-30,NL,Netherlands,11.4583
+1997-09-30,NL,Netherlands,11.4804
 1997-09-30,NO,Norway,12.1569
 1997-09-30,NZ,New Zealand,6.3979
-1997-09-30,PE,Peru,
-1997-09-30,PH,Philippines,
-1997-09-30,PL,Poland,
-1997-09-30,PT,Portugal,
-1997-09-30,RO,Romania,
-1997-09-30,RS,Serbia,
-1997-09-30,RU,Russia,
+1997-09-30,PT,Portugal,4.2696
 1997-09-30,SE,Sweden,7.4866
-1997-09-30,SG,Singapore,
-1997-09-30,SI,Slovenia,
-1997-09-30,SK,Slovak Republic,
 1997-09-30,TH,Thailand,10.3163
-1997-09-30,TR,Türkiye,
-1997-09-30,US,United States,3.7376
-1997-09-30,XM,Euro area,1.97
-1997-09-30,XW,World,
+1997-09-30,US,United States,3.7473
+1997-09-30,XM,Euro area,1.9556
 1997-09-30,ZA,South Africa,10.689
-1997-12-31,4T,Emerging market economies (aggregate),
-1997-12-31,5R,Advanced economies,
-1997-12-31,AE,United Arab Emirates,
-1997-12-31,AT,Austria,
+1997-12-31,AT,Austria,2.9952
 1997-12-31,AU,Australia,6.0418
 1997-12-31,BE,Belgium,3.1106
-1997-12-31,BG,Bulgaria,
-1997-12-31,BR,Brazil,
 1997-12-31,CA,Canada,1.7893
-1997-12-31,CH,Switzerland,-1.1455
-1997-12-31,CL,Chile,
-1997-12-31,CN,China,
-1997-12-31,CO,Colombia,14.2913
-1997-12-31,CY,Cyprus,
-1997-12-31,CZ,Czechia,
-1997-12-31,DE,Germany,-1.6618
+1997-12-31,CH,Switzerland,-1.1174
+1997-12-31,CO,Colombia,14.1887
+1997-12-31,DE,Germany,-1.5786
 1997-12-31,DK,Denmark,8.7715
-1997-12-31,EE,Estonia,
 1997-12-31,ES,Spain,2.2696
 1997-12-31,FI,Finland,15.1452
 1997-12-31,FR,France,0
 1997-12-31,GB,United Kingdom,7.9392
-1997-12-31,GR,Greece,
 1997-12-31,HK,Hong Kong SAR,26.6598
-1997-12-31,HR,Croatia,
-1997-12-31,HU,Hungary,
-1997-12-31,ID,Indonesia,
+1997-12-31,HU,Hungary,6.1331
 1997-12-31,IE,Ireland,21.7843
 1997-12-31,IL,Israel,7.1819
-1997-12-31,IN,India,
-1997-12-31,IS,Iceland,
+1997-12-31,IS,Iceland,1.8337
 1997-12-31,IT,Italy,2.3196
 1997-12-31,JP,Japan,-1.224
-1997-12-31,KR,Korea,2.4584
-1997-12-31,LT,Lithuania,
-1997-12-31,LU,Luxembourg,
-1997-12-31,LV,Latvia,
-1997-12-31,MA,Morocco,
-1997-12-31,MK,North Macedonia,
-1997-12-31,MT,Malta,
-1997-12-31,MX,Mexico,
-1997-12-31,MY,Malaysia,-4.4886
-1997-12-31,NL,Netherlands,11.4286
+1997-12-31,KR,Korea,2.4655
+1997-12-31,MY,Malaysia,-4.4887
+1997-12-31,NL,Netherlands,10.8824
 1997-12-31,NO,Norway,11.1111
 1997-12-31,NZ,New Zealand,4.859
-1997-12-31,PE,Peru,
-1997-12-31,PH,Philippines,
-1997-12-31,PL,Poland,
-1997-12-31,PT,Portugal,
-1997-12-31,RO,Romania,
-1997-12-31,RS,Serbia,
-1997-12-31,RU,Russia,
+1997-12-31,PT,Portugal,4.6589
 1997-12-31,SE,Sweden,7.4866
-1997-12-31,SG,Singapore,
-1997-12-31,SI,Slovenia,
-1997-12-31,SK,Slovak Republic,
 1997-12-31,TH,Thailand,8.2212
-1997-12-31,TR,Türkiye,
-1997-12-31,US,United States,4.6368
-1997-12-31,XM,Euro area,2.251
-1997-12-31,XW,World,
+1997-12-31,US,United States,4.6424
+1997-12-31,XM,Euro area,2.2146
 1997-12-31,ZA,South Africa,15.2882
-1998-03-31,4T,Emerging market economies (aggregate),
-1998-03-31,5R,Advanced economies,
-1998-03-31,AE,United Arab Emirates,
-1998-03-31,AT,Austria,
+1998-03-31,AT,Austria,-2.6852
 1998-03-31,AU,Australia,7.7186
 1998-03-31,BE,Belgium,8.3583
-1998-03-31,BG,Bulgaria,
-1998-03-31,BR,Brazil,
 1998-03-31,CA,Canada,-0.3359
-1998-03-31,CH,Switzerland,-0.8078
-1998-03-31,CL,Chile,
-1998-03-31,CN,China,
-1998-03-31,CO,Colombia,16.0329
-1998-03-31,CY,Cyprus,
-1998-03-31,CZ,Czechia,
-1998-03-31,DE,Germany,-1.6342
+1998-03-31,CH,Switzerland,-0.7823
+1998-03-31,CO,Colombia,16.0047
+1998-03-31,DE,Germany,-1.7177
 1998-03-31,DK,Denmark,8.1106
-1998-03-31,EE,Estonia,
 1998-03-31,ES,Spain,2.4507
 1998-03-31,FI,Finland,10.7392
 1998-03-31,FR,France,2.5
 1998-03-31,GB,United Kingdom,9.1667
-1998-03-31,GR,Greece,
+1998-03-31,GR,Greece,14.4118
 1998-03-31,HK,Hong Kong SAR,-8.7543
-1998-03-31,HR,Croatia,
-1998-03-31,HU,Hungary,
-1998-03-31,ID,Indonesia,
+1998-03-31,HR,Croatia,10.6716
+1998-03-31,HU,Hungary,3.2205
 1998-03-31,IE,Ireland,26.2112
 1998-03-31,IL,Israel,4.5255
-1998-03-31,IN,India,
-1998-03-31,IS,Iceland,
+1998-03-31,IS,Iceland,6.1671
 1998-03-31,IT,Italy,-0.6689
 1998-03-31,JP,Japan,-1.2891
-1998-03-31,KR,Korea,-2.3346
-1998-03-31,LT,Lithuania,
-1998-03-31,LU,Luxembourg,
-1998-03-31,LV,Latvia,
-1998-03-31,MA,Morocco,
-1998-03-31,MK,North Macedonia,
-1998-03-31,MT,Malta,
-1998-03-31,MX,Mexico,
+1998-03-31,KR,Korea,-2.3548
 1998-03-31,MY,Malaysia,-7.3977
-1998-03-31,NL,Netherlands,10.4743
+1998-03-31,NL,Netherlands,10.3152
 1998-03-31,NO,Norway,13.9623
 1998-03-31,NZ,New Zealand,0.2223
-1998-03-31,PE,Peru,
-1998-03-31,PH,Philippines,
-1998-03-31,PL,Poland,
-1998-03-31,PT,Portugal,
-1998-03-31,RO,Romania,
-1998-03-31,RS,Serbia,
-1998-03-31,RU,Russia,
+1998-03-31,PT,Portugal,4.0791
 1998-03-31,SE,Sweden,8.9474
-1998-03-31,SG,Singapore,
-1998-03-31,SI,Slovenia,
-1998-03-31,SK,Slovak Republic,
 1998-03-31,TH,Thailand,8.1042
-1998-03-31,TR,Türkiye,
-1998-03-31,US,United States,5.8637
-1998-03-31,XM,Euro area,2.4235
-1998-03-31,XW,World,
+1998-03-31,US,United States,5.8721
+1998-03-31,XM,Euro area,2.3604
 1998-03-31,ZA,South Africa,17.6412
-1998-06-30,4T,Emerging market economies (aggregate),
-1998-06-30,5R,Advanced economies,
-1998-06-30,AE,United Arab Emirates,
-1998-06-30,AT,Austria,
+1998-06-30,AT,Austria,-4.627
 1998-06-30,AU,Australia,8.6516
 1998-06-30,BE,Belgium,4.9697
-1998-06-30,BG,Bulgaria,
-1998-06-30,BR,Brazil,
 1998-06-30,CA,Canada,-1.9466
-1998-06-30,CH,Switzerland,-0.933
-1998-06-30,CL,Chile,
-1998-06-30,CN,China,
-1998-06-30,CO,Colombia,15.1722
-1998-06-30,CY,Cyprus,
-1998-06-30,CZ,Czechia,
-1998-06-30,DE,Germany,-1.0258
+1998-06-30,CH,Switzerland,-0.9355
+1998-06-30,CO,Colombia,14.504
+1998-06-30,DE,Germany,-0.9927
 1998-06-30,DK,Denmark,9.6508
-1998-06-30,EE,Estonia,
 1998-06-30,ES,Spain,3.8946
 1998-06-30,FI,Finland,9.6926
 1998-06-30,FR,France,0
 1998-06-30,GB,United Kingdom,12.7451
-1998-06-30,GR,Greece,
+1998-06-30,GR,Greece,16.0073
 1998-06-30,HK,Hong Kong SAR,-25.3142
-1998-06-30,HR,Croatia,
-1998-06-30,HU,Hungary,
-1998-06-30,ID,Indonesia,
+1998-06-30,HR,Croatia,10.3928
+1998-06-30,HU,Hungary,-0.9133
 1998-06-30,IE,Ireland,22.5405
 1998-06-30,IL,Israel,2.4321
-1998-06-30,IN,India,
-1998-06-30,IS,Iceland,
+1998-06-30,IS,Iceland,5.9544
 1998-06-30,IT,Italy,0.2111
 1998-06-30,JP,Japan,-1.5069
-1998-06-30,KR,Korea,-9.8221
-1998-06-30,LT,Lithuania,
-1998-06-30,LU,Luxembourg,
-1998-06-30,LV,Latvia,
-1998-06-30,MA,Morocco,
-1998-06-30,MK,North Macedonia,
-1998-06-30,MT,Malta,
-1998-06-30,MX,Mexico,
+1998-06-30,KR,Korea,-9.7498
 1998-06-30,MY,Malaysia,-10.7705
-1998-06-30,NL,Netherlands,10.3846
+1998-06-30,NL,Netherlands,10.0279
 1998-06-30,NO,Norway,13.0282
 1998-06-30,NZ,New Zealand,-2.4802
-1998-06-30,PE,Peru,
-1998-06-30,PH,Philippines,
-1998-06-30,PL,Poland,
-1998-06-30,PT,Portugal,
-1998-06-30,RO,Romania,
-1998-06-30,RS,Serbia,
-1998-06-30,RU,Russia,
+1998-06-30,PT,Portugal,4.3212
 1998-06-30,SE,Sweden,8.6294
-1998-06-30,SG,Singapore,
-1998-06-30,SI,Slovenia,
-1998-06-30,SK,Slovak Republic,
 1998-06-30,TH,Thailand,-8.265
-1998-06-30,TR,Türkiye,
-1998-06-30,US,United States,6.2127
-1998-06-30,XM,Euro area,2.0179
-1998-06-30,XW,World,
+1998-06-30,US,United States,6.2095
+1998-06-30,XM,Euro area,1.9825
 1998-06-30,ZA,South Africa,16.5063
-1998-09-30,4T,Emerging market economies (aggregate),
-1998-09-30,5R,Advanced economies,
-1998-09-30,AE,United Arab Emirates,
-1998-09-30,AT,Austria,
+1998-09-30,AT,Austria,-6.0524
 1998-09-30,AU,Australia,6.7267
 1998-09-30,BE,Belgium,6.3124
-1998-09-30,BG,Bulgaria,
-1998-09-30,BR,Brazil,
 1998-09-30,CA,Canada,-2.1871
-1998-09-30,CH,Switzerland,-0.9154
-1998-09-30,CL,Chile,
-1998-09-30,CN,China,
-1998-09-30,CO,Colombia,10.4678
-1998-09-30,CY,Cyprus,
-1998-09-30,CZ,Czechia,
-1998-09-30,DE,Germany,-0.8894
+1998-09-30,CH,Switzerland,-0.9413
+1998-09-30,CO,Colombia,10.9151
+1998-09-30,DE,Germany,-0.9026
 1998-09-30,DK,Denmark,8.797
-1998-09-30,EE,Estonia,
 1998-09-30,ES,Spain,5.4356
 1998-09-30,FI,Finland,10.9026
 1998-09-30,FR,France,2.381
 1998-09-30,GB,United Kingdom,11.9751
-1998-09-30,GR,Greece,
+1998-09-30,GR,Greece,14.792
 1998-09-30,HK,Hong Kong SAR,-38.8518
-1998-09-30,HR,Croatia,
-1998-09-30,HU,Hungary,
-1998-09-30,ID,Indonesia,
+1998-09-30,HR,Croatia,5.8631
+1998-09-30,HU,Hungary,3.2821
 1998-09-30,IE,Ireland,19.6076
 1998-09-30,IL,Israel,0.5573
-1998-09-30,IN,India,
-1998-09-30,IS,Iceland,
+1998-09-30,IS,Iceland,10.1936
 1998-09-30,IT,Italy,0.3645
 1998-09-30,JP,Japan,-1.7284
-1998-09-30,KR,Korea,-11.9103
-1998-09-30,LT,Lithuania,
-1998-09-30,LU,Luxembourg,
-1998-09-30,LV,Latvia,
-1998-09-30,MA,Morocco,
-1998-09-30,MK,North Macedonia,
-1998-09-30,MT,Malta,
-1998-09-30,MX,Mexico,
-1998-09-30,MY,Malaysia,-11.6236
-1998-09-30,NL,Netherlands,10.8411
+1998-09-30,KR,Korea,-11.8628
+1998-09-30,MY,Malaysia,-11.6235
+1998-09-30,NL,Netherlands,10.5691
 1998-09-30,NO,Norway,11.1888
 1998-09-30,NZ,New Zealand,-2.6189
-1998-09-30,PE,Peru,
-1998-09-30,PH,Philippines,
-1998-09-30,PL,Poland,
-1998-09-30,PT,Portugal,
-1998-09-30,RO,Romania,
-1998-09-30,RS,Serbia,
-1998-09-30,RU,Russia,
+1998-09-30,PT,Portugal,4.2955
 1998-09-30,SE,Sweden,9.4527
-1998-09-30,SG,Singapore,
-1998-09-30,SI,Slovenia,
-1998-09-30,SK,Slovak Republic,
 1998-09-30,TH,Thailand,-3.7543
-1998-09-30,TR,Türkiye,
-1998-09-30,US,United States,6.7731
-1998-09-30,XM,Euro area,2.691
-1998-09-30,XW,World,
+1998-09-30,US,United States,6.7676
+1998-09-30,XM,Euro area,2.6538
 1998-09-30,ZA,South Africa,13.6842
-1998-12-31,4T,Emerging market economies (aggregate),
-1998-12-31,5R,Advanced economies,
-1998-12-31,AE,United Arab Emirates,
-1998-12-31,AT,Austria,
+1998-12-31,AT,Austria,-6.0976
 1998-12-31,AU,Australia,6.4318
 1998-12-31,BE,Belgium,5.8752
-1998-12-31,BG,Bulgaria,
-1998-12-31,BR,Brazil,
 1998-12-31,CA,Canada,-0.6678
-1998-12-31,CH,Switzerland,0.1377
-1998-12-31,CL,Chile,
-1998-12-31,CN,China,
-1998-12-31,CO,Colombia,3.9862
-1998-12-31,CY,Cyprus,
-1998-12-31,CZ,Czechia,
-1998-12-31,DE,Germany,-0.3904
+1998-12-31,CH,Switzerland,0.1414
+1998-12-31,CO,Colombia,4.4348
+1998-12-31,DE,Germany,-0.3272
 1998-12-31,DK,Denmark,9.3437
-1998-12-31,EE,Estonia,
 1998-12-31,ES,Spain,6.763
 1998-12-31,FI,Finland,9.5603
 1998-12-31,FR,France,2.381
 1998-12-31,GB,United Kingdom,12.0501
-1998-12-31,GR,Greece,
+1998-12-31,GR,Greece,12.3321
 1998-12-31,HK,Hong Kong SAR,-38.4726
-1998-12-31,HR,Croatia,
-1998-12-31,HU,Hungary,
-1998-12-31,ID,Indonesia,
+1998-12-31,HR,Croatia,1.9856
+1998-12-31,HU,Hungary,5.5931
 1998-12-31,IE,Ireland,21.2958
 1998-12-31,IL,Israel,7.5425
-1998-12-31,IN,India,
-1998-12-31,IS,Iceland,
+1998-12-31,IS,Iceland,7.9
 1998-12-31,IT,Italy,-0.0671
 1998-12-31,JP,Japan,-2.1995
-1998-12-31,KR,Korea,-12.7709
-1998-12-31,LT,Lithuania,
-1998-12-31,LU,Luxembourg,
-1998-12-31,LV,Latvia,
-1998-12-31,MA,Morocco,
-1998-12-31,MK,North Macedonia,
-1998-12-31,MT,Malta,
-1998-12-31,MX,Mexico,
+1998-12-31,KR,Korea,-12.8008
 1998-12-31,MY,Malaysia,-7.7577
-1998-12-31,NL,Netherlands,11.7216
+1998-12-31,NL,Netherlands,11.1406
 1998-12-31,NO,Norway,6.5517
 1998-12-31,NZ,New Zealand,-2.2804
-1998-12-31,PE,Peru,
-1998-12-31,PH,Philippines,
-1998-12-31,PL,Poland,
-1998-12-31,PT,Portugal,
-1998-12-31,RO,Romania,
-1998-12-31,RS,Serbia,
-1998-12-31,RU,Russia,
+1998-12-31,PT,Portugal,5.1272
 1998-12-31,SE,Sweden,10.9453
-1998-12-31,SG,Singapore,
-1998-12-31,SI,Slovenia,
-1998-12-31,SK,Slovak Republic,
 1998-12-31,TH,Thailand,-3.8674
-1998-12-31,TR,Türkiye,
-1998-12-31,US,United States,7.1885
-1998-12-31,XM,Euro area,2.9878
-1998-12-31,XW,World,
+1998-12-31,US,United States,7.1794
+1998-12-31,XM,Euro area,2.9553
 1998-12-31,ZA,South Africa,8.1304
-1999-03-31,4T,Emerging market economies (aggregate),
-1999-03-31,5R,Advanced economies,
-1999-03-31,AE,United Arab Emirates,
-1999-03-31,AT,Austria,
+1999-03-31,AT,Austria,-4.3768
 1999-03-31,AU,Australia,5.7234
 1999-03-31,BE,Belgium,6.8657
-1999-03-31,BG,Bulgaria,
-1999-03-31,BR,Brazil,
+1999-03-31,BG,Bulgaria,2.9164
 1999-03-31,CA,Canada,0.7732
-1999-03-31,CH,Switzerland,0.8202
-1999-03-31,CL,Chile,
-1999-03-31,CN,China,
-1999-03-31,CO,Colombia,0.6368
-1999-03-31,CY,Cyprus,
-1999-03-31,CZ,Czechia,
-1999-03-31,DE,Germany,-0.0586
+1999-03-31,CH,Switzerland,0.8334
+1999-03-31,CO,Colombia,0.5691
+1999-03-31,DE,Germany,-0.0017
 1999-03-31,DK,Denmark,8.9592
-1999-03-31,EE,Estonia,
 1999-03-31,ES,Spain,9.5969
 1999-03-31,FI,Finland,7.8794
 1999-03-31,FR,France,4.878
 1999-03-31,GB,United Kingdom,10.0763
-1999-03-31,GR,Greece,
+1999-03-31,GR,Greece,9.348
 1999-03-31,HK,Hong Kong SAR,-26.611
-1999-03-31,HR,Croatia,
-1999-03-31,HU,Hungary,
-1999-03-31,ID,Indonesia,
+1999-03-31,HR,Croatia,-1.9871
+1999-03-31,HU,Hungary,12.9945
 1999-03-31,IE,Ireland,20.8008
 1999-03-31,IL,Israel,6.4245
-1999-03-31,IN,India,
-1999-03-31,IS,Iceland,
+1999-03-31,IS,Iceland,11.0585
 1999-03-31,IT,Italy,1.0992
 1999-03-31,JP,Japan,-2.6741
-1999-03-31,KR,Korea,-8.9243
-1999-03-31,LT,Lithuania,
-1999-03-31,LU,Luxembourg,
-1999-03-31,LV,Latvia,
-1999-03-31,MA,Morocco,
-1999-03-31,MK,North Macedonia,
-1999-03-31,MT,Malta,
-1999-03-31,MX,Mexico,
+1999-03-31,KR,Korea,-8.7876
 1999-03-31,MY,Malaysia,-7.8302
-1999-03-31,NL,Netherlands,13.4168
+1999-03-31,NL,Netherlands,12.7273
 1999-03-31,NO,Norway,6.2914
 1999-03-31,NZ,New Zealand,0.4583
 1999-03-31,PE,Peru,20.2326
-1999-03-31,PH,Philippines,
-1999-03-31,PL,Poland,
-1999-03-31,PT,Portugal,
-1999-03-31,RO,Romania,
-1999-03-31,RS,Serbia,
-1999-03-31,RU,Russia,
+1999-03-31,PT,Portugal,8.2344
 1999-03-31,SE,Sweden,9.1787
 1999-03-31,SG,Singapore,-23.296
-1999-03-31,SI,Slovenia,
-1999-03-31,SK,Slovak Republic,
 1999-03-31,TH,Thailand,-7.7644
-1999-03-31,TR,Türkiye,
-1999-03-31,US,United States,6.6621
-1999-03-31,XM,Euro area,4.2665
-1999-03-31,XW,World,
+1999-03-31,US,United States,6.6979
+1999-03-31,XM,Euro area,4.2419
 1999-03-31,ZA,South Africa,4.5072
-1999-06-30,4T,Emerging market economies (aggregate),
-1999-06-30,5R,Advanced economies,
-1999-06-30,AE,United Arab Emirates,
-1999-06-30,AT,Austria,
+1999-06-30,AT,Austria,-0.396
 1999-06-30,AU,Australia,5.8322
 1999-06-30,BE,Belgium,8.4044
-1999-06-30,BG,Bulgaria,
-1999-06-30,BR,Brazil,
+1999-06-30,BG,Bulgaria,-0.536
 1999-06-30,CA,Canada,3.8231
-1999-06-30,CH,Switzerland,1.4462
-1999-06-30,CL,Chile,
-1999-06-30,CN,China,
-1999-06-30,CO,Colombia,-2.3695
-1999-06-30,CY,Cyprus,
-1999-06-30,CZ,Czechia,
-1999-06-30,DE,Germany,-0.0637
+1999-06-30,CH,Switzerland,1.4662
+1999-06-30,CO,Colombia,-1.817
+1999-06-30,DE,Germany,-0.0537
 1999-06-30,DK,Denmark,6.1975
-1999-06-30,EE,Estonia,
 1999-06-30,ES,Spain,10.8169
 1999-06-30,FI,Finland,8.1633
 1999-06-30,FR,France,4.7619
 1999-06-30,GB,United Kingdom,8.8406
-1999-06-30,GR,Greece,
+1999-06-30,GR,Greece,8.4914
 1999-06-30,HK,Hong Kong SAR,-17.9487
-1999-06-30,HR,Croatia,
-1999-06-30,HU,Hungary,
-1999-06-30,ID,Indonesia,
+1999-06-30,HR,Croatia,1.0788
+1999-06-30,HU,Hungary,22.518
 1999-06-30,IE,Ireland,15.8692
 1999-06-30,IL,Israel,4.9394
-1999-06-30,IN,India,
-1999-06-30,IS,Iceland,
+1999-06-30,IS,Iceland,15.9112
 1999-06-30,IT,Italy,0.6591
 1999-06-30,JP,Japan,-2.9982
-1999-06-30,KR,Korea,-1.2864
-1999-06-30,LT,Lithuania,
-1999-06-30,LU,Luxembourg,
-1999-06-30,LV,Latvia,
-1999-06-30,MA,Morocco,
-1999-06-30,MK,North Macedonia,
-1999-06-30,MT,Malta,
-1999-06-30,MX,Mexico,
+1999-06-30,KR,Korea,-1.3504
 1999-06-30,MY,Malaysia,-4.1462
-1999-06-30,NL,Netherlands,15.1568
+1999-06-30,NL,Netherlands,14.6835
 1999-06-30,NO,Norway,8.0997
 1999-06-30,NZ,New Zealand,3.0098
 1999-06-30,PE,Peru,16.7445
-1999-06-30,PH,Philippines,
-1999-06-30,PL,Poland,
-1999-06-30,PT,Portugal,
-1999-06-30,RO,Romania,
-1999-06-30,RS,Serbia,
-1999-06-30,RU,Russia,
+1999-06-30,PT,Portugal,8.7143
 1999-06-30,SE,Sweden,9.8131
 1999-06-30,SG,Singapore,-6.4373
-1999-06-30,SI,Slovenia,
-1999-06-30,SK,Slovak Republic,
 1999-06-30,TH,Thailand,-18.6895
-1999-06-30,TR,Türkiye,
-1999-06-30,US,United States,7.3813
-1999-06-30,XM,Euro area,4.4557
-1999-06-30,XW,World,
+1999-06-30,US,United States,7.3751
+1999-06-30,XM,Euro area,4.4409
 1999-06-30,ZA,South Africa,4.8327
-1999-09-30,4T,Emerging market economies (aggregate),
-1999-09-30,5R,Advanced economies,
-1999-09-30,AE,United Arab Emirates,
-1999-09-30,AT,Austria,
+1999-09-30,AT,Austria,-3.8462
 1999-09-30,AU,Australia,7.8029
 1999-09-30,BE,Belgium,7.3957
-1999-09-30,BG,Bulgaria,
-1999-09-30,BR,Brazil,
+1999-09-30,BG,Bulgaria,0.2056
 1999-09-30,CA,Canada,5.0035
-1999-09-30,CH,Switzerland,0.4239
-1999-09-30,CL,Chile,
-1999-09-30,CN,China,
-1999-09-30,CO,Colombia,-3.1832
-1999-09-30,CY,Cyprus,
-1999-09-30,CZ,Czechia,
-1999-09-30,DE,Germany,0.2037
+1999-09-30,CH,Switzerland,0.3887
+1999-09-30,CO,Colombia,-4.2314
+1999-09-30,DE,Germany,0.2328
 1999-09-30,DK,Denmark,6.7063
-1999-09-30,EE,Estonia,
 1999-09-30,ES,Spain,11.5905
 1999-09-30,FI,Finland,9.1178
 1999-09-30,FR,France,6.9767
 1999-09-30,GB,United Kingdom,10.4167
-1999-09-30,GR,Greece,
+1999-09-30,GR,Greece,8.9038
 1999-09-30,HK,Hong Kong SAR,-3.7942
-1999-09-30,HR,Croatia,
-1999-09-30,HU,Hungary,
-1999-09-30,ID,Indonesia,
+1999-09-30,HR,Croatia,1.1602
+1999-09-30,HU,Hungary,23.535
 1999-09-30,IE,Ireland,21.6183
 1999-09-30,IL,Israel,6.1309
-1999-09-30,IN,India,
-1999-09-30,IS,Iceland,
+1999-09-30,IS,Iceland,18.1248
 1999-09-30,IT,Italy,0.9494
 1999-09-30,JP,Japan,-3.3291
-1999-09-30,KR,Korea,2.0193
-1999-09-30,LT,Lithuania,
-1999-09-30,LU,Luxembourg,
-1999-09-30,LV,Latvia,
-1999-09-30,MA,Morocco,
-1999-09-30,MK,North Macedonia,
-1999-09-30,MT,Malta,
-1999-09-30,MX,Mexico,
+1999-09-30,KR,Korea,2.0735
 1999-09-30,MY,Malaysia,0.438
-1999-09-30,NL,Netherlands,17.3693
+1999-09-30,NL,Netherlands,16.6667
 1999-09-30,NO,Norway,11.3208
 1999-09-30,NZ,New Zealand,2.6893
 1999-09-30,PE,Peru,12.4232
-1999-09-30,PH,Philippines,
-1999-09-30,PL,Poland,
-1999-09-30,PT,Portugal,
-1999-09-30,RO,Romania,
-1999-09-30,RS,Serbia,
-1999-09-30,RU,Russia,
+1999-09-30,PT,Portugal,9.8537
 1999-09-30,SE,Sweden,10
 1999-09-30,SG,Singapore,16.3473
-1999-09-30,SI,Slovenia,
-1999-09-30,SK,Slovak Republic,
 1999-09-30,TH,Thailand,-5.461
-1999-09-30,TR,Türkiye,
-1999-09-30,US,United States,7.5879
-1999-09-30,XM,Euro area,5.321
-1999-09-30,XW,World,
+1999-09-30,US,United States,7.5863
+1999-09-30,XM,Euro area,5.299
 1999-09-30,ZA,South Africa,3.5829
-1999-12-31,4T,Emerging market economies (aggregate),
-1999-12-31,5R,Advanced economies,
-1999-12-31,AE,United Arab Emirates,
-1999-12-31,AT,Austria,
+1999-12-31,AT,Austria,-1.1988
 1999-12-31,AU,Australia,9.5363
 1999-12-31,BE,Belgium,5.7954
-1999-12-31,BG,Bulgaria,
-1999-12-31,BR,Brazil,
+1999-12-31,BG,Bulgaria,0.8027
 1999-12-31,CA,Canada,5.0321
-1999-12-31,CH,Switzerland,0.537
-1999-12-31,CL,Chile,
-1999-12-31,CN,China,
-1999-12-31,CO,Colombia,-0.5835
-1999-12-31,CY,Cyprus,
-1999-12-31,CZ,Czechia,
-1999-12-31,DE,Germany,0.3109
+1999-12-31,CH,Switzerland,0.5395
+1999-12-31,CO,Colombia,-0.4689
+1999-12-31,DE,Germany,0.216
 1999-12-31,DK,Denmark,5.2441
-1999-12-31,EE,Estonia,
 1999-12-31,ES,Spain,9.5153
 1999-12-31,FI,Finland,10.4869
 1999-12-31,FR,France,6.9767
 1999-12-31,GB,United Kingdom,13.9665
-1999-12-31,GR,Greece,
+1999-12-31,GR,Greece,8.8696
 1999-12-31,HK,Hong Kong SAR,-4.8918
-1999-12-31,HR,Croatia,
-1999-12-31,HU,Hungary,
-1999-12-31,ID,Indonesia,
+1999-12-31,HR,Croatia,3.0846
+1999-12-31,HU,Hungary,26.6792
 1999-12-31,IE,Ireland,16.4273
 1999-12-31,IL,Israel,-0.4567
-1999-12-31,IN,India,
-1999-12-31,IS,Iceland,
+1999-12-31,IS,Iceland,22.0414
 1999-12-31,IT,Italy,1.4881
 1999-12-31,JP,Japan,-3.4526
-1999-12-31,KR,Korea,3.8154
+1999-12-31,KR,Korea,3.7896
 1999-12-31,LT,Lithuania,-15
-1999-12-31,LU,Luxembourg,
-1999-12-31,LV,Latvia,
-1999-12-31,MA,Morocco,
-1999-12-31,MK,North Macedonia,
-1999-12-31,MT,Malta,
-1999-12-31,MX,Mexico,
 1999-12-31,MY,Malaysia,2.4205
-1999-12-31,NL,Netherlands,19.0164
+1999-12-31,NL,Netherlands,18.6158
 1999-12-31,NO,Norway,18.7702
 1999-12-31,NZ,New Zealand,2.2887
 1999-12-31,PE,Peru,12.2437
-1999-12-31,PH,Philippines,
-1999-12-31,PL,Poland,
-1999-12-31,PT,Portugal,
-1999-12-31,RO,Romania,
-1999-12-31,RS,Serbia,
-1999-12-31,RU,Russia,
+1999-12-31,PT,Portugal,9.0737
 1999-12-31,SE,Sweden,8.5202
 1999-12-31,SG,Singapore,34.1258
-1999-12-31,SI,Slovenia,
-1999-12-31,SK,Slovak Republic,
 1999-12-31,TH,Thailand,-7.7586
-1999-12-31,TR,Türkiye,
-1999-12-31,US,United States,7.8618
-1999-12-31,XM,Euro area,5.1626
-1999-12-31,XW,World,
+1999-12-31,US,United States,7.8549
+1999-12-31,XM,Euro area,5.152
 1999-12-31,ZA,South Africa,6.7149
-2000-03-31,4T,Emerging market economies (aggregate),
-2000-03-31,5R,Advanced economies,
-2000-03-31,AE,United Arab Emirates,
-2000-03-31,AT,Austria,
+2000-03-31,AT,Austria,1.6915
 2000-03-31,AU,Australia,9.5916
 2000-03-31,BE,Belgium,6.9248
-2000-03-31,BG,Bulgaria,
-2000-03-31,BR,Brazil,
+2000-03-31,BG,Bulgaria,-0.7318
 2000-03-31,CA,Canada,5.0167
-2000-03-31,CH,Switzerland,-0.2719
-2000-03-31,CL,Chile,
-2000-03-31,CN,China,
-2000-03-31,CO,Colombia,0.8911
-2000-03-31,CY,Cyprus,
-2000-03-31,CZ,Czechia,
-2000-03-31,DE,Germany,0.5874
+2000-03-31,CH,Switzerland,-0.2987
+2000-03-31,CO,Colombia,-0.4995
+2000-03-31,DE,Germany,0.5778
 2000-03-31,DK,Denmark,5.164
-2000-03-31,EE,Estonia,
 2000-03-31,ES,Spain,9.7478
 2000-03-31,FI,Finland,10.7803
 2000-03-31,FR,France,9.6989
 2000-03-31,GB,United Kingdom,15.9501
-2000-03-31,GR,Greece,
+2000-03-31,GR,Greece,9.6816
 2000-03-31,HK,Hong Kong SAR,-5.5935
-2000-03-31,HR,Croatia,
-2000-03-31,HU,Hungary,
-2000-03-31,ID,Indonesia,
+2000-03-31,HR,Croatia,5.8384
+2000-03-31,HU,Hungary,33.4176
 2000-03-31,IE,Ireland,12.8965
 2000-03-31,IL,Israel,-4.2323
-2000-03-31,IN,India,
-2000-03-31,IS,Iceland,NaN
+2000-03-31,IS,Iceland,20.3457
 2000-03-31,IT,Italy,3.1486
 2000-03-31,JP,Japan,-3.5783
-2000-03-31,KR,Korea,2.7997
+2000-03-31,KR,Korea,2.6802
 2000-03-31,LT,Lithuania,-17.2515
-2000-03-31,LU,Luxembourg,
-2000-03-31,LV,Latvia,
-2000-03-31,MA,Morocco,
-2000-03-31,MK,North Macedonia,
-2000-03-31,MT,Malta,
-2000-03-31,MX,Mexico,
 2000-03-31,MY,Malaysia,4.818
-2000-03-31,NL,Netherlands,19.7161
+2000-03-31,NL,Netherlands,19.3548
 2000-03-31,NO,Norway,21.1838
 2000-03-31,NZ,New Zealand,0.8094
 2000-03-31,PE,Peru,-8.3715
-2000-03-31,PH,Philippines,
-2000-03-31,PL,Poland,
-2000-03-31,PT,Portugal,
-2000-03-31,RO,Romania,
-2000-03-31,RS,Serbia,
-2000-03-31,RU,Russia,
+2000-03-31,PT,Portugal,7.3153
 2000-03-31,SE,Sweden,10.177
 2000-03-31,SG,Singapore,31.1671
-2000-03-31,SI,Slovenia,
-2000-03-31,SK,Slovak Republic,
 2000-03-31,TH,Thailand,-6.3135
-2000-03-31,TR,Türkiye,
-2000-03-31,US,United States,8.8877
-2000-03-31,XM,Euro area,6.1058
-2000-03-31,XW,World,
-2000-03-31,ZA,South Africa,23.0417
-2000-06-30,4T,Emerging market economies (aggregate),
-2000-06-30,5R,Advanced economies,
-2000-06-30,AE,United Arab Emirates,
-2000-06-30,AT,Austria,
+2000-03-31,US,United States,8.8319
+2000-03-31,XM,Euro area,6.1028
+2000-03-31,ZA,South Africa,23.0393
+2000-06-30,AT,Austria,-0.0994
 2000-06-30,AU,Australia,9.6796
 2000-06-30,BE,Belgium,5.3745
-2000-06-30,BG,Bulgaria,
-2000-06-30,BR,Brazil,
+2000-06-30,BG,Bulgaria,-2.6672
 2000-06-30,CA,Canada,3.0292
-2000-06-30,CH,Switzerland,-0.3475
-2000-06-30,CL,Chile,
-2000-06-30,CN,China,
-2000-06-30,CO,Colombia,2.8841
-2000-06-30,CY,Cyprus,
-2000-06-30,CZ,Czechia,
-2000-06-30,DE,Germany,0.6943
+2000-06-30,CH,Switzerland,-0.3513
+2000-06-30,CO,Colombia,1.7138
+2000-06-30,DE,Germany,0.687
 2000-06-30,DK,Denmark,6.4033
-2000-06-30,EE,Estonia,
 2000-06-30,ES,Spain,9.1804
 2000-06-30,FI,Finland,9.3793
 2000-06-30,FR,France,10.3523
 2000-06-30,GB,United Kingdom,17.4434
-2000-06-30,GR,Greece,
+2000-06-30,GR,Greece,9.8251
 2000-06-30,HK,Hong Kong SAR,-12.0444
-2000-06-30,HR,Croatia,
-2000-06-30,HU,Hungary,
-2000-06-30,ID,Indonesia,
+2000-06-30,HR,Croatia,0.804
+2000-06-30,HU,Hungary,35.251
 2000-06-30,IE,Ireland,17.177
 2000-06-30,IL,Israel,-2.4939
-2000-06-30,IN,India,
-2000-06-30,IS,Iceland,NaN
+2000-06-30,IS,Iceland,19.0786
 2000-06-30,IT,Italy,3.3606
 2000-06-30,JP,Japan,-3.7416
-2000-06-30,KR,Korea,2.4327
+2000-06-30,KR,Korea,2.4856
 2000-06-30,LT,Lithuania,-9.375
-2000-06-30,LU,Luxembourg,
-2000-06-30,LV,Latvia,
-2000-06-30,MA,Morocco,
-2000-06-30,MK,North Macedonia,
-2000-06-30,MT,Malta,
-2000-06-30,MX,Mexico,
 2000-06-30,MY,Malaysia,7.3561
-2000-06-30,NL,Netherlands,19.3646
+2000-06-30,NL,Netherlands,18.7638
 2000-06-30,NO,Norway,19.5965
 2000-06-30,NZ,New Zealand,-0.2191
 2000-06-30,PE,Peru,0.2079
-2000-06-30,PH,Philippines,
-2000-06-30,PL,Poland,
-2000-06-30,PT,Portugal,
-2000-06-30,RO,Romania,
-2000-06-30,RS,Serbia,
-2000-06-30,RU,Russia,
+2000-06-30,PT,Portugal,8.0877
 2000-06-30,SE,Sweden,11.0638
 2000-06-30,SG,Singapore,19.0984
-2000-06-30,SI,Slovenia,
-2000-06-30,SK,Slovak Republic,
 2000-06-30,TH,Thailand,22.1612
-2000-06-30,TR,Türkiye,
-2000-06-30,US,United States,9.4634
-2000-06-30,XM,Euro area,6.2514
-2000-06-30,XW,World,
-2000-06-30,ZA,South Africa,19.4853
-2000-09-30,4T,Emerging market economies (aggregate),
-2000-09-30,5R,Advanced economies,
-2000-09-30,AE,United Arab Emirates,
-2000-09-30,AT,Austria,
+2000-06-30,US,United States,9.4652
+2000-06-30,XM,Euro area,6.2391
+2000-06-30,ZA,South Africa,19.489
+2000-09-30,AT,Austria,-1.2
 2000-09-30,AU,Australia,7.5264
 2000-09-30,BE,Belgium,3.2551
-2000-09-30,BG,Bulgaria,
-2000-09-30,BR,Brazil,
+2000-09-30,BG,Bulgaria,2.1026
 2000-09-30,CA,Canada,3.7147
-2000-09-30,CH,Switzerland,0.4686
-2000-09-30,CL,Chile,
-2000-09-30,CN,China,
-2000-09-30,CO,Colombia,1.6554
-2000-09-30,CY,Cyprus,
-2000-09-30,CZ,Czechia,
-2000-09-30,DE,Germany,0.6292
+2000-09-30,CH,Switzerland,0.4841
+2000-09-30,CO,Colombia,1.797
+2000-09-30,DE,Germany,0.6194
 2000-09-30,DK,Denmark,6.8418
-2000-09-30,EE,Estonia,
 2000-09-30,ES,Spain,7.7326
 2000-09-30,FI,Finland,3.5509
 2000-09-30,FR,France,9.209
 2000-09-30,GB,United Kingdom,13.0818
-2000-09-30,GR,Greece,
+2000-09-30,GR,Greece,10.8053
 2000-09-30,HK,Hong Kong SAR,-12.4331
-2000-09-30,HR,Croatia,
-2000-09-30,HU,Hungary,
-2000-09-30,ID,Indonesia,
+2000-09-30,HR,Croatia,-5.3468
+2000-09-30,HU,Hungary,35.2892
 2000-09-30,IE,Ireland,11.8554
 2000-09-30,IL,Israel,-5.6951
-2000-09-30,IN,India,
-2000-09-30,IS,Iceland,NaN
+2000-09-30,IS,Iceland,14.2753
 2000-09-30,IT,Italy,4.262
 2000-09-30,JP,Japan,-3.8986
-2000-09-30,KR,Korea,1.463
+2000-09-30,KR,Korea,1.3542
 2000-09-30,LT,Lithuania,-8.9888
-2000-09-30,LU,Luxembourg,
-2000-09-30,LV,Latvia,
-2000-09-30,MA,Morocco,
-2000-09-30,MK,North Macedonia,
-2000-09-30,MT,Malta,
-2000-09-30,MX,Mexico,
 2000-09-30,MY,Malaysia,6.4008
-2000-09-30,NL,Netherlands,18.2471
+2000-09-30,NL,Netherlands,17.6471
 2000-09-30,NO,Norway,13.8418
 2000-09-30,NZ,New Zealand,-0.8486
 2000-09-30,PE,Peru,-3.0065
-2000-09-30,PH,Philippines,
-2000-09-30,PL,Poland,
-2000-09-30,PT,Portugal,
-2000-09-30,RO,Romania,
-2000-09-30,RS,Serbia,
-2000-09-30,RU,Russia,
+2000-09-30,PT,Portugal,7.0778
 2000-09-30,SE,Sweden,11.5702
 2000-09-30,SG,Singapore,7.135
-2000-09-30,SI,Slovenia,
-2000-09-30,SK,Slovak Republic,
 2000-09-30,TH,Thailand,-2.7007
-2000-09-30,TR,Türkiye,
-2000-09-30,US,United States,9.6886
-2000-09-30,XM,Euro area,5.5724
-2000-09-30,XW,World,
-2000-09-30,ZA,South Africa,15.573
-2000-12-31,4T,Emerging market economies (aggregate),
-2000-12-31,5R,Advanced economies,
-2000-12-31,AE,United Arab Emirates,
-2000-12-31,AT,Austria,
+2000-09-30,US,United States,9.6748
+2000-09-30,XM,Euro area,5.5648
+2000-09-30,ZA,South Africa,15.5733
+2000-12-31,AT,Austria,-0.4044
 2000-12-31,AU,Australia,6.5853
 2000-12-31,BE,Belgium,6.251
-2000-12-31,BG,Bulgaria,
-2000-12-31,BR,Brazil,
+2000-12-31,BG,Bulgaria,-1.6424
 2000-12-31,CA,Canada,3.3038
-2000-12-31,CH,Switzerland,-1.4522
-2000-12-31,CL,Chile,
-2000-12-31,CN,China,
-2000-12-31,CO,Colombia,-1.0761
-2000-12-31,CY,Cyprus,
-2000-12-31,CZ,Czechia,
-2000-12-31,DE,Germany,0.4733
+2000-12-31,CH,Switzerland,-1.438
+2000-12-31,CO,Colombia,-1.8647
+2000-12-31,DE,Germany,0.4997
 2000-12-31,DK,Denmark,7.5635
-2000-12-31,EE,Estonia,
 2000-12-31,ES,Spain,7.7231
 2000-12-31,FI,Finland,-0.2323
 2000-12-31,FR,France,8.779
 2000-12-31,GB,United Kingdom,13.3578
-2000-12-31,GR,Greece,
+2000-12-31,GR,Greece,11.881
 2000-12-31,HK,Hong Kong SAR,-11.6514
-2000-12-31,HR,Croatia,
-2000-12-31,HU,Hungary,
-2000-12-31,ID,Indonesia,
+2000-12-31,HR,Croatia,-9.0424
+2000-12-31,HU,Hungary,31.2556
 2000-12-31,IE,Ireland,13.8316
 2000-12-31,IL,Israel,-6.7836
-2000-12-31,IN,India,
-2000-12-31,IS,Iceland,NaN
+2000-12-31,IS,Iceland,12.9198
 2000-12-31,IT,Italy,4.8734
 2000-12-31,JP,Japan,-4.0026
-2000-12-31,KR,Korea,0.5983
+2000-12-31,KR,Korea,0.709
 2000-12-31,LT,Lithuania,-1.4706
-2000-12-31,LU,Luxembourg,
-2000-12-31,LV,Latvia,
-2000-12-31,MA,Morocco,
-2000-12-31,MK,North Macedonia,
-2000-12-31,MT,Malta,
-2000-12-31,MX,Mexico,
 2000-12-31,MY,Malaysia,4.5267
-2000-12-31,NL,Netherlands,15.978
+2000-12-31,NL,Netherlands,15.2918
 2000-12-31,NO,Norway,9.8093
 2000-12-31,NZ,New Zealand,-1.1553
 2000-12-31,PE,Peru,-6.2841
-2000-12-31,PH,Philippines,
-2000-12-31,PL,Poland,
-2000-12-31,PT,Portugal,
-2000-12-31,RO,Romania,
-2000-12-31,RS,Serbia,
-2000-12-31,RU,Russia,
+2000-12-31,PT,Portugal,8.4922
 2000-12-31,SE,Sweden,11.9835
 2000-12-31,SG,Singapore,-1.0428
-2000-12-31,SI,Slovenia,
-2000-12-31,SK,Slovak Republic,
 2000-12-31,TH,Thailand,3.4268
-2000-12-31,TR,Türkiye,
-2000-12-31,US,United States,9.8089
-2000-12-31,XM,Euro area,5.6178
-2000-12-31,XW,World,
-2000-12-31,ZA,South Africa,10.8556
-2001-03-31,4T,Emerging market economies (aggregate),
-2001-03-31,5R,Advanced economies,
-2001-03-31,AE,United Arab Emirates,
-2001-03-31,AT,Austria,1.0762
+2000-12-31,US,United States,9.807
+2000-12-31,XM,Euro area,5.61
+2000-12-31,ZA,South Africa,10.8539
+2001-03-31,AT,Austria,1.0763
 2001-03-31,AU,Australia,6.9516
 2001-03-31,BE,Belgium,4.6133
-2001-03-31,BG,Bulgaria,
-2001-03-31,BR,Brazil,
+2001-03-31,BG,Bulgaria,1.2579
 2001-03-31,CA,Canada,2.5197
-2001-03-31,CH,Switzerland,0.2852
-2001-03-31,CL,Chile,
-2001-03-31,CN,China,
-2001-03-31,CO,Colombia,4.1715
-2001-03-31,CY,Cyprus,
-2001-03-31,CZ,Czechia,
-2001-03-31,DE,Germany,0.2347
+2001-03-31,CH,Switzerland,0.2857
+2001-03-31,CO,Colombia,5.2412
+2001-03-31,DE,Germany,0.2554
 2001-03-31,DK,Denmark,8.0014
-2001-03-31,EE,Estonia,
 2001-03-31,ES,Spain,8.6443
 2001-03-31,FI,Finland,-1.7053
 2001-03-31,FR,France,7.3375
 2001-03-31,GB,United Kingdom,10.1675
-2001-03-31,GR,Greece,
+2001-03-31,GR,Greece,13.9517
 2001-03-31,HK,Hong Kong SAR,-16.2934
-2001-03-31,HR,Croatia,
-2001-03-31,HU,Hungary,
-2001-03-31,ID,Indonesia,
+2001-03-31,HR,Croatia,-0.5905
+2001-03-31,HU,Hungary,25.4312
 2001-03-31,IE,Ireland,13.8836
 2001-03-31,IL,Israel,-3.3573
-2001-03-31,IN,India,
-2001-03-31,IS,Iceland,8.1
+2001-03-31,IS,Iceland,8.12
 2001-03-31,IT,Italy,4.601
 2001-03-31,JP,Japan,-4.1087
 2001-03-31,KR,Korea,0
 2001-03-31,LT,Lithuania,12.0141
-2001-03-31,LU,Luxembourg,
-2001-03-31,LV,Latvia,
-2001-03-31,MA,Morocco,
-2001-03-31,MK,North Macedonia,21.061
-2001-03-31,MT,Malta,
-2001-03-31,MX,Mexico,
+2001-03-31,MK,North Macedonia,21.0452
 2001-03-31,MY,Malaysia,2.7579
-2001-03-31,NL,Netherlands,13.5705
+2001-03-31,NL,Netherlands,13.7066
 2001-03-31,NO,Norway,7.1979
 2001-03-31,NZ,New Zealand,0.0292
 2001-03-31,PE,Peru,-10.2158
-2001-03-31,PH,Philippines,
-2001-03-31,PL,Poland,
-2001-03-31,PT,Portugal,
-2001-03-31,RO,Romania,
+2001-03-31,PT,Portugal,7.7028
 2001-03-31,RS,Serbia,51.3279
-2001-03-31,RU,Russia,
 2001-03-31,SE,Sweden,12.0482
 2001-03-31,SG,Singapore,-7.8868
-2001-03-31,SI,Slovenia,
-2001-03-31,SK,Slovak Republic,
 2001-03-31,TH,Thailand,4.3377
-2001-03-31,TR,Türkiye,
-2001-03-31,US,United States,9.7337
-2001-03-31,XM,Euro area,5.2438
-2001-03-31,XW,World,
-2001-03-31,ZA,South Africa,-2.2232
-2001-06-30,4T,Emerging market economies (aggregate),
-2001-06-30,5R,Advanced economies,
-2001-06-30,AE,United Arab Emirates,
-2001-06-30,AT,Austria,-1.6916
+2001-03-31,US,United States,9.7327
+2001-03-31,XM,Euro area,5.2447
+2001-03-31,ZA,South Africa,-2.222
+2001-06-30,AT,Austria,-1.6915
 2001-06-30,AU,Australia,8.2135
 2001-06-30,BE,Belgium,5.1325
-2001-06-30,BG,Bulgaria,
-2001-06-30,BR,Brazil,
+2001-06-30,BG,Bulgaria,-0.5349
 2001-06-30,CA,Canada,4.8787
-2001-06-30,CH,Switzerland,0.1017
-2001-06-30,CL,Chile,
-2001-06-30,CN,China,
-2001-06-30,CO,Colombia,1.3534
-2001-06-30,CY,Cyprus,
-2001-06-30,CZ,Czechia,
-2001-06-30,DE,Germany,-0.002
+2001-06-30,CH,Switzerland,0.1036
+2001-06-30,CO,Colombia,1.9284
+2001-06-30,DE,Germany,0.0128
 2001-06-30,DK,Denmark,6.5512
-2001-06-30,EE,Estonia,
 2001-06-30,ES,Spain,9.3179
 2001-06-30,FI,Finland,-2.125
 2001-06-30,FR,France,7.5356
 2001-06-30,GB,United Kingdom,8.1633
-2001-06-30,GR,Greece,
+2001-06-30,GR,Greece,14.9735
 2001-06-30,HK,Hong Kong SAR,-9.8445
-2001-06-30,HR,Croatia,
-2001-06-30,HU,Hungary,
-2001-06-30,ID,Indonesia,
+2001-06-30,HR,Croatia,2.85
+2001-06-30,HU,Hungary,18.1554
 2001-06-30,IE,Ireland,12.1936
 2001-06-30,IL,Israel,-5.6572
-2001-06-30,IN,India,
-2001-06-30,IS,Iceland,5.4284
+2001-06-30,IS,Iceland,5.4778
 2001-06-30,IT,Italy,5.036
 2001-06-30,JP,Japan,-4.2775
-2001-06-30,KR,Korea,1.5267
+2001-06-30,KR,Korea,1.5817
 2001-06-30,LT,Lithuania,14.1762
-2001-06-30,LU,Luxembourg,
-2001-06-30,LV,Latvia,
-2001-06-30,MA,Morocco,
-2001-06-30,MK,North Macedonia,14.2446
-2001-06-30,MT,Malta,
-2001-06-30,MX,Mexico,
+2001-06-30,MK,North Macedonia,14.5787
 2001-06-30,MY,Malaysia,0.6951
-2001-06-30,NL,Netherlands,12.1673
+2001-06-30,NL,Netherlands,12.2677
 2001-06-30,NO,Norway,4.8193
 2001-06-30,NZ,New Zealand,0.7028
 2001-06-30,PE,Peru,-2.15
-2001-06-30,PH,Philippines,
-2001-06-30,PL,Poland,
-2001-06-30,PT,Portugal,
-2001-06-30,RO,Romania,
+2001-06-30,PT,Portugal,6.4849
 2001-06-30,RS,Serbia,29.8617
-2001-06-30,RU,Russia,
 2001-06-30,SE,Sweden,8.4291
 2001-06-30,SG,Singapore,-10.0597
-2001-06-30,SI,Slovenia,
-2001-06-30,SK,Slovak Republic,
 2001-06-30,TH,Thailand,-2.4738
-2001-06-30,TR,Türkiye,
-2001-06-30,US,United States,8.8722
-2001-06-30,XM,Euro area,5.1027
-2001-06-30,XW,World,
-2001-06-30,ZA,South Africa,0.4297
-2001-09-30,4T,Emerging market economies (aggregate),
-2001-09-30,5R,Advanced economies,
-2001-09-30,AE,United Arab Emirates,
+2001-06-30,US,United States,8.867
+2001-06-30,XM,Euro area,5.1004
+2001-06-30,ZA,South Africa,0.4271
 2001-09-30,AT,Austria,4.0486
 2001-09-30,AU,Australia,14.0067
 2001-09-30,BE,Belgium,5.497
-2001-09-30,BG,Bulgaria,
-2001-09-30,BR,Brazil,
+2001-09-30,BG,Bulgaria,-0.1113
 2001-09-30,CA,Canada,5.3955
-2001-09-30,CH,Switzerland,-0.5129
-2001-09-30,CL,Chile,
-2001-09-30,CN,China,
-2001-09-30,CO,Colombia,4.1269
-2001-09-30,CY,Cyprus,
-2001-09-30,CZ,Czechia,
-2001-09-30,DE,Germany,-0.152
+2001-09-30,CH,Switzerland,-0.5118
+2001-09-30,CO,Colombia,4.0045
+2001-09-30,DE,Germany,-0.1236
 2001-09-30,DK,Denmark,5.3611
-2001-09-30,EE,Estonia,
 2001-09-30,ES,Spain,10.2038
 2001-09-30,FI,Finland,-0.631
 2001-09-30,FR,France,6.8898
 2001-09-30,GB,United Kingdom,9.8999
-2001-09-30,GR,Greece,
+2001-09-30,GR,Greece,14.9425
 2001-09-30,HK,Hong Kong SAR,-9.9618
-2001-09-30,HR,Croatia,
-2001-09-30,HU,Hungary,
-2001-09-30,ID,Indonesia,
+2001-09-30,HR,Croatia,-0.3097
+2001-09-30,HU,Hungary,16.7607
 2001-09-30,IE,Ireland,5.5611
 2001-09-30,IL,Israel,-3.0109
-2001-09-30,IN,India,
-2001-09-30,IS,Iceland,5.5818
+2001-09-30,IS,Iceland,5.6013
 2001-09-30,IT,Italy,5.8416
 2001-09-30,JP,Japan,-4.4625
-2001-09-30,KR,Korea,5.5131
+2001-09-30,KR,Korea,5.5907
 2001-09-30,LT,Lithuania,35.8025
-2001-09-30,LU,Luxembourg,
-2001-09-30,LV,Latvia,
-2001-09-30,MA,Morocco,
-2001-09-30,MK,North Macedonia,8.3239
-2001-09-30,MT,Malta,
-2001-09-30,MX,Mexico,
+2001-09-30,MK,North Macedonia,7.5931
 2001-09-30,MY,Malaysia,0.9862
-2001-09-30,NL,Netherlands,10.3281
+2001-09-30,NL,Netherlands,10.3571
 2001-09-30,NO,Norway,7.9404
 2001-09-30,NZ,New Zealand,2.3757
 2001-09-30,PE,Peru,-9.6972
-2001-09-30,PH,Philippines,
-2001-09-30,PL,Poland,
-2001-09-30,PT,Portugal,
-2001-09-30,RO,Romania,
+2001-09-30,PT,Portugal,5.072
 2001-09-30,RS,Serbia,15.1386
-2001-09-30,RU,Russia,
 2001-09-30,SE,Sweden,6.6667
 2001-09-30,SG,Singapore,-10.2459
-2001-09-30,SI,Slovenia,
-2001-09-30,SK,Slovak Republic,
 2001-09-30,TH,Thailand,-1.542
-2001-09-30,TR,Türkiye,
-2001-09-30,US,United States,8.5883
-2001-09-30,XM,Euro area,4.9771
-2001-09-30,XW,World,
-2001-09-30,ZA,South Africa,5.6873
-2001-12-31,4T,Emerging market economies (aggregate),
-2001-12-31,5R,Advanced economies,
-2001-12-31,AE,United Arab Emirates,
+2001-09-30,US,United States,8.5927
+2001-09-30,XM,Euro area,5.0006
+2001-09-30,ZA,South Africa,5.6858
 2001-12-31,AT,Austria,0
 2001-12-31,AU,Australia,15.5359
 2001-12-31,BE,Belgium,4.0995
-2001-12-31,BG,Bulgaria,
-2001-12-31,BR,Brazil,
+2001-12-31,BG,Bulgaria,0.6705
 2001-12-31,CA,Canada,5.6674
-2001-12-31,CH,Switzerland,3.05
-2001-12-31,CL,Chile,
-2001-12-31,CN,China,
-2001-12-31,CO,Colombia,10.2009
-2001-12-31,CY,Cyprus,
-2001-12-31,CZ,Czechia,
-2001-12-31,DE,Germany,-0.468
+2001-12-31,CH,Switzerland,3.0522
+2001-12-31,CO,Colombia,10.0749
+2001-12-31,DE,Germany,-0.5313
 2001-12-31,DK,Denmark,3.6052
-2001-12-31,EE,Estonia,
 2001-12-31,ES,Spain,11.1947
 2001-12-31,FI,Finland,1.2806
 2001-12-31,FR,France,7.7075
 2001-12-31,GB,United Kingdom,4.6486
-2001-12-31,GR,Greece,
+2001-12-31,GR,Greece,13.7426
 2001-12-31,HK,Hong Kong SAR,-12.2774
-2001-12-31,HR,Croatia,
-2001-12-31,HU,Hungary,
-2001-12-31,ID,Indonesia,
+2001-12-31,HR,Croatia,5.7355
+2001-12-31,HU,Hungary,19.0228
 2001-12-31,IE,Ireland,0.6425
 2001-12-31,IL,Israel,-1.8456
-2001-12-31,IN,India,
-2001-12-31,IS,Iceland,4.7354
+2001-12-31,IS,Iceland,4.7725
 2001-12-31,IT,Italy,7.4325
 2001-12-31,JP,Japan,-4.7163
-2001-12-31,KR,Korea,8.6661
+2001-12-31,KR,Korea,8.5885
 2001-12-31,LT,Lithuania,41.4179
-2001-12-31,LU,Luxembourg,
-2001-12-31,LV,Latvia,
-2001-12-31,MA,Morocco,
-2001-12-31,MK,North Macedonia,-0.1487
-2001-12-31,MT,Malta,
-2001-12-31,MX,Mexico,
+2001-12-31,MK,North Macedonia,-0.1783
 2001-12-31,MY,Malaysia,0.7874
-2001-12-31,NL,Netherlands,8.7886
+2001-12-31,NL,Netherlands,8.9005
 2001-12-31,NO,Norway,7.6923
 2001-12-31,NZ,New Zealand,4.3941
 2001-12-31,PE,Peru,-6.8684
-2001-12-31,PH,Philippines,
-2001-12-31,PL,Poland,
-2001-12-31,PT,Portugal,
-2001-12-31,RO,Romania,
+2001-12-31,PT,Portugal,2.5879
 2001-12-31,RS,Serbia,8.0993
-2001-12-31,RU,Russia,
 2001-12-31,SE,Sweden,4.797
 2001-12-31,SG,Singapore,-11.6965
-2001-12-31,SI,Slovenia,
-2001-12-31,SK,Slovak Republic,
 2001-12-31,TH,Thailand,-1.2801
-2001-12-31,TR,Türkiye,
-2001-12-31,US,United States,7.9335
-2001-12-31,XM,Euro area,4.8677
-2001-12-31,XW,World,
-2001-12-31,ZA,South Africa,10.7227
-2002-03-31,4T,Emerging market economies (aggregate),
-2002-03-31,5R,Advanced economies,
-2002-03-31,AE,United Arab Emirates,
+2001-12-31,US,United States,7.941
+2001-12-31,XM,Euro area,4.8994
+2001-12-31,ZA,South Africa,10.7242
 2002-03-31,AT,Austria,-1.5489
 2002-03-31,AU,Australia,17.3474
 2002-03-31,BE,Belgium,4.8878
-2002-03-31,BG,Bulgaria,
+2002-03-31,BG,Bulgaria,-0.9635
 2002-03-31,BR,Brazil,0.98
 2002-03-31,CA,Canada,10.6076
-2002-03-31,CH,Switzerland,1.1506
-2002-03-31,CL,Chile,
-2002-03-31,CN,China,
-2002-03-31,CO,Colombia,-1.2989
-2002-03-31,CY,Cyprus,
-2002-03-31,CZ,Czechia,
-2002-03-31,DE,Germany,-0.5318
+2002-03-31,CH,Switzerland,1.1529
+2002-03-31,CO,Colombia,-1.4804
+2002-03-31,DE,Germany,-0.5631
 2002-03-31,DK,Denmark,3.1939
-2002-03-31,EE,Estonia,
 2002-03-31,ES,Spain,13.1199
 2002-03-31,FI,Finland,4.8371
 2002-03-31,FR,France,7.4219
 2002-03-31,GB,United Kingdom,8.5776
-2002-03-31,GR,Greece,
-2002-03-31,HK,Hong Kong SAR,-8.8889
-2002-03-31,HR,Croatia,
-2002-03-31,HU,Hungary,
-2002-03-31,ID,Indonesia,
+2002-03-31,GR,Greece,13.9706
+2002-03-31,HK,Hong Kong SAR,-8.93
+2002-03-31,HR,Croatia,0.4486
+2002-03-31,HU,Hungary,15.04
 2002-03-31,IE,Ireland,3.7924
 2002-03-31,IL,Israel,4.2715
-2002-03-31,IN,India,
-2002-03-31,IS,Iceland,5.4579
+2002-03-31,IS,Iceland,5.4384
 2002-03-31,IT,Italy,12.2957
 2002-03-31,JP,Japan,-4.9758
-2002-03-31,KR,Korea,15.1489
+2002-03-31,KR,Korea,15.1675
 2002-03-31,LT,Lithuania,12.6183
-2002-03-31,LU,Luxembourg,
-2002-03-31,LV,Latvia,
-2002-03-31,MA,Morocco,
-2002-03-31,MK,North Macedonia,2.4749
-2002-03-31,MT,Malta,
-2002-03-31,MX,Mexico,
+2002-03-31,MK,North Macedonia,2.0498
 2002-03-31,MY,Malaysia,1.7893
-2002-03-31,NL,Netherlands,8.1206
+2002-03-31,NL,Netherlands,7.6401
 2002-03-31,NO,Norway,7.4341
 2002-03-31,NZ,New Zealand,7.0636
 2002-03-31,PE,Peru,-1.0668
-2002-03-31,PH,Philippines,
-2002-03-31,PL,Poland,
-2002-03-31,PT,Portugal,
-2002-03-31,RO,Romania,
+2002-03-31,PT,Portugal,1.7089
 2002-03-31,RS,Serbia,6.0051
 2002-03-31,RU,Russia,34.158
 2002-03-31,SE,Sweden,3.5842
 2002-03-31,SG,Singapore,-9.1109
-2002-03-31,SI,Slovenia,
-2002-03-31,SK,Slovak Republic,
 2002-03-31,TH,Thailand,-2.7468
-2002-03-31,TR,Türkiye,
-2002-03-31,US,United States,7.3269
-2002-03-31,XM,Euro area,5.7634
-2002-03-31,XW,World,
-2002-03-31,ZA,South Africa,12.669
-2002-06-30,4T,Emerging market economies (aggregate),
-2002-06-30,5R,Advanced economies,
-2002-06-30,AE,United Arab Emirates,
-2002-06-30,AT,Austria,1.2145
+2002-03-31,US,United States,7.3294
+2002-03-31,XM,Euro area,5.7883
+2002-03-31,ZA,South Africa,12.6677
+2002-06-30,AT,Austria,1.2146
 2002-06-30,AU,Australia,20.0424
 2002-06-30,BE,Belgium,5.8599
-2002-06-30,BG,Bulgaria,
+2002-06-30,BG,Bulgaria,1.9814
 2002-06-30,BR,Brazil,1.427
 2002-06-30,CA,Canada,10.2234
-2002-06-30,CH,Switzerland,0.3505
-2002-06-30,CL,Chile,
-2002-06-30,CN,China,
-2002-06-30,CO,Colombia,2.5922
-2002-06-30,CY,Cyprus,
-2002-06-30,CZ,Czechia,
-2002-06-30,DE,Germany,-0.5949
+2002-06-30,CH,Switzerland,0.3523
+2002-06-30,CO,Colombia,2.3381
+2002-06-30,DE,Germany,-0.5941
 2002-06-30,DK,Denmark,3.8188
-2002-06-30,EE,Estonia,
 2002-06-30,ES,Spain,16.1097
 2002-06-30,FI,Finland,7.2286
 2002-06-30,FR,France,7.7652
 2002-06-30,GB,United Kingdom,13.4172
-2002-06-30,GR,Greece,
-2002-06-30,HK,Hong Kong SAR,-11.1248
-2002-06-30,HR,Croatia,
-2002-06-30,HU,Hungary,
-2002-06-30,ID,Indonesia,
+2002-06-30,GR,Greece,15.5127
+2002-06-30,HK,Hong Kong SAR,-11.0838
+2002-06-30,HR,Croatia,-1.9351
+2002-06-30,HU,Hungary,16.5842
 2002-06-30,IE,Ireland,4.8582
 2002-06-30,IL,Israel,7.756
-2002-06-30,IN,India,
-2002-06-30,IS,Iceland,3.3424
+2002-06-30,IS,Iceland,3.3598
 2002-06-30,IT,Italy,13.2273
 2002-06-30,JP,Japan,-5.1737
-2002-06-30,KR,Korea,17.4603
+2002-06-30,KR,Korea,17.4394
 2002-06-30,LT,Lithuania,20.8054
-2002-06-30,LU,Luxembourg,
-2002-06-30,LV,Latvia,
-2002-06-30,MA,Morocco,
-2002-06-30,MK,North Macedonia,9.8888
-2002-06-30,MT,Malta,
-2002-06-30,MX,Mexico,
+2002-06-30,MK,North Macedonia,9.8388
 2002-06-30,MY,Malaysia,2.6627
-2002-06-30,NL,Netherlands,6.7797
+2002-06-30,NL,Netherlands,6.6225
 2002-06-30,NO,Norway,6.6667
 2002-06-30,NZ,New Zealand,9.2323
 2002-06-30,PE,Peru,-8.8864
-2002-06-30,PH,Philippines,
-2002-06-30,PL,Poland,
-2002-06-30,PT,Portugal,
-2002-06-30,RO,Romania,
+2002-06-30,PT,Portugal,0.6246
 2002-06-30,RS,Serbia,2.6631
 2002-06-30,RU,Russia,35.7743
 2002-06-30,SE,Sweden,5.3004
 2002-06-30,SG,Singapore,-8.97
-2002-06-30,SI,Slovenia,
-2002-06-30,SK,Slovak Republic,
 2002-06-30,TH,Thailand,1.6141
-2002-06-30,TR,Türkiye,
-2002-06-30,US,United States,8.2245
-2002-06-30,XM,Euro area,6.3359
-2002-06-30,XW,World,
-2002-06-30,ZA,South Africa,13.6424
-2002-09-30,4T,Emerging market economies (aggregate),
-2002-09-30,5R,Advanced economies,
-2002-09-30,AE,United Arab Emirates,
-2002-09-30,AT,Austria,0.5836
+2002-06-30,US,United States,8.2184
+2002-06-30,XM,Euro area,6.3618
+2002-06-30,ZA,South Africa,13.642
+2002-09-30,AT,Austria,0.5837
 2002-09-30,AU,Australia,18.8554
 2002-09-30,BE,Belgium,6.7047
-2002-09-30,BG,Bulgaria,
+2002-09-30,BG,Bulgaria,2.1359
 2002-09-30,BR,Brazil,2.35
 2002-09-30,CA,Canada,8.9893
-2002-09-30,CH,Switzerland,0.8708
-2002-09-30,CL,Chile,
-2002-09-30,CN,China,
-2002-09-30,CO,Colombia,1.5488
-2002-09-30,CY,Cyprus,
-2002-09-30,CZ,Czechia,
-2002-09-30,DE,Germany,-0.7629
+2002-09-30,CH,Switzerland,0.8733
+2002-09-30,CO,Colombia,1.6201
+2002-09-30,DE,Germany,-0.7675
 2002-09-30,DK,Denmark,3.2863
-2002-09-30,EE,Estonia,
 2002-09-30,ES,Spain,16.2757
 2002-09-30,FI,Finland,8.9801
 2002-09-30,FR,France,9.0239
 2002-09-30,GB,United Kingdom,16.9028
-2002-09-30,GR,Greece,
+2002-09-30,GR,Greece,13.2903
 2002-09-30,HK,Hong Kong SAR,-12.7174
-2002-09-30,HR,Croatia,
-2002-09-30,HU,Hungary,
-2002-09-30,ID,Indonesia,
+2002-09-30,HR,Croatia,13.4013
+2002-09-30,HU,Hungary,15.7019
 2002-09-30,IE,Ireland,11.3727
 2002-09-30,IL,Israel,5.1382
-2002-09-30,IN,India,
-2002-09-30,IS,Iceland,5.5554
+2002-09-30,IS,Iceland,5.5551
 2002-09-30,IT,Italy,12.182
 2002-09-30,JP,Japan,-5.3786
-2002-09-30,KR,Korea,17.0418
+2002-09-30,KR,Korea,16.9497
 2002-09-30,LT,Lithuania,13.6364
-2002-09-30,LU,Luxembourg,
-2002-09-30,LV,Latvia,
-2002-09-30,MA,Morocco,
-2002-09-30,MK,North Macedonia,16.6393
-2002-09-30,MT,Malta,
-2002-09-30,MX,Mexico,
+2002-09-30,MK,North Macedonia,17.5757
 2002-09-30,MY,Malaysia,3.125
-2002-09-30,NL,Netherlands,5.837
+2002-09-30,NL,Netherlands,5.9871
 2002-09-30,NO,Norway,3.2184
 2002-09-30,NZ,New Zealand,11.6892
 2002-09-30,PE,Peru,17.7205
-2002-09-30,PH,Philippines,
-2002-09-30,PL,Poland,
-2002-09-30,PT,Portugal,
-2002-09-30,RO,Romania,
+2002-09-30,PT,Portugal,0.0623
 2002-09-30,RS,Serbia,-1.8462
 2002-09-30,RU,Russia,33.3025
 2002-09-30,SE,Sweden,7.2917
 2002-09-30,SG,Singapore,-5.7077
-2002-09-30,SI,Slovenia,
-2002-09-30,SK,Slovak Republic,
 2002-09-30,TH,Thailand,3.3673
-2002-09-30,TR,Türkiye,
-2002-09-30,US,United States,8.9111
-2002-09-30,XM,Euro area,6.6556
-2002-09-30,XW,World,
-2002-09-30,ZA,South Africa,13.5593
-2002-12-31,4T,Emerging market economies (aggregate),
-2002-12-31,5R,Advanced economies,
-2002-12-31,AE,United Arab Emirates,
-2002-12-31,AT,Austria,2.1319
+2002-09-30,US,United States,8.9071
+2002-09-30,XM,Euro area,6.67
+2002-09-30,ZA,South Africa,13.563
+2002-12-31,AT,Austria,2.132
 2002-12-31,AU,Australia,18.7362
 2002-12-31,BE,Belgium,8.1016
-2002-12-31,BG,Bulgaria,
+2002-12-31,BG,Bulgaria,4.2536
 2002-12-31,BR,Brazil,3.945
 2002-12-31,CA,Canada,10.9942
-2002-12-31,CH,Switzerland,-0.4862
-2002-12-31,CL,Chile,
-2002-12-31,CN,China,
-2002-12-31,CO,Colombia,-2.3935
-2002-12-31,CY,Cyprus,
-2002-12-31,CZ,Czechia,
-2002-12-31,DE,Germany,-0.8708
+2002-12-31,CH,Switzerland,-0.4835
+2002-12-31,CO,Colombia,-2.703
+2002-12-31,DE,Germany,-0.8363
 2002-12-31,DK,Denmark,4.1387
-2002-12-31,EE,Estonia,
 2002-12-31,ES,Spain,17.3212
 2002-12-31,FI,Finland,8.7229
 2002-12-31,FR,France,9.7248
 2002-12-31,GB,United Kingdom,25.2066
-2002-12-31,GR,Greece,
+2002-12-31,GR,Greece,12.7413
 2002-12-31,HK,Hong Kong SAR,-11.8283
-2002-12-31,HR,Croatia,
-2002-12-31,HU,Hungary,
-2002-12-31,ID,Indonesia,
+2002-12-31,HR,Croatia,11.2507
+2002-12-31,HU,Hungary,13.4099
 2002-12-31,IE,Ireland,14.1927
 2002-12-31,IL,Israel,3.9219
-2002-12-31,IN,India,
-2002-12-31,IS,Iceland,6.6491
+2002-12-31,IS,Iceland,6.6377
 2002-12-31,IT,Italy,10.0749
 2002-12-31,JP,Japan,-5.6313
-2002-12-31,KR,Korea,16.9664
+2002-12-31,KR,Korea,17.0178
 2002-12-31,LT,Lithuania,2.9024
-2002-12-31,LU,Luxembourg,
-2002-12-31,LV,Latvia,
-2002-12-31,MA,Morocco,
-2002-12-31,MK,North Macedonia,12.8816
-2002-12-31,MT,Malta,
-2002-12-31,MX,Mexico,
+2002-12-31,MK,North Macedonia,12.7995
 2002-12-31,MY,Malaysia,4.7852
-2002-12-31,NL,Netherlands,4.8035
+2002-12-31,NL,Netherlands,4.8077
 2002-12-31,NO,Norway,2.765
 2002-12-31,NZ,New Zealand,13.9598
 2002-12-31,PE,Peru,-1.6242
-2002-12-31,PH,Philippines,
-2002-12-31,PL,Poland,
-2002-12-31,PT,Portugal,
-2002-12-31,RO,Romania,
+2002-12-31,PT,Portugal,0.1246
 2002-12-31,RS,Serbia,6.6522
 2002-12-31,RU,Russia,27.3815
 2002-12-31,SE,Sweden,9.1549
 2002-12-31,SG,Singapore,-1.79
-2002-12-31,SI,Slovenia,
-2002-12-31,SK,Slovak Republic,
 2002-12-31,TH,Thailand,0.6102
-2002-12-31,TR,Türkiye,
-2002-12-31,US,United States,9.3287
-2002-12-31,XM,Euro area,6.7143
-2002-12-31,XW,World,
-2002-12-31,ZA,South Africa,13.7087
-2003-03-31,4T,Emerging market economies (aggregate),
-2003-03-31,5R,Advanced economies,
-2003-03-31,AE,United Arab Emirates,
-2003-03-31,AT,Austria,0.5899
+2002-12-31,US,United States,9.3046
+2002-12-31,XM,Euro area,6.7222
+2002-12-31,ZA,South Africa,13.7103
+2003-03-31,AT,Austria,0.59
 2003-03-31,AU,Australia,17.4651
 2003-03-31,BE,Belgium,7.3649
-2003-03-31,BG,Bulgaria,
+2003-03-31,BG,Bulgaria,5.1833
 2003-03-31,BR,Brazil,6.2786
 2003-03-31,CA,Canada,8.6156
-2003-03-31,CH,Switzerland,-0.9887
-2003-03-31,CL,Chile,7.5711
-2003-03-31,CN,China,
-2003-03-31,CO,Colombia,0.505
+2003-03-31,CH,Switzerland,-0.9864
+2003-03-31,CL,Chile,7.5709
+2003-03-31,CO,Colombia,-0.1645
 2003-03-31,CY,Cyprus,4.6097
-2003-03-31,CZ,Czechia,
-2003-03-31,DE,Germany,-1.0589
+2003-03-31,DE,Germany,-1.0255
 2003-03-31,DK,Denmark,2.3599
-2003-03-31,EE,Estonia,
 2003-03-31,ES,Spain,16.917
 2003-03-31,FI,Finland,6.6133
 2003-03-31,FR,France,10.9091
 2003-03-31,GB,United Kingdom,23.4
-2003-03-31,GR,Greece,
-2003-03-31,HK,Hong Kong SAR,-14.9955
+2003-03-31,GR,Greece,10.0075
+2003-03-31,HK,Hong Kong SAR,-14.9571
 2003-03-31,HR,Croatia,14.4737
-2003-03-31,HU,Hungary,
+2003-03-31,HU,Hungary,20.266
 2003-03-31,ID,Indonesia,6.29
 2003-03-31,IE,Ireland,12.6201
 2003-03-31,IL,Israel,-2.3456
-2003-03-31,IN,India,
-2003-03-31,IS,Iceland,9.386
+2003-03-31,IS,Iceland,9.3596
 2003-03-31,IT,Italy,6.4602
 2003-03-31,JP,Japan,-5.8909
-2003-03-31,KR,Korea,11.2343
+2003-03-31,KR,Korea,11.2711
 2003-03-31,LT,Lithuania,23.8095
-2003-03-31,LU,Luxembourg,
-2003-03-31,LV,Latvia,
-2003-03-31,MA,Morocco,
-2003-03-31,MK,North Macedonia,11.3653
-2003-03-31,MT,Malta,
-2003-03-31,MX,Mexico,
+2003-03-31,MK,North Macedonia,11.7379
 2003-03-31,MY,Malaysia,4.6875
-2003-03-31,NL,Netherlands,3.97
+2003-03-31,NL,Netherlands,4.2587
 2003-03-31,NO,Norway,1.7857
 2003-03-31,NZ,New Zealand,15.6352
 2003-03-31,PE,Peru,-12.2723
-2003-03-31,PH,Philippines,
-2003-03-31,PL,Poland,
-2003-03-31,PT,Portugal,
-2003-03-31,RO,Romania,
+2003-03-31,PT,Portugal,0.5289
 2003-03-31,RS,Serbia,27.913
 2003-03-31,RU,Russia,26.7979
 2003-03-31,SE,Sweden,7.9585
 2003-03-31,SG,Singapore,-1.4493
-2003-03-31,SI,Slovenia,
-2003-03-31,SK,Slovak Republic,
 2003-03-31,TH,Thailand,2.0611
-2003-03-31,TR,Türkiye,
-2003-03-31,US,United States,9.5326
-2003-03-31,XM,Euro area,6.0706
-2003-03-31,XW,World,
-2003-03-31,ZA,South Africa,14.8226
-2003-06-30,4T,Emerging market economies (aggregate),
-2003-06-30,5R,Advanced economies,
-2003-06-30,AE,United Arab Emirates,
+2003-03-31,US,United States,9.5384
+2003-03-31,XM,Euro area,6.0772
+2003-03-31,ZA,South Africa,14.8246
 2003-06-30,AT,Austria,1.3
 2003-06-30,AU,Australia,16.8492
 2003-06-30,BE,Belgium,6.4449
-2003-06-30,BG,Bulgaria,
+2003-06-30,BG,Bulgaria,8.1509
 2003-06-30,BR,Brazil,9.1392
 2003-06-30,CA,Canada,7.9479
-2003-06-30,CH,Switzerland,2.5785
-2003-06-30,CL,Chile,4.7103
-2003-06-30,CN,China,
-2003-06-30,CO,Colombia,0.9754
+2003-06-30,CH,Switzerland,2.5805
+2003-06-30,CL,Chile,4.7101
+2003-06-30,CO,Colombia,0.5571
 2003-06-30,CY,Cyprus,6.4511
-2003-06-30,CZ,Czechia,
-2003-06-30,DE,Germany,-1.3302
+2003-06-30,DE,Germany,-1.3394
 2003-06-30,DK,Denmark,2.5421
-2003-06-30,EE,Estonia,
 2003-06-30,ES,Spain,17.281
 2003-06-30,FI,Finland,5.3061
 2003-06-30,FR,France,11.2478
 2003-06-30,GB,United Kingdom,17.5601
-2003-06-30,GR,Greece,
-2003-06-30,HK,Hong Kong SAR,-17.09
+2003-06-30,GR,Greece,3.996
+2003-06-30,HK,Hong Kong SAR,-17.1283
 2003-06-30,HR,Croatia,19.1348
-2003-06-30,HU,Hungary,
+2003-06-30,HU,Hungary,19.7563
 2003-06-30,ID,Indonesia,6.1564
 2003-06-30,IE,Ireland,13.0158
 2003-06-30,IL,Israel,-8.2973
-2003-06-30,IN,India,
-2003-06-30,IS,Iceland,11.8008
+2003-06-30,IS,Iceland,11.7354
 2003-06-30,IT,Italy,5.6575
 2003-06-30,JP,Japan,-6.1563
-2003-06-30,KR,Korea,10.2418
+2003-06-30,KR,Korea,10.165
 2003-06-30,LT,Lithuania,11.1111
-2003-06-30,LU,Luxembourg,
-2003-06-30,LV,Latvia,
-2003-06-30,MA,Morocco,
-2003-06-30,MK,North Macedonia,5.5586
-2003-06-30,MT,Malta,
-2003-06-30,MX,Mexico,
+2003-06-30,MK,North Macedonia,5.2802
 2003-06-30,MY,Malaysia,2.8818
-2003-06-30,NL,Netherlands,3.5979
+2003-06-30,NL,Netherlands,3.7267
 2003-06-30,NO,Norway,-1.0776
 2003-06-30,NZ,New Zealand,16.8242
 2003-06-30,PE,Peru,-6.9285
-2003-06-30,PH,Philippines,
-2003-06-30,PL,Poland,
-2003-06-30,PT,Portugal,
-2003-06-30,RO,Romania,
+2003-06-30,PT,Portugal,0.869
 2003-06-30,RS,Serbia,39.8308
 2003-06-30,RU,Russia,21.9101
 2003-06-30,SE,Sweden,7.047
 2003-06-30,SG,Singapore,-1.3383
-2003-06-30,SI,Slovenia,
-2003-06-30,SK,Slovak Republic,
 2003-06-30,TH,Thailand,1.2859
-2003-06-30,TR,Türkiye,
-2003-06-30,US,United States,9.0569
-2003-06-30,XM,Euro area,5.9308
-2003-06-30,XW,World,
-2003-06-30,ZA,South Africa,17.0388
-2003-09-30,4T,Emerging market economies (aggregate),
-2003-09-30,5R,Advanced economies,
-2003-09-30,AE,United Arab Emirates,
+2003-06-30,US,United States,9.0485
+2003-06-30,XM,Euro area,5.9442
+2003-06-30,ZA,South Africa,17.0409
 2003-09-30,AT,Austria,-2.9981
 2003-09-30,AU,Australia,18.7747
 2003-09-30,BE,Belgium,6.6001
-2003-09-30,BG,Bulgaria,
+2003-09-30,BG,Bulgaria,14.0233
 2003-09-30,BR,Brazil,12.0242
 2003-09-30,CA,Canada,11.1735
-2003-09-30,CH,Switzerland,2.9204
-2003-09-30,CL,Chile,3.5581
-2003-09-30,CN,China,
-2003-09-30,CO,Colombia,1.2007
+2003-09-30,CH,Switzerland,2.9226
+2003-09-30,CL,Chile,3.5583
+2003-09-30,CO,Colombia,1.2107
 2003-09-30,CY,Cyprus,2.505
-2003-09-30,CZ,Czechia,
-2003-09-30,DE,Germany,-1.526
+2003-09-30,DE,Germany,-1.5469
 2003-09-30,DK,Denmark,3.6948
-2003-09-30,EE,Estonia,
 2003-09-30,ES,Spain,17.6704
 2003-09-30,FI,Finland,6.2036
 2003-09-30,FR,France,11.4865
 2003-09-30,GB,United Kingdom,13.1602
-2003-09-30,GR,Greece,
+2003-09-30,GR,Greece,4.5558
 2003-09-30,HK,Hong Kong SAR,-13.5987
 2003-09-30,HR,Croatia,13.8583
-2003-09-30,HU,Hungary,
+2003-09-30,HU,Hungary,17.5266
 2003-09-30,ID,Indonesia,6.1833
 2003-09-30,IE,Ireland,13.1184
 2003-09-30,IL,Israel,-6.1597
-2003-09-30,IN,India,
-2003-09-30,IS,Iceland,14.0068
+2003-09-30,IS,Iceland,13.9632
 2003-09-30,IT,Italy,6.3386
 2003-09-30,JP,Japan,-6.4323
-2003-09-30,KR,Korea,8.3104
+2003-09-30,KR,Korea,8.3251
 2003-09-30,LT,Lithuania,9.3333
-2003-09-30,LU,Luxembourg,
-2003-09-30,LV,Latvia,
-2003-09-30,MA,Morocco,
-2003-09-30,MK,North Macedonia,-2.3199
-2003-09-30,MT,Malta,
-2003-09-30,MX,Mexico,
+2003-09-30,MK,North Macedonia,-3.1605
 2003-09-30,MY,Malaysia,4.7348
-2003-09-30,NL,Netherlands,2.8096
+2003-09-30,NL,Netherlands,2.9008
 2003-09-30,NO,Norway,2.0045
 2003-09-30,NZ,New Zealand,20.8801
 2003-09-30,PE,Peru,-24.5016
-2003-09-30,PH,Philippines,
-2003-09-30,PL,Poland,
-2003-09-30,PT,Portugal,
-2003-09-30,RO,Romania,
+2003-09-30,PT,Portugal,1.4628
 2003-09-30,RS,Serbia,42.3479
 2003-09-30,RU,Russia,20.7391
 2003-09-30,SE,Sweden,5.5016
 2003-09-30,SG,Singapore,-2.3002
-2003-09-30,SI,Slovenia,
-2003-09-30,SK,Slovak Republic,
 2003-09-30,TH,Thailand,3.0303
-2003-09-30,TR,Türkiye,
-2003-09-30,US,United States,9.4248
-2003-09-30,XM,Euro area,5.7891
-2003-09-30,XW,World,
-2003-09-30,ZA,South Africa,20.2962
-2003-12-31,4T,Emerging market economies (aggregate),
-2003-12-31,5R,Advanced economies,
-2003-12-31,AE,United Arab Emirates,
-2003-12-31,AT,Austria,2.2864
+2003-09-30,US,United States,9.4271
+2003-09-30,XM,Euro area,5.7946
+2003-09-30,ZA,South Africa,20.2959
+2003-12-31,AT,Austria,2.2863
 2003-12-31,AU,Australia,18.9095
 2003-12-31,BE,Belgium,7.1607
-2003-12-31,BG,Bulgaria,
+2003-12-31,BG,Bulgaria,21.1324
 2003-12-31,BR,Brazil,14.1669
 2003-12-31,CA,Canada,10.9152
-2003-12-31,CH,Switzerland,3.2281
-2003-12-31,CL,Chile,4.6404
-2003-12-31,CN,China,
-2003-12-31,CO,Colombia,5.7979
+2003-12-31,CH,Switzerland,3.2296
+2003-12-31,CL,Chile,4.6403
+2003-12-31,CO,Colombia,6.197
 2003-12-31,CY,Cyprus,3.9296
-2003-12-31,CZ,Czechia,
-2003-12-31,DE,Germany,-1.646
+2003-12-31,DE,Germany,-1.6487
 2003-12-31,DK,Denmark,4.0235
-2003-12-31,EE,Estonia,
 2003-12-31,ES,Spain,18.4549
 2003-12-31,FI,Finland,7.3946
 2003-12-31,FR,France,12.2074
 2003-12-31,GB,United Kingdom,10.066
-2003-12-31,GR,Greece,
+2003-12-31,GR,Greece,3.2846
 2003-12-31,HK,Hong Kong SAR,-1.1266
-2003-12-31,HR,Croatia,20.9704
-2003-12-31,HU,Hungary,
+2003-12-31,HR,Croatia,20.9703
+2003-12-31,HU,Hungary,22.0465
 2003-12-31,ID,Indonesia,5.9843
 2003-12-31,IE,Ireland,13.9232
 2003-12-31,IL,Israel,-5.8073
-2003-12-31,IN,India,
-2003-12-31,IS,Iceland,12.3025
+2003-12-31,IS,Iceland,12.2912
 2003-12-31,IT,Italy,6.2101
 2003-12-31,JP,Japan,-6.4234
-2003-12-31,KR,Korea,6.5508
+2003-12-31,KR,Korea,6.6008
 2003-12-31,LT,Lithuania,11.5385
-2003-12-31,LU,Luxembourg,
-2003-12-31,LV,Latvia,
-2003-12-31,MA,Morocco,
-2003-12-31,MK,North Macedonia,5.752
-2003-12-31,MT,Malta,
-2003-12-31,MX,Mexico,
+2003-12-31,MK,North Macedonia,5.6868
 2003-12-31,MY,Malaysia,3.6347
-2003-12-31,NL,Netherlands,4.0625
+2003-12-31,NL,Netherlands,3.9755
 2003-12-31,NO,Norway,4.0359
 2003-12-31,NZ,New Zealand,24.3626
 2003-12-31,PE,Peru,-10.5377
-2003-12-31,PH,Philippines,
-2003-12-31,PL,Poland,
-2003-12-31,PT,Portugal,
-2003-12-31,RO,Romania,
+2003-12-31,PT,Portugal,1.4619
 2003-12-31,RS,Serbia,34.9618
 2003-12-31,RU,Russia,20.8576
 2003-12-31,SE,Sweden,6.129
 2003-12-31,SG,Singapore,-2.0656
-2003-12-31,SI,Slovenia,
-2003-12-31,SK,Slovak Republic,
 2003-12-31,TH,Thailand,5.4587
-2003-12-31,TR,Türkiye,
-2003-12-31,US,United States,10.7575
-2003-12-31,XM,Euro area,6.3399
-2003-12-31,XW,World,
-2003-12-31,ZA,South Africa,25.18
-2004-03-31,4T,Emerging market economies (aggregate),
-2004-03-31,5R,Advanced economies,
-2004-03-31,AE,United Arab Emirates,11.7319
-2004-03-31,AT,Austria,-6.9403
+2003-12-31,US,United States,10.7587
+2003-12-31,XM,Euro area,6.3448
+2003-12-31,ZA,South Africa,25.1795
+2004-03-31,AT,Austria,-6.9404
 2004-03-31,AU,Australia,15.3198
 2004-03-31,BE,Belgium,8.3659
-2004-03-31,BG,Bulgaria,
+2004-03-31,BG,Bulgaria,34.4803
 2004-03-31,BR,Brazil,14.9925
 2004-03-31,CA,Canada,10.419
-2004-03-31,CH,Switzerland,5.1139
+2004-03-31,CH,Switzerland,5.1144
 2004-03-31,CL,Chile,5.073
-2004-03-31,CN,China,
-2004-03-31,CO,Colombia,8.6236
+2004-03-31,CO,Colombia,8.5434
 2004-03-31,CY,Cyprus,19.1971
-2004-03-31,CZ,Czechia,
-2004-03-31,DE,Germany,-1.8497
+2004-03-31,DE,Germany,-2.0013
 2004-03-31,DK,Denmark,7.743
-2004-03-31,EE,Estonia,
 2004-03-31,ES,Spain,18.3788
 2004-03-31,FI,Finland,8.3266
 2004-03-31,FR,France,13.6066
 2004-03-31,GB,United Kingdom,9.0762
-2004-03-31,GR,Greece,
+2004-03-31,GR,Greece,1.0502
 2004-03-31,HK,Hong Kong SAR,17.3219
 2004-03-31,HR,Croatia,13.2184
-2004-03-31,HU,Hungary,
+2004-03-31,HU,Hungary,9.8523
 2004-03-31,ID,Indonesia,4.4689
 2004-03-31,IE,Ireland,11.3043
 2004-03-31,IL,Israel,-4.1602
-2004-03-31,IN,India,
-2004-03-31,IS,Iceland,8.5003
+2004-03-31,IS,Iceland,8.5105
 2004-03-31,IT,Italy,4.9331
 2004-03-31,JP,Japan,-6.4142
-2004-03-31,KR,Korea,5.0498
+2004-03-31,KR,Korea,4.9982
 2004-03-31,LT,Lithuania,6.5611
-2004-03-31,LU,Luxembourg,
-2004-03-31,LV,Latvia,
-2004-03-31,MA,Morocco,
-2004-03-31,MK,North Macedonia,0.1914
-2004-03-31,MT,Malta,
-2004-03-31,MX,Mexico,
+2004-03-31,MK,North Macedonia,0.1402
 2004-03-31,MY,Malaysia,5.2239
-2004-03-31,NL,Netherlands,4.2312
+2004-03-31,NL,Netherlands,4.0847
 2004-03-31,NO,Norway,9.2105
 2004-03-31,NZ,New Zealand,23.1286
 2004-03-31,PE,Peru,17.976
-2004-03-31,PH,Philippines,
-2004-03-31,PL,Poland,
-2004-03-31,PT,Portugal,
-2004-03-31,RO,Romania,
+2004-03-31,PT,Portugal,1.0833
 2004-03-31,RS,Serbia,22.0281
 2004-03-31,RU,Russia,25.4131
 2004-03-31,SE,Sweden,7.6923
 2004-03-31,SG,Singapore,-1.5932
-2004-03-31,SI,Slovenia,
-2004-03-31,SK,Slovak Republic,
 2004-03-31,TH,Thailand,4.9364
-2004-03-31,TR,Türkiye,
-2004-03-31,US,United States,12.2597
-2004-03-31,XM,Euro area,5.9786
-2004-03-31,XW,World,
-2004-03-31,ZA,South Africa,30.617
-2004-06-30,4T,Emerging market economies (aggregate),
-2004-06-30,5R,Advanced economies,
-2004-06-30,AE,United Arab Emirates,19.2476
-2004-06-30,AT,Austria,-1.0858
+2004-03-31,US,United States,12.2388
+2004-03-31,XM,Euro area,5.9867
+2004-03-31,ZA,South Africa,30.6199
+2004-06-30,AT,Austria,-1.0859
 2004-06-30,AU,Australia,8.3425
 2004-06-30,BE,Belgium,7.8649
-2004-06-30,BG,Bulgaria,
+2004-06-30,BG,Bulgaria,44.5379
 2004-06-30,BR,Brazil,14.413
 2004-06-30,CA,Canada,11.8392
-2004-06-30,CH,Switzerland,3.5579
-2004-06-30,CL,Chile,6.3648
-2004-06-30,CN,China,
-2004-06-30,CO,Colombia,7.7985
+2004-06-30,CH,Switzerland,3.5586
+2004-06-30,CL,Chile,6.365
+2004-06-30,CO,Colombia,7.8956
 2004-06-30,CY,Cyprus,22.5575
-2004-06-30,CZ,Czechia,
-2004-06-30,DE,Germany,-1.2886
+2004-06-30,DE,Germany,-1.2125
 2004-06-30,DK,Denmark,10.1613
-2004-06-30,EE,Estonia,
 2004-06-30,ES,Spain,17.4786
 2004-06-30,FI,Finland,8.6411
 2004-06-30,FR,France,13.9021
 2004-06-30,GB,United Kingdom,12.0283
-2004-06-30,GR,Greece,
+2004-06-30,GR,Greece,2.1682
 2004-06-30,HK,Hong Kong SAR,29.0251
 2004-06-30,HR,Croatia,13.6872
-2004-06-30,HU,Hungary,
+2004-06-30,HU,Hungary,8.6743
 2004-06-30,ID,Indonesia,4.3426
 2004-06-30,IE,Ireland,10.6775
 2004-06-30,IL,Israel,1.8896
-2004-06-30,IN,India,
-2004-06-30,IS,Iceland,12.0406
+2004-06-30,IS,Iceland,12.0357
 2004-06-30,IT,Italy,5.6406
 2004-06-30,JP,Japan,-6.2563
-2004-06-30,KR,Korea,2.2581
+2004-06-30,KR,Korea,2.3005
 2004-06-30,LT,Lithuania,13.25
-2004-06-30,LU,Luxembourg,
-2004-06-30,LV,Latvia,
-2004-06-30,MA,Morocco,
-2004-06-30,MK,North Macedonia,-1.3165
-2004-06-30,MT,Malta,
-2004-06-30,MX,Mexico,
+2004-06-30,MK,North Macedonia,-1.3307
 2004-06-30,MY,Malaysia,5.6022
-2004-06-30,NL,Netherlands,4.2901
+2004-06-30,NL,Netherlands,4.1916
 2004-06-30,NO,Norway,10.2397
 2004-06-30,NZ,New Zealand,21.1234
 2004-06-30,PE,Peru,10.1005
-2004-06-30,PH,Philippines,
-2004-06-30,PL,Poland,
-2004-06-30,PT,Portugal,
-2004-06-30,RO,Romania,
+2004-06-30,PT,Portugal,0.5538
 2004-06-30,RS,Serbia,16.1326
 2004-06-30,RU,Russia,28.6605
 2004-06-30,SE,Sweden,9.7179
 2004-06-30,SG,Singapore,-0.8631
-2004-06-30,SI,Slovenia,
-2004-06-30,SK,Slovak Republic,
 2004-06-30,TH,Thailand,6.124
-2004-06-30,TR,Türkiye,
-2004-06-30,US,United States,14.2402
-2004-06-30,XM,Euro area,6.4513
-2004-06-30,XW,World,
-2004-06-30,ZA,South Africa,33.7225
-2004-09-30,4T,Emerging market economies (aggregate),
-2004-09-30,5R,Advanced economies,
-2004-09-30,AE,United Arab Emirates,24.816
+2004-06-30,US,United States,14.234
+2004-06-30,XM,Euro area,6.4599
+2004-06-30,ZA,South Africa,33.7206
 2004-09-30,AT,Austria,0.3988
 2004-09-30,AU,Australia,2.3212
 2004-09-30,BE,Belgium,8.9703
-2004-09-30,BG,Bulgaria,
+2004-09-30,BG,Bulgaria,51.1536
 2004-09-30,BR,Brazil,12.931
 2004-09-30,CA,Canada,6.943
-2004-09-30,CH,Switzerland,4.6632
+2004-09-30,CH,Switzerland,4.6645
 2004-09-30,CL,Chile,7.8895
-2004-09-30,CN,China,
-2004-09-30,CO,Colombia,10.2325
+2004-09-30,CO,Colombia,9.8493
 2004-09-30,CY,Cyprus,24.5418
-2004-09-30,CZ,Czechia,
-2004-09-30,DE,Germany,-1.161
+2004-09-30,DE,Germany,-1.142
 2004-09-30,DK,Denmark,11.7274
-2004-09-30,EE,Estonia,
 2004-09-30,ES,Spain,16.802
 2004-09-30,FI,Finland,6.5894
 2004-09-30,FR,France,14.5455
 2004-09-30,GB,United Kingdom,13.8485
-2004-09-30,GR,Greece,
+2004-09-30,GR,Greece,2.3012
 2004-09-30,HK,Hong Kong SAR,31.1973
 2004-09-30,HR,Croatia,16.5975
-2004-09-30,HU,Hungary,
+2004-09-30,HU,Hungary,9.1205
 2004-09-30,ID,Indonesia,3.7206
 2004-09-30,IE,Ireland,10.6457
 2004-09-30,IL,Israel,0.4159
-2004-09-30,IN,India,
-2004-09-30,IS,Iceland,9.0842
+2004-09-30,IS,Iceland,9.1166
 2004-09-30,IT,Italy,6.4342
 2004-09-30,JP,Japan,-6.0751
-2004-09-30,KR,Korea,-0.2536
+2004-09-30,KR,Korea,-0.2377
 2004-09-30,LT,Lithuania,23.4146
-2004-09-30,LU,Luxembourg,
-2004-09-30,LV,Latvia,
-2004-09-30,MA,Morocco,
-2004-09-30,MK,North Macedonia,1.5484
-2004-09-30,MT,Malta,
-2004-09-30,MX,Mexico,
+2004-09-30,MK,North Macedonia,1.8686
 2004-09-30,MY,Malaysia,2.5316
-2004-09-30,NL,Netherlands,4.8583
+2004-09-30,NL,Netherlands,4.5994
 2004-09-30,NO,Norway,10.6987
 2004-09-30,NZ,New Zealand,15.8215
 2004-09-30,PE,Peru,12.5225
-2004-09-30,PH,Philippines,
-2004-09-30,PL,Poland,
-2004-09-30,PT,Portugal,
-2004-09-30,RO,Romania,
+2004-09-30,PT,Portugal,0.4601
 2004-09-30,RS,Serbia,14.4038
 2004-09-30,RU,Russia,29.0232
 2004-09-30,SE,Sweden,9.816
 2004-09-30,SG,Singapore,0
-2004-09-30,SI,Slovenia,
-2004-09-30,SK,Slovak Republic,
 2004-09-30,TH,Thailand,5.0735
-2004-09-30,TR,Türkiye,
-2004-09-30,US,United States,14.8024
-2004-09-30,XM,Euro area,6.8366
-2004-09-30,XW,World,
-2004-09-30,ZA,South Africa,34.9699
-2004-12-31,4T,Emerging market economies (aggregate),
-2004-12-31,5R,Advanced economies,
-2004-12-31,AE,United Arab Emirates,23.1214
+2004-09-30,US,United States,14.7808
+2004-09-30,XM,Euro area,6.8453
+2004-09-30,ZA,South Africa,34.9684
 2004-12-31,AT,Austria,0
 2004-12-31,AU,Australia,0.2812
 2004-12-31,BE,Belgium,9.4979
-2004-12-31,BG,Bulgaria,
+2004-12-31,BG,Bulgaria,57.4915
 2004-12-31,BR,Brazil,11.2367
 2004-12-31,CA,Canada,7.8798
-2004-12-31,CH,Switzerland,5.1146
-2004-12-31,CL,Chile,8.3883
-2004-12-31,CN,China,
-2004-12-31,CO,Colombia,11.8012
+2004-12-31,CH,Switzerland,5.1172
+2004-12-31,CL,Chile,8.3885
+2004-12-31,CO,Colombia,11.3202
 2004-12-31,CY,Cyprus,26.8389
-2004-12-31,CZ,Czechia,
-2004-12-31,DE,Germany,-0.9488
+2004-12-31,DE,Germany,-0.892
 2004-12-31,DK,Denmark,14.06
-2004-12-31,EE,Estonia,
 2004-12-31,ES,Spain,17.2458
 2004-12-31,FI,Finland,5.7643
 2004-12-31,FR,France,15.3502
 2004-12-31,GB,United Kingdom,12.2939
-2004-12-31,GR,Greece,
+2004-12-31,GR,Greece,3.7192
 2004-12-31,HK,Hong Kong SAR,29.5183
-2004-12-31,HR,Croatia,15.7826
-2004-12-31,HU,Hungary,
+2004-12-31,HR,Croatia,15.7827
+2004-12-31,HU,Hungary,2.7177
 2004-12-31,ID,Indonesia,3.4404
 2004-12-31,IE,Ireland,11.2827
 2004-12-31,IL,Israel,-0.9879
-2004-12-31,IN,India,
-2004-12-31,IS,Iceland,13.4715
+2004-12-31,IS,Iceland,13.4473
 2004-12-31,IT,Italy,7.3975
 2004-12-31,JP,Japan,-5.7271
-2004-12-31,KR,Korea,-2.2585
+2004-12-31,KR,Korea,-2.3085
 2004-12-31,LT,Lithuania,30.5747
-2004-12-31,LU,Luxembourg,
-2004-12-31,LV,Latvia,
-2004-12-31,MA,Morocco,
-2004-12-31,MK,North Macedonia,-1.6093
-2004-12-31,MT,Malta,
-2004-12-31,MX,Mexico,
+2004-12-31,MK,North Macedonia,-1.3982
 2004-12-31,MY,Malaysia,2.518
-2004-12-31,NL,Netherlands,4.004
+2004-12-31,NL,Netherlands,3.9706
 2004-12-31,NO,Norway,10.5603
 2004-12-31,NZ,New Zealand,12.41
 2004-12-31,PE,Peru,2.3215
-2004-12-31,PH,Philippines,
-2004-12-31,PL,Poland,
-2004-12-31,PT,Portugal,
-2004-12-31,RO,Romania,
+2004-12-31,PT,Portugal,0.4598
 2004-12-31,RS,Serbia,13.597
 2004-12-31,RU,Russia,28.3794
 2004-12-31,SE,Sweden,10.0304
 2004-12-31,SG,Singapore,0.8685
-2004-12-31,SI,Slovenia,
-2004-12-31,SK,Slovak Republic,
 2004-12-31,TH,Thailand,5.5356
-2004-12-31,TR,Türkiye,
-2004-12-31,US,United States,15.3479
-2004-12-31,XM,Euro area,7.2068
-2004-12-31,XW,World,
-2004-12-31,ZA,South Africa,35.1069
-2005-03-31,4T,Emerging market economies (aggregate),
-2005-03-31,5R,Advanced economies,
-2005-03-31,AE,United Arab Emirates,12.8354
-2005-03-31,AT,Austria,8.5083
+2004-12-31,US,United States,15.3344
+2004-12-31,XM,Euro area,7.2139
+2004-12-31,ZA,South Africa,35.1075
+2005-03-31,AT,Austria,8.5084
 2005-03-31,AU,Australia,0.561
-2005-03-31,BE,Belgium,11.4677
-2005-03-31,BG,Bulgaria,
+2005-03-31,BE,Belgium,11.4703
+2005-03-31,BG,Bulgaria,54.9091
 2005-03-31,BR,Brazil,9.7966
-2005-03-31,CA,Canada,9.8144
-2005-03-31,CH,Switzerland,4.7206
+2005-03-31,CA,Canada,9.9467
+2005-03-31,CH,Switzerland,4.7228
 2005-03-31,CL,Chile,5.4056
-2005-03-31,CN,China,
-2005-03-31,CO,Colombia,9.0823
+2005-03-31,CO,Colombia,9.9808
 2005-03-31,CY,Cyprus,12.1707
-2005-03-31,CZ,Czechia,
-2005-03-31,DE,Germany,-0.5589
+2005-03-31,DE,Germany,-0.3784
 2005-03-31,DK,Denmark,15.4434
-2005-03-31,EE,Estonia,
 2005-03-31,ES,Spain,15.7257
 2005-03-31,FI,Finland,5.4234
 2005-03-31,FR,France,15.1515
-2005-03-31,GB,United Kingdom,9.0022
-2005-03-31,GR,Greece,
+2005-03-31,GB,United Kingdom,9.0035
+2005-03-31,GR,Greece,7.6529
 2005-03-31,HK,Hong Kong SAR,22.1468
-2005-03-31,HR,Croatia,13.5786
-2005-03-31,HU,Hungary,
+2005-03-31,HR,Croatia,13.5787
+2005-03-31,HU,Hungary,4.6261
 2005-03-31,ID,Indonesia,3.8816
-2005-03-31,IE,Ireland,11.2788
+2005-03-31,IE,Ireland,11.2546
 2005-03-31,IL,Israel,-1.8706
-2005-03-31,IN,India,
-2005-03-31,IS,Iceland,24.0946
+2005-03-31,IS,Iceland,24.0834
 2005-03-31,IT,Italy,8.3229
 2005-03-31,JP,Japan,-5.3675
-2005-03-31,KR,Korea,-1.8343
+2005-03-31,KR,Korea,-1.8016
 2005-03-31,LT,Lithuania,40.3397
-2005-03-31,LU,Luxembourg,
-2005-03-31,LV,Latvia,
-2005-03-31,MA,Morocco,
-2005-03-31,MK,North Macedonia,-2.6483
-2005-03-31,MT,Malta,
-2005-03-31,MX,Mexico,
+2005-03-31,MK,North Macedonia,-2.7244
 2005-03-31,MY,Malaysia,1.9504
-2005-03-31,NL,Netherlands,3.8441
+2005-03-31,NL,Netherlands,3.8285
 2005-03-31,NO,Norway,7.2289
 2005-03-31,NZ,New Zealand,12.5993
 2005-03-31,PE,Peru,-0.5794
-2005-03-31,PH,Philippines,
-2005-03-31,PL,Poland,
-2005-03-31,PT,Portugal,
-2005-03-31,RO,Romania,
+2005-03-31,PT,Portugal,0.1531
 2005-03-31,RS,Serbia,13.656
 2005-03-31,RU,Russia,25.7625
 2005-03-31,SE,Sweden,8.4263
 2005-03-31,SG,Singapore,1.9926
-2005-03-31,SI,Slovenia,
-2005-03-31,SK,Slovak Republic,
 2005-03-31,TH,Thailand,7.9116
-2005-03-31,TR,Türkiye,
-2005-03-31,US,United States,16.1486
-2005-03-31,XM,Euro area,7.616
-2005-03-31,XW,World,
-2005-03-31,ZA,South Africa,33.5474
-2005-06-30,4T,Emerging market economies (aggregate),
-2005-06-30,5R,Advanced economies,
-2005-06-30,AE,United Arab Emirates,10.4526
-2005-06-30,AT,Austria,4.0917
+2005-03-31,US,United States,16.1427
+2005-03-31,XM,Euro area,7.6196
+2005-03-31,ZA,South Africa,33.5457
+2005-06-30,AT,Austria,4.0918
 2005-06-30,AU,Australia,2.2663
-2005-06-30,BE,Belgium,13.3902
-2005-06-30,BG,Bulgaria,
+2005-06-30,BE,Belgium,13.3804
+2005-06-30,BG,Bulgaria,44.104
 2005-06-30,BR,Brazil,8.8475
-2005-06-30,CA,Canada,7.6602
-2005-06-30,CH,Switzerland,4.3517
+2005-06-30,CA,Canada,7.7898
+2005-06-30,CH,Switzerland,4.3524
 2005-06-30,CL,Chile,7.2376
-2005-06-30,CN,China,
-2005-06-30,CO,Colombia,9.5964
+2005-06-30,CO,Colombia,9.3461
 2005-06-30,CY,Cyprus,10.9098
-2005-06-30,CZ,Czechia,
-2005-06-30,DE,Germany,-1.2865
+2005-06-30,DE,Germany,-1.4059
 2005-06-30,DK,Denmark,16.3982
-2005-06-30,EE,Estonia,
 2005-06-30,ES,Spain,13.9086
 2005-06-30,FI,Finland,5.9593
 2005-06-30,FR,France,15.3953
-2005-06-30,GB,United Kingdom,5.9492
-2005-06-30,GR,Greece,
+2005-06-30,GB,United Kingdom,5.8581
+2005-06-30,GR,Greece,10.4634
 2005-06-30,HK,Hong Kong SAR,22.4525
 2005-06-30,HR,Croatia,14.6192
-2005-06-30,HU,Hungary,
+2005-06-30,HU,Hungary,2.9711
 2005-06-30,ID,Indonesia,3.646
-2005-06-30,IE,Ireland,12.4387
+2005-06-30,IE,Ireland,12.4163
 2005-06-30,IL,Israel,-1.7118
-2005-06-30,IN,India,
-2005-06-30,IS,Iceland,29.0999
+2005-06-30,IS,Iceland,29.1219
 2005-06-30,IT,Italy,8.1393
 2005-06-30,JP,Japan,-5.0233
-2005-06-30,KR,Korea,-0.5678
+2005-06-30,KR,Korea,-0.5223
 2005-06-30,LT,Lithuania,39.0728
-2005-06-30,LU,Luxembourg,
-2005-06-30,LV,Latvia,
-2005-06-30,MA,Morocco,
-2005-06-30,MK,North Macedonia,2.4349
-2005-06-30,MT,Malta,
-2005-06-30,MX,Mexico,
+2005-06-30,MK,North Macedonia,2.7879
 2005-06-30,MY,Malaysia,3.3599
-2005-06-30,NL,Netherlands,3.9054
+2005-06-30,NL,Netherlands,3.823
 2005-06-30,NO,Norway,8.498
 2005-06-30,NZ,New Zealand,13.7334
 2005-06-30,PE,Peru,-12.4483
-2005-06-30,PH,Philippines,
-2005-06-30,PL,Poland,
-2005-06-30,PT,Portugal,
-2005-06-30,RO,Romania,
+2005-06-30,PT,Portugal,1.6524
 2005-06-30,RS,Serbia,16.3471
 2005-06-30,RU,Russia,22.5791
 2005-06-30,SE,Sweden,7.5699
 2005-06-30,SG,Singapore,2.3632
-2005-06-30,SI,Slovenia,
-2005-06-30,SK,Slovak Republic,
 2005-06-30,TH,Thailand,7.741
-2005-06-30,TR,Türkiye,
-2005-06-30,US,United States,16.1448
-2005-06-30,XM,Euro area,7.2321
-2005-06-30,XW,World,
-2005-06-30,ZA,South Africa,30.8117
-2005-09-30,4T,Emerging market economies (aggregate),
-2005-09-30,5R,Advanced economies,
-2005-09-30,AE,United Arab Emirates,8.8555
+2005-06-30,US,United States,16.14
+2005-06-30,XM,Euro area,7.2278
+2005-06-30,ZA,South Africa,30.8137
 2005-09-30,AT,Austria,3.6743
 2005-09-30,AU,Australia,2.1246
-2005-09-30,BE,Belgium,13.165
-2005-09-30,BG,Bulgaria,
+2005-09-30,BE,Belgium,13.121
+2005-09-30,BG,Bulgaria,32.1572
 2005-09-30,BR,Brazil,8.4589
-2005-09-30,CA,Canada,12.3756
-2005-09-30,CH,Switzerland,4.0665
+2005-09-30,CA,Canada,12.2983
+2005-09-30,CH,Switzerland,4.063
 2005-09-30,CL,Chile,6.8522
-2005-09-30,CN,China,
-2005-09-30,CO,Colombia,9.8258
+2005-09-30,CO,Colombia,10.0363
 2005-09-30,CY,Cyprus,7.9668
-2005-09-30,CZ,Czechia,
-2005-09-30,DE,Germany,-1.1139
+2005-09-30,DE,Germany,-1.1469
 2005-09-30,DK,Denmark,21.4184
-2005-09-30,EE,Estonia,
 2005-09-30,ES,Spain,13.4309
 2005-09-30,FI,Finland,7.6556
 2005-09-30,FR,France,15.2116
-2005-09-30,GB,United Kingdom,3.9534
-2005-09-30,GR,Greece,
-2005-09-30,HK,Hong Kong SAR,20.0514
+2005-09-30,GB,United Kingdom,3.9661
+2005-09-30,GR,Greece,12.2055
+2005-09-30,HK,Hong Kong SAR,20.2655
 2005-09-30,HR,Croatia,12.4555
-2005-09-30,HU,Hungary,
+2005-09-30,HU,Hungary,2.1826
 2005-09-30,ID,Indonesia,3.3757
-2005-09-30,IE,Ireland,11.4787
+2005-09-30,IE,Ireland,11.516
 2005-09-30,IL,Israel,0.5221
-2005-09-30,IN,India,
-2005-09-30,IS,Iceland,33.447
+2005-09-30,IS,Iceland,33.4266
 2005-09-30,IT,Italy,7.4342
 2005-09-30,JP,Japan,-4.6809
-2005-09-30,KR,Korea,2.1615
+2005-09-30,KR,Korea,2.1458
 2005-09-30,LT,Lithuania,37.5494
-2005-09-30,LU,Luxembourg,
-2005-09-30,LV,Latvia,
-2005-09-30,MA,Morocco,
-2005-09-30,MK,North Macedonia,-1.1888
-2005-09-30,MT,Malta,
-2005-09-30,MX,Mexico,
+2005-09-30,MK,North Macedonia,-1.1239
 2005-09-30,MY,Malaysia,2.6455
-2005-09-30,NL,Netherlands,3.7674
+2005-09-30,NL,Netherlands,3.8659
 2005-09-30,NO,Norway,9.2702
 2005-09-30,NZ,New Zealand,14.9599
 2005-09-30,PE,Peru,-9.5302
-2005-09-30,PH,Philippines,
-2005-09-30,PL,Poland,
-2005-09-30,PT,Portugal,
-2005-09-30,RO,Romania,
+2005-09-30,PT,Portugal,3.6031
 2005-09-30,RS,Serbia,21.8078
 2005-09-30,RU,Russia,21.7547
 2005-09-30,SE,Sweden,9.2202
 2005-09-30,SG,Singapore,3.2218
-2005-09-30,SI,Slovenia,
-2005-09-30,SK,Slovak Republic,
 2005-09-30,TH,Thailand,9.0273
-2005-09-30,TR,Türkiye,
-2005-09-30,US,United States,16.2224
-2005-09-30,XM,Euro area,7.105
-2005-09-30,XW,World,
-2005-09-30,ZA,South Africa,27.7606
-2005-12-31,4T,Emerging market economies (aggregate),
-2005-12-31,5R,Advanced economies,
-2005-12-31,AE,United Arab Emirates,7.0442
+2005-09-30,US,United States,16.2049
+2005-09-30,XM,Euro area,7.1011
+2005-09-30,ZA,South Africa,27.76
 2005-12-31,AT,Austria,3.8873
 2005-12-31,AU,Australia,2.3677
-2005-12-31,BE,Belgium,12.8814
-2005-12-31,BG,Bulgaria,
+2005-12-31,BE,Belgium,12.9319
+2005-12-31,BG,Bulgaria,21.5753
 2005-12-31,BR,Brazil,8.6412
-2005-12-31,CA,Canada,9.7585
-2005-12-31,CH,Switzerland,4.2175
-2005-12-31,CL,Chile,7.3554
-2005-12-31,CN,China,
-2005-12-31,CO,Colombia,4.824
+2005-12-31,CA,Canada,9.5834
+2005-12-31,CH,Switzerland,4.2108
+2005-12-31,CL,Chile,7.3553
+2005-12-31,CO,Colombia,5.3741
 2005-12-31,CY,Cyprus,6.5156
-2005-12-31,CZ,Czechia,
-2005-12-31,DE,Germany,-0.7115
+2005-12-31,DE,Germany,-0.7372
 2005-12-31,DK,Denmark,26.3158
-2005-12-31,EE,Estonia,
 2005-12-31,ES,Spain,12.7306
 2005-12-31,FI,Finland,9.4293
 2005-12-31,FR,France,14.7287
-2005-12-31,GB,United Kingdom,3.3831
-2005-12-31,GR,Greece,
+2005-12-31,GB,United Kingdom,3.4558
+2005-12-31,GR,Greece,13.161
 2005-12-31,HK,Hong Kong SAR,8.1168
-2005-12-31,HR,Croatia,11.3967
-2005-12-31,HU,Hungary,
+2005-12-31,HR,Croatia,11.3966
+2005-12-31,HU,Hungary,2.6982
 2005-12-31,ID,Indonesia,4.9056
-2005-12-31,IE,Ireland,10.6202
+2005-12-31,IE,Ireland,10.6259
 2005-12-31,IL,Israel,4.028
-2005-12-31,IN,India,
-2005-12-31,IS,Iceland,31.833
+2005-12-31,IS,Iceland,31.8547
 2005-12-31,IT,Italy,6.7655
 2005-12-31,JP,Japan,-4.2654
-2005-12-31,KR,Korea,3.466
+2005-12-31,KR,Korea,3.4407
 2005-12-31,LT,Lithuania,55.6338
-2005-12-31,LU,Luxembourg,
-2005-12-31,LV,Latvia,
-2005-12-31,MA,Morocco,
-2005-12-31,MK,North Macedonia,-1.2045
-2005-12-31,MT,Malta,
-2005-12-31,MX,Mexico,
+2005-12-31,MK,North Macedonia,-1.2155
 2005-12-31,MY,Malaysia,2.5439
-2005-12-31,NL,Netherlands,3.9703
+2005-12-31,NL,Netherlands,4.0733
 2005-12-31,NO,Norway,7.9922
 2005-12-31,NZ,New Zealand,15.2389
 2005-12-31,PE,Peru,5.4863
-2005-12-31,PH,Philippines,
-2005-12-31,PL,Poland,
-2005-12-31,PT,Portugal,
-2005-12-31,RO,Romania,
+2005-12-31,PT,Portugal,3.6619
 2005-12-31,RS,Serbia,18.6566
 2005-12-31,RU,Russia,23.6175
 2005-12-31,SE,Sweden,10.8301
 2005-12-31,SG,Singapore,3.9361
-2005-12-31,SI,Slovenia,
-2005-12-31,SK,Slovak Republic,
 2005-12-31,TH,Thailand,7.2207
-2005-12-31,TR,Türkiye,
-2005-12-31,US,United States,15.0926
-2005-12-31,XM,Euro area,7.0118
-2005-12-31,XW,World,
-2005-12-31,ZA,South Africa,23.4655
-2006-03-31,4T,Emerging market economies (aggregate),
-2006-03-31,5R,Advanced economies,
-2006-03-31,AE,United Arab Emirates,10.9203
+2005-12-31,US,United States,15.0987
+2005-12-31,XM,Euro area,7.0091
+2005-12-31,ZA,South Africa,23.4659
 2006-03-31,AT,Austria,4.6467
 2006-03-31,AU,Australia,3.6262
-2006-03-31,BE,Belgium,10.0746
+2006-03-31,BE,Belgium,10.0957
 2006-03-31,BG,Bulgaria,15.077
 2006-03-31,BR,Brazil,9.3726
-2006-03-31,CA,Canada,10.2767
-2006-03-31,CH,Switzerland,5.1186
-2006-03-31,CL,Chile,7.5996
-2006-03-31,CN,China,
-2006-03-31,CO,Colombia,10.1268
+2006-03-31,CA,Canada,9.6838
+2006-03-31,CH,Switzerland,5.1121
+2006-03-31,CL,Chile,7.5998
+2006-03-31,CO,Colombia,8.7285
 2006-03-31,CY,Cyprus,11.0294
-2006-03-31,CZ,Czechia,
-2006-03-31,DE,Germany,-1.6628
+2006-03-31,DE,Germany,-1.7042
 2006-03-31,DK,Denmark,29.404
 2006-03-31,EE,Estonia,52.2728
 2006-03-31,ES,Spain,9.2559
 2006-03-31,FI,Finland,8.1522
 2006-03-31,FR,France,13.7845
-2006-03-31,GB,United Kingdom,6.3131
-2006-03-31,GR,Greece,
+2006-03-31,GB,United Kingdom,6.379
+2006-03-31,GR,Greece,13.4476
 2006-03-31,HK,Hong Kong SAR,1.7797
 2006-03-31,HR,Croatia,15.7542
-2006-03-31,HU,Hungary,
+2006-03-31,HU,Hungary,4.6316
 2006-03-31,ID,Indonesia,6.1811
-2006-03-31,IE,Ireland,12.773
+2006-03-31,IE,Ireland,12.7716
 2006-03-31,IL,Israel,5.0342
-2006-03-31,IN,India,
-2006-03-31,IS,Iceland,24.598
+2006-03-31,IS,Iceland,24.6277
 2006-03-31,IT,Italy,5.8984
 2006-03-31,JP,Japan,-3.8394
-2006-03-31,KR,Korea,4.8969
+2006-03-31,KR,Korea,4.8303
 2006-03-31,LT,Lithuania,40.6783
-2006-03-31,LU,Luxembourg,
-2006-03-31,LV,Latvia,
-2006-03-31,MA,Morocco,-1.6716
-2006-03-31,MK,North Macedonia,2.2888
+2006-03-31,MA,Morocco,-2.1526
+2006-03-31,MK,North Macedonia,2.5521
 2006-03-31,MT,Malta,9.8764
 2006-03-31,MX,Mexico,7.4687
 2006-03-31,MY,Malaysia,2.3478
-2006-03-31,NL,Netherlands,4.1356
+2006-03-31,NL,Netherlands,4.1477
 2006-03-31,NO,Norway,10.2996
 2006-03-31,NZ,New Zealand,12.2524
 2006-03-31,PE,Peru,-2.5327
-2006-03-31,PH,Philippines,
-2006-03-31,PL,Poland,
-2006-03-31,PT,Portugal,
-2006-03-31,RO,Romania,
+2006-03-31,PT,Portugal,3.9132
 2006-03-31,RS,Serbia,8.1941
 2006-03-31,RU,Russia,31.2438
 2006-03-31,SE,Sweden,13.9924
 2006-03-31,SG,Singapore,4.7619
-2006-03-31,SI,Slovenia,
-2006-03-31,SK,Slovak Republic,
 2006-03-31,TH,Thailand,4.9538
-2006-03-31,TR,Türkiye,
-2006-03-31,US,United States,12.5983
-2006-03-31,XM,Euro area,6.3421
-2006-03-31,XW,World,
+2006-03-31,US,United States,12.608
+2006-03-31,XM,Euro area,6.3294
 2006-03-31,ZA,South Africa,19.1727
-2006-06-30,4T,Emerging market economies (aggregate),
-2006-06-30,5R,Advanced economies,
-2006-06-30,AE,United Arab Emirates,13.5026
 2006-06-30,AT,Austria,4.5062
 2006-06-30,AU,Australia,6.6482
-2006-06-30,BE,Belgium,10.598
-2006-06-30,BG,Bulgaria,12.1752
+2006-06-30,BE,Belgium,10.602
+2006-06-30,BG,Bulgaria,12.1751
 2006-06-30,BR,Brazil,10.5675
-2006-06-30,CA,Canada,12.9094
-2006-06-30,CH,Switzerland,6.2615
+2006-06-30,CA,Canada,12.0424
+2006-06-30,CH,Switzerland,6.2561
 2006-06-30,CL,Chile,6.3776
 2006-06-30,CN,China,4.8459
-2006-06-30,CO,Colombia,11.7151
+2006-06-30,CO,Colombia,12.1786
 2006-06-30,CY,Cyprus,14.4851
-2006-06-30,CZ,Czechia,
-2006-06-30,DE,Germany,0.3999
+2006-06-30,DE,Germany,0.4313
 2006-06-30,DK,Denmark,30.3145
 2006-06-30,EE,Estonia,48.6002
 2006-06-30,ES,Spain,9.5098
 2006-06-30,FI,Finland,7.5297
 2006-06-30,FR,France,12.5
-2006-06-30,GB,United Kingdom,7.2393
-2006-06-30,GR,Greece,
+2006-06-30,GB,United Kingdom,7.2993
+2006-06-30,GR,Greece,13.1809
 2006-06-30,HK,Hong Kong SAR,-1.3753
-2006-06-30,HR,Croatia,12.6473
-2006-06-30,HU,Hungary,
+2006-06-30,HR,Croatia,12.6474
+2006-06-30,HU,Hungary,3.4573
 2006-06-30,ID,Indonesia,5.4483
-2006-06-30,IE,Ireland,14.8088
+2006-06-30,IE,Ireland,14.8158
 2006-06-30,IL,Israel,1.2336
-2006-06-30,IN,India,
-2006-06-30,IS,Iceland,17.1351
+2006-06-30,IS,Iceland,17.1424
 2006-06-30,IT,Italy,5.9909
 2006-06-30,JP,Japan,-3.2689
-2006-06-30,KR,Korea,5.6472
+2006-06-30,KR,Korea,5.5952
 2006-06-30,LT,Lithuania,48.9641
-2006-06-30,LU,Luxembourg,
-2006-06-30,LV,Latvia,
-2006-06-30,MA,Morocco,-4.4291
-2006-06-30,MK,North Macedonia,-4.3115
+2006-06-30,MA,Morocco,-2.2572
+2006-06-30,MK,North Macedonia,-4.4405
 2006-06-30,MT,Malta,22.6549
 2006-06-30,MX,Mexico,6.5905
 2006-06-30,MY,Malaysia,1.3687
-2006-06-30,NL,Netherlands,4.3157
+2006-06-30,NL,Netherlands,4.3046
 2006-06-30,NO,Norway,12.5683
 2006-06-30,NZ,New Zealand,10.1563
 2006-06-30,PE,Peru,4.7706
-2006-06-30,PH,Philippines,
-2006-06-30,PL,Poland,
-2006-06-30,PT,Portugal,
-2006-06-30,RO,Romania,
+2006-06-30,PT,Portugal,2.95
 2006-06-30,RS,Serbia,2.7571
 2006-06-30,RU,Russia,39.8192
 2006-06-30,SE,Sweden,13.4417
 2006-06-30,SG,Singapore,6.0753
-2006-06-30,SI,Slovenia,
-2006-06-30,SK,Slovak Republic,
 2006-06-30,TH,Thailand,4.9641
-2006-06-30,TR,Türkiye,
-2006-06-30,US,United States,7.5526
-2006-06-30,XM,Euro area,6.8572
-2006-06-30,XW,World,
-2006-06-30,ZA,South Africa,17.3415
-2006-09-30,4T,Emerging market economies (aggregate),
-2006-09-30,5R,Advanced economies,
-2006-09-30,AE,United Arab Emirates,24.0633
+2006-06-30,US,United States,7.5498
+2006-06-30,XM,Euro area,6.8404
+2006-06-30,ZA,South Africa,17.339
 2006-09-30,AT,Austria,5.0766
 2006-09-30,AU,Australia,8.7379
-2006-09-30,BE,Belgium,9.8807
-2006-09-30,BG,Bulgaria,13.9915
+2006-09-30,BE,Belgium,10.0108
+2006-09-30,BG,Bulgaria,13.9914
 2006-09-30,BR,Brazil,12.0605
-2006-09-30,CA,Canada,13.7996
-2006-09-30,CH,Switzerland,5.5109
-2006-09-30,CL,Chile,6.2555
+2006-09-30,CA,Canada,12.9735
+2006-09-30,CH,Switzerland,5.5077
+2006-09-30,CL,Chile,6.2554
 2006-09-30,CN,China,4.9186
-2006-09-30,CO,Colombia,14.6709
+2006-09-30,CO,Colombia,14.3082
 2006-09-30,CY,Cyprus,15.0244
-2006-09-30,CZ,Czechia,
-2006-09-30,DE,Germany,1.3834
+2006-09-30,DE,Germany,1.3988
 2006-09-30,DK,Denmark,23.4813
 2006-09-30,EE,Estonia,50.5833
 2006-09-30,ES,Spain,11.2489
 2006-09-30,FI,Finland,6.4935
 2006-09-30,FR,France,10.7922
-2006-09-30,GB,United Kingdom,7.9042
-2006-09-30,GR,Greece,
-2006-09-30,HK,Hong Kong SAR,-0.7138
+2006-09-30,GB,United Kingdom,7.8292
+2006-09-30,GR,Greece,12.1905
+2006-09-30,HK,Hong Kong SAR,-0.8906
 2006-09-30,HR,Croatia,13.5021
-2006-09-30,HU,Hungary,
+2006-09-30,HU,Hungary,4.3473
 2006-09-30,ID,Indonesia,5.4139
-2006-09-30,IE,Ireland,17.1553
+2006-09-30,IE,Ireland,17.1243
 2006-09-30,IL,Israel,-0.3761
-2006-09-30,IN,India,
-2006-09-30,IS,Iceland,11.509
+2006-09-30,IS,Iceland,11.5158
 2006-09-30,IT,Italy,5.8518
 2006-09-30,JP,Japan,-2.6786
-2006-09-30,KR,Korea,4.8538
+2006-09-30,KR,Korea,4.8828
 2006-09-30,LT,Lithuania,48.43
-2006-09-30,LU,Luxembourg,
-2006-09-30,LV,Latvia,
-2006-09-30,MA,Morocco,-6.2621
-2006-09-30,MK,North Macedonia,1.1639
+2006-09-30,MA,Morocco,-3.0303
+2006-09-30,MK,North Macedonia,0.9537
 2006-09-30,MT,Malta,16.9935
 2006-09-30,MX,Mexico,6.1811
 2006-09-30,MY,Malaysia,2.0619
-2006-09-30,NL,Netherlands,4.1188
+2006-09-30,NL,Netherlands,4.1135
 2006-09-30,NO,Norway,15.1625
 2006-09-30,NZ,New Zealand,9.2768
 2006-09-30,PE,Peru,-3.9564
-2006-09-30,PH,Philippines,
-2006-09-30,PL,Poland,
-2006-09-30,PT,Portugal,
-2006-09-30,RO,Romania,
+2006-09-30,PT,Portugal,0.7663
 2006-09-30,RS,Serbia,1.2782
 2006-09-30,RU,Russia,54.0391
 2006-09-30,SE,Sweden,12.1427
 2006-09-30,SG,Singapore,7.563
-2006-09-30,SI,Slovenia,
-2006-09-30,SK,Slovak Republic,
 2006-09-30,TH,Thailand,2.5032
-2006-09-30,TR,Türkiye,
-2006-09-30,US,United States,3.1487
-2006-09-30,XM,Euro area,6.991
-2006-09-30,XW,World,
-2006-09-30,ZA,South Africa,16.1721
-2006-12-31,4T,Emerging market economies (aggregate),
-2006-12-31,5R,Advanced economies,
-2006-12-31,AE,United Arab Emirates,20.4368
-2006-12-31,AT,Austria,2.245
+2006-09-30,US,United States,3.1786
+2006-09-30,XM,Euro area,6.9746
+2006-09-30,ZA,South Africa,16.1723
+2006-12-31,AT,Austria,2.2451
 2006-12-31,AU,Australia,8.5714
-2006-12-31,BE,Belgium,8.5726
+2006-12-31,BE,Belgium,8.6054
 2006-12-31,BG,Bulgaria,17.4449
 2006-12-31,BR,Brazil,13.6562
-2006-12-31,CA,Canada,12.9543
-2006-12-31,CH,Switzerland,9.1506
+2006-12-31,CA,Canada,12.1495
+2006-12-31,CH,Switzerland,9.1485
 2006-12-31,CL,Chile,4.5826
 2006-12-31,CN,China,5.0109
-2006-12-31,CO,Colombia,14.7734
+2006-12-31,CO,Colombia,14.3399
 2006-12-31,CY,Cyprus,19.6055
-2006-12-31,CZ,Czechia,
-2006-12-31,DE,Germany,0.297
+2006-12-31,DE,Germany,0.2923
 2006-12-31,DK,Denmark,14.693
 2006-12-31,EE,Estonia,47.1857
 2006-12-31,ES,Spain,11.5046
 2006-12-31,FI,Finland,5.7179
 2006-12-31,FR,France,9.5721
-2006-12-31,GB,United Kingdom,9.8086
-2006-12-31,GR,Greece,
+2006-12-31,GB,United Kingdom,9.7691
+2006-12-31,GR,Greece,13.1431
 2006-12-31,HK,Hong Kong SAR,3.5133
 2006-12-31,HR,Croatia,15.2457
-2006-12-31,HU,Hungary,
+2006-12-31,HU,Hungary,5.8471
 2006-12-31,ID,Indonesia,4.0572
-2006-12-31,IE,Ireland,14.6699
+2006-12-31,IE,Ireland,14.6616
 2006-12-31,IL,Israel,-3.8721
-2006-12-31,IN,India,
-2006-12-31,IS,Iceland,7.8179
+2006-12-31,IS,Iceland,7.8023
 2006-12-31,IT,Italy,5.6131
 2006-12-31,JP,Japan,-2.1152
-2006-12-31,KR,Korea,9.2432
+2006-12-31,KR,Korea,9.2748
 2006-12-31,LT,Lithuania,29.7025
-2006-12-31,LU,Luxembourg,
-2006-12-31,LV,Latvia,
-2006-12-31,MA,Morocco,-4.8276
-2006-12-31,MK,North Macedonia,-4.9153
+2006-12-31,MA,Morocco,-2.0669
+2006-12-31,MK,North Macedonia,-5.1397
 2006-12-31,MT,Malta,29.4613
 2006-12-31,MX,Mexico,6.9712
 2006-12-31,MY,Malaysia,4.7049
-2006-12-31,NL,Netherlands,4.5171
+2006-12-31,NL,Netherlands,4.5084
 2006-12-31,NO,Norway,16.6065
 2006-12-31,NZ,New Zealand,8.9239
 2006-12-31,PE,Peru,-6.3226
-2006-12-31,PH,Philippines,
-2006-12-31,PL,Poland,
-2006-12-31,PT,Portugal,
-2006-12-31,RO,Romania,
+2006-12-31,PT,Portugal,0.8831
 2006-12-31,RS,Serbia,0.3721
 2006-12-31,RU,Russia,65.189
 2006-12-31,SE,Sweden,9.9465
 2006-12-31,SG,Singapore,10.1776
-2006-12-31,SI,Slovenia,
-2006-12-31,SK,Slovak Republic,
 2006-12-31,TH,Thailand,2.6048
-2006-12-31,TR,Türkiye,
-2006-12-31,US,United States,0.3718
-2006-12-31,XM,Euro area,6.3186
-2006-12-31,XW,World,
-2006-12-31,ZA,South Africa,14.5951
-2007-03-31,4T,Emerging market economies (aggregate),
-2007-03-31,5R,Advanced economies,
-2007-03-31,AE,United Arab Emirates,24.0705
+2006-12-31,US,United States,0.3761
+2006-12-31,XM,Euro area,6.3093
+2006-12-31,ZA,South Africa,14.5945
 2007-03-31,AT,Austria,4.0703
 2007-03-31,AU,Australia,8.3445
-2007-03-31,BE,Belgium,9.0222
+2007-03-31,BE,Belgium,9.0143
 2007-03-31,BG,Bulgaria,22.5906
 2007-03-31,BR,Brazil,15.2092
-2007-03-31,CA,Canada,12.0968
-2007-03-31,CH,Switzerland,8.4642
+2007-03-31,CA,Canada,11.4414
+2007-03-31,CH,Switzerland,8.4629
 2007-03-31,CL,Chile,7.7549
 2007-03-31,CN,China,5.2977
-2007-03-31,CO,Colombia,18.2146
+2007-03-31,CO,Colombia,18.9859
 2007-03-31,CY,Cyprus,21.5871
-2007-03-31,CZ,Czechia,
 2007-03-31,DE,Germany,0.8351
 2007-03-31,DK,Denmark,7.4719
 2007-03-31,EE,Estonia,34.3283
 2007-03-31,ES,Spain,13.1255
 2007-03-31,FI,Finland,6.9095
 2007-03-31,FR,France,7.9295
-2007-03-31,GB,United Kingdom,10.5701
-2007-03-31,GR,Greece,8.678
+2007-03-31,GB,United Kingdom,10.582
+2007-03-31,GR,Greece,8.6779
 2007-03-31,HK,Hong Kong SAR,5.5374
 2007-03-31,HR,Croatia,14.1892
-2007-03-31,HU,Hungary,
+2007-03-31,HU,Hungary,5.8754
 2007-03-31,ID,Indonesia,1.8125
-2007-03-31,IE,Ireland,14.5833
+2007-03-31,IE,Ireland,14.5677
 2007-03-31,IL,Israel,-5.2158
-2007-03-31,IN,India,
-2007-03-31,IS,Iceland,6.1186
+2007-03-31,IS,Iceland,6.0994
 2007-03-31,IT,Italy,5.8623
 2007-03-31,JP,Japan,-1.5426
-2007-03-31,KR,Korea,11.9165
+2007-03-31,KR,Korea,11.9637
 2007-03-31,LT,Lithuania,28.4758
-2007-03-31,LU,Luxembourg,
 2007-03-31,LV,Latvia,49.6293
-2007-03-31,MA,Morocco,-2.2
-2007-03-31,MK,North Macedonia,-0.6137
+2007-03-31,MA,Morocco,0.7
+2007-03-31,MK,North Macedonia,-0.753
 2007-03-31,MT,Malta,29.8556
 2007-03-31,MX,Mexico,7.4542
 2007-03-31,MY,Malaysia,4.8428
-2007-03-31,NL,Netherlands,4.7527
+2007-03-31,NL,Netherlands,4.7367
 2007-03-31,NO,Norway,16.4686
 2007-03-31,NZ,New Zealand,11.324
 2007-03-31,PE,Peru,-10.1229
-2007-03-31,PH,Philippines,
-2007-03-31,PL,Poland,
-2007-03-31,PT,Portugal,
-2007-03-31,RO,Romania,
+2007-03-31,PT,Portugal,1.3533
 2007-03-31,RS,Serbia,-0.0298
 2007-03-31,RU,Russia,62.9832
 2007-03-31,SE,Sweden,10.2852
 2007-03-31,SG,Singapore,13.7529
-2007-03-31,SI,Slovenia,
-2007-03-31,SK,Slovak Republic,21.8645
+2007-03-31,SK,Slovakia,21.8644
 2007-03-31,TH,Thailand,0.3776
-2007-03-31,TR,Türkiye,
-2007-03-31,US,United States,-2.4205
-2007-03-31,XM,Euro area,6.3474
-2007-03-31,XW,World,
-2007-03-31,ZA,South Africa,14.6017
-2007-06-30,4T,Emerging market economies (aggregate),
-2007-06-30,5R,Advanced economies,
-2007-06-30,AE,United Arab Emirates,27.2241
+2007-03-31,US,United States,-2.4194
+2007-03-31,XM,Euro area,6.3416
+2007-03-31,ZA,South Africa,14.6014
 2007-06-30,AT,Austria,5.3211
 2007-06-30,AU,Australia,9.2208
-2007-06-30,BE,Belgium,8.2371
-2007-06-30,BG,Bulgaria,27.061
+2007-06-30,BE,Belgium,8.2975
+2007-06-30,BG,Bulgaria,27.0611
 2007-06-30,BR,Brazil,16.6666
-2007-06-30,CA,Canada,11.4334
-2007-06-30,CH,Switzerland,8.5456
-2007-06-30,CL,Chile,8.4628
+2007-06-30,CA,Canada,11.006
+2007-06-30,CH,Switzerland,8.5429
+2007-06-30,CL,Chile,8.4627
 2007-06-30,CN,China,5.876
-2007-06-30,CO,Colombia,17.7814
+2007-06-30,CO,Colombia,16.7355
 2007-06-30,CY,Cyprus,24.0577
-2007-06-30,CZ,Czechia,
 2007-06-30,DE,Germany,-0.8222
 2007-06-30,DK,Denmark,2.7027
 2007-06-30,EE,Estonia,29.9171
 2007-06-30,ES,Spain,11.5853
 2007-06-30,FI,Finland,6.3882
 2007-06-30,FR,France,6.5171
-2007-06-30,GB,United Kingdom,10.6407
+2007-06-30,GB,United Kingdom,10.7143
 2007-06-30,GR,Greece,6.796
 2007-06-30,HK,Hong Kong SAR,7.5439
 2007-06-30,HR,Croatia,17.0314
-2007-06-30,HU,Hungary,
+2007-06-30,HU,Hungary,7.0153
 2007-06-30,ID,Indonesia,2.1482
-2007-06-30,IE,Ireland,10.6125
+2007-06-30,IE,Ireland,10.5989
 2007-06-30,IL,Israel,-2.8853
-2007-06-30,IN,India,
-2007-06-30,IS,Iceland,7.6743
+2007-06-30,IS,Iceland,7.6792
 2007-06-30,IT,Italy,5.0386
 2007-06-30,JP,Japan,-1.1427
-2007-06-30,KR,Korea,9.97
+2007-06-30,KR,Korea,9.9068
 2007-06-30,LT,Lithuania,32.5744
-2007-06-30,LU,Luxembourg,
 2007-06-30,LV,Latvia,39.6744
-2007-06-30,MA,Morocco,1.7508
-2007-06-30,MK,North Macedonia,3.158
+2007-06-30,MA,Morocco,2.3093
+2007-06-30,MK,North Macedonia,2.9174
 2007-06-30,MT,Malta,22.3665
 2007-06-30,MX,Mexico,7.7004
 2007-06-30,MY,Malaysia,4.3882
-2007-06-30,NL,Netherlands,4.2914
+2007-06-30,NL,Netherlands,4.2967
 2007-06-30,NO,Norway,15.2104
 2007-06-30,NZ,New Zealand,13.4394
 2007-06-30,PE,Peru,-0.0775
-2007-06-30,PH,Philippines,
-2007-06-30,PL,Poland,
-2007-06-30,PT,Portugal,
-2007-06-30,RO,Romania,
+2007-06-30,PT,Portugal,0.3509
 2007-06-30,RS,Serbia,0.3954
 2007-06-30,RU,Russia,53.6637
 2007-06-30,SE,Sweden,13.7705
 2007-06-30,SG,Singapore,20.9623
-2007-06-30,SI,Slovenia,
-2007-06-30,SK,Slovak Republic,25.4287
+2007-06-30,SK,Slovakia,25.4288
 2007-06-30,TH,Thailand,0.1867
-2007-06-30,TR,Türkiye,
-2007-06-30,US,United States,-4.6657
-2007-06-30,XM,Euro area,5.122
-2007-06-30,XW,World,
-2007-06-30,ZA,South Africa,15.8048
-2007-09-30,4T,Emerging market economies (aggregate),
-2007-09-30,5R,Advanced economies,
-2007-09-30,AE,United Arab Emirates,25.9647
-2007-09-30,AT,Austria,5.2872
+2007-06-30,US,United States,-4.6445
+2007-06-30,XM,Euro area,5.1271
+2007-06-30,ZA,South Africa,15.8055
+2007-09-30,AT,Austria,5.2871
 2007-09-30,AU,Australia,11.0969
-2007-09-30,BE,Belgium,7.1913
+2007-09-30,BE,Belgium,7.064
 2007-09-30,BG,Bulgaria,30.6153
 2007-09-30,BR,Brazil,18.0512
-2007-09-30,CA,Canada,10.8804
-2007-09-30,CH,Switzerland,7.0762
+2007-09-30,CA,Canada,10.4778
+2007-09-30,CH,Switzerland,7.0758
 2007-09-30,CL,Chile,9.7245
 2007-09-30,CN,China,6.9792
-2007-09-30,CO,Colombia,14.355
+2007-09-30,CO,Colombia,14.1133
 2007-09-30,CY,Cyprus,25.3472
-2007-09-30,CZ,Czechia,
 2007-09-30,DE,Germany,-1.0194
 2007-09-30,DK,Denmark,0.8515
 2007-09-30,EE,Estonia,17.8874
 2007-09-30,ES,Spain,9.2212
 2007-09-30,FI,Finland,5.8537
 2007-09-30,FR,France,5.6995
-2007-09-30,GB,United Kingdom,10.3219
+2007-09-30,GB,United Kingdom,10.396
 2007-09-30,GR,Greece,6.1821
 2007-09-30,HK,Hong Kong SAR,12.1855
-2007-09-30,HR,Croatia,16.264
-2007-09-30,HU,Hungary,
+2007-09-30,HR,Croatia,16.2639
+2007-09-30,HU,Hungary,8.3278
 2007-09-30,ID,Indonesia,1.8684
-2007-09-30,IE,Ireland,4.2066
+2007-09-30,IE,Ireland,4.1986
 2007-09-30,IL,Israel,0.3056
-2007-09-30,IN,India,
-2007-09-30,IS,Iceland,12.5688
+2007-09-30,IS,Iceland,12.5929
 2007-09-30,IT,Italy,4.5842
 2007-09-30,JP,Japan,-0.7339
-2007-09-30,KR,Korea,9.1988
+2007-09-30,KR,Korea,9.232
 2007-09-30,LT,Lithuania,28.2819
-2007-09-30,LU,Luxembourg,
 2007-09-30,LV,Latvia,36.5097
-2007-09-30,MA,Morocco,4.1753
-2007-09-30,MK,North Macedonia,-0.9695
+2007-09-30,MA,Morocco,3.629
+2007-09-30,MK,North Macedonia,-0.9577
 2007-09-30,MT,Malta,20.3911
 2007-09-30,MX,Mexico,8.1443
 2007-09-30,MY,Malaysia,5.3872
-2007-09-30,NL,Netherlands,5.122
+2007-09-30,NL,Netherlands,5.1259
 2007-09-30,NO,Norway,11.442
 2007-09-30,NZ,New Zealand,11.2921
 2007-09-30,PE,Peru,12.0556
-2007-09-30,PH,Philippines,
-2007-09-30,PL,Poland,
-2007-09-30,PT,Portugal,
-2007-09-30,RO,Romania,
+2007-09-30,PT,Portugal,1.0822
 2007-09-30,RS,Serbia,1.643
 2007-09-30,RU,Russia,39.335
 2007-09-30,SE,Sweden,14.8137
 2007-09-30,SG,Singapore,27.6786
-2007-09-30,SI,Slovenia,
-2007-09-30,SK,Slovak Republic,32.6194
+2007-09-30,SK,Slovakia,32.6195
 2007-09-30,TH,Thailand,2.5673
-2007-09-30,TR,Türkiye,
-2007-09-30,US,United States,-6.625
-2007-09-30,XM,Euro area,4.3795
-2007-09-30,XW,World,
-2007-09-30,ZA,South Africa,15.2608
-2007-12-31,4T,Emerging market economies (aggregate),
-2007-12-31,5R,Advanced economies,
-2007-12-31,AE,United Arab Emirates,42.4754
+2007-09-30,US,United States,-6.5743
+2007-09-30,XM,Euro area,4.4023
+2007-09-30,ZA,South Africa,15.2614
 2007-12-31,AT,Austria,4.0256
 2007-12-31,AU,Australia,13.2832
-2007-12-31,BE,Belgium,6.794
+2007-12-31,BE,Belgium,6.7429
 2007-12-31,BG,Bulgaria,34.6315
 2007-12-31,BR,Brazil,19.4282
-2007-12-31,CA,Canada,10.4785
+2007-12-31,CA,Canada,10.1667
 2007-12-31,CH,Switzerland,3.5123
-2007-12-31,CL,Chile,9.1669
+2007-12-31,CL,Chile,9.1671
 2007-12-31,CN,China,8.9517
-2007-12-31,CO,Colombia,16.1859
+2007-12-31,CO,Colombia,15.322
 2007-12-31,CY,Cyprus,22.0561
-2007-12-31,CZ,Czechia,
 2007-12-31,DE,Germany,0.206
 2007-12-31,DK,Denmark,0
 2007-12-31,EE,Estonia,5.1625
 2007-12-31,ES,Spain,5.7006
 2007-12-31,FI,Finland,4.5673
 2007-12-31,FR,France,5.4471
-2007-12-31,GB,United Kingdom,8.1699
+2007-12-31,GB,United Kingdom,8.2524
 2007-12-31,GR,Greece,2.4198
 2007-12-31,HK,Hong Kong SAR,21.3648
 2007-12-31,HR,Croatia,8.3551
-2007-12-31,HU,Hungary,
+2007-12-31,HU,Hungary,8.6754
 2007-12-31,ID,Indonesia,1.7446
-2007-12-31,IE,Ireland,1.407
+2007-12-31,IE,Ireland,1.3976
 2007-12-31,IL,Israel,1.7554
-2007-12-31,IN,India,
-2007-12-31,IS,Iceland,15.0986
+2007-12-31,IS,Iceland,15.1269
 2007-12-31,IT,Italy,4.4336
 2007-12-31,JP,Japan,-0.7356
-2007-12-31,KR,Korea,5.2811
+2007-12-31,KR,Korea,5.2746
 2007-12-31,LT,Lithuania,17.6906
-2007-12-31,LU,Luxembourg,
 2007-12-31,LV,Latvia,23.1428
-2007-12-31,MA,Morocco,8.4887
-2007-12-31,MK,North Macedonia,10.9461
+2007-12-31,MA,Morocco,8.0401
+2007-12-31,MK,North Macedonia,11.0796
 2007-12-31,MT,Malta,13.2639
 2007-12-31,MX,Mexico,7.4517
 2007-12-31,MY,Malaysia,2.8595
-2007-12-31,NL,Netherlands,5.1934
+2007-12-31,NL,Netherlands,5.1971
 2007-12-31,NO,Norway,7.5851
 2007-12-31,NZ,New Zealand,7.6541
 2007-12-31,PE,Peru,16.6564
-2007-12-31,PH,Philippines,
-2007-12-31,PL,Poland,
-2007-12-31,PT,Portugal,
-2007-12-31,RO,Romania,
+2007-12-31,PT,Portugal,-0.9629
 2007-12-31,RS,Serbia,5.9766
 2007-12-31,RU,Russia,28.9244
 2007-12-31,SE,Sweden,10.8752
 2007-12-31,SG,Singapore,31.1492
-2007-12-31,SI,Slovenia,
-2007-12-31,SK,Slovak Republic,35.1037
+2007-12-31,SK,Slovakia,35.1038
 2007-12-31,TH,Thailand,1.2384
-2007-12-31,TR,Türkiye,
-2007-12-31,US,United States,-9.6186
-2007-12-31,XM,Euro area,3.8985
-2007-12-31,XW,World,
-2007-12-31,ZA,South Africa,12.335
-2008-03-31,4T,Emerging market economies (aggregate),
-2008-03-31,5R,Advanced economies,
-2008-03-31,AE,United Arab Emirates,40.4117
+2007-12-31,US,United States,-9.5445
+2007-12-31,XM,Euro area,3.9159
+2007-12-31,ZA,South Africa,12.3353
 2008-03-31,AT,Austria,1.7778
 2008-03-31,AU,Australia,12.795
-2008-03-31,BE,Belgium,5.3456
+2008-03-31,BE,Belgium,5.3064
 2008-03-31,BG,Bulgaria,31.5677
 2008-03-31,BR,Brazil,20.7977
-2008-03-31,CA,Canada,8.6331
-2008-03-31,CH,Switzerland,3.4786
+2008-03-31,CA,Canada,8.4883
+2008-03-31,CH,Switzerland,3.479
 2008-03-31,CL,Chile,10.3622
 2008-03-31,CN,China,9.4033
-2008-03-31,CO,Colombia,15.7055
+2008-03-31,CO,Colombia,15.9745
 2008-03-31,CY,Cyprus,25.1753
-2008-03-31,CZ,Czechia,
 2008-03-31,DE,Germany,2.8986
 2008-03-31,DK,Denmark,-1.7143
 2008-03-31,EE,Estonia,-1.2346
 2008-03-31,ES,Spain,2.8455
 2008-03-31,FI,Finland,3.2902
 2008-03-31,FR,France,4.0816
-2008-03-31,GB,United Kingdom,3.7594
+2008-03-31,GB,United Kingdom,3.6683
 2008-03-31,GR,Greece,2.8916
 2008-03-31,HK,Hong Kong SAR,29.4787
-2008-03-31,HR,Croatia,4.1419
+2008-03-31,HR,Croatia,4.142
 2008-03-31,HU,Hungary,5.8947
 2008-03-31,ID,Indonesia,2.2454
-2008-03-31,IE,Ireland,-2.4328
+2008-03-31,IE,Ireland,-2.3995
 2008-03-31,IL,Israel,4.5732
-2008-03-31,IN,India,
-2008-03-31,IS,Iceland,13.9189
+2008-03-31,IS,Iceland,13.962
 2008-03-31,IT,Italy,3.7354
 2008-03-31,JP,Japan,-0.7373
-2008-03-31,KR,Korea,2.6894
+2008-03-31,KR,Korea,2.6897
 2008-03-31,LT,Lithuania,16.7536
 2008-03-31,LU,Luxembourg,3.7277
 2008-03-31,LV,Latvia,16.6796
-2008-03-31,MA,Morocco,3.1697
-2008-03-31,MK,North Macedonia,11.6943
+2008-03-31,MA,Morocco,2.6812
+2008-03-31,MK,North Macedonia,11.4441
 2008-03-31,MT,Malta,16.6872
 2008-03-31,MX,Mexico,6.2774
 2008-03-31,MY,Malaysia,4.295
-2008-03-31,NL,Netherlands,3.8701
+2008-03-31,NL,Netherlands,3.8782
 2008-03-31,NO,Norway,3.6443
 2008-03-31,NZ,New Zealand,2.7353
 2008-03-31,PE,Peru,17.3623
-2008-03-31,PH,Philippines,
-2008-03-31,PL,Poland,
-2008-03-31,PT,Portugal,
-2008-03-31,RO,Romania,
+2008-03-31,PT,Portugal,-5.1937
 2008-03-31,RS,Serbia,13.593
 2008-03-31,RU,Russia,24.7383
 2008-03-31,SE,Sweden,7.0998
 2008-03-31,SG,Singapore,29.8156
 2008-03-31,SI,Slovenia,11.8105
-2008-03-31,SK,Slovak Republic,33.3333
+2008-03-31,SK,Slovakia,33.3334
 2008-03-31,TH,Thailand,-5.4327
-2008-03-31,TR,Türkiye,
-2008-03-31,US,United States,-12.3007
-2008-03-31,XM,Euro area,3.6749
-2008-03-31,XW,World,
-2008-03-31,ZA,South Africa,7.1255
-2008-06-30,4T,Emerging market economies (aggregate),
-2008-06-30,5R,Advanced economies,
-2008-06-30,AE,United Arab Emirates,39.9002
+2008-03-31,US,United States,-12.2212
+2008-03-31,XM,Euro area,3.7013
+2008-03-31,ZA,South Africa,7.1261
 2008-06-30,AT,Austria,-0.9582
 2008-06-30,AU,Australia,7.0155
-2008-06-30,BE,Belgium,4.7608
-2008-06-30,BG,Bulgaria,32.212
+2008-06-30,BE,Belgium,4.5948
+2008-06-30,BG,Bulgaria,32.2121
 2008-06-30,BR,Brazil,22.0346
-2008-06-30,CA,Canada,4.6708
-2008-06-30,CH,Switzerland,3.2042
-2008-06-30,CL,Chile,9.9353
+2008-06-30,CA,Canada,4.725
+2008-06-30,CH,Switzerland,3.2087
+2008-06-30,CL,Chile,9.9354
 2008-06-30,CN,China,7.8512
-2008-06-30,CO,Colombia,16.1216
+2008-06-30,CO,Colombia,15.5635
 2008-06-30,CY,Cyprus,19.4705
-2008-06-30,CZ,Czechia,
 2008-06-30,DE,Germany,3.9378
 2008-06-30,DK,Denmark,-2.6316
 2008-06-30,EE,Estonia,-9.9768
 2008-06-30,ES,Spain,-0.2746
 2008-06-30,FI,Finland,2.4249
 2008-06-30,FR,France,2.7081
-2008-06-30,GB,United Kingdom,-0.7239
+2008-06-30,GB,United Kingdom,-0.768
 2008-06-30,GR,Greece,1.7364
 2008-06-30,HK,Hong Kong SAR,25.5651
 2008-06-30,HR,Croatia,0.813
 2008-06-30,HU,Hungary,4.7276
 2008-06-30,ID,Indonesia,2.4135
-2008-06-30,IE,Ireland,-5.4351
+2008-06-30,IE,Ireland,-5.4352
 2008-06-30,IL,Israel,6.4588
-2008-06-30,IN,India,
-2008-06-30,IS,Iceland,7.1872
+2008-06-30,IS,Iceland,7.1915
 2008-06-30,IT,Italy,3.5845
 2008-06-30,JP,Japan,-1.2467
-2008-06-30,KR,Korea,4.3692
+2008-06-30,KR,Korea,4.3918
 2008-06-30,LT,Lithuania,16.0697
 2008-06-30,LU,Luxembourg,6.005
 2008-06-30,LV,Latvia,11.2657
-2008-06-30,MA,Morocco,1.7207
-2008-06-30,MK,North Macedonia,19.5978
+2008-06-30,MA,Morocco,1.6683
+2008-06-30,MK,North Macedonia,19.7024
 2008-06-30,MT,Malta,6.7217
 2008-06-30,MX,Mexico,6.2656
 2008-06-30,MY,Malaysia,4.2037
-2008-06-30,NL,Netherlands,3.1231
+2008-06-30,NL,Netherlands,3.1305
 2008-06-30,NO,Norway,1.1236
 2008-06-30,NZ,New Zealand,-4.4543
 2008-06-30,PE,Peru,26.19
-2008-06-30,PH,Philippines,
-2008-06-30,PL,Poland,
-2008-06-30,PT,Portugal,
-2008-06-30,RO,Romania,
+2008-06-30,PT,Portugal,-4.5209
 2008-06-30,RS,Serbia,20.2473
 2008-06-30,RU,Russia,26.5354
 2008-06-30,SE,Sweden,2.8997
 2008-06-30,SG,Singapore,20.1704
 2008-06-30,SI,Slovenia,9.2787
-2008-06-30,SK,Slovak Republic,28.5943
+2008-06-30,SK,Slovakia,28.5943
 2008-06-30,TH,Thailand,-2.6377
-2008-06-30,TR,Türkiye,
-2008-06-30,US,United States,-13.72
-2008-06-30,XM,Euro area,2.9363
-2008-06-30,XW,World,
-2008-06-30,ZA,South Africa,-0.1307
-2008-09-30,4T,Emerging market economies (aggregate),
-2008-09-30,5R,Advanced economies,
-2008-09-30,AE,United Arab Emirates,25.3168
+2008-06-30,US,United States,-13.6179
+2008-06-30,XM,Euro area,2.9598
+2008-06-30,ZA,South Africa,-0.1314
 2008-09-30,AT,Austria,0.2597
 2008-09-30,AU,Australia,1.0333
-2008-09-30,BE,Belgium,4.2808
-2008-09-30,BG,Bulgaria,26.7665
+2008-09-30,BE,Belgium,4.3184
+2008-09-30,BG,Bulgaria,26.7666
 2008-09-30,BR,Brazil,23.0143
-2008-09-30,CA,Canada,0.2996
-2008-09-30,CH,Switzerland,4.8386
-2008-09-30,CL,Chile,9.4737
+2008-09-30,CA,Canada,0.5311
+2008-09-30,CH,Switzerland,4.8399
+2008-09-30,CL,Chile,9.4738
 2008-09-30,CN,China,5.5026
-2008-09-30,CO,Colombia,16.8847
+2008-09-30,CO,Colombia,16.2513
 2008-09-30,CY,Cyprus,17.0379
-2008-09-30,CZ,Czechia,
 2008-09-30,DE,Germany,2.8836
 2008-09-30,DK,Denmark,-5.3471
 2008-09-30,EE,Estonia,-7.4074
 2008-09-30,ES,Spain,-2.9092
 2008-09-30,FI,Finland,0.8065
 2008-09-30,FR,France,0.5882
-2008-09-30,GB,United Kingdom,-7.2435
+2008-09-30,GB,United Kingdom,-7.1749
 2008-09-30,GR,Greece,1.5599
 2008-09-30,HK,Hong Kong SAR,18.4557
 2008-09-30,HR,Croatia,0.9592
 2008-09-30,HU,Hungary,1.087
 2008-09-30,ID,Indonesia,2.5644
-2008-09-30,IE,Ireland,-7.8436
+2008-09-30,IE,Ireland,-7.8748
 2008-09-30,IL,Israel,8.3902
-2008-09-30,IN,India,
-2008-09-30,IS,Iceland,1.1003
+2008-09-30,IS,Iceland,1.0757
 2008-09-30,IT,Italy,2.6154
 2008-09-30,JP,Japan,-1.756
-2008-09-30,KR,Korea,5.0543
+2008-09-30,KR,Korea,5.0484
 2008-09-30,LT,Lithuania,7.0248
 2008-09-30,LU,Luxembourg,1.4898
 2008-09-30,LV,Latvia,-3.81
-2008-09-30,MA,Morocco,3.2064
-2008-09-30,MK,North Macedonia,24.2919
+2008-09-30,MA,Morocco,1.8483
+2008-09-30,MK,North Macedonia,24.0952
 2008-09-30,MT,Malta,11.8329
 2008-09-30,MX,Mexico,6.8708
 2008-09-30,MY,Malaysia,4.9521
-2008-09-30,NL,Netherlands,2.449
+2008-09-30,NL,Netherlands,2.4441
 2008-09-30,NO,Norway,-2.1097
 2008-09-30,NZ,New Zealand,-6.6653
 2008-09-30,PE,Peru,38.8744
-2008-09-30,PH,Philippines,
-2008-09-30,PL,Poland,
-2008-09-30,PT,Portugal,
-2008-09-30,RO,Romania,
+2008-09-30,PT,Portugal,-7.8055
 2008-09-30,RS,Serbia,25.4802
 2008-09-30,RU,Russia,26.9494
 2008-09-30,SE,Sweden,-1.3851
 2008-09-30,SG,Singapore,8.3041
 2008-09-30,SI,Slovenia,7.7326
-2008-09-30,SK,Slovak Republic,13.0072
+2008-09-30,SK,Slovakia,13.0071
 2008-09-30,TH,Thailand,0.2402
-2008-09-30,TR,Türkiye,
-2008-09-30,US,United States,-15.1632
-2008-09-30,XM,Euro area,1.3453
-2008-09-30,XW,World,
-2008-09-30,ZA,South Africa,-4.9785
-2008-12-31,4T,Emerging market economies (aggregate),5.8725
-2008-12-31,5R,Advanced economies,-8.4785
-2008-12-31,AE,United Arab Emirates,2.5787
+2008-09-30,US,United States,-15.1099
+2008-09-30,XM,Euro area,1.3638
+2008-09-30,ZA,South Africa,-4.9791
+2008-12-31,4T,Emerging market economies (aggregate),6.252
+2008-12-31,5R,Advanced economies,-7.6044
 2008-12-31,AT,Austria,3.2542
 2008-12-31,AU,Australia,-3.9823
-2008-12-31,BE,Belgium,3.3012
+2008-12-31,BE,Belgium,3.2155
 2008-12-31,BG,Bulgaria,11.7144
 2008-12-31,BR,Brazil,23.7253
-2008-12-31,CA,Canada,-4.0329
-2008-12-31,CH,Switzerland,5.1854
+2008-12-31,CA,Canada,-3.7065
+2008-12-31,CH,Switzerland,5.1864
 2008-12-31,CL,Chile,10.47
 2008-12-31,CN,China,1.7903
-2008-12-31,CO,Colombia,14.9578
+2008-12-31,CO,Colombia,15.3021
 2008-12-31,CY,Cyprus,9.7317
-2008-12-31,CZ,Czechia,
 2008-12-31,DE,Germany,3.3916
 2008-12-31,DK,Denmark,-11.0899
 2008-12-31,EE,Estonia,-19.6364
 2008-12-31,ES,Spain,-5.2263
 2008-12-31,FI,Finland,-3.2184
 2008-12-31,FR,France,-3.3138
-2008-12-31,GB,United Kingdom,-13.2931
+2008-12-31,GB,United Kingdom,-13.3034
 2008-12-31,GR,Greece,0.5931
 2008-12-31,HK,Hong Kong SAR,-4.6217
 2008-12-31,HR,Croatia,-1.2048
 2008-12-31,HU,Hungary,-1.6667
 2008-12-31,ID,Indonesia,2.56
-2008-12-31,IE,Ireland,-12.0761
+2008-12-31,IE,Ireland,-12.0757
 2008-12-31,IL,Israel,10.7681
-2008-12-31,IN,India,
-2008-12-31,IS,Iceland,-2.7113
+2008-12-31,IS,Iceland,-2.7188
 2008-12-31,IT,Italy,0.5234
 2008-12-31,JP,Japan,-2.5475
-2008-12-31,KR,Korea,3.9374
+2008-12-31,KR,Korea,3.9371
 2008-12-31,LT,Lithuania,-2.4907
 2008-12-31,LU,Luxembourg,2.2548
 2008-12-31,LV,Latvia,-17.7588
-2008-12-31,MA,Morocco,-0.668
-2008-12-31,MK,North Macedonia,24.6472
+2008-12-31,MA,Morocco,-2.4185
+2008-12-31,MK,North Macedonia,24.3766
 2008-12-31,MT,Malta,9.2996
 2008-12-31,MX,Mexico,8.1075
 2008-12-31,MY,Malaysia,2.4623
-2008-12-31,NL,Netherlands,-0.5833
+2008-12-31,NL,Netherlands,-0.5841
 2008-12-31,NO,Norway,-6.9065
 2008-12-31,NZ,New Zealand,-8.9269
 2008-12-31,PE,Peru,28.3199
-2008-12-31,PH,Philippines,
-2008-12-31,PL,Poland,
-2008-12-31,PT,Portugal,
-2008-12-31,RO,Romania,
+2008-12-31,PT,Portugal,-7.7247
 2008-12-31,RS,Serbia,28.4275
 2008-12-31,RU,Russia,19.6776
 2008-12-31,SE,Sweden,-3.6856
 2008-12-31,SG,Singapore,-4.6684
 2008-12-31,SI,Slovenia,-0.1647
-2008-12-31,SK,Slovak Republic,0.9691
+2008-12-31,SK,Slovakia,0.9691
 2008-12-31,TH,Thailand,3.2166
-2008-12-31,TR,Türkiye,
-2008-12-31,US,United States,-16.8652
-2008-12-31,XM,Euro area,-0.4012
-2008-12-31,XW,World,-1.953
-2008-12-31,ZA,South Africa,-5.6186
-2009-03-31,4T,Emerging market economies (aggregate),2.7991
-2009-03-31,5R,Advanced economies,-9.3438
-2009-03-31,AE,United Arab Emirates,-13.9081
-2009-03-31,AT,Austria,4.5414
+2008-12-31,US,United States,-16.8181
+2008-12-31,XM,Euro area,-0.3732
+2008-12-31,XW,World,-2.0975
+2008-12-31,ZA,South Africa,-5.6195
+2009-03-31,4T,Emerging market economies (aggregate),3.5973
+2009-03-31,5R,Advanced economies,-8.7658
+2009-03-31,AT,Austria,4.5415
 2009-03-31,AU,Australia,-4.6256
-2009-03-31,BE,Belgium,0.9763
+2009-03-31,BE,Belgium,0.9716
 2009-03-31,BG,Bulgaria,-7.3079
 2009-03-31,BR,Brazil,24.2764
-2009-03-31,CA,Canada,-8.4621
-2009-03-31,CH,Switzerland,4.1514
-2009-03-31,CL,Chile,2.5631
+2009-03-31,CA,Canada,-8.1222
+2009-03-31,CH,Switzerland,4.1567
+2009-03-31,CL,Chile,2.563
 2009-03-31,CN,China,-0.1903
-2009-03-31,CO,Colombia,11.7837
+2009-03-31,CO,Colombia,11.5201
 2009-03-31,CY,Cyprus,-4.1132
 2009-03-31,CZ,Czechia,2.7778
 2009-03-31,DE,Germany,0.9054
@@ -20356,60 +4631,55 @@ date,country_code,country,price
 2009-03-31,ES,Spain,-7.4161
 2009-03-31,FI,Finland,-1.934
 2009-03-31,FR,France,-6.3725
-2009-03-31,GB,United Kingdom,-15.4244
-2009-03-31,GR,Greece,-3.2935
+2009-03-31,GB,United Kingdom,-15.3846
+2009-03-31,GR,Greece,-3.2936
 2009-03-31,HK,Hong Kong SAR,-13.5964
 2009-03-31,HR,Croatia,-0.487
-2009-03-31,HU,Hungary,-0.8947
+2009-03-31,HU,Hungary,-0.8946
 2009-03-31,ID,Indonesia,2.2824
-2009-03-31,IE,Ireland,-16.4829
+2009-03-31,IE,Ireland,-16.4951
 2009-03-31,IL,Israel,10.4534
-2009-03-31,IN,India,
-2009-03-31,IS,Iceland,-11.0715
+2009-03-31,IS,Iceland,-11.0852
 2009-03-31,IT,Italy,0.2378
 2009-03-31,JP,Japan,-4.2
-2009-03-31,KR,Korea,1.55
+2009-03-31,KR,Korea,1.5563
 2009-03-31,LT,Lithuania,-24.5804
 2009-03-31,LU,Luxembourg,0.2741
 2009-03-31,LV,Latvia,-36.9762
-2009-03-31,MA,Morocco,6.4421
-2009-03-31,MK,North Macedonia,13.7526
+2009-03-31,MA,Morocco,1.9343
+2009-03-31,MK,North Macedonia,13.8687
 2009-03-31,MT,Malta,-2.8602
 2009-03-31,MX,Mexico,7.9763
 2009-03-31,MY,Malaysia,0.6258
-2009-03-31,NL,Netherlands,-1.6729
+2009-03-31,NL,Netherlands,-1.6661
 2009-03-31,NO,Norway,-5.2039
 2009-03-31,NZ,New Zealand,-9.0006
 2009-03-31,PE,Peru,28.5317
 2009-03-31,PH,Philippines,4.5819
-2009-03-31,PL,Poland,
-2009-03-31,PT,Portugal,-3.2593
-2009-03-31,RO,Romania,
+2009-03-31,PT,Portugal,-3.2592
 2009-03-31,RS,Serbia,29.1918
 2009-03-31,RU,Russia,10.5996
 2009-03-31,SE,Sweden,-1.3327
 2009-03-31,SG,Singapore,-21.0734
 2009-03-31,SI,Slovenia,-7.6941
-2009-03-31,SK,Slovak Republic,-11.3293
+2009-03-31,SK,Slovakia,-11.3293
 2009-03-31,TH,Thailand,9.6413
-2009-03-31,TR,Türkiye,
-2009-03-31,US,United States,-15.9898
-2009-03-31,XM,Euro area,-2.7928
-2009-03-31,XW,World,-3.7706
-2009-03-31,ZA,South Africa,-4.691
-2009-06-30,4T,Emerging market economies (aggregate),1.3143
-2009-06-30,5R,Advanced economies,-7.9914
-2009-06-30,AE,United Arab Emirates,-23.8361
-2009-06-30,AT,Austria,5.7169
+2009-03-31,US,United States,-15.9533
+2009-03-31,XM,Euro area,-2.7623
+2009-03-31,XW,World,-3.8075
+2009-03-31,ZA,South Africa,-4.6906
+2009-06-30,4T,Emerging market economies (aggregate),2.2432
+2009-06-30,5R,Advanced economies,-7.662
+2009-06-30,AT,Austria,5.7168
 2009-06-30,AU,Australia,0.2222
-2009-06-30,BE,Belgium,-1.3991
+2009-06-30,BE,Belgium,-1.2599
 2009-06-30,BG,Bulgaria,-20.8824
 2009-06-30,BR,Brazil,24.8287
-2009-06-30,CA,Canada,-6.9495
-2009-06-30,CH,Switzerland,2.1073
+2009-06-30,CA,Canada,-6.7308
+2009-06-30,CH,Switzerland,2.1093
 2009-06-30,CL,Chile,1.3503
 2009-06-30,CN,China,-0.4707
-2009-06-30,CO,Colombia,9.1116
+2009-06-30,CO,Colombia,10.3545
 2009-06-30,CY,Cyprus,-6.3674
 2009-06-30,CZ,Czechia,-4.4466
 2009-06-30,DE,Germany,-1.2961
@@ -20418,60 +4688,55 @@ date,country_code,country,price
 2009-06-30,ES,Spain,-7.59
 2009-06-30,FI,Finland,-1.3529
 2009-06-30,FR,France,-8.0078
-2009-06-30,GB,United Kingdom,-13.75
+2009-06-30,GB,United Kingdom,-13.7771
 2009-06-30,GR,Greece,-2.4763
 2009-06-30,HK,Hong Kong SAR,-7.0161
 2009-06-30,HR,Croatia,-4.4355
 2009-06-30,HU,Hungary,-5.2012
 2009-06-30,ID,Indonesia,2.1311
-2009-06-30,IE,Ireland,-20.0486
+2009-06-30,IE,Ireland,-20.0303
 2009-06-30,IL,Israel,12.4285
-2009-06-30,IN,India,
-2009-06-30,IS,Iceland,-10.5158
+2009-06-30,IS,Iceland,-10.5194
 2009-06-30,IT,Italy,-0.8568
 2009-06-30,JP,Japan,-5.0314
-2009-06-30,KR,Korea,-0.6279
+2009-06-30,KR,Korea,-0.5428
 2009-06-30,LT,Lithuania,-31.006
 2009-06-30,LU,Luxembourg,-1.9362
 2009-06-30,LV,Latvia,-42.2512
-2009-06-30,MA,Morocco,5.5721
-2009-06-30,MK,North Macedonia,7.4007
+2009-06-30,MA,Morocco,1.3513
+2009-06-30,MK,North Macedonia,7.2225
 2009-06-30,MT,Malta,-0.7735
 2009-06-30,MX,Mexico,6.312
 2009-06-30,MY,Malaysia,2.5357
-2009-06-30,NL,Netherlands,-4.6482
+2009-06-30,NL,Netherlands,-4.6503
 2009-06-30,NO,Norway,-1.5278
 2009-06-30,NZ,New Zealand,-3.0964
 2009-06-30,PE,Peru,12.0735
 2009-06-30,PH,Philippines,-0.6375
-2009-06-30,PL,Poland,
 2009-06-30,PT,Portugal,-2.6827
-2009-06-30,RO,Romania,
 2009-06-30,RS,Serbia,24.7587
 2009-06-30,RU,Russia,0.4444
 2009-06-30,SE,Sweden,-0.3567
 2009-06-30,SG,Singapore,-24.9015
 2009-06-30,SI,Slovenia,-9.4127
-2009-06-30,SK,Slovak Republic,-18.1078
+2009-06-30,SK,Slovakia,-18.1078
 2009-06-30,TH,Thailand,6.2567
-2009-06-30,TR,Türkiye,
-2009-06-30,US,United States,-11.9862
-2009-06-30,XM,Euro area,-4.4874
-2009-06-30,XW,World,-3.6684
-2009-06-30,ZA,South Africa,-2.7211
-2009-09-30,4T,Emerging market economies (aggregate),1.8795
-2009-09-30,5R,Advanced economies,-5.0711
-2009-09-30,AE,United Arab Emirates,-24.4362
+2009-06-30,US,United States,-11.98
+2009-06-30,XM,Euro area,-4.4505
+2009-06-30,XW,World,-3.6396
+2009-06-30,ZA,South Africa,-2.7197
+2009-09-30,4T,Emerging market economies (aggregate),2.5392
+2009-09-30,5R,Advanced economies,-4.7996
 2009-09-30,AT,Austria,3.1952
 2009-09-30,AU,Australia,6.8182
-2009-09-30,BE,Belgium,-0.5186
+2009-09-30,BE,Belgium,-0.5051
 2009-09-30,BG,Bulgaria,-26.8321
 2009-09-30,BR,Brazil,25.4488
-2009-09-30,CA,Canada,-1.643
-2009-09-30,CH,Switzerland,1.1149
-2009-09-30,CL,Chile,3.6618
+2009-09-30,CA,Canada,-1.5094
+2009-09-30,CH,Switzerland,1.1181
+2009-09-30,CL,Chile,3.6619
 2009-09-30,CN,China,1.1868
-2009-09-30,CO,Colombia,9.2549
+2009-09-30,CO,Colombia,9.7833
 2009-09-30,CY,Cyprus,-6.4989
 2009-09-30,CZ,Czechia,-6.6212
 2009-09-30,DE,Germany,-0.9009
@@ -20480,60 +4745,55 @@ date,country_code,country,price
 2009-09-30,ES,Spain,-6.9483
 2009-09-30,FI,Finland,1.6
 2009-09-30,FR,France,-6.7251
-2009-09-30,GB,United Kingdom,-6.7245
+2009-09-30,GB,United Kingdom,-6.7633
 2009-09-30,GR,Greece,-5.1066
 2009-09-30,HK,Hong Kong SAR,3.1647
 2009-09-30,HR,Croatia,-7.8385
-2009-09-30,HU,Hungary,-7.0382
+2009-09-30,HU,Hungary,-7.0381
 2009-09-30,ID,Indonesia,2.0979
-2009-09-30,IE,Ireland,-21.2642
+2009-09-30,IE,Ireland,-21.2478
 2009-09-30,IL,Israel,13.3476
-2009-09-30,IN,India,
-2009-09-30,IS,Iceland,-11.3261
+2009-09-30,IS,Iceland,-11.3274
 2009-09-30,IT,Italy,-1.1306
 2009-09-30,JP,Japan,-3.0036
-2009-09-30,KR,Korea,-0.8277
+2009-09-30,KR,Korea,-0.8564
 2009-09-30,LT,Lithuania,-32.9851
 2009-09-30,LU,Luxembourg,-2.4656
 2009-09-30,LV,Latvia,-39.095
-2009-09-30,MA,Morocco,0.9709
-2009-09-30,MK,North Macedonia,2.3524
+2009-09-30,MA,Morocco,0.0955
+2009-09-30,MK,North Macedonia,2.5271
 2009-09-30,MT,Malta,-5.7054
 2009-09-30,MX,Mexico,3.979
 2009-09-30,MY,Malaysia,1.9715
-2009-09-30,NL,Netherlands,-6.68
+2009-09-30,NL,Netherlands,-6.6779
 2009-09-30,NO,Norway,3.7356
 2009-09-30,NZ,New Zealand,1.0525
 2009-09-30,PE,Peru,8.1014
 2009-09-30,PH,Philippines,-2.1867
-2009-09-30,PL,Poland,
 2009-09-30,PT,Portugal,0.1314
-2009-09-30,RO,Romania,
 2009-09-30,RS,Serbia,16.1245
 2009-09-30,RU,Russia,-6.097
 2009-09-30,SE,Sweden,3.1002
 2009-09-30,SG,Singapore,-10.9766
 2009-09-30,SI,Slovenia,-12.5988
-2009-09-30,SK,Slovak Republic,-10.0898
+2009-09-30,SK,Slovakia,-10.0897
 2009-09-30,TH,Thailand,3.0896
-2009-09-30,TR,Türkiye,
-2009-09-30,US,United States,-7.6211
-2009-09-30,XM,Euro area,-4.328
-2009-09-30,XW,World,-1.7953
-2009-09-30,ZA,South Africa,-0.2354
-2009-12-31,4T,Emerging market economies (aggregate),4.5588
-2009-12-31,5R,Advanced economies,-1.2442
-2009-12-31,AE,United Arab Emirates,-17.4362
-2009-12-31,AT,Austria,2.2146
+2009-09-30,US,United States,-7.6367
+2009-09-30,XM,Euro area,-4.2925
+2009-09-30,XW,World,-1.7731
+2009-09-30,ZA,South Africa,-0.2351
+2009-12-31,4T,Emerging market economies (aggregate),4.86
+2009-12-31,5R,Advanced economies,-0.9499
+2009-12-31,AT,Austria,2.2147
 2009-12-31,AU,Australia,14.2857
-2009-12-31,BE,Belgium,-0.9099
+2009-12-31,BE,Belgium,-0.8285
 2009-12-31,BG,Bulgaria,-25.7236
 2009-12-31,BR,Brazil,25.9952
-2009-12-31,CA,Canada,5.4475
-2009-12-31,CH,Switzerland,0.3231
+2009-12-31,CA,Canada,5.4203
+2009-12-31,CH,Switzerland,0.3262
 2009-12-31,CL,Chile,7.3717
 2009-12-31,CN,China,4.4284
-2009-12-31,CO,Colombia,8.7665
+2009-12-31,CO,Colombia,9.0569
 2009-12-31,CY,Cyprus,-1.8615
 2009-12-31,CZ,Czechia,-6.7581
 2009-12-31,DE,Germany,-1.1928
@@ -20542,60 +4802,55 @@ date,country_code,country,price
 2009-12-31,ES,Spain,-4.3735
 2009-12-31,FI,Finland,7.7197
 2009-12-31,FR,France,-3.2258
-2009-12-31,GB,United Kingdom,1.8583
+2009-12-31,GB,United Kingdom,1.7241
 2009-12-31,GR,Greece,-3.9996
 2009-12-31,HK,Hong Kong SAR,23.0556
 2009-12-31,HR,Croatia,-7.0732
 2009-12-31,HU,Hungary,-7.8764
 2009-12-31,ID,Indonesia,2.3036
-2009-12-31,IE,Ireland,-18.9363
+2009-12-31,IE,Ireland,-18.9284
 2009-12-31,IL,Israel,18.2131
-2009-12-31,IN,India,
-2009-12-31,IS,Iceland,-8.3197
+2009-12-31,IS,Iceland,-8.3473
 2009-12-31,IT,Italy,-0.2557
 2009-12-31,JP,Japan,-2.8462
-2009-12-31,KR,Korea,0.6746
+2009-12-31,KR,Korea,0.6588
 2009-12-31,LT,Lithuania,-31.1164
 2009-12-31,LU,Luxembourg,-0.433
 2009-12-31,LV,Latvia,-29.3017
-2009-12-31,MA,Morocco,-0.5763
-2009-12-31,MK,North Macedonia,-7.886
+2009-12-31,MA,Morocco,0.6672
+2009-12-31,MK,North Macedonia,-8.0196
 2009-12-31,MT,Malta,-7.668
 2009-12-31,MX,Mexico,2.8288
 2009-12-31,MY,Malaysia,5.0637
-2009-12-31,NL,Netherlands,-4.8044
+2009-12-31,NL,Netherlands,-4.798
 2009-12-31,NO,Norway,11.592
 2009-12-31,NZ,New Zealand,5.3925
 2009-12-31,PE,Peru,7.084
 2009-12-31,PH,Philippines,-2.5006
-2009-12-31,PL,Poland,
 2009-12-31,PT,Portugal,2.2818
-2009-12-31,RO,Romania,
 2009-12-31,RS,Serbia,10.5032
 2009-12-31,RU,Russia,-6.3715
 2009-12-31,SE,Sweden,11.5954
 2009-12-31,SG,Singapore,1.7182
 2009-12-31,SI,Slovenia,-8.1219
-2009-12-31,SK,Slovak Republic,-11.1825
+2009-12-31,SK,Slovakia,-11.1825
 2009-12-31,TH,Thailand,2.505
-2009-12-31,TR,Türkiye,
-2009-12-31,US,United States,-2.0446
-2009-12-31,XM,Euro area,-2.8586
-2009-12-31,XW,World,1.5349
-2009-12-31,ZA,South Africa,1.6448
-2010-03-31,4T,Emerging market economies (aggregate),8.7268
-2010-03-31,5R,Advanced economies,1.0637
-2010-03-31,AE,United Arab Emirates,-14.8139
+2009-12-31,US,United States,-2.0645
+2009-12-31,XM,Euro area,-2.829
+2009-12-31,XW,World,1.4908
+2009-12-31,ZA,South Africa,1.6445
+2010-03-31,4T,Emerging market economies (aggregate),8.953
+2010-03-31,5R,Advanced economies,1.5139
 2010-03-31,AT,Austria,5.5973
 2010-03-31,AU,Australia,18.1293
-2010-03-31,BE,Belgium,1.4952
+2010-03-31,BE,Belgium,0.828
 2010-03-31,BG,Bulgaria,-18.0393
 2010-03-31,BR,Brazil,26.1665
-2010-03-31,CA,Canada,12.3794
-2010-03-31,CH,Switzerland,2.0359
-2010-03-31,CL,Chile,9.8168
+2010-03-31,CA,Canada,12.3277
+2010-03-31,CH,Switzerland,2.0344
+2010-03-31,CL,Chile,9.8134
 2010-03-31,CN,China,8.9926
-2010-03-31,CO,Colombia,7.8881
+2010-03-31,CO,Colombia,7.682
 2010-03-31,CY,Cyprus,0.6948
 2010-03-31,CZ,Czechia,-4.7047
 2010-03-31,DE,Germany,-1.6949
@@ -20604,60 +4859,57 @@ date,country_code,country,price
 2010-03-31,ES,Spain,-2.9812
 2010-03-31,FI,Finland,7.6566
 2010-03-31,FR,France,1.2565
-2010-03-31,GB,United Kingdom,7.7111
+2010-03-31,GB,United Kingdom,7.6364
 2010-03-31,GR,Greece,-1.7742
 2010-03-31,HK,Hong Kong SAR,30.3302
 2010-03-31,HR,Croatia,-8.5644
 2010-03-31,HU,Hungary,-5.015
 2010-03-31,ID,Indonesia,2.5381
-2010-03-31,IE,Ireland,-15.8077
+2010-03-31,IE,Ireland,-15.8027
 2010-03-31,IL,Israel,20.5055
 2010-03-31,IN,India,18.5
-2010-03-31,IS,Iceland,-4.4909
+2010-03-31,IS,Iceland,-4.4907
 2010-03-31,IT,Italy,-2.1038
 2010-03-31,JP,Japan,0.4032
-2010-03-31,KR,Korea,2.6842
+2010-03-31,KR,Korea,2.6757
 2010-03-31,LT,Lithuania,-15.5354
 2010-03-31,LU,Luxembourg,5.9692
 2010-03-31,LV,Latvia,-20.6689
-2010-03-31,MA,Morocco,-4.5624
-2010-03-31,MK,North Macedonia,1.3568
+2010-03-31,MA,Morocco,-0.5693
+2010-03-31,MK,North Macedonia,1.3578
 2010-03-31,MT,Malta,-0.2181
 2010-03-31,MX,Mexico,2.2184
 2010-03-31,MY,Malaysia,5.1948
-2010-03-31,NL,Netherlands,-4.0986
+2010-03-31,NL,Netherlands,-4.1059
 2010-03-31,NO,Norway,10.6825
 2010-03-31,NZ,New Zealand,6.2009
 2010-03-31,PE,Peru,20.8291
 2010-03-31,PH,Philippines,-1.7911
-2010-03-31,PL,Poland,
-2010-03-31,PT,Portugal,1.959
+2010-03-31,PT,Portugal,1.9589
 2010-03-31,RO,Romania,-6.7669
 2010-03-31,RS,Serbia,7.3654
 2010-03-31,RU,Russia,2.0768
 2010-03-31,SE,Sweden,10.2241
 2010-03-31,SG,Singapore,25.1
 2010-03-31,SI,Slovenia,-1.642
-2010-03-31,SK,Slovak Republic,-5.6425
+2010-03-31,SK,Slovakia,-5.3677
 2010-03-31,TH,Thailand,2.6585
-2010-03-31,TR,Türkiye,
-2010-03-31,US,United States,-0.0524
-2010-03-31,XM,Euro area,-1.5778
-2010-03-31,XW,World,4.7683
-2010-03-31,ZA,South Africa,3.7338
-2010-06-30,4T,Emerging market economies (aggregate),10.3149
-2010-06-30,5R,Advanced economies,2.054
-2010-06-30,AE,United Arab Emirates,-12.207
-2010-06-30,AT,Austria,5.5741
+2010-03-31,US,United States,-0.0581
+2010-03-31,XM,Euro area,-1.559
+2010-03-31,XW,World,4.6722
+2010-03-31,ZA,South Africa,3.734
+2010-06-30,4T,Emerging market economies (aggregate),10.5314
+2010-06-30,5R,Advanced economies,2.5617
+2010-06-30,AT,Austria,5.574
 2010-06-30,AU,Australia,15.6319
-2010-06-30,BE,Belgium,3.4397
+2010-06-30,BE,Belgium,2.5632
 2010-06-30,BG,Bulgaria,-9.8587
 2010-06-30,BR,Brazil,25.7727
-2010-06-30,CA,Canada,11.7925
-2010-06-30,CH,Switzerland,3.4487
-2010-06-30,CL,Chile,11.6365
+2010-06-30,CA,Canada,11.7367
+2010-06-30,CH,Switzerland,3.4472
+2010-06-30,CL,Chile,11.6398
 2010-06-30,CN,China,10.6241
-2010-06-30,CO,Colombia,7.6357
+2010-06-30,CO,Colombia,7.0989
 2010-06-30,CY,Cyprus,-0.4993
 2010-06-30,CZ,Czechia,-1.3444
 2010-06-30,DE,Germany,0.8081
@@ -20666,33 +4918,32 @@ date,country_code,country,price
 2010-06-30,ES,Spain,-0.9594
 2010-06-30,FI,Finland,6.9714
 2010-06-30,FR,France,4.6709
-2010-06-30,GB,United Kingdom,8.2126
-2010-06-30,GR,Greece,-4.6838
+2010-06-30,GB,United Kingdom,8.2585
+2010-06-30,GR,Greece,-4.6839
 2010-06-30,HK,Hong Kong SAR,25.0854
 2010-06-30,HR,Croatia,-6.7511
 2010-06-30,HU,Hungary,-2.4845
 2010-06-30,ID,Indonesia,2.8939
-2010-06-30,IE,Ireland,-12.6561
+2010-06-30,IE,Ireland,-12.6723
 2010-06-30,IL,Israel,19.3956
 2010-06-30,IN,India,19.4286
-2010-06-30,IS,Iceland,-1.6979
+2010-06-30,IS,Iceland,-1.7158
 2010-06-30,IT,Italy,-1.0773
 2010-06-30,JP,Japan,2.1153
-2010-06-30,KR,Korea,3.2649
+2010-06-30,KR,Korea,3.1839
 2010-06-30,LT,Lithuania,-8.8587
 2010-06-30,LU,Luxembourg,3.8559
 2010-06-30,LV,Latvia,-11.5051
-2010-06-30,MA,Morocco,-0.6598
-2010-06-30,MK,North Macedonia,0.0698
+2010-06-30,MA,Morocco,-0.0952
+2010-06-30,MK,North Macedonia,0.1899
 2010-06-30,MT,Malta,1.559
 2010-06-30,MX,Mexico,2.025
 2010-06-30,MY,Malaysia,6.4687
-2010-06-30,NL,Netherlands,-1.3713
+2010-06-30,NL,Netherlands,-1.3753
 2010-06-30,NO,Norway,9.1678
 2010-06-30,NZ,New Zealand,3.1668
 2010-06-30,PE,Peru,26.2083
 2010-06-30,PH,Philippines,-0.8683
-2010-06-30,PL,Poland,
 2010-06-30,PT,Portugal,1.4158
 2010-06-30,RO,Romania,-3.937
 2010-06-30,RS,Serbia,7.9581
@@ -20700,26 +4951,24 @@ date,country_code,country,price
 2010-06-30,SE,Sweden,8.3919
 2010-06-30,SG,Singapore,38.1952
 2010-06-30,SI,Slovenia,0.9835
-2010-06-30,SK,Slovak Republic,-1.6375
+2010-06-30,SK,Slovakia,-1.3511
 2010-06-30,TH,Thailand,2.7411
-2010-06-30,TR,Türkiye,
-2010-06-30,US,United States,0.278
-2010-06-30,XM,Euro area,0.6121
-2010-06-30,XW,World,6.0632
-2010-06-30,ZA,South Africa,5.1847
-2010-09-30,4T,Emerging market economies (aggregate),9.8352
-2010-09-30,5R,Advanced economies,0.7099
-2010-09-30,AE,United Arab Emirates,-12.4291
-2010-09-30,AT,Austria,6.2761
+2010-06-30,US,United States,0.2697
+2010-06-30,XM,Euro area,0.6272
+2010-06-30,XW,World,5.96
+2010-06-30,ZA,South Africa,4.9192
+2010-09-30,4T,Emerging market economies (aggregate),10.3314
+2010-09-30,5R,Advanced economies,1.1834
+2010-09-30,AT,Austria,6.2762
 2010-09-30,AU,Australia,9.5745
-2010-09-30,BE,Belgium,3.0061
+2010-09-30,BE,Belgium,2.417
 2010-09-30,BG,Bulgaria,-6.4287
 2010-09-30,BR,Brazil,24.8011
-2010-09-30,CA,Canada,6.7578
-2010-09-30,CH,Switzerland,5.1079
-2010-09-30,CL,Chile,7.6171
+2010-09-30,CA,Canada,6.8199
+2010-09-30,CH,Switzerland,5.1059
+2010-09-30,CL,Chile,7.6179
 2010-09-30,CN,China,8.7036
-2010-09-30,CO,Colombia,6.1184
+2010-09-30,CO,Colombia,6.4911
 2010-09-30,CY,Cyprus,-1.0327
 2010-09-30,CZ,Czechia,-0.8342
 2010-09-30,DE,Germany,1.6162
@@ -20728,33 +4977,32 @@ date,country_code,country,price
 2010-09-30,ES,Spain,-1.7018
 2010-09-30,FI,Finland,6.4117
 2010-09-30,FR,France,5.8516
-2010-09-30,GB,United Kingdom,5.6977
+2010-09-30,GB,United Kingdom,5.6995
 2010-09-30,GR,Greece,-5.1959
 2010-09-30,HK,Hong Kong SAR,21.2114
-2010-09-30,HR,Croatia,-5.9279
+2010-09-30,HR,Croatia,-5.9278
 2010-09-30,HU,Hungary,-1.367
 2010-09-30,ID,Indonesia,2.9266
-2010-09-30,IE,Ireland,-11.5493
+2010-09-30,IE,Ireland,-11.5591
 2010-09-30,IL,Israel,16.5913
 2010-09-30,IN,India,21.3285
-2010-09-30,IS,Iceland,-1.0454
+2010-09-30,IS,Iceland,-1.0229
 2010-09-30,IT,Italy,-0.4717
 2010-09-30,JP,Japan,1.2441
-2010-09-30,KR,Korea,2.1909
+2010-09-30,KR,Korea,2.1994
 2010-09-30,LT,Lithuania,-5.174
 2010-09-30,LU,Luxembourg,6.4209
 2010-09-30,LV,Latvia,-7.7234
-2010-09-30,MA,Morocco,0.2884
-2010-09-30,MK,North Macedonia,1.0363
+2010-09-30,MA,Morocco,0.2862
+2010-09-30,MK,North Macedonia,1.0374
 2010-09-30,MT,Malta,3.4103
 2010-09-30,MX,Mexico,3.0538
 2010-09-30,MY,Malaysia,6.6946
-2010-09-30,NL,Netherlands,-0.4106
+2010-09-30,NL,Netherlands,-0.4111
 2010-09-30,NO,Norway,6.6482
 2010-09-30,NZ,New Zealand,0.2726
 2010-09-30,PE,Peru,19.364
 2010-09-30,PH,Philippines,1.9267
-2010-09-30,PL,Poland,
 2010-09-30,PT,Portugal,0.5811
 2010-09-30,RO,Romania,-7.8741
 2010-09-30,RS,Serbia,12.0896
@@ -20762,26 +5010,24 @@ date,country_code,country,price
 2010-09-30,SE,Sweden,7.1025
 2010-09-30,SG,Singapore,22.8468
 2010-09-30,SI,Slovenia,1.3745
-2010-09-30,SK,Slovak Republic,-6.6789
+2010-09-30,SK,Slovakia,-6.4071
 2010-09-30,TH,Thailand,3.7962
-2010-09-30,TR,Türkiye,
-2010-09-30,US,United States,-2.158
-2010-09-30,XM,Euro area,1.2719
-2010-09-30,XW,World,5.1504
-2010-09-30,ZA,South Africa,4.791
-2010-12-31,4T,Emerging market economies (aggregate),8.8751
-2010-12-31,5R,Advanced economies,-0.2028
-2010-12-31,AE,United Arab Emirates,-13.2234
-2010-12-31,AT,Austria,7.3334
+2010-09-30,US,United States,-2.1418
+2010-09-30,XM,Euro area,1.2819
+2010-09-30,XW,World,5.0877
+2010-09-30,ZA,South Africa,4.6589
+2010-12-31,4T,Emerging market economies (aggregate),9.3863
+2010-12-31,5R,Advanced economies,0.2982
+2010-12-31,AT,Austria,7.3333
 2010-12-31,AU,Australia,4.4355
-2010-12-31,BE,Belgium,4.6025
-2010-12-31,BG,Bulgaria,-4.9552
+2010-12-31,BE,Belgium,3.2082
+2010-12-31,BG,Bulgaria,-4.9553
 2010-12-31,BR,Brazil,23.3989
-2010-12-31,CA,Canada,3.321
-2010-12-31,CH,Switzerland,6.366
-2010-12-31,CL,Chile,3.3884
+2010-12-31,CA,Canada,3.4277
+2010-12-31,CH,Switzerland,6.3651
+2010-12-31,CL,Chile,3.3876
 2010-12-31,CN,China,7.4887
-2010-12-31,CO,Colombia,9.0289
+2010-12-31,CO,Colombia,9.0446
 2010-12-31,CY,Cyprus,-3.5701
 2010-12-31,CZ,Czechia,0
 2010-12-31,DE,Germany,1.6097
@@ -20790,33 +5036,32 @@ date,country_code,country,price
 2010-12-31,ES,Spain,-1.4141
 2010-12-31,FI,Finland,4.2999
 2010-12-31,FR,France,6.7708
-2010-12-31,GB,United Kingdom,1.3683
+2010-12-31,GB,United Kingdom,1.5254
 2010-12-31,GR,Greece,-6.971
 2010-12-31,HK,Hong Kong SAR,22.1219
 2010-12-31,HR,Croatia,-3.937
 2010-12-31,HU,Hungary,-0.4329
 2010-12-31,ID,Indonesia,2.9069
-2010-12-31,IE,Ireland,-13.4102
+2010-12-31,IE,Ireland,-13.4199
 2010-12-31,IL,Israel,14.4363
 2010-12-31,IN,India,16.2762
-2010-12-31,IS,Iceland,-1.3858
+2010-12-31,IS,Iceland,-1.3771
 2010-12-31,IT,Italy,0.2648
 2010-12-31,JP,Japan,2.0014
-2010-12-31,KR,Korea,1.6495
+2010-12-31,KR,Korea,1.6627
 2010-12-31,LT,Lithuania,1.3506
 2010-12-31,LU,Luxembourg,5.4389
 2010-12-31,LV,Latvia,-2.448
-2010-12-31,MA,Morocco,0
-2010-12-31,MK,North Macedonia,7.099
+2010-12-31,MA,Morocco,-0.5682
+2010-12-31,MK,North Macedonia,7.7405
 2010-12-31,MT,Malta,-0.4551
 2010-12-31,MX,Mexico,4.4056
 2010-12-31,MY,Malaysia,7.8594
-2010-12-31,NL,Netherlands,-0.9111
+2010-12-31,NL,Netherlands,-0.9128
 2010-12-31,NO,Norway,6.5097
 2010-12-31,NZ,New Zealand,-1.6118
 2010-12-31,PE,Peru,20.0058
 2010-12-31,PH,Philippines,3.1233
-2010-12-31,PL,Poland,
 2010-12-31,PT,Portugal,-0.8588
 2010-12-31,RO,Romania,-12.2137
 2010-12-31,RS,Serbia,11.846
@@ -20824,26 +5069,24 @@ date,country_code,country,price
 2010-12-31,SE,Sweden,5.9765
 2010-12-31,SG,Singapore,17.5676
 2010-12-31,SI,Slovenia,-0.1453
-2010-12-31,SK,Slovak Republic,-1.7282
+2010-12-31,SK,Slovakia,-1.442
 2010-12-31,TH,Thailand,1.7595
-2010-12-31,TR,Türkiye,
-2010-12-31,US,United States,-3.5424
-2010-12-31,XM,Euro area,1.4831
-2010-12-31,XW,World,4.2351
-2010-12-31,ZA,South Africa,3.4562
-2011-03-31,4T,Emerging market economies (aggregate),6.137
-2011-03-31,5R,Advanced economies,-0.8621
-2011-03-31,AE,United Arab Emirates,-6.5768
+2010-12-31,US,United States,-3.5396
+2010-12-31,XM,Euro area,1.4984
+2010-12-31,XW,World,4.1938
+2010-12-31,ZA,South Africa,4.3475
+2011-03-31,4T,Emerging market economies (aggregate),6.0193
+2011-03-31,5R,Advanced economies,-0.2729
 2011-03-31,AT,Austria,4.5886
 2011-03-31,AU,Australia,0.391
-2011-03-31,BE,Belgium,4.1981
-2011-03-31,BG,Bulgaria,-4.8051
+2011-03-31,BE,Belgium,3.7732
+2011-03-31,BG,Bulgaria,-4.805
 2011-03-31,BR,Brazil,21.8096
-2011-03-31,CA,Canada,3.0758
-2011-03-31,CH,Switzerland,7.1961
-2011-03-31,CL,Chile,9.7188
+2011-03-31,CA,Canada,2.9603
+2011-03-31,CH,Switzerland,7.196
+2011-03-31,CL,Chile,9.7191
 2011-03-31,CN,China,5.8892
-2011-03-31,CO,Colombia,6.0161
+2011-03-31,CO,Colombia,6.3568
 2011-03-31,CY,Cyprus,-1.89
 2011-03-31,CZ,Czechia,0.2102
 2011-03-31,DE,Germany,2.9412
@@ -20852,28 +5095,28 @@ date,country_code,country,price
 2011-03-31,ES,Spain,-3.5576
 2011-03-31,FI,Finland,3.2328
 2011-03-31,FR,France,6.6184
-2011-03-31,GB,United Kingdom,-0.7955
+2011-03-31,GB,United Kingdom,-0.6757
 2011-03-31,GR,Greece,-5.4085
 2011-03-31,HK,Hong Kong SAR,24.3844
 2011-03-31,HR,Croatia,-2.9438
 2011-03-31,HU,Hungary,-3.1679
 2011-03-31,ID,Indonesia,4.4796
-2011-03-31,IE,Ireland,-14.4457
+2011-03-31,IE,Ireland,-14.4053
 2011-03-31,IL,Israel,14.1979
 2011-03-31,IN,India,19.7527
-2011-03-31,IS,Iceland,3.445
+2011-03-31,IS,Iceland,3.4309
 2011-03-31,IT,Italy,1.2842
 2011-03-31,JP,Japan,0.8367
-2011-03-31,KR,Korea,2.8191
+2011-03-31,KR,Korea,2.8292
 2011-03-31,LT,Lithuania,7.7946
 2011-03-31,LU,Luxembourg,1.046
 2011-03-31,LV,Latvia,10.7757
-2011-03-31,MA,Morocco,1.561
-2011-03-31,MK,North Macedonia,-3.4066
+2011-03-31,MA,Morocco,0.3816
+2011-03-31,MK,North Macedonia,-3.499
 2011-03-31,MT,Malta,-3.0601
 2011-03-31,MX,Mexico,5.6071
 2011-03-31,MY,Malaysia,9.465
-2011-03-31,NL,Netherlands,-0.4838
+2011-03-31,NL,Netherlands,-0.4901
 2011-03-31,NO,Norway,8.445
 2011-03-31,NZ,New Zealand,-1.4529
 2011-03-31,PE,Peru,18.5122
@@ -20886,26 +5129,25 @@ date,country_code,country,price
 2011-03-31,SE,Sweden,5.3644
 2011-03-31,SG,Singapore,13.749
 2011-03-31,SI,Slovenia,4.1138
-2011-03-31,SK,Slovak Republic,-1.0912
-2011-03-31,TH,Thailand,6.2417
-2011-03-31,TR,Türkiye,6.5218
-2011-03-31,US,United States,-4.3279
-2011-03-31,XM,Euro area,1.5587
-2011-03-31,XW,World,2.5877
-2011-03-31,ZA,South Africa,2.3253
-2011-06-30,4T,Emerging market economies (aggregate),6.1588
-2011-06-30,5R,Advanced economies,-1.0786
-2011-06-30,AE,United Arab Emirates,-3.7804
+2011-03-31,SK,Slovakia,-1.0912
+2011-03-31,TH,Thailand,4.6974
+2011-03-31,TR,Türkiye,8.2362
+2011-03-31,US,United States,-4.3173
+2011-03-31,XM,Euro area,1.5769
+2011-03-31,XW,World,2.4475
+2011-03-31,ZA,South Africa,3.2291
+2011-06-30,4T,Emerging market economies (aggregate),5.9878
+2011-06-30,5R,Advanced economies,-0.437
 2011-06-30,AT,Austria,1.3396
 2011-06-30,AU,Australia,-2.2052
-2011-06-30,BE,Belgium,4.1813
+2011-06-30,BE,Belgium,3.6662
 2011-06-30,BG,Bulgaria,-5.905
 2011-06-30,BR,Brazil,20.1488
-2011-06-30,CA,Canada,4.782
-2011-06-30,CH,Switzerland,7.9237
-2011-06-30,CL,Chile,11.2296
+2011-06-30,CA,Canada,4.6132
+2011-06-30,CH,Switzerland,7.9242
+2011-06-30,CL,Chile,11.2251
 2011-06-30,CN,China,4.2748
-2011-06-30,CO,Colombia,7.7761
+2011-06-30,CO,Colombia,8.3999
 2011-06-30,CY,Cyprus,-2.6495
 2011-06-30,CZ,Czechia,0.524
 2011-06-30,DE,Germany,2.1042
@@ -20914,28 +5156,28 @@ date,country_code,country,price
 2011-06-30,ES,Spain,-6.2381
 2011-06-30,FI,Finland,4.2735
 2011-06-30,FR,France,6.5923
-2011-06-30,GB,United Kingdom,-1.7857
+2011-06-30,GB,United Kingdom,-1.8242
 2011-06-30,GR,Greece,-5.1157
 2011-06-30,HK,Hong Kong SAR,26.8609
 2011-06-30,HR,Croatia,0
 2011-06-30,HU,Hungary,-3.397
 2011-06-30,ID,Indonesia,4.5297
-2011-06-30,IE,Ireland,-15.9969
+2011-06-30,IE,Ireland,-15.9963
 2011-06-30,IL,Israel,13.0424
 2011-06-30,IN,India,23.1423
-2011-06-30,IS,Iceland,3.7727
+2011-06-30,IS,Iceland,3.7871
 2011-06-30,IT,Italy,2.3749
 2011-06-30,JP,Japan,0.2005
-2011-06-30,KR,Korea,4.6915
+2011-06-30,KR,Korea,4.7672
 2011-06-30,LT,Lithuania,6.2788
 2011-06-30,LU,Luxembourg,4.9272
 2011-06-30,LV,Latvia,12.3177
-2011-06-30,MA,Morocco,-1.0437
-2011-06-30,MK,North Macedonia,-1.6044
+2011-06-30,MA,Morocco,0.8579
+2011-06-30,MK,North Macedonia,-1.5461
 2011-06-30,MT,Malta,-0.4386
 2011-06-30,MX,Mexico,6.1299
 2011-06-30,MY,Malaysia,8.7649
-2011-06-30,NL,Netherlands,-1.7313
+2011-06-30,NL,Netherlands,-1.7301
 2011-06-30,NO,Norway,7.3643
 2011-06-30,NZ,New Zealand,0.1247
 2011-06-30,PE,Peru,19.5208
@@ -20948,26 +5190,25 @@ date,country_code,country,price
 2011-06-30,SE,Sweden,4.1043
 2011-06-30,SG,Singapore,10.1747
 2011-06-30,SI,Slovenia,3.2266
-2011-06-30,SK,Slovak Republic,-1.996
-2011-06-30,TH,Thailand,6.5613
-2011-06-30,TR,Türkiye,6.867
-2011-06-30,US,United States,-4.097
-2011-06-30,XM,Euro area,1.0233
-2011-06-30,XW,World,2.5113
-2011-06-30,ZA,South Africa,2.588
-2011-09-30,4T,Emerging market economies (aggregate),5.6315
-2011-09-30,5R,Advanced economies,-0.1499
-2011-09-30,AE,United Arab Emirates,1.0665
+2011-06-30,SK,Slovakia,-1.996
+2011-06-30,TH,Thailand,6.1803
+2011-06-30,TR,Türkiye,9.1494
+2011-06-30,US,United States,-4.1045
+2011-06-30,XM,Euro area,1.0399
+2011-06-30,XW,World,2.3617
+2011-06-30,ZA,South Africa,3.1532
+2011-09-30,4T,Emerging market economies (aggregate),5.2503
+2011-09-30,5R,Advanced economies,0.3977
 2011-09-30,AT,Austria,5.9843
 2011-09-30,AU,Australia,-2.7184
-2011-09-30,BE,Belgium,4.2429
-2011-09-30,BG,Bulgaria,-5.5419
+2011-09-30,BE,Belgium,3.5022
+2011-09-30,BG,Bulgaria,-5.5418
 2011-09-30,BR,Brazil,18.3226
-2011-09-30,CA,Canada,7.3257
-2011-09-30,CH,Switzerland,8.2692
-2011-09-30,CL,Chile,12.8776
+2011-09-30,CA,Canada,7.1736
+2011-09-30,CH,Switzerland,8.2714
+2011-09-30,CL,Chile,12.8767
 2011-09-30,CN,China,4.0887
-2011-09-30,CO,Colombia,10.305
+2011-09-30,CO,Colombia,10.046
 2011-09-30,CY,Cyprus,-3.7925
 2011-09-30,CZ,Czechia,0.2104
 2011-09-30,DE,Germany,2.4851
@@ -20976,28 +5217,28 @@ date,country_code,country,price
 2011-09-30,ES,Spain,-8.0666
 2011-09-30,FI,Finland,2.8541
 2011-09-30,FR,France,5.923
-2011-09-30,GB,United Kingdom,-2.0902
+2011-09-30,GB,United Kingdom,-1.9608
 2011-09-30,GR,Greece,-4.7412
 2011-09-30,HK,Hong Kong SAR,20.1817
-2011-09-30,HR,Croatia,1.6439
-2011-09-30,HU,Hungary,-4.2643
+2011-09-30,HR,Croatia,1.6438
+2011-09-30,HU,Hungary,-4.2644
 2011-09-30,ID,Indonesia,4.5378
-2011-09-30,IE,Ireland,-18.6306
+2011-09-30,IE,Ireland,-18.5846
 2011-09-30,IL,Israel,9.9499
 2011-09-30,IN,India,19.6393
-2011-09-30,IS,Iceland,6.6605
+2011-09-30,IS,Iceland,6.6691
 2011-09-30,IT,Italy,1.2626
 2011-09-30,JP,Japan,0.2325
-2011-09-30,KR,Korea,6.3808
+2011-09-30,KR,Korea,6.4007
 2011-09-30,LT,Lithuania,6.8263
 2011-09-30,LU,Luxembourg,3.3273
 2011-09-30,LV,Latvia,13.0219
-2011-09-30,MA,Morocco,0.8629
-2011-09-30,MK,North Macedonia,0.6601
+2011-09-30,MA,Morocco,0.666
+2011-09-30,MK,North Macedonia,0.8132
 2011-09-30,MT,Malta,-3.1915
 2011-09-30,MX,Mexico,5.9452
 2011-09-30,MY,Malaysia,9.8039
-2011-09-30,NL,Netherlands,-2.2854
+2011-09-30,NL,Netherlands,-2.2833
 2011-09-30,NO,Norway,8.3117
 2011-09-30,NZ,New Zealand,2.0913
 2011-09-30,PE,Peru,23.0657
@@ -21010,26 +5251,25 @@ date,country_code,country,price
 2011-09-30,SE,Sweden,2.3139
 2011-09-30,SG,Singapore,8.4871
 2011-09-30,SI,Slovenia,2.1282
-2011-09-30,SK,Slovak Republic,-0.7035
-2011-09-30,TH,Thailand,2.4575
-2011-09-30,TR,Türkiye,7.8891
-2011-09-30,US,United States,-1.6151
-2011-09-30,XM,Euro area,0.6965
-2011-09-30,XW,World,2.7436
-2011-09-30,ZA,South Africa,3.6178
-2011-12-31,4T,Emerging market economies (aggregate),5.736
-2011-12-31,5R,Advanced economies,-0.4554
-2011-12-31,AE,United Arab Emirates,6.2979
-2011-12-31,AT,Austria,4.969
+2011-09-30,SK,Slovakia,-0.804
+2011-09-30,TH,Thailand,2.3981
+2011-09-30,TR,Türkiye,8.668
+2011-09-30,US,United States,-1.6426
+2011-09-30,XM,Euro area,0.715
+2011-09-30,XW,World,2.5332
+2011-09-30,ZA,South Africa,4.0484
+2011-12-31,4T,Emerging market economies (aggregate),5.4607
+2011-12-31,5R,Advanced economies,-0.0049
+2011-12-31,AT,Austria,4.9689
 2011-12-31,AU,Australia,-4.0541
-2011-12-31,BE,Belgium,3.4579
-2011-12-31,BG,Bulgaria,-5.809
+2011-12-31,BE,Belgium,3.3891
+2011-12-31,BG,Bulgaria,-5.8089
 2011-12-31,BR,Brazil,16.2766
-2011-12-31,CA,Canada,8.0714
-2011-12-31,CH,Switzerland,6.6662
-2011-12-31,CL,Chile,14.9264
+2011-12-31,CA,Canada,7.853
+2011-12-31,CH,Switzerland,6.6688
+2011-12-31,CL,Chile,14.9257
 2011-12-31,CN,China,2.2944
-2011-12-31,CO,Colombia,7.4438
+2011-12-31,CO,Colombia,7.5011
 2011-12-31,CY,Cyprus,-4.9531
 2011-12-31,CZ,Czechia,-0.8403
 2011-12-31,DE,Germany,2.1782
@@ -21038,60 +5278,59 @@ date,country_code,country,price
 2011-12-31,ES,Spain,-12.7447
 2011-12-31,FI,Finland,2.3256
 2011-12-31,FR,France,3.7073
-2011-12-31,GB,United Kingdom,-1.2373
-2011-12-31,GR,Greece,-6.6242
+2011-12-31,GB,United Kingdom,-1.3356
+2011-12-31,GR,Greece,-6.6241
 2011-12-31,HK,Hong Kong SAR,12.1997
 2011-12-31,HR,Croatia,2.0036
 2011-12-31,HU,Hungary,-2.9348
 2011-12-31,ID,Indonesia,5.0494
-2011-12-31,IE,Ireland,-19.6503
+2011-12-31,IE,Ireland,-19.6333
 2011-12-31,IL,Israel,5.3684
 2011-12-31,IN,India,26.2576
-2011-12-31,IS,Iceland,8.0689
+2011-12-31,IS,Iceland,8.0968
 2011-12-31,IT,Italy,0.5046
 2011-12-31,JP,Japan,-0.9977
-2011-12-31,KR,Korea,6.998
+2011-12-31,KR,Korea,7.0337
 2011-12-31,LT,Lithuania,5.564
 2011-12-31,LU,Luxembourg,5.3969
 2011-12-31,LV,Latvia,5.762
-2011-12-31,MA,Morocco,0.9662
-2011-12-31,MK,North Macedonia,-1.761
+2011-12-31,MA,Morocco,0.4763
+2011-12-31,MK,North Macedonia,-1.8849
 2011-12-31,MT,Malta,1.3715
 2011-12-31,MX,Mexico,5.4956
 2011-12-31,MY,Malaysia,11.2176
-2011-12-31,NL,Netherlands,-3.4436
+2011-12-31,NL,Netherlands,-3.4384
 2011-12-31,NO,Norway,7.9324
 2011-12-31,NZ,New Zealand,2.2795
 2011-12-31,PE,Peru,20.4702
 2011-12-31,PH,Philippines,6.771
 2011-12-31,PL,Poland,-0.9721
-2011-12-31,PT,Portugal,-7.4945
+2011-12-31,PT,Portugal,-7.4946
 2011-12-31,RO,Romania,-13.913
 2011-12-31,RS,Serbia,-9.7319
 2011-12-31,RU,Russia,-19.5916
 2011-12-31,SE,Sweden,-1.2931
 2011-12-31,SG,Singapore,5.8908
 2011-12-31,SI,Slovenia,1.3698
-2011-12-31,SK,Slovak Republic,-2.3092
-2011-12-31,TH,Thailand,2.8754
-2011-12-31,TR,Türkiye,6.4449
-2011-12-31,US,United States,-0.8702
-2011-12-31,XM,Euro area,-0.6364
-2011-12-31,XW,World,2.663
-2011-12-31,ZA,South Africa,4.3349
-2012-03-31,4T,Emerging market economies (aggregate),7.2496
-2012-03-31,5R,Advanced economies,0.5707
-2012-03-31,AE,United Arab Emirates,6.929
+2011-12-31,SK,Slovakia,-2.3092
+2011-12-31,TH,Thailand,3.8349
+2011-12-31,TR,Türkiye,9.1349
+2011-12-31,US,United States,-0.9017
+2011-12-31,XM,Euro area,-0.6212
+2011-12-31,XW,World,2.4175
+2011-12-31,ZA,South Africa,3.9184
+2012-03-31,4T,Emerging market economies (aggregate),7.5042
+2012-03-31,5R,Advanced economies,0.8099
 2012-03-31,AT,Austria,10.7413
 2012-03-31,AU,Australia,-2.629
-2012-03-31,BE,Belgium,3.4655
+2012-03-31,BE,Belgium,3.2082
 2012-03-31,BG,Bulgaria,-3.7244
 2012-03-31,BR,Brazil,14.1679
-2012-03-31,CA,Canada,7.356
-2012-03-31,CH,Switzerland,6.2823
-2012-03-31,CL,Chile,12.6757
+2012-03-31,CA,Canada,7.3633
+2012-03-31,CH,Switzerland,6.2826
+2012-03-31,CL,Chile,12.676
 2012-03-31,CN,China,0.1377
-2012-03-31,CO,Colombia,11.0996
+2012-03-31,CO,Colombia,11.2361
 2012-03-31,CY,Cyprus,-5.0147
 2012-03-31,CZ,Czechia,-1.5723
 2012-03-31,DE,Germany,2.5616
@@ -21100,28 +5339,28 @@ date,country_code,country,price
 2012-03-31,ES,Spain,-14.183
 2012-03-31,FI,Finland,2.714
 2012-03-31,FR,France,1.7459
-2012-03-31,GB,United Kingdom,-0.4582
-2012-03-31,GR,Greece,-10.5466
+2012-03-31,GB,United Kingdom,-0.5102
+2012-03-31,GR,Greece,-10.5465
 2012-03-31,HK,Hong Kong SAR,5.7861
 2012-03-31,HR,Croatia,2.3897
-2012-03-31,HU,Hungary,-1.6357
+2012-03-31,HU,Hungary,-1.6358
 2012-03-31,ID,Indonesia,3.5932
-2012-03-31,IE,Ireland,-19.5462
+2012-03-31,IE,Ireland,-19.6229
 2012-03-31,IL,Israel,2.2222
 2012-03-31,IN,India,25.7973
-2012-03-31,IS,Iceland,7.3357
+2012-03-31,IS,Iceland,7.3454
 2012-03-31,IT,Italy,0.5917
 2012-03-31,JP,Japan,-0.4978
-2012-03-31,KR,Korea,5.7827
+2012-03-31,KR,Korea,5.7943
 2012-03-31,LT,Lithuania,0.8857
 2012-03-31,LU,Luxembourg,4.53
 2012-03-31,LV,Latvia,2.5866
-2012-03-31,MA,Morocco,0.4803
-2012-03-31,MK,North Macedonia,2.2546
+2012-03-31,MA,Morocco,0.7605
+2012-03-31,MK,North Macedonia,2.4967
 2012-03-31,MT,Malta,2.0293
 2012-03-31,MX,Mexico,4.0637
 2012-03-31,MY,Malaysia,12.688
-2012-03-31,NL,Netherlands,-5.402
+2012-03-31,NL,Netherlands,-5.3914
 2012-03-31,NO,Norway,6.3041
 2012-03-31,NZ,New Zealand,3.1085
 2012-03-31,PE,Peru,19.4379
@@ -21134,26 +5373,25 @@ date,country_code,country,price
 2012-03-31,SE,Sweden,-1.0197
 2012-03-31,SG,Singapore,3.4435
 2012-03-31,SI,Slovenia,-7.0681
-2012-03-31,SK,Slovak Republic,-3.0091
-2012-03-31,TH,Thailand,2.2
-2012-03-31,TR,Türkiye,8.1633
-2012-03-31,US,United States,1.7244
-2012-03-31,XM,Euro area,-1.0094
-2012-03-31,XW,World,3.9516
-2012-03-31,ZA,South Africa,4.7268
-2012-06-30,4T,Emerging market economies (aggregate),6.3503
-2012-06-30,5R,Advanced economies,1.1625
-2012-06-30,AE,United Arab Emirates,13.1299
+2012-03-31,SK,Slovakia,-3.1093
+2012-03-31,TH,Thailand,3.9434
+2012-03-31,TR,Türkiye,9.9664
+2012-03-31,US,United States,1.7328
+2012-03-31,XM,Euro area,-0.9968
+2012-03-31,XW,World,3.7902
+2012-03-31,ZA,South Africa,4.6814
+2012-06-30,4T,Emerging market economies (aggregate),6.4648
+2012-06-30,5R,Advanced economies,1.2472
 2012-06-30,AT,Austria,15.5521
 2012-06-30,AU,Australia,-1.5686
-2012-06-30,BE,Belgium,2.623
-2012-06-30,BG,Bulgaria,-1.5563
+2012-06-30,BE,Belgium,2.7188
+2012-06-30,BG,Bulgaria,-1.5564
 2012-06-30,BR,Brazil,12.2824
-2012-06-30,CA,Canada,5.8389
-2012-06-30,CH,Switzerland,5.9517
-2012-06-30,CL,Chile,9.6015
+2012-06-30,CA,Canada,5.9023
+2012-06-30,CH,Switzerland,5.9525
+2012-06-30,CL,Chile,9.6014
 2012-06-30,CN,China,-1.1206
-2012-06-30,CO,Colombia,10.3851
+2012-06-30,CO,Colombia,9.9657
 2012-06-30,CY,Cyprus,-5.8351
 2012-06-30,CZ,Czechia,-1.9812
 2012-06-30,DE,Germany,3.4347
@@ -21162,28 +5400,28 @@ date,country_code,country,price
 2012-06-30,ES,Spain,-15.9596
 2012-06-30,FI,Finland,1.8443
 2012-06-30,FR,France,-0.1903
-2012-06-30,GB,United Kingdom,0.5682
-2012-06-30,GR,Greece,-10.8278
+2012-06-30,GB,United Kingdom,0.6757
+2012-06-30,GR,Greece,-10.8277
 2012-06-30,HK,Hong Kong SAR,8.8821
 2012-06-30,HR,Croatia,-0.543
 2012-06-30,HU,Hungary,-4.2857
 2012-06-30,ID,Indonesia,3.6819
-2012-06-30,IE,Ireland,-17.1573
+2012-06-30,IE,Ireland,-17.1271
 2012-06-30,IL,Israel,1.1195
 2012-06-30,IN,India,22.931
-2012-06-30,IS,Iceland,7.6653
+2012-06-30,IS,Iceland,7.6744
 2012-06-30,IT,Italy,-2.1541
 2012-06-30,JP,Japan,-1.1004
-2012-06-30,KR,Korea,3.6532
+2012-06-30,KR,Korea,3.6244
 2012-06-30,LT,Lithuania,-0.9235
 2012-06-30,LU,Luxembourg,4.0763
 2012-06-30,LV,Latvia,2.0064
-2012-06-30,MA,Morocco,0.9588
-2012-06-30,MK,North Macedonia,-1.4888
+2012-06-30,MA,Morocco,1.1342
+2012-06-30,MK,North Macedonia,-1.4489
 2012-06-30,MT,Malta,-1.4317
 2012-06-30,MX,Mexico,3.0643
 2012-06-30,MY,Malaysia,13.4615
-2012-06-30,NL,Netherlands,-5.6778
+2012-06-30,NL,Netherlands,-5.676
 2012-06-30,NO,Norway,6.8592
 2012-06-30,NZ,New Zealand,3.8201
 2012-06-30,PE,Peru,20.0482
@@ -21196,26 +5434,25 @@ date,country_code,country,price
 2012-06-30,SE,Sweden,0.4166
 2012-06-30,SG,Singapore,1.9297
 2012-06-30,SI,Slovenia,-5.7265
-2012-06-30,SK,Slovak Republic,-2.444
-2012-06-30,TH,Thailand,0.1978
-2012-06-30,TR,Türkiye,9.8393
-2012-06-30,US,United States,3.8044
-2012-06-30,XM,Euro area,-1.6811
-2012-06-30,XW,World,3.8065
-2012-06-30,ZA,South Africa,4.7992
-2012-09-30,4T,Emerging market economies (aggregate),6.4618
-2012-09-30,5R,Advanced economies,1.4542
-2012-09-30,AE,United Arab Emirates,15.3268
+2012-06-30,SK,Slovakia,-2.5458
+2012-06-30,TH,Thailand,1.1869
+2012-06-30,TR,Türkiye,10.3471
+2012-06-30,US,United States,3.7639
+2012-06-30,XM,Euro area,-1.6875
+2012-06-30,XW,World,3.588
+2012-06-30,ZA,South Africa,4.6986
+2012-09-30,4T,Emerging market economies (aggregate),6.6449
+2012-09-30,5R,Advanced economies,1.466
 2012-09-30,AT,Austria,11.8871
 2012-09-30,AU,Australia,0
-2012-09-30,BE,Belgium,1.7769
+2012-09-30,BE,Belgium,1.7907
 2012-09-30,BG,Bulgaria,-0.9745
 2012-09-30,BR,Brazil,10.8895
-2012-09-30,CA,Canada,3.446
-2012-09-30,CH,Switzerland,5.3664
-2012-09-30,CL,Chile,9.4822
+2012-09-30,CA,Canada,3.4806
+2012-09-30,CH,Switzerland,5.3656
+2012-09-30,CL,Chile,9.4767
 2012-09-30,CN,China,-1.173
-2012-09-30,CO,Colombia,8.9344
+2012-09-30,CO,Colombia,8.9458
 2012-09-30,CY,Cyprus,-5.6732
 2012-09-30,CZ,Czechia,-1.5741
 2012-09-30,DE,Germany,2.6188
@@ -21224,28 +5461,28 @@ date,country_code,country,price
 2012-09-30,ES,Spain,-16.1039
 2012-09-30,FI,Finland,2.1583
 2012-09-30,FR,France,-1.5843
-2012-09-30,GB,United Kingdom,0.5618
-2012-09-30,GR,Greece,-12.5914
+2012-09-30,GB,United Kingdom,0.3333
+2012-09-30,GR,Greece,-12.5913
 2012-09-30,HK,Hong Kong SAR,14.2369
 2012-09-30,HR,Croatia,-1.9766
 2012-09-30,HU,Hungary,-3.7862
 2012-09-30,ID,Indonesia,4.2492
-2012-09-30,IE,Ireland,-10.8611
+2012-09-30,IE,Ireland,-10.8849
 2012-09-30,IL,Israel,2.5953
 2012-09-30,IN,India,23.1994
-2012-09-30,IS,Iceland,6.5891
+2012-09-30,IS,Iceland,6.5794
 2012-09-30,IT,Italy,-3.6575
 2012-09-30,JP,Japan,-1.4579
-2012-09-30,KR,Korea,1.9194
+2012-09-30,KR,Korea,1.8648
 2012-09-30,LT,Lithuania,0.3011
 2012-09-30,LU,Luxembourg,4.3629
 2012-09-30,LV,Latvia,1.3017
-2012-09-30,MA,Morocco,0.7605
-2012-09-30,MK,North Macedonia,-3.0468
+2012-09-30,MA,Morocco,0.378
+2012-09-30,MK,North Macedonia,-2.9946
 2012-09-30,MT,Malta,5.4945
 2012-09-30,MX,Mexico,2.8696
 2012-09-30,MY,Malaysia,13.2143
-2012-09-30,NL,Netherlands,-8.915
+2012-09-30,NL,Netherlands,-8.9109
 2012-09-30,NO,Norway,7.0743
 2012-09-30,NZ,New Zealand,4.4657
 2012-09-30,PE,Peru,16.4211
@@ -21258,26 +5495,25 @@ date,country_code,country,price
 2012-09-30,SE,Sweden,1.8307
 2012-09-30,SG,Singapore,1.2244
 2012-09-30,SI,Slovenia,-5.9743
-2012-09-30,SK,Slovak Republic,-2.4291
-2012-09-30,TH,Thailand,2.8056
-2012-09-30,TR,Türkiye,9.6838
-2012-09-30,US,United States,5.435
-2012-09-30,XM,Euro area,-2.5878
-2012-09-30,XW,World,4.0141
-2012-09-30,ZA,South Africa,5.2101
-2012-12-31,4T,Emerging market economies (aggregate),7.3208
-2012-12-31,5R,Advanced economies,2.7876
-2012-12-31,AE,United Arab Emirates,17.5306
-2012-12-31,AT,Austria,11.4644
+2012-09-30,SK,Slovakia,-2.4316
+2012-09-30,TH,Thailand,2.7972
+2012-09-30,TR,Türkiye,12.192
+2012-09-30,US,United States,5.4471
+2012-09-30,XM,Euro area,-2.6111
+2012-09-30,XW,World,3.7961
+2012-09-30,ZA,South Africa,4.4262
+2012-12-31,4T,Emerging market economies (aggregate),7.3606
+2012-12-31,5R,Advanced economies,2.7673
+2012-12-31,AT,Austria,11.4645
 2012-12-31,AU,Australia,3.0181
-2012-12-31,BE,Belgium,1.1175
-2012-12-31,BG,Bulgaria,-1.3047
+2012-12-31,BE,Belgium,1.7121
+2012-12-31,BG,Bulgaria,-1.3048
 2012-12-31,BR,Brazil,10.0776
-2012-12-31,CA,Canada,1.7845
-2012-12-31,CH,Switzerland,5.528
-2012-12-31,CL,Chile,10.4516
+2012-12-31,CA,Canada,1.9372
+2012-12-31,CH,Switzerland,5.5256
+2012-12-31,CL,Chile,10.4481
 2012-12-31,CN,China,-0.5198
-2012-12-31,CO,Colombia,10.543
+2012-12-31,CO,Colombia,10.1877
 2012-12-31,CY,Cyprus,-4.7124
 2012-12-31,CZ,Czechia,-0.7415
 2012-12-31,DE,Germany,3.2946
@@ -21286,28 +5522,28 @@ date,country_code,country,price
 2012-12-31,ES,Spain,-12.7483
 2012-12-31,FI,Finland,2.8926
 2012-12-31,FR,France,-2.0696
-2012-12-31,GB,United Kingdom,1.0251
+2012-12-31,GB,United Kingdom,1.0152
 2012-12-31,GR,Greece,-12.774
-2012-12-31,HK,Hong Kong SAR,24.0344
+2012-12-31,HK,Hong Kong SAR,23.9612
 2012-12-31,HR,Croatia,-5.8929
 2012-12-31,HU,Hungary,-5.1512
 2012-12-31,ID,Indonesia,6.7641
-2012-12-31,IE,Ireland,-4.8187
+2012-12-31,IE,Ireland,-4.8113
 2012-12-31,IL,Israel,7.0155
 2012-12-31,IN,India,25.0996
-2012-12-31,IS,Iceland,4.5721
+2012-12-31,IS,Iceland,4.5504
 2012-12-31,IT,Italy,-4.9372
 2012-12-31,JP,Japan,-0.4367
-2012-12-31,KR,Korea,0.2844
+2012-12-31,KR,Korea,0.2859
 2012-12-31,LT,Lithuania,-1.1737
 2012-12-31,LU,Luxembourg,3.8423
 2012-12-31,LV,Latvia,6.096
-2012-12-31,MA,Morocco,2.2966
-2012-12-31,MK,North Macedonia,-4.4109
+2012-12-31,MA,Morocco,1.0426
+2012-12-31,MK,North Macedonia,-4.5966
 2012-12-31,MT,Malta,6.0879
 2012-12-31,MX,Mexico,2.7791
 2012-12-31,MY,Malaysia,14.3103
-2012-12-31,NL,Netherlands,-6.8901
+2012-12-31,NL,Netherlands,-6.8933
 2012-12-31,NO,Norway,6.8675
 2012-12-31,NZ,New Zealand,6.4408
 2012-12-31,PE,Peru,19.6082
@@ -21320,26 +5556,25 @@ date,country_code,country,price
 2012-12-31,SE,Sweden,3.8262
 2012-12-31,SG,Singapore,2.7815
 2012-12-31,SI,Slovenia,-8.826
-2012-12-31,SK,Slovak Republic,-2.8777
-2012-12-31,TH,Thailand,5.6773
-2012-12-31,TR,Türkiye,10.1563
-2012-12-31,US,United States,7.8444
-2012-12-31,XM,Euro area,-2.0522
-2012-12-31,XW,World,5.1268
-2012-12-31,ZA,South Africa,5.7353
-2013-03-31,4T,Emerging market economies (aggregate),6.9273
-2013-03-31,5R,Advanced economies,3.221
-2013-03-31,AE,United Arab Emirates,16.0394
-2013-03-31,AT,Austria,4.8498
+2012-12-31,SK,Slovakia,-2.9805
+2012-12-31,TH,Thailand,5.0147
+2012-12-31,TR,Türkiye,11.0971
+2012-12-31,US,United States,7.882
+2012-12-31,XM,Euro area,-2.0854
+2012-12-31,XW,World,4.8565
+2012-12-31,ZA,South Africa,4.7911
+2013-03-31,4T,Emerging market economies (aggregate),6.8558
+2013-03-31,5R,Advanced economies,3.1722
+2013-03-31,AT,Austria,4.8497
 2013-03-31,AU,Australia,3.1
-2013-03-31,BE,Belgium,1.0377
+2013-03-31,BE,Belgium,1.4092
 2013-03-31,BG,Bulgaria,-2.2702
 2013-03-31,BR,Brazil,9.6769
-2013-03-31,CA,Canada,0.6464
-2013-03-31,CH,Switzerland,4.8846
-2013-03-31,CL,Chile,11.4123
+2013-03-31,CA,Canada,0.8491
+2013-03-31,CH,Switzerland,4.8832
+2013-03-31,CL,Chile,11.1617
 2013-03-31,CN,China,1.8698
-2013-03-31,CO,Colombia,10.2436
+2013-03-31,CO,Colombia,8.9954
 2013-03-31,CY,Cyprus,-5.1937
 2013-03-31,CZ,Czechia,-0.3195
 2013-03-31,DE,Germany,3.17
@@ -21348,60 +5583,59 @@ date,country_code,country,price
 2013-03-31,ES,Spain,-12.8143
 2013-03-31,FI,Finland,1.9309
 2013-03-31,FR,France,-2.0019
-2013-03-31,GB,United Kingdom,1.3809
+2013-03-31,GB,United Kingdom,1.3675
 2013-03-31,GR,Greece,-11.4833
 2013-03-31,HK,Hong Kong SAR,28.1756
 2013-03-31,HR,Croatia,-5.4758
-2013-03-31,HU,Hungary,-5.8759
+2013-03-31,HU,Hungary,-5.8758
 2013-03-31,ID,Indonesia,10.9998
-2013-03-31,IE,Ireland,-3.2538
+2013-03-31,IE,Ireland,-3.1277
 2013-03-31,IL,Israel,9.6911
 2013-03-31,IN,India,19.9106
-2013-03-31,IS,Iceland,4.5702
+2013-03-31,IS,Iceland,4.5744
 2013-03-31,IT,Italy,-7.1429
 2013-03-31,JP,Japan,-0.467
-2013-03-31,KR,Korea,-0.4241
+2013-03-31,KR,Korea,-0.4541
 2013-03-31,LT,Lithuania,-0.1445
 2013-03-31,LU,Luxembourg,5.3928
 2013-03-31,LV,Latvia,4.8086
-2013-03-31,MA,Morocco,1.8164
-2013-03-31,MK,North Macedonia,-5.3808
+2013-03-31,MA,Morocco,0.1886
+2013-03-31,MK,North Macedonia,-5.468
 2013-03-31,MT,Malta,0.9945
 2013-03-31,MX,Mexico,3.7812
 2013-03-31,MY,Malaysia,11.0092
-2013-03-31,NL,Netherlands,-7.6616
+2013-03-31,NL,Netherlands,-7.6712
 2013-03-31,NO,Norway,6.2791
 2013-03-31,NZ,New Zealand,7.7426
 2013-03-31,PE,Peru,19.0246
 2013-03-31,PH,Philippines,7.2672
 2013-03-31,PL,Poland,-5.6039
-2013-03-31,PT,Portugal,-4.5332
+2013-03-31,PT,Portugal,-4.5333
 2013-03-31,RO,Romania,-0.9804
 2013-03-31,RS,Serbia,-5.3033
 2013-03-31,RU,Russia,6.7678
 2013-03-31,SE,Sweden,4.1638
 2013-03-31,SG,Singapore,3.5327
 2013-03-31,SI,Slovenia,-4.2958
-2013-03-31,SK,Slovak Republic,0
-2013-03-31,TH,Thailand,5.3816
-2013-03-31,TR,Türkiye,10.1887
-2013-03-31,US,United States,9.6204
-2013-03-31,XM,Euro area,-2.7589
-2013-03-31,XW,World,5.1403
-2013-03-31,ZA,South Africa,6.0541
-2013-06-30,4T,Emerging market economies (aggregate),7.3758
-2013-06-30,5R,Advanced economies,3.6861
-2013-06-30,AE,United Arab Emirates,16.5505
-2013-06-30,AT,Austria,4.9797
+2013-03-31,SK,Slovakia,0
+2013-03-31,TH,Thailand,5.5447
+2013-03-31,TR,Türkiye,10.8389
+2013-03-31,US,United States,9.6182
+2013-03-31,XM,Euro area,-2.8055
+2013-03-31,XW,World,4.86
+2013-03-31,ZA,South Africa,4.9923
+2013-06-30,4T,Emerging market economies (aggregate),7.4061
+2013-06-30,5R,Advanced economies,3.5516
+2013-06-30,AT,Austria,4.9798
 2013-06-30,AU,Australia,5.2789
-2013-06-30,BE,Belgium,1.2113
+2013-06-30,BE,Belgium,1.6749
 2013-06-30,BG,Bulgaria,-2.2195
 2013-06-30,BR,Brazil,9.4085
-2013-06-30,CA,Canada,0.6975
-2013-06-30,CH,Switzerland,4.3722
-2013-06-30,CL,Chile,11.6643
+2013-06-30,CA,Canada,0.8969
+2013-06-30,CH,Switzerland,4.37
+2013-06-30,CL,Chile,11.0388
 2013-06-30,CN,China,5.2792
-2013-06-30,CO,Colombia,9.8211
+2013-06-30,CO,Colombia,9.5448
 2013-06-30,CY,Cyprus,-5.4959
 2013-06-30,CZ,Czechia,0.1064
 2013-06-30,DE,Germany,3.0361
@@ -21410,28 +5644,28 @@ date,country_code,country,price
 2013-06-30,ES,Spain,-10.6082
 2013-06-30,FI,Finland,1.3078
 2013-06-30,FR,France,-2.0972
-2013-06-30,GB,United Kingdom,1.5819
+2013-06-30,GB,United Kingdom,1.5101
 2013-06-30,GR,Greece,-11.9669
 2013-06-30,HK,Hong Kong SAR,19.232
-2013-06-30,HR,Croatia,-4.8225
-2013-06-30,HU,Hungary,-2.2963
+2013-06-30,HR,Croatia,-4.8226
+2013-06-30,HU,Hungary,-2.2962
 2013-06-30,ID,Indonesia,12.1082
-2013-06-30,IE,Ireland,-0.8884
+2013-06-30,IE,Ireland,-0.8889
 2013-06-30,IL,Israel,9.399
 2013-06-30,IN,India,13.8149
-2013-06-30,IS,Iceland,4.8821
+2013-06-30,IS,Iceland,4.8696
 2013-06-30,IT,Italy,-6.6892
 2013-06-30,JP,Japan,1.7195
-2013-06-30,KR,Korea,-0.7519
+2013-06-30,KR,Korea,-0.8058
 2013-06-30,LT,Lithuania,2.4144
 2013-06-30,LU,Luxembourg,4.6556
 2013-06-30,LV,Latvia,7.8587
-2013-06-30,MA,Morocco,1.0446
-2013-06-30,MK,North Macedonia,-4.0197
+2013-06-30,MA,Morocco,-0.2803
+2013-06-30,MK,North Macedonia,-3.9581
 2013-06-30,MT,Malta,0.6704
 2013-06-30,MX,Mexico,5.0948
 2013-06-30,MY,Malaysia,11.4609
-2013-06-30,NL,Netherlands,-8.0422
+2013-06-30,NL,Netherlands,-8.0373
 2013-06-30,NO,Norway,5.7432
 2013-06-30,NZ,New Zealand,8.7588
 2013-06-30,PE,Peru,14.5239
@@ -21444,26 +5678,25 @@ date,country_code,country,price
 2013-06-30,SE,Sweden,4.5339
 2013-06-30,SG,Singapore,4.1244
 2013-06-30,SI,Slovenia,-4.621
-2013-06-30,SK,Slovak Republic,1.1482
-2013-06-30,TH,Thailand,8.6871
-2013-06-30,TR,Türkiye,10.7861
-2013-06-30,US,United States,9.6014
-2013-06-30,XM,Euro area,-2.3712
-2013-06-30,XW,World,5.5992
-2013-06-30,ZA,South Africa,6.232
-2013-09-30,4T,Emerging market economies (aggregate),8.3988
-2013-09-30,5R,Advanced economies,4.5618
-2013-09-30,AE,United Arab Emirates,21.5997
-2013-09-30,AT,Austria,4.7144
+2013-06-30,SK,Slovakia,1.1494
+2013-06-30,TH,Thailand,7.6246
+2013-06-30,TR,Türkiye,11.0979
+2013-06-30,US,United States,9.6554
+2013-06-30,XM,Euro area,-2.413
+2013-06-30,XW,World,5.323
+2013-06-30,ZA,South Africa,6.1266
+2013-09-30,4T,Emerging market economies (aggregate),8.4751
+2013-09-30,5R,Advanced economies,4.363
+2013-09-30,AT,Austria,4.7145
 2013-09-30,AU,Australia,8.0838
-2013-09-30,BE,Belgium,1.3195
-2013-09-30,BG,Bulgaria,-3.0941
+2013-09-30,BE,Belgium,1.7285
+2013-09-30,BG,Bulgaria,-3.0942
 2013-09-30,BR,Brazil,9.0969
-2013-09-30,CA,Canada,2.3062
-2013-09-30,CH,Switzerland,3.0376
-2013-09-30,CL,Chile,9.3805
+2013-09-30,CA,Canada,2.458
+2013-09-30,CH,Switzerland,3.0354
+2013-09-30,CL,Chile,9.1328
 2013-09-30,CN,China,7.5076
-2013-09-30,CO,Colombia,10.6098
+2013-09-30,CO,Colombia,10.2305
 2013-09-30,CY,Cyprus,-6.9431
 2013-09-30,CZ,Czechia,0.2133
 2013-09-30,DE,Germany,3.5917
@@ -21472,28 +5705,28 @@ date,country_code,country,price
 2013-09-30,ES,Spain,-6.4241
 2013-09-30,FI,Finland,1.1066
 2013-09-30,FR,France,-1.8939
-2013-09-30,GB,United Kingdom,2.905
-2013-09-30,GR,Greece,-10.1867
+2013-09-30,GB,United Kingdom,2.99
+2013-09-30,GR,Greece,-10.1868
 2013-09-30,HK,Hong Kong SAR,16.1021
-2013-09-30,HR,Croatia,-3.7581
-2013-09-30,HU,Hungary,-1.2732
+2013-09-30,HR,Croatia,-3.758
+2013-09-30,HU,Hungary,-1.2731
 2013-09-30,ID,Indonesia,13.5055
-2013-09-30,IE,Ireland,3.5126
+2013-09-30,IE,Ireland,3.5149
 2013-09-30,IL,Israel,9.4973
 2013-09-30,IN,India,15.0238
-2013-09-30,IS,Iceland,6.0202
+2013-09-30,IS,Iceland,6.0238
 2013-09-30,IT,Italy,-6.2985
 2013-09-30,JP,Japan,2.4882
-2013-09-30,KR,Korea,-0.6121
+2013-09-30,KR,Korea,-0.612
 2013-09-30,LT,Lithuania,-0.378
 2013-09-30,LU,Luxembourg,5.6855
 2013-09-30,LV,Latvia,6.4508
-2013-09-30,MA,Morocco,0.4717
-2013-09-30,MK,North Macedonia,-1.9979
+2013-09-30,MA,Morocco,0.2825
+2013-09-30,MK,North Macedonia,-2.1827
 2013-09-30,MT,Malta,-1.7708
 2013-09-30,MX,Mexico,5.705
 2013-09-30,MY,Malaysia,13.2492
-2013-09-30,NL,Netherlands,-3.7056
+2013-09-30,NL,Netherlands,-3.7101
 2013-09-30,NO,Norway,3.1355
 2013-09-30,NZ,New Zealand,9.981
 2013-09-30,PE,Peru,12.5781
@@ -21506,26 +5739,25 @@ date,country_code,country,price
 2013-09-30,SE,Sweden,5.136
 2013-09-30,SG,Singapore,3.8979
 2013-09-30,SI,Slovenia,-7.6854
-2013-09-30,SK,Slovak Republic,0.3112
-2013-09-30,TH,Thailand,9.2593
-2013-09-30,TR,Türkiye,11.7117
-2013-09-30,US,United States,10.1608
-2013-09-30,XM,Euro area,-1.2089
-2013-09-30,XW,World,6.5534
-2013-09-30,ZA,South Africa,6.3859
-2013-12-31,4T,Emerging market economies (aggregate),7.8643
-2013-12-31,5R,Advanced economies,4.6648
-2013-12-31,AE,United Arab Emirates,25.1237
-2013-12-31,AT,Austria,4.1142
+2013-09-30,SK,Slovakia,0.1039
+2013-09-30,TH,Thailand,9.5238
+2013-09-30,TR,Türkiye,11.3294
+2013-09-30,US,United States,10.1869
+2013-09-30,XM,Euro area,-1.25
+2013-09-30,XW,World,6.2583
+2013-09-30,ZA,South Africa,7.1503
+2013-12-31,4T,Emerging market economies (aggregate),7.9668
+2013-12-31,5R,Advanced economies,4.3808
+2013-12-31,AT,Austria,4.1141
 2013-12-31,AU,Australia,9.9609
-2013-12-31,BE,Belgium,1.1359
+2013-12-31,BE,Belgium,1.129
 2013-12-31,BG,Bulgaria,-1.1981
 2013-12-31,BR,Brazil,8.7113
-2013-12-31,CA,Canada,4.026
-2013-12-31,CH,Switzerland,3.8434
-2013-12-31,CL,Chile,9.2869
+2013-12-31,CA,Canada,4.1284
+2013-12-31,CH,Switzerland,3.842
+2013-12-31,CL,Chile,9.0694
 2013-12-31,CN,China,9.0735
-2013-12-31,CO,Colombia,8.2989
+2013-12-31,CO,Colombia,8.828
 2013-12-31,CY,Cyprus,-8.4986
 2013-12-31,CZ,Czechia,0.1067
 2013-12-31,DE,Germany,2.3452
@@ -21534,60 +5766,59 @@ date,country_code,country,price
 2013-12-31,ES,Spain,-6.2899
 2013-12-31,FI,Finland,0.3012
 2013-12-31,FR,France,-1.537
-2013-12-31,GB,United Kingdom,4.3968
+2013-12-31,GB,United Kingdom,4.3551
 2013-12-31,GR,Greece,-9.6325
-2013-12-31,HK,Hong Kong SAR,8.5449
+2013-12-31,HK,Hong Kong SAR,8.609
 2013-12-31,HR,Croatia,-1.7078
 2013-12-31,HU,Hungary,-0.7084
 2013-12-31,ID,Indonesia,11.5099
-2013-12-31,IE,Ireland,5.607
+2013-12-31,IE,Ireland,5.5773
 2013-12-31,IL,Israel,7.7807
 2013-12-31,IN,India,10.0637
-2013-12-31,IS,Iceland,8.6643
+2013-12-31,IS,Iceland,8.6887
 2013-12-31,IT,Italy,-5.7218
 2013-12-31,JP,Japan,2.8003
-2013-12-31,KR,Korea,0.1418
+2013-12-31,KR,Korea,0.1121
 2013-12-31,LT,Lithuania,2.9916
 2013-12-31,LU,Luxembourg,4.2497
 2013-12-31,LV,Latvia,8.2057
-2013-12-31,MA,Morocco,0.7484
-2013-12-31,MK,North Macedonia,-2.6443
+2013-12-31,MA,Morocco,0.6567
+2013-12-31,MK,North Macedonia,-2.3406
 2013-12-31,MT,Malta,-1.3815
 2013-12-31,MX,Mexico,5.8626
 2013-12-31,MY,Malaysia,9.3514
-2013-12-31,NL,Netherlands,-4.4219
+2013-12-31,NL,Netherlands,-4.4307
 2013-12-31,NO,Norway,1.0147
 2013-12-31,NZ,New Zealand,8.9646
 2013-12-31,PE,Peru,9.522
 2013-12-31,PH,Philippines,14.8368
 2013-12-31,PL,Poland,-2.7919
-2013-12-31,PT,Portugal,0.6149
+2013-12-31,PT,Portugal,0.615
 2013-12-31,RO,Romania,0
 2013-12-31,RS,Serbia,-1.9999
 2013-12-31,RU,Russia,0.1927
 2013-12-31,SE,Sweden,6.7736
 2013-12-31,SG,Singapore,1.1221
 2013-12-31,SI,Slovenia,-4.3817
-2013-12-31,SK,Slovak Republic,2.2222
-2013-12-31,TH,Thailand,8.1056
-2013-12-31,TR,Türkiye,12.7659
-2013-12-31,US,United States,9.8979
-2013-12-31,XM,Euro area,-1.3156
-2013-12-31,XW,World,6.3325
-2013-12-31,ZA,South Africa,7.1337
-2014-03-31,4T,Emerging market economies (aggregate),7.8856
-2014-03-31,5R,Advanced economies,4.7773
-2014-03-31,AE,United Arab Emirates,37.9378
+2013-12-31,SK,Slovakia,2.1186
+2013-12-31,TH,Thailand,8.3333
+2013-12-31,TR,Türkiye,12.3858
+2013-12-31,US,United States,9.8937
+2013-12-31,XM,Euro area,-1.3572
+2013-12-31,XW,World,6.0479
+2013-12-31,ZA,South Africa,7.5171
+2014-03-31,4T,Emerging market economies (aggregate),7.8614
+2014-03-31,5R,Advanced economies,4.486
 2014-03-31,AT,Austria,4.1042
 2014-03-31,AU,Australia,10.7662
-2014-03-31,BE,Belgium,-1.3626
+2014-03-31,BE,Belgium,-0.4496
 2014-03-31,BG,Bulgaria,0.6875
 2014-03-31,BR,Brazil,8.4642
-2014-03-31,CA,Canada,5.0739
-2014-03-31,CH,Switzerland,2.3482
-2014-03-31,CL,Chile,9.5224
+2014-03-31,CA,Canada,5.1166
+2014-03-31,CH,Switzerland,2.3477
+2014-03-31,CL,Chile,9.7726
 2014-03-31,CN,China,8.2321
-2014-03-31,CO,Colombia,9.225
+2014-03-31,CO,Colombia,9.6436
 2014-03-31,CY,Cyprus,-9.4511
 2014-03-31,CZ,Czechia,1.4957
 2014-03-31,DE,Germany,2.3277
@@ -21596,61 +5827,60 @@ date,country_code,country,price
 2014-03-31,ES,Spain,-1.6021
 2014-03-31,FI,Finland,-0.1994
 2014-03-31,FR,France,-1.4591
-2014-03-31,GB,United Kingdom,6.4699
+2014-03-31,GB,United Kingdom,6.5767
 2014-03-31,GR,Greece,-9.0922
 2014-03-31,HK,Hong Kong SAR,2.8495
-2014-03-31,HR,Croatia,-2.2793
+2014-03-31,HR,Croatia,-2.2792
 2014-03-31,HU,Hungary,0.9423
 2014-03-31,ID,Indonesia,7.9241
-2014-03-31,IE,Ireland,10.4821
+2014-03-31,IE,Ireland,10.3587
 2014-03-31,IL,Israel,7.6145
 2014-03-31,IN,India,12.2512
-2014-03-31,IS,Iceland,9.7434
+2014-03-31,IS,Iceland,9.747
 2014-03-31,IT,Italy,-4.3439
 2014-03-31,JP,Japan,3.0831
-2014-03-31,KR,Korea,0.8045
+2014-03-31,KR,Korea,0.7968
 2014-03-31,LT,Lithuania,3.8616
 2014-03-31,LU,Luxembourg,2.4635
 2014-03-31,LV,Latvia,10.5507
-2014-03-31,MA,Morocco,0.939
-2014-03-31,MK,North Macedonia,-2.2662
+2014-03-31,MA,Morocco,0.6591
+2014-03-31,MK,North Macedonia,-2.0635
 2014-03-31,MT,Malta,1.5317
 2014-03-31,MX,Mexico,5.6966
 2014-03-31,MY,Malaysia,10.2179
-2014-03-31,NL,Netherlands,-1.2575
+2014-03-31,NL,Netherlands,-1.2463
 2014-03-31,NO,Norway,0.3282
 2014-03-31,NZ,New Zealand,7.6307
 2014-03-31,PE,Peru,6.8983
 2014-03-31,PH,Philippines,13.4859
 2014-03-31,PL,Poland,-0.563
-2014-03-31,PT,Portugal,4.0129
+2014-03-31,PT,Portugal,4.013
 2014-03-31,RO,Romania,-2.9702
 2014-03-31,RS,Serbia,5.408
 2014-03-31,RU,Russia,0.9098
 2014-03-31,SE,Sweden,8.2415
 2014-03-31,SG,Singapore,-0.7218
 2014-03-31,SI,Slovenia,-6.6317
-2014-03-31,SK,Slovak Republic,-0.2068
-2014-03-31,TH,Thailand,8.4494
-2014-03-31,TR,Türkiye,12.5
-2014-03-31,US,United States,8.5889
-2014-03-31,XM,Euro area,-0.0565
-2014-03-31,XW,World,6.4005
-2014-03-31,ZA,South Africa,8.0068
-2014-06-30,4T,Emerging market economies (aggregate),7.2429
-2014-06-30,5R,Advanced economies,4.1875
-2014-06-30,AE,United Arab Emirates,35.3283
+2014-03-31,SK,Slovakia,-0.4141
+2014-03-31,TH,Thailand,8.4793
+2014-03-31,TR,Türkiye,11.8232
+2014-03-31,US,United States,8.596
+2014-03-31,XM,Euro area,-0.0914
+2014-03-31,XW,World,6.0623
+2014-03-31,ZA,South Africa,7.9857
+2014-06-30,4T,Emerging market economies (aggregate),7.2305
+2014-06-30,5R,Advanced economies,3.962
 2014-06-30,AT,Austria,4.8077
 2014-06-30,AU,Australia,10.123
-2014-06-30,BE,Belgium,-0.9432
+2014-06-30,BE,Belgium,-0.9355
 2014-06-30,BG,Bulgaria,0.5079
 2014-06-30,BR,Brazil,7.7145
-2014-06-30,CA,Canada,5.3526
-2014-06-30,CH,Switzerland,2.8894
-2014-06-30,CL,Chile,10.2343
+2014-06-30,CA,Canada,5.5238
+2014-06-30,CH,Switzerland,2.8886
+2014-06-30,CL,Chile,10.8585
 2014-06-30,CN,China,5.3294
-2014-06-30,CO,Colombia,7.4952
-2014-06-30,CY,Cyprus,-9.1172
+2014-06-30,CO,Colombia,7.6632
+2014-06-30,CY,Cyprus,-9.1404
 2014-06-30,CZ,Czechia,1.8065
 2014-06-30,DE,Germany,3.2228
 2014-06-30,DK,Denmark,3.8377
@@ -21658,28 +5888,28 @@ date,country_code,country,price
 2014-06-30,ES,Spain,0.8335
 2014-06-30,FI,Finland,-0.1986
 2014-06-30,FR,France,-1.1685
-2014-06-30,GB,United Kingdom,8.1201
-2014-06-30,GR,Greece,-8.2073
+2014-06-30,GB,United Kingdom,8.0992
+2014-06-30,GR,Greece,-8.2075
 2014-06-30,HK,Hong Kong SAR,2.6538
-2014-06-30,HR,Croatia,-0.7649
-2014-06-30,HU,Hungary,2.8203
+2014-06-30,HR,Croatia,-0.7648
+2014-06-30,HU,Hungary,2.8202
 2014-06-30,ID,Indonesia,7.4013
-2014-06-30,IE,Ireland,16.5826
+2014-06-30,IE,Ireland,16.5022
 2014-06-30,IL,Israel,7.7551
 2014-06-30,IN,India,15.8349
-2014-06-30,IS,Iceland,8.4174
+2014-06-30,IS,Iceland,8.4297
 2014-06-30,IT,Italy,-4.9909
 2014-06-30,JP,Japan,1.4915
-2014-06-30,KR,Korea,1.3731
+2014-06-30,KR,Korea,1.3881
 2014-06-30,LT,Lithuania,6.4803
 2014-06-30,LU,Luxembourg,4.9324
 2014-06-30,LV,Latvia,7.7317
-2014-06-30,MA,Morocco,1.1278
-2014-06-30,MK,North Macedonia,-0.1071
+2014-06-30,MA,Morocco,0.5623
+2014-06-30,MK,North Macedonia,0.1392
 2014-06-30,MT,Malta,2.8857
 2014-06-30,MX,Mexico,4.2044
 2014-06-30,MY,Malaysia,10.0652
-2014-06-30,NL,Netherlands,1.2734
+2014-06-30,NL,Netherlands,1.2572
 2014-06-30,NO,Norway,1.3845
 2014-06-30,NZ,New Zealand,6.4231
 2014-06-30,PE,Peru,9.3991
@@ -21692,26 +5922,25 @@ date,country_code,country,price
 2014-06-30,SE,Sweden,8.6599
 2014-06-30,SG,Singapore,-2.7922
 2014-06-30,SI,Slovenia,-9.8175
-2014-06-30,SK,Slovak Republic,1.1352
-2014-06-30,TH,Thailand,9.1735
-2014-06-30,TR,Türkiye,12.5413
-2014-06-30,US,United States,6.5415
-2014-06-30,XM,Euro area,0.8259
-2014-06-30,XW,World,5.7846
-2014-06-30,ZA,South Africa,8.1489
-2014-09-30,4T,Emerging market economies (aggregate),5.1175
-2014-09-30,5R,Advanced economies,3.7062
-2014-09-30,AE,United Arab Emirates,23.9839
-2014-09-30,AT,Austria,2.4097
+2014-06-30,SK,Slovakia,1.0331
+2014-06-30,TH,Thailand,10.6267
+2014-06-30,TR,Türkiye,11.8055
+2014-06-30,US,United States,6.5431
+2014-06-30,XM,Euro area,0.7845
+2014-06-30,XW,World,5.493
+2014-06-30,ZA,South Africa,8.0055
+2014-09-30,4T,Emerging market economies (aggregate),4.9906
+2014-09-30,5R,Advanced economies,3.5364
+2014-09-30,AT,Austria,2.4096
 2014-09-30,AU,Australia,8.7719
-2014-09-30,BE,Belgium,-0.8616
-2014-09-30,BG,Bulgaria,1.7692
+2014-09-30,BE,Belgium,-0.6535
+2014-09-30,BG,Bulgaria,1.7693
 2014-09-30,BR,Brazil,6.5498
-2014-09-30,CA,Canada,5.3851
-2014-09-30,CH,Switzerland,2.5891
-2014-09-30,CL,Chile,17.1544
+2014-09-30,CA,Canada,5.4924
+2014-09-30,CH,Switzerland,2.5889
+2014-09-30,CL,Chile,17.4237
 2014-09-30,CN,China,0.6418
-2014-09-30,CO,Colombia,7.8269
+2014-09-30,CO,Colombia,7.7892
 2014-09-30,CY,Cyprus,-8.3877
 2014-09-30,CZ,Czechia,2.7659
 2014-09-30,DE,Germany,2.8285
@@ -21720,60 +5949,59 @@ date,country_code,country,price
 2014-09-30,ES,Spain,0.2792
 2014-09-30,FI,Finland,-0.4975
 2014-09-30,FR,France,-1.2548
-2014-09-30,GB,United Kingdom,8.9034
+2014-09-30,GB,United Kingdom,8.871
 2014-09-30,GR,Greece,-6.878
 2014-09-30,HK,Hong Kong SAR,6.3781
-2014-09-30,HR,Croatia,-1.9047
+2014-09-30,HR,Croatia,-1.9048
 2014-09-30,HU,Hungary,4.5721
 2014-09-30,ID,Indonesia,6.5269
-2014-09-30,IE,Ireland,19.2471
+2014-09-30,IE,Ireland,19.2275
 2014-09-30,IL,Israel,5.2285
 2014-09-30,IN,India,14.0662
-2014-09-30,IS,Iceland,8.6509
+2014-09-30,IS,Iceland,8.6309
 2014-09-30,IT,Italy,-4.6961
 2014-09-30,JP,Japan,1.0827
-2014-09-30,KR,Korea,1.8001
+2014-09-30,KR,Korea,1.7785
 2014-09-30,LT,Lithuania,10.1339
 2014-09-30,LU,Luxembourg,5.0112
 2014-09-30,LV,Latvia,10.6843
-2014-09-30,MA,Morocco,2.0658
-2014-09-30,MK,North Macedonia,2.3466
+2014-09-30,MA,Morocco,0.1878
+2014-09-30,MK,North Macedonia,2.4651
 2014-09-30,MT,Malta,0.3181
 2014-09-30,MX,Mexico,3.3506
 2014-09-30,MY,Malaysia,8.844
-2014-09-30,NL,Netherlands,1.2758
+2014-09-30,NL,Netherlands,1.2643
 2014-09-30,NO,Norway,3.4745
 2014-09-30,NZ,New Zealand,4.814
 2014-09-30,PE,Peru,3.1533
 2014-09-30,PH,Philippines,11.0603
 2014-09-30,PL,Poland,1.2625
-2014-09-30,PT,Portugal,4.9165
+2014-09-30,PT,Portugal,4.9164
 2014-09-30,RO,Romania,-2.0409
 2014-09-30,RS,Serbia,5.0607
 2014-09-30,RU,Russia,1.5514
 2014-09-30,SE,Sweden,10.3374
 2014-09-30,SG,Singapore,-3.881
 2014-09-30,SI,Slovenia,-5.3534
-2014-09-30,SK,Slovak Republic,1.241
-2014-09-30,TH,Thailand,8.2962
-2014-09-30,TR,Türkiye,14.3548
-2014-09-30,US,United States,5.3172
-2014-09-30,XM,Euro area,0.8669
-2014-09-30,XW,World,4.4481
-2014-09-30,ZA,South Africa,7.7169
-2014-12-31,4T,Emerging market economies (aggregate),3.8743
-2014-12-31,5R,Advanced economies,3.4763
-2014-12-31,AE,United Arab Emirates,12.849
+2014-09-30,SK,Slovakia,1.3486
+2014-09-30,TH,Thailand,8.8731
+2014-09-30,TR,Türkiye,12.7726
+2014-09-30,US,United States,5.3003
+2014-09-30,XM,Euro area,0.8187
+2014-09-30,XW,World,4.2213
+2014-09-30,ZA,South Africa,7.2906
+2014-12-31,4T,Emerging market economies (aggregate),3.8197
+2014-12-31,5R,Advanced economies,3.3902
 2014-12-31,AT,Austria,2.4219
 2014-12-31,AU,Australia,6.7496
-2014-12-31,BE,Belgium,0.9612
+2014-12-31,BE,Belgium,0.68
 2014-12-31,BG,Bulgaria,2.7807
 2014-12-31,BR,Brazil,5.023
-2014-12-31,CA,Canada,5.5556
-2014-12-31,CH,Switzerland,2.8558
-2014-12-31,CL,Chile,14.8406
+2014-12-31,CA,Canada,5.5381
+2014-12-31,CH,Switzerland,2.8552
+2014-12-31,CL,Chile,15.0709
 2014-12-31,CN,China,-3.4535
-2014-12-31,CO,Colombia,7.3488
+2014-12-31,CO,Colombia,7.2721
 2014-12-31,CY,Cyprus,-8.0219
 2014-12-31,CZ,Czechia,3.7313
 2014-12-31,DE,Germany,3.2997
@@ -21782,28 +6010,28 @@ date,country_code,country,price
 2014-12-31,ES,Spain,1.7592
 2014-12-31,FI,Finland,-0.5005
 2014-12-31,FR,France,-2.1463
-2014-12-31,GB,United Kingdom,8.5313
+2014-12-31,GB,United Kingdom,8.5072
 2014-12-31,GR,Greece,-5.5464
 2014-12-31,HK,Hong Kong SAR,11.8967
 2014-12-31,HR,Croatia,-1.4479
 2014-12-31,HU,Hungary,8.4423
 2014-12-31,ID,Indonesia,6.2844
-2014-12-31,IE,Ireland,19.5361
+2014-12-31,IE,Ireland,19.5625
 2014-12-31,IL,Israel,4.9058
 2014-12-31,IN,India,16.8982
-2014-12-31,IS,Iceland,6.0908
+2014-12-31,IS,Iceland,6.0897
 2014-12-31,IT,Italy,-4.8553
 2014-12-31,JP,Japan,0.5907
-2014-12-31,KR,Korea,2.0765
+2014-12-31,KR,Korea,2.0971
 2014-12-31,LT,Lithuania,5.2654
 2014-12-31,LU,Luxembourg,5.0731
 2014-12-31,LV,Latvia,-4.4674
-2014-12-31,MA,Morocco,-1.2071
-2014-12-31,MK,North Macedonia,-1.2877
+2014-12-31,MA,Morocco,-0.1864
+2014-12-31,MK,North Macedonia,-1.4682
 2014-12-31,MT,Malta,5.4957
 2014-12-31,MX,Mexico,3.8416
 2014-12-31,MY,Malaysia,8.6897
-2014-12-31,NL,Netherlands,2.0248
+2014-12-31,NL,Netherlands,2.0387
 2014-12-31,NO,Norway,5.8036
 2014-12-31,NZ,New Zealand,7.1575
 2014-12-31,PE,Peru,3.9573
@@ -21816,26 +6044,25 @@ date,country_code,country,price
 2014-12-31,SE,Sweden,10.4095
 2014-12-31,SG,Singapore,-4.047
 2014-12-31,SI,Slovenia,-4.3887
-2014-12-31,SK,Slovak Republic,3.4161
-2014-12-31,TH,Thailand,7.585
-2014-12-31,TR,Türkiye,14.9371
-2014-12-31,US,United States,4.8892
-2014-12-31,XM,Euro area,0.9351
-2014-12-31,XW,World,3.6881
-2014-12-31,ZA,South Africa,6.7808
-2015-03-31,4T,Emerging market economies (aggregate),3.0588
-2015-03-31,5R,Advanced economies,3.7209
-2015-03-31,AE,United Arab Emirates,-3.323
+2014-12-31,SK,Slovakia,3.3195
+2014-12-31,TH,Thailand,10.1988
+2014-12-31,TR,Türkiye,13.4586
+2014-12-31,US,United States,4.8918
+2014-12-31,XM,Euro area,0.89
+2014-12-31,XW,World,3.5966
+2014-12-31,ZA,South Africa,6.5137
+2015-03-31,4T,Emerging market economies (aggregate),3.1471
+2015-03-31,5R,Advanced economies,3.6502
 2015-03-31,AT,Austria,3.567
 2015-03-31,AU,Australia,6.9177
-2015-03-31,BE,Belgium,0.4124
+2015-03-31,BE,Belgium,0.5235
 2015-03-31,BG,Bulgaria,2.2657
 2015-03-31,BR,Brazil,2.9776
-2015-03-31,CA,Canada,6.0513
-2015-03-31,CH,Switzerland,3.4664
-2015-03-31,CL,Chile,13.4258
+2015-03-31,CA,Canada,6.1614
+2015-03-31,CH,Switzerland,3.4657
+2015-03-31,CL,Chile,13.4245
 2015-03-31,CN,China,-5.6608
-2015-03-31,CO,Colombia,7.1898
+2015-03-31,CO,Colombia,7.8085
 2015-03-31,CY,Cyprus,-6.4999
 2015-03-31,CZ,Czechia,3.4737
 2015-03-31,DE,Germany,4.2766
@@ -21844,28 +6071,28 @@ date,country_code,country,price
 2015-03-31,ES,Spain,1.5441
 2015-03-31,FI,Finland,-0.5994
 2015-03-31,FR,France,-1.8756
-2015-03-31,GB,United Kingdom,6.823
+2015-03-31,GB,United Kingdom,6.6456
 2015-03-31,GR,Greece,-4.1165
 2015-03-31,HK,Hong Kong SAR,18.4113
-2015-03-31,HR,Croatia,-1.7492
+2015-03-31,HR,Croatia,-1.7493
 2015-03-31,HU,Hungary,9.2182
 2015-03-31,ID,Indonesia,6.2694
-2015-03-31,IE,Ireland,17.5038
+2015-03-31,IE,Ireland,17.5132
 2015-03-31,IL,Israel,4.0709
 2015-03-31,IN,India,17.5069
-2015-03-31,IS,Iceland,9.3898
+2015-03-31,IS,Iceland,9.3965
 2015-03-31,IT,Italy,-5.6764
 2015-03-31,JP,Japan,2.3732
-2015-03-31,KR,Korea,2.1596
+2015-03-31,KR,Korea,2.2104
 2015-03-31,LT,Lithuania,4.4573
 2015-03-31,LU,Luxembourg,7.05
 2015-03-31,LV,Latvia,-6.5361
-2015-03-31,MA,Morocco,3.5349
-2015-03-31,MK,North Macedonia,1.4984
+2015-03-31,MA,Morocco,-0.3741
+2015-03-31,MK,North Macedonia,1.4847
 2015-03-31,MT,Malta,2.694
 2015-03-31,MX,Mexico,4.3184
 2015-03-31,MY,Malaysia,9.2025
-2015-03-31,NL,Netherlands,2.5783
+2015-03-31,NL,Netherlands,2.4639
 2015-03-31,NO,Norway,7.1974
 2015-03-31,NZ,New Zealand,9.3986
 2015-03-31,PE,Peru,-0.4501
@@ -21878,27 +6105,26 @@ date,country_code,country,price
 2015-03-31,SE,Sweden,11.7845
 2015-03-31,SG,Singapore,-3.8334
 2015-03-31,SI,Slovenia,-1.3792
-2015-03-31,SK,Slovak Republic,5.1813
-2015-03-31,TH,Thailand,6.4212
-2015-03-31,TR,Türkiye,16.5905
-2015-03-31,US,United States,4.8635
-2015-03-31,XM,Euro area,1.1403
-2015-03-31,XW,World,3.3731
-2015-03-31,ZA,South Africa,6.1758
-2015-06-30,4T,Emerging market economies (aggregate),2.3493
-2015-06-30,5R,Advanced economies,4.0532
-2015-06-30,AE,United Arab Emirates,-10.288
+2015-03-31,SK,Slovakia,5.1975
+2015-03-31,TH,Thailand,10.2804
+2015-03-31,TR,Türkiye,15.3162
+2015-03-31,US,United States,4.8501
+2015-03-31,XM,Euro area,1.0968
+2015-03-31,XW,World,3.4118
+2015-03-31,ZA,South Africa,6.2148
+2015-06-30,4T,Emerging market economies (aggregate),2.427
+2015-06-30,5R,Advanced economies,4.0331
 2015-06-30,AT,Austria,1.4679
 2015-06-30,AU,Australia,9.7938
-2015-06-30,BE,Belgium,1.9351
+2015-06-30,BE,Belgium,1.7553
 2015-06-30,BG,Bulgaria,2.8256
-2015-06-30,BR,Brazil,1.1421
-2015-06-30,CA,Canada,7.3521
-2015-06-30,CH,Switzerland,1.7917
-2015-06-30,CL,Chile,13.5175
+2015-06-30,BR,Brazil,1.1402
+2015-06-30,CA,Canada,7.2202
+2015-06-30,CH,Switzerland,1.7932
+2015-06-30,CL,Chile,13.5148
 2015-06-30,CN,China,-5.9072
-2015-06-30,CO,Colombia,10.0078
-2015-06-30,CY,Cyprus,-5.0606
+2015-06-30,CO,Colombia,10.0491
+2015-06-30,CY,Cyprus,-5.0364
 2015-06-30,CZ,Czechia,3.7579
 2015-06-30,DE,Germany,4.3711
 2015-06-30,DK,Denmark,6.6526
@@ -21906,28 +6132,28 @@ date,country_code,country,price
 2015-06-30,ES,Spain,4.0194
 2015-06-30,FI,Finland,-0.0995
 2015-06-30,FR,France,-1.9704
-2015-06-30,GB,United Kingdom,5.2469
-2015-06-30,GR,Greece,-4.9675
+2015-06-30,GB,United Kingdom,5.3517
+2015-06-30,GR,Greece,-4.9674
 2015-06-30,HK,Hong Kong SAR,20.8429
 2015-06-30,HR,Croatia,-4.5279
 2015-06-30,HU,Hungary,12.8
 2015-06-30,ID,Indonesia,5.9497
-2015-06-30,IE,Ireland,13.7914
+2015-06-30,IE,Ireland,13.8183
 2015-06-30,IL,Israel,4.8682
 2015-06-30,IN,India,14.5213
-2015-06-30,IS,Iceland,7.8354
+2015-06-30,IS,Iceland,7.8459
 2015-06-30,IT,Italy,-4.68
 2015-06-30,JP,Japan,2.5147
-2015-06-30,KR,Korea,2.9426
+2015-06-30,KR,Korea,2.9583
 2015-06-30,LT,Lithuania,3.4806
 2015-06-30,LU,Luxembourg,5.4367
 2015-06-30,LV,Latvia,-4.6186
-2015-06-30,MA,Morocco,-0.8364
-2015-06-30,MK,North Macedonia,0.4075
+2015-06-30,MA,Morocco,-0.2796
+2015-06-30,MK,North Macedonia,0.0107
 2015-06-30,MT,Malta,3.6677
 2015-06-30,MX,Mexico,7.658
 2015-06-30,MY,Malaysia,7.1053
-2015-06-30,NL,Netherlands,3.024
+2015-06-30,NL,Netherlands,3.0666
 2015-06-30,NO,Norway,6.6176
 2015-06-30,NZ,New Zealand,12.0594
 2015-06-30,PE,Peru,-5.6517
@@ -21940,26 +6166,25 @@ date,country_code,country,price
 2015-06-30,SE,Sweden,12.9781
 2015-06-30,SG,Singapore,-3.6741
 2015-06-30,SI,Slovenia,3.5815
-2015-06-30,SK,Slovak Republic,5.6122
-2015-06-30,TH,Thailand,4.6589
-2015-06-30,TR,Türkiye,17.1554
-2015-06-30,US,United States,5.3931
-2015-06-30,XM,Euro area,1.4377
-2015-06-30,XW,World,3.1545
-2015-06-30,ZA,South Africa,6.254
-2015-09-30,4T,Emerging market economies (aggregate),2.9703
-2015-09-30,5R,Advanced economies,4.3472
-2015-09-30,AE,United Arab Emirates,-10.8546
-2015-09-30,AT,Austria,4.0247
+2015-06-30,SK,Slovakia,5.5214
+2015-06-30,TH,Thailand,6.8145
+2015-06-30,TR,Türkiye,16.5791
+2015-06-30,US,United States,5.3812
+2015-06-30,XM,Euro area,1.4088
+2015-06-30,XW,World,3.2643
+2015-06-30,ZA,South Africa,6.1312
+2015-09-30,4T,Emerging market economies (aggregate),3.1028
+2015-09-30,5R,Advanced economies,4.3251
+2015-09-30,AT,Austria,4.0248
 2015-09-30,AU,Australia,10.6961
-2015-09-30,BE,Belgium,2.8193
+2015-09-30,BE,Belgium,2.7123
 2015-09-30,BG,Bulgaria,2.0574
 2015-09-30,BR,Brazil,-0.3996
-2015-09-30,CA,Canada,8.8532
-2015-09-30,CH,Switzerland,2.1645
-2015-09-30,CL,Chile,11.9323
+2015-09-30,CA,Canada,8.6176
+2015-09-30,CH,Switzerland,2.1658
+2015-09-30,CL,Chile,11.9367
 2015-09-30,CN,China,-3.1122
-2015-09-30,CO,Colombia,9.1836
+2015-09-30,CO,Colombia,9.1427
 2015-09-30,CY,Cyprus,-3.7479
 2015-09-30,CZ,Czechia,4.1408
 2015-09-30,DE,Germany,4.3478
@@ -21968,28 +6193,28 @@ date,country_code,country,price
 2015-09-30,ES,Spain,4.485
 2015-09-30,FI,Finland,0.3
 2015-09-30,FR,France,-1.3685
-2015-09-30,GB,United Kingdom,5.3838
+2015-09-30,GB,United Kingdom,5.3333
 2015-09-30,GR,Greece,-5.7933
-2015-09-30,HK,Hong Kong SAR,16.7368
+2015-09-30,HK,Hong Kong SAR,16.7878
 2015-09-30,HR,Croatia,-3.0097
 2015-09-30,HU,Hungary,15.583
 2015-09-30,ID,Indonesia,5.4618
-2015-09-30,IE,Ireland,8.6705
+2015-09-30,IE,Ireland,8.6508
 2015-09-30,IL,Israel,6.8369
 2015-09-30,IN,India,13.057
-2015-09-30,IS,Iceland,7.2607
+2015-09-30,IS,Iceland,7.2541
 2015-09-30,IT,Italy,-2.7053
 2015-09-30,JP,Japan,2.8562
-2015-09-30,KR,Korea,3.8623
+2015-09-30,KR,Korea,3.9184
 2015-09-30,LT,Lithuania,3.4353
 2015-09-30,LU,Luxembourg,5.5022
 2015-09-30,LV,Latvia,-7.9213
-2015-09-30,MA,Morocco,-2.024
-2015-09-30,MK,North Macedonia,-3.434
+2015-09-30,MA,Morocco,0
+2015-09-30,MK,North Macedonia,-3.3703
 2015-09-30,MT,Malta,8.5624
 2015-09-30,MX,Mexico,10.3212
 2015-09-30,MY,Malaysia,6.9098
-2015-09-30,NL,Netherlands,4.4295
+2015-09-30,NL,Netherlands,4.1914
 2015-09-30,NO,Norway,6.086
 2015-09-30,NZ,New Zealand,15.474
 2015-09-30,PE,Peru,-1.2893
@@ -22002,26 +6227,25 @@ date,country_code,country,price
 2015-09-30,SE,Sweden,13.4987
 2015-09-30,SG,Singapore,-4.2396
 2015-09-30,SI,Slovenia,1.0228
-2015-09-30,SK,Slovak Republic,5.8223
-2015-09-30,TH,Thailand,3.9539
-2015-09-30,TR,Türkiye,15.2327
-2015-09-30,US,United States,5.4884
-2015-09-30,XM,Euro area,1.7811
-2015-09-30,XW,World,3.6222
-2015-09-30,ZA,South Africa,6.2227
-2015-12-31,4T,Emerging market economies (aggregate),3.1476
-2015-12-31,5R,Advanced economies,4.5534
-2015-12-31,AE,United Arab Emirates,-10.5763
+2015-09-30,SK,Slovakia,5.7318
+2015-09-30,TH,Thailand,5.2975
+2015-09-30,TR,Türkiye,15.4697
+2015-09-30,US,United States,5.497
+2015-09-30,XM,Euro area,1.7683
+2015-09-30,XW,World,3.7361
+2015-09-30,ZA,South Africa,6.128
+2015-12-31,4T,Emerging market economies (aggregate),3.3145
+2015-12-31,5R,Advanced economies,4.4945
 2015-12-31,AT,Austria,7.5918
 2015-12-31,AU,Australia,8.6522
-2015-12-31,BE,Belgium,1.5133
+2015-12-31,BE,Belgium,2.248
 2015-12-31,BG,Bulgaria,3.9768
 2015-12-31,BR,Brazil,-1.5742
-2015-12-31,CA,Canada,9.8758
-2015-12-31,CH,Switzerland,1.2055
-2015-12-31,CL,Chile,13.4399
+2015-12-31,CA,Canada,9.4812
+2015-12-31,CH,Switzerland,1.2071
+2015-12-31,CL,Chile,13.4459
 2015-12-31,CN,China,-0.2872
-2015-12-31,CO,Colombia,8.7649
+2015-12-31,CO,Colombia,8.0421
 2015-12-31,CY,Cyprus,-1.813
 2015-12-31,CZ,Czechia,4.5222
 2015-12-31,DE,Germany,5.8563
@@ -22030,28 +6254,28 @@ date,country_code,country,price
 2015-12-31,ES,Spain,4.2498
 2015-12-31,FI,Finland,0.4024
 2015-12-31,FR,France,-0.0997
-2015-12-31,GB,United Kingdom,6.4677
+2015-12-31,GB,United Kingdom,6.5089
 2015-12-31,GR,Greece,-5.1124
 2015-12-31,HK,Hong Kong SAR,7.0109
 2015-12-31,HR,Croatia,-2.0568
 2015-12-31,HU,Hungary,14.693
 2015-12-31,ID,Indonesia,4.6135
-2015-12-31,IE,Ireland,6.9426
+2015-12-31,IE,Ireland,6.9037
 2015-12-31,IL,Israel,7.6229
 2015-12-31,IN,India,9.7525
-2015-12-31,IS,Iceland,9.0466
+2015-12-31,IS,Iceland,9.0242
 2015-12-31,IT,Italy,-2.0608
 2015-12-31,JP,Japan,1.9576
-2015-12-31,KR,Korea,4.3458
+2015-12-31,KR,Korea,4.3427
 2015-12-31,LT,Lithuania,3.2968
 2015-12-31,LU,Luxembourg,3.7118
 2015-12-31,LV,Latvia,6.5735
-2015-12-31,MA,Morocco,0.7519
-2015-12-31,MK,North Macedonia,1.1291
+2015-12-31,MA,Morocco,0.3734
+2015-12-31,MK,North Macedonia,1.0956
 2015-12-31,MT,Malta,8.1716
 2015-12-31,MX,Mexico,10.2212
 2015-12-31,MY,Malaysia,6.4721
-2015-12-31,NL,Netherlands,4.3188
+2015-12-31,NL,Netherlands,4.3362
 2015-12-31,NO,Norway,4.5359
 2015-12-31,NZ,New Zealand,12.6241
 2015-12-31,PE,Peru,-3.8275
@@ -22064,26 +6288,25 @@ date,country_code,country,price
 2015-12-31,SE,Sweden,14.1158
 2015-12-31,SG,Singapore,-3.6735
 2015-12-31,SI,Slovenia,0.0507
-2015-12-31,SK,Slovak Republic,4.8048
-2015-12-31,TH,Thailand,3.6467
-2015-12-31,TR,Türkiye,15.5951
-2015-12-31,US,United States,5.4262
-2015-12-31,XM,Euro area,2.7462
-2015-12-31,XW,World,3.8132
-2015-12-31,ZA,South Africa,6.2168
-2016-03-31,4T,Emerging market economies (aggregate),3.2055
-2016-03-31,5R,Advanced economies,4.8438
-2016-03-31,AE,United Arab Emirates,-5.8459
+2015-12-31,SK,Slovakia,4.8193
+2015-12-31,TH,Thailand,5.8824
+2015-12-31,TR,Türkiye,15.667
+2015-12-31,US,United States,5.4456
+2015-12-31,XM,Euro area,2.7345
+2015-12-31,XW,World,3.9261
+2015-12-31,ZA,South Africa,6.7096
+2016-03-31,4T,Emerging market economies (aggregate),3.4434
+2016-03-31,5R,Advanced economies,4.6618
 2016-03-31,AT,Austria,8.0967
 2016-03-31,AU,Australia,6.7977
-2016-03-31,BE,Belgium,3.2444
-2016-03-31,BG,Bulgaria,4.5826
-2016-03-31,BR,Brazil,-2.3469
-2016-03-31,CA,Canada,12.853
-2016-03-31,CH,Switzerland,1.4004
-2016-03-31,CL,Chile,12.2928
+2016-03-31,BE,Belgium,2.4811
+2016-03-31,BG,Bulgaria,4.5827
+2016-03-31,BR,Brazil,-2.3488
+2016-03-31,CA,Canada,12.188
+2016-03-31,CH,Switzerland,1.4023
+2016-03-31,CL,Chile,12.2895
 2016-03-31,CN,China,3.4475
-2016-03-31,CO,Colombia,10.5219
+2016-03-31,CO,Colombia,10.1503
 2016-03-31,CY,Cyprus,-1.6177
 2016-03-31,CZ,Czechia,4.7813
 2016-03-31,DE,Germany,6.1955
@@ -22092,60 +6315,59 @@ date,country_code,country,price
 2016-03-31,ES,Spain,6.2791
 2016-03-31,FI,Finland,1.005
 2016-03-31,FR,France,0.3018
-2016-03-31,GB,United Kingdom,7.984
-2016-03-31,GR,Greece,-4.3569
-2016-03-31,HK,Hong Kong SAR,-5.0369
+2016-03-31,GB,United Kingdom,8.0119
+2016-03-31,GR,Greece,-4.3568
+2016-03-31,HK,Hong Kong SAR,-5.0138
 2016-03-31,HR,Croatia,0.0989
 2016-03-31,HU,Hungary,16.8716
 2016-03-31,ID,Indonesia,4.152
-2016-03-31,IE,Ireland,7.4698
+2016-03-31,IE,Ireland,7.5726
 2016-03-31,IL,Israel,7.5254
 2016-03-31,IN,India,3.3004
-2016-03-31,IS,Iceland,6.7135
+2016-03-31,IS,Iceland,6.6858
 2016-03-31,IT,Italy,0.1003
 2016-03-31,JP,Japan,1.6196
-2016-03-31,KR,Korea,4.182
+2016-03-31,KR,Korea,4.1272
 2016-03-31,LT,Lithuania,3.3747
 2016-03-31,LU,Luxembourg,4.9512
 2016-03-31,LV,Latvia,7.1096
-2016-03-31,MA,Morocco,-3.8634
-2016-03-31,MK,North Macedonia,2.4138
+2016-03-31,MA,Morocco,0.5634
+2016-03-31,MK,North Macedonia,2.3559
 2016-03-31,MT,Malta,5.2466
 2016-03-31,MX,Mexico,9.5607
 2016-03-31,MY,Malaysia,7.2409
-2016-03-31,NL,Netherlands,4.6199
+2016-03-31,NL,Netherlands,4.3988
 2016-03-31,NO,Norway,4.5778
 2016-03-31,NZ,New Zealand,13.1632
 2016-03-31,PE,Peru,-5.6862
 2016-03-31,PH,Philippines,10.9763
 2016-03-31,PL,Poland,0.949
-2016-03-31,PT,Portugal,6.9425
+2016-03-31,PT,Portugal,6.9424
 2016-03-31,RO,Romania,2.9703
 2016-03-31,RS,Serbia,-1.5834
 2016-03-31,RU,Russia,-5.7529
 2016-03-31,SE,Sweden,10.975
 2016-03-31,SG,Singapore,-3.3677
 2016-03-31,SI,Slovenia,0.8291
-2016-03-31,SK,Slovak Republic,5.0247
-2016-03-31,TH,Thailand,2.8962
-2016-03-31,TR,Türkiye,14.2298
-2016-03-31,US,United States,5.3802
-2016-03-31,XM,Euro area,3.5284
-2016-03-31,XW,World,3.98
-2016-03-31,ZA,South Africa,6.2362
-2016-06-30,4T,Emerging market economies (aggregate),4.4517
-2016-06-30,5R,Advanced economies,5.086
-2016-06-30,AE,United Arab Emirates,-2.2949
+2016-03-31,SK,Slovakia,5.0395
+2016-03-31,TH,Thailand,4.9307
+2016-03-31,TR,Türkiye,14.3102
+2016-03-31,US,United States,5.3843
+2016-03-31,XM,Euro area,3.5246
+2016-03-31,XW,World,4.0739
+2016-03-31,ZA,South Africa,5.8707
+2016-06-30,4T,Emerging market economies (aggregate),4.7799
+2016-06-30,5R,Advanced economies,4.808
 2016-06-30,AT,Austria,9.5238
 2016-06-30,AU,Australia,4.0689
-2016-06-30,BE,Belgium,2.1997
+2016-06-30,BE,Belgium,2.3101
 2016-06-30,BG,Bulgaria,6.549
-2016-06-30,BR,Brazil,-2.7501
-2016-06-30,CA,Canada,16.147
-2016-06-30,CH,Switzerland,0.7962
-2016-06-30,CL,Chile,7.4634
+2016-06-30,BR,Brazil,-2.7483
+2016-06-30,CA,Canada,15.3199
+2016-06-30,CH,Switzerland,0.7964
+2016-06-30,CL,Chile,7.4683
 2016-06-30,CN,China,5.8039
-2016-06-30,CO,Colombia,9.4896
+2016-06-30,CO,Colombia,8.3418
 2016-06-30,CY,Cyprus,-1.6783
 2016-06-30,CZ,Czechia,5.7344
 2016-06-30,DE,Germany,7.0085
@@ -22154,28 +6376,28 @@ date,country_code,country,price
 2016-06-30,ES,Spain,3.8542
 2016-06-30,FI,Finland,1.1952
 2016-06-30,FR,France,0.7035
-2016-06-30,GB,United Kingdom,8.0156
+2016-06-30,GB,United Kingdom,7.9826
 2016-06-30,GR,Greece,-2.5319
-2016-06-30,HK,Hong Kong SAR,-8.0446
+2016-06-30,HK,Hong Kong SAR,-8.0223
 2016-06-30,HR,Croatia,1.2109
 2016-06-30,HU,Hungary,13.4477
 2016-06-30,ID,Indonesia,3.3886
-2016-06-30,IE,Ireland,6.2922
+2016-06-30,IE,Ireland,6.324
 2016-06-30,IL,Israel,7.3472
 2016-06-30,IN,India,7.3319
-2016-06-30,IS,Iceland,8.0623
+2016-06-30,IS,Iceland,8.0613
 2016-06-30,IT,Italy,0.7014
 2016-06-30,JP,Japan,2.9627
-2016-06-30,KR,Korea,2.9946
+2016-06-30,KR,Korea,3.0062
 2016-06-30,LT,Lithuania,3.4033
 2016-06-30,LU,Luxembourg,5.5722
 2016-06-30,LV,Latvia,9.4596
-2016-06-30,MA,Morocco,0.5623
-2016-06-30,MK,North Macedonia,0.7369
+2016-06-30,MA,Morocco,0.8412
+2016-06-30,MK,North Macedonia,0.9086
 2016-06-30,MT,Malta,6.9719
 2016-06-30,MX,Mexico,7.7904
 2016-06-30,MY,Malaysia,7.1253
-2016-06-30,NL,Netherlands,4.4785
+2016-06-30,NL,Netherlands,4.7896
 2016-06-30,NO,Norway,5.5172
 2016-06-30,NZ,New Zealand,15.1763
 2016-06-30,PE,Peru,-2.7359
@@ -22188,26 +6410,25 @@ date,country_code,country,price
 2016-06-30,SE,Sweden,8.663
 2016-06-30,SG,Singapore,-2.9126
 2016-06-30,SI,Slovenia,0.4493
-2016-06-30,SK,Slovak Republic,5.8937
-2016-06-30,TH,Thailand,2.7822
-2016-06-30,TR,Türkiye,13.2666
-2016-06-30,US,United States,5.3293
-2016-06-30,XM,Euro area,3.7707
-2016-06-30,XW,World,4.7531
-2016-06-30,ZA,South Africa,6.0023
-2016-09-30,4T,Emerging market economies (aggregate),5.0444
-2016-09-30,5R,Advanced economies,5.0742
-2016-09-30,AE,United Arab Emirates,-1.7124
-2016-09-30,AT,Austria,7.1429
+2016-06-30,SK,Slovakia,5.9109
+2016-06-30,TH,Thailand,5.7648
+2016-06-30,TR,Türkiye,12.7869
+2016-06-30,US,United States,5.3476
+2016-06-30,XM,Euro area,3.7656
+2016-06-30,XW,World,4.799
+2016-06-30,ZA,South Africa,4.9565
+2016-09-30,4T,Emerging market economies (aggregate),5.4964
+2016-09-30,5R,Advanced economies,4.8038
+2016-09-30,AT,Austria,7.3214
 2016-09-30,AU,Australia,3.5276
-2016-09-30,BE,Belgium,2.516
-2016-09-30,BG,Bulgaria,8.7996
+2016-09-30,BE,Belgium,2.1086
+2016-09-30,BG,Bulgaria,8.7995
 2016-09-30,BR,Brazil,-2.8853
-2016-09-30,CA,Canada,17.1943
-2016-09-30,CH,Switzerland,-0.068
-2016-09-30,CL,Chile,3.5622
+2016-09-30,CA,Canada,16.5289
+2016-09-30,CH,Switzerland,-0.0677
+2016-09-30,CL,Chile,3.5586
 2016-09-30,CN,China,7.5571
-2016-09-30,CO,Colombia,9.5719
+2016-09-30,CO,Colombia,8.7974
 2016-09-30,CY,Cyprus,-1.253
 2016-09-30,CZ,Czechia,7.0577
 2016-09-30,DE,Germany,8.4184
@@ -22216,28 +6437,28 @@ date,country_code,country,price
 2016-09-30,ES,Spain,4.0162
 2016-09-30,FI,Finland,1.5952
 2016-09-30,FR,France,1.4866
-2016-09-30,GB,United Kingdom,6.7171
-2016-09-30,GR,Greece,-1.7571
-2016-09-30,HK,Hong Kong SAR,-5.442
-2016-09-30,HR,Croatia,1.4015
-2016-09-30,HU,Hungary,11.7336
+2016-09-30,GB,United Kingdom,6.7511
+2016-09-30,GR,Greece,-1.757
+2016-09-30,HK,Hong Kong SAR,-5.4833
+2016-09-30,HR,Croatia,1.4014
+2016-09-30,HU,Hungary,11.7337
 2016-09-30,ID,Indonesia,2.7458
-2016-09-30,IE,Ireland,7.4468
+2016-09-30,IE,Ireland,7.4705
 2016-09-30,IL,Israel,8.1748
 2016-09-30,IN,India,7.6535
-2016-09-30,IS,Iceland,12.8515
+2016-09-30,IS,Iceland,12.8663
 2016-09-30,IT,Italy,0
 2016-09-30,JP,Japan,1.7671
-2016-09-30,KR,Korea,2.0161
+2016-09-30,KR,Korea,2.0549
 2016-09-30,LT,Lithuania,5.3003
 2016-09-30,LU,Luxembourg,5.6871
 2016-09-30,LV,Latvia,9.6031
-2016-09-30,MA,Morocco,2.4414
-2016-09-30,MK,North Macedonia,0.3975
+2016-09-30,MA,Morocco,3.7488
+2016-09-30,MK,North Macedonia,0.3005
 2016-09-30,MT,Malta,4.7711
 2016-09-30,MX,Mexico,6.0896
 2016-09-30,MY,Malaysia,6.8223
-2016-09-30,NL,Netherlands,4.9634
+2016-09-30,NL,Netherlands,5.5635
 2016-09-30,NO,Norway,7.913
 2016-09-30,NZ,New Zealand,14.0683
 2016-09-30,PE,Peru,-1.4345
@@ -22250,26 +6471,25 @@ date,country_code,country,price
 2016-09-30,SE,Sweden,7.0805
 2016-09-30,SG,Singapore,-3.0921
 2016-09-30,SI,Slovenia,4.9813
-2016-09-30,SK,Slovak Republic,7.529
-2016-09-30,TH,Thailand,0.1585
-2016-09-30,TR,Türkiye,13.5863
-2016-09-30,US,United States,5.2997
-2016-09-30,XM,Euro area,4.3878
-2016-09-30,XW,World,5.0589
-2016-09-30,ZA,South Africa,5.4229
-2016-12-31,4T,Emerging market economies (aggregate),6.034
-2016-12-31,5R,Advanced economies,5.2258
-2016-12-31,AE,United Arab Emirates,-0.4919
+2016-09-30,SK,Slovakia,7.454
+2016-09-30,TH,Thailand,4.7214
+2016-09-30,TR,Türkiye,12.5199
+2016-09-30,US,United States,5.3131
+2016-09-30,XM,Euro area,4.3768
+2016-09-30,XW,World,5.1414
+2016-09-30,ZA,South Africa,4.8451
+2016-12-31,4T,Emerging market economies (aggregate),6.4843
+2016-12-31,5R,Advanced economies,5.0331
 2016-12-31,AT,Austria,4.5691
 2016-12-31,AU,Australia,7.657
-2016-12-31,BE,Belgium,2.6163
-2016-12-31,BG,Bulgaria,8.1091
+2016-12-31,BE,Belgium,2.4352
+2016-12-31,BG,Bulgaria,8.1092
 2016-12-31,BR,Brazil,-2.8282
-2016-12-31,CA,Canada,16.0926
+2016-12-31,CA,Canada,16.0131
 2016-12-31,CH,Switzerland,-1.3343
-2016-12-31,CL,Chile,3.5989
+2016-12-31,CL,Chile,3.5927
 2016-12-31,CN,China,9.514
-2016-12-31,CO,Colombia,10.0556
+2016-12-31,CO,Colombia,9.6801
 2016-12-31,CY,Cyprus,-0.9436
 2016-12-31,CZ,Czechia,10.9145
 2016-12-31,DE,Germany,8.3822
@@ -22278,60 +6498,59 @@ date,country_code,country,price
 2016-12-31,ES,Spain,4.4122
 2016-12-31,FI,Finland,1.3026
 2016-12-31,FR,France,1.5968
-2016-12-31,GB,United Kingdom,5.3271
+2016-12-31,GB,United Kingdom,5.4167
 2016-12-31,GR,Greece,-1.0342
 2016-12-31,HK,Hong Kong SAR,4.2807
-2016-12-31,HR,Croatia,0.8001
-2016-12-31,HU,Hungary,11.8052
+2016-12-31,HR,Croatia,0.8
+2016-12-31,HU,Hungary,11.8053
 2016-12-31,ID,Indonesia,2.3787
-2016-12-31,IE,Ireland,8.5484
+2016-12-31,IE,Ireland,8.5244
 2016-12-31,IL,Israel,6.8003
 2016-12-31,IN,India,8.3446
-2016-12-31,IS,Iceland,14.6778
+2016-12-31,IS,Iceland,14.6846
 2016-12-31,IT,Italy,0.2004
 2016-12-31,JP,Japan,2.528
-2016-12-31,KR,Korea,1.5064
+2016-12-31,KR,Korea,1.4866
 2016-12-31,LT,Lithuania,9.4547
 2016-12-31,LU,Luxembourg,7.7749
 2016-12-31,LV,Latvia,7.7608
-2016-12-31,MA,Morocco,5.0374
-2016-12-31,MK,North Macedonia,1.4743
+2016-12-31,MA,Morocco,4.4651
+2016-12-31,MK,North Macedonia,1.6365
 2016-12-31,MT,Malta,4.9103
 2016-12-31,MX,Mexico,5.8685
 2016-12-31,MY,Malaysia,6.9726
-2016-12-31,NL,Netherlands,5.9832
+2016-12-31,NL,Netherlands,6.383
 2016-12-31,NO,Norway,10.0908
 2016-12-31,NZ,New Zealand,14.2718
 2016-12-31,PE,Peru,2.173
 2016-12-31,PH,Philippines,7.5512
 2016-12-31,PL,Poland,3.9848
-2016-12-31,PT,Portugal,7.5904
+2016-12-31,PT,Portugal,7.5903
 2016-12-31,RO,Romania,8
 2016-12-31,RS,Serbia,23.2706
 2016-12-31,RU,Russia,-4.0864
 2016-12-31,SE,Sweden,6.486
 2016-12-31,SG,Singapore,-3.1074
 2016-12-31,SI,Slovenia,6.8868
-2016-12-31,SK,Slovak Republic,8.3095
-2016-12-31,TH,Thailand,-0.5473
-2016-12-31,TR,Türkiye,12.1893
-2016-12-31,US,United States,5.4014
-2016-12-31,XM,Euro area,4.5436
-2016-12-31,XW,World,5.6522
-2016-12-31,ZA,South Africa,4.8367
-2017-03-31,4T,Emerging market economies (aggregate),5.938
-2017-03-31,5R,Advanced economies,5.4359
-2017-03-31,AE,United Arab Emirates,-1.4054
-2017-03-31,AT,Austria,2.2917
+2016-12-31,SK,Slovakia,8.2376
+2016-12-31,TH,Thailand,3.4815
+2016-12-31,TR,Türkiye,11.6486
+2016-12-31,US,United States,5.3897
+2016-12-31,XM,Euro area,4.5359
+2016-12-31,XW,World,5.7402
+2016-12-31,ZA,South Africa,3.8852
+2017-03-31,4T,Emerging market economies (aggregate),6.2712
+2017-03-31,5R,Advanced economies,5.3008
+2017-03-31,AT,Austria,2.2918
 2017-03-31,AU,Australia,10.1994
-2017-03-31,BE,Belgium,4.4252
-2017-03-31,BG,Bulgaria,8.9767
-2017-03-31,BR,Brazil,-2.6078
-2017-03-31,CA,Canada,17.5689
-2017-03-31,CH,Switzerland,-2.2963
-2017-03-31,CL,Chile,6.0422
+2017-03-31,BE,Belgium,3.9753
+2017-03-31,BG,Bulgaria,8.9766
+2017-03-31,BR,Brazil,-2.606
+2017-03-31,CA,Canada,17.5892
+2017-03-31,CH,Switzerland,-2.2962
+2017-03-31,CL,Chile,6.0463
 2017-03-31,CN,China,8.148
-2017-03-31,CO,Colombia,5.9439
+2017-03-31,CO,Colombia,5.7277
 2017-03-31,CY,Cyprus,0.0816
 2017-03-31,CZ,Czechia,12.8155
 2017-03-31,DE,Germany,6.7379
@@ -22340,28 +6559,28 @@ date,country_code,country,price
 2017-03-31,ES,Spain,5.3144
 2017-03-31,FI,Finland,1.194
 2017-03-31,FR,France,2.8084
-2017-03-31,GB,United Kingdom,4.4362
+2017-03-31,GB,United Kingdom,4.3956
 2017-03-31,GR,Greece,-1.8786
-2017-03-31,HK,Hong Kong SAR,14.6862
+2017-03-31,HK,Hong Kong SAR,14.6584
 2017-03-31,HR,Croatia,-0.2964
 2017-03-31,HU,Hungary,11.7492
 2017-03-31,ID,Indonesia,2.6264
-2017-03-31,IE,Ireland,9.4014
+2017-03-31,IE,Ireland,9.3218
 2017-03-31,IL,Israel,5.1971
 2017-03-31,IN,India,10.4531
-2017-03-31,IS,Iceland,17.8403
+2017-03-31,IS,Iceland,17.8551
 2017-03-31,IT,Italy,-0.7014
 2017-03-31,JP,Japan,3.9063
-2017-03-31,KR,Korea,1.2351
+2017-03-31,KR,Korea,1.2497
 2017-03-31,LT,Lithuania,10.2401
 2017-03-31,LU,Luxembourg,6.9759
 2017-03-31,LV,Latvia,9.285
-2017-03-31,MA,Morocco,7.2897
-2017-03-31,MK,North Macedonia,-3.8089
+2017-03-31,MA,Morocco,5.2288
+2017-03-31,MK,North Macedonia,-3.9306
 2017-03-31,MT,Malta,5.2841
 2017-03-31,MX,Mexico,7.3644
 2017-03-31,MY,Malaysia,6.6938
-2017-03-31,NL,Netherlands,6.6725
+2017-03-31,NL,Netherlands,7.4438
 2017-03-31,NO,Norway,10.1167
 2017-03-31,NZ,New Zealand,12.1019
 2017-03-31,PE,Peru,5.1332
@@ -22369,31 +6588,30 @@ date,country_code,country,price
 2017-03-31,PL,Poland,3.33
 2017-03-31,PT,Portugal,7.929
 2017-03-31,RO,Romania,4.8077
-2017-03-31,RS,Serbia,13.4598
+2017-03-31,RS,Serbia,12.7653
 2017-03-31,RU,Russia,-4.1605
 2017-03-31,SE,Sweden,7.9108
 2017-03-31,SG,Singapore,-2.7738
 2017-03-31,SI,Slovenia,6.6772
-2017-03-31,SK,Slovak Republic,3.7523
-2017-03-31,TH,Thailand,-1.1728
-2017-03-31,TR,Türkiye,11.8857
-2017-03-31,US,United States,5.5327
-2017-03-31,XM,Euro area,4.4071
-2017-03-31,XW,World,5.6996
-2017-03-31,ZA,South Africa,4.5293
-2017-06-30,4T,Emerging market economies (aggregate),5.8234
-2017-06-30,5R,Advanced economies,5.3115
-2017-06-30,AE,United Arab Emirates,-0.9989
+2017-03-31,SK,Slovakia,3.5748
+2017-03-31,TH,Thailand,1.4684
+2017-03-31,TR,Türkiye,11.919
+2017-03-31,US,United States,5.5262
+2017-03-31,XM,Euro area,4.3965
+2017-03-31,XW,World,5.7709
+2017-03-31,ZA,South Africa,3.7316
+2017-06-30,4T,Emerging market economies (aggregate),6.1013
+2017-06-30,5R,Advanced economies,5.2411
 2017-06-30,AT,Austria,3.6324
 2017-06-30,AU,Australia,10.1504
-2017-06-30,BE,Belgium,2.8698
-2017-06-30,BG,Bulgaria,8.5937
-2017-06-30,BR,Brazil,-2.2379
-2017-06-30,CA,Canada,16.6012
-2017-06-30,CH,Switzerland,0.0257
-2017-06-30,CL,Chile,8.1249
+2017-06-30,BE,Belgium,3.0172
+2017-06-30,BG,Bulgaria,8.5938
+2017-06-30,BR,Brazil,-2.2361
+2017-06-30,CA,Canada,16.8691
+2017-06-30,CH,Switzerland,0.0262
+2017-06-30,CL,Chile,8.1177
 2017-06-30,CN,China,8.0474
-2017-06-30,CO,Colombia,6.6626
+2017-06-30,CO,Colombia,6.6967
 2017-06-30,CY,Cyprus,1.311
 2017-06-30,CZ,Czechia,13.3206
 2017-06-30,DE,Germany,5.8307
@@ -22402,28 +6620,28 @@ date,country_code,country,price
 2017-06-30,ES,Spain,5.5858
 2017-06-30,FI,Finland,1.5748
 2017-06-30,FR,France,3.2934
-2017-06-30,GB,United Kingdom,4.5249
+2017-06-30,GB,United Kingdom,4.4355
 2017-06-30,GR,Greece,-1.0558
-2017-06-30,HK,Hong Kong SAR,21.1802
-2017-06-30,HR,Croatia,4.2872
-2017-06-30,HU,Hungary,12.0658
+2017-06-30,HK,Hong Kong SAR,21.1024
+2017-06-30,HR,Croatia,4.2871
+2017-06-30,HU,Hungary,12.0659
 2017-06-30,ID,Indonesia,3.1741
-2017-06-30,IE,Ireland,10.5681
+2017-06-30,IE,Ireland,10.5598
 2017-06-30,IL,Israel,4.7076
 2017-06-30,IN,India,8.7044
-2017-06-30,IS,Iceland,23.1502
+2017-06-30,IS,Iceland,23.1412
 2017-06-30,IT,Italy,-0.8955
 2017-06-30,JP,Japan,2.0111
-2017-06-30,KR,Korea,1.2335
+2017-06-30,KR,Korea,1.2395
 2017-06-30,LT,Lithuania,10.2108
 2017-06-30,LU,Luxembourg,6.4129
 2017-06-30,LV,Latvia,9.1336
-2017-06-30,MA,Morocco,6.4306
-2017-06-30,MK,North Macedonia,-2.2368
+2017-06-30,MA,Morocco,4.2632
+2017-06-30,MK,North Macedonia,-2.3621
 2017-06-30,MT,Malta,5.9338
 2017-06-30,MX,Mexico,7.4817
 2017-06-30,MY,Malaysia,6.8234
-2017-06-30,NL,Netherlands,7.5401
+2017-06-30,NL,Netherlands,7.7562
 2017-06-30,NO,Norway,6.9094
 2017-06-30,NZ,New Zealand,6.6798
 2017-06-30,PE,Peru,1.5838
@@ -22431,31 +6649,30 @@ date,country_code,country,price
 2017-06-30,PL,Poland,4.5616
 2017-06-30,PT,Portugal,8.0441
 2017-06-30,RO,Romania,6.5421
-2017-06-30,RS,Serbia,8.0907
+2017-06-30,RS,Serbia,7.8883
 2017-06-30,RU,Russia,-3.7138
 2017-06-30,SE,Sweden,8.4913
 2017-06-30,SG,Singapore,-2.4286
 2017-06-30,SI,Slovenia,8.2555
-2017-06-30,SK,Slovak Republic,6.6606
-2017-06-30,TH,Thailand,-0.3094
-2017-06-30,TR,Türkiye,10.8287
-2017-06-30,US,United States,5.8428
-2017-06-30,XM,Euro area,4.3357
-2017-06-30,XW,World,5.5817
-2017-06-30,ZA,South Africa,4.2593
-2017-09-30,4T,Emerging market economies (aggregate),5.233
-2017-09-30,5R,Advanced economies,5.3135
-2017-09-30,AE,United Arab Emirates,-2.4876
-2017-09-30,AT,Austria,4.5556
+2017-06-30,SK,Slovakia,6.4959
+2017-06-30,TH,Thailand,0.7994
+2017-06-30,TR,Türkiye,11.7369
+2017-06-30,US,United States,5.8406
+2017-06-30,XM,Euro area,4.3298
+2017-06-30,XW,World,5.6612
+2017-06-30,ZA,South Africa,4.3104
+2017-09-30,4T,Emerging market economies (aggregate),5.4467
+2017-09-30,5R,Advanced economies,5.2445
+2017-09-30,AT,Austria,4.3816
 2017-09-30,AU,Australia,8.2963
-2017-09-30,BE,Belgium,3.7101
+2017-09-30,BE,Belgium,4.0336
 2017-09-30,BG,Bulgaria,8.9679
-2017-09-30,BR,Brazil,-1.726
-2017-09-30,CA,Canada,14.7495
-2017-09-30,CH,Switzerland,2.6006
-2017-09-30,CL,Chile,8.752
+2017-09-30,BR,Brazil,-1.7222
+2017-09-30,CA,Canada,15.0182
+2017-09-30,CH,Switzerland,2.6007
+2017-09-30,CL,Chile,8.7481
 2017-09-30,CN,China,6.8338
-2017-09-30,CO,Colombia,6.7862
+2017-09-30,CO,Colombia,6.6706
 2017-09-30,CY,Cyprus,1.61
 2017-09-30,CZ,Czechia,12.5348
 2017-09-30,DE,Germany,5.6471
@@ -22464,28 +6681,28 @@ date,country_code,country,price
 2017-09-30,ES,Spain,6.6597
 2017-09-30,FI,Finland,0.5888
 2017-09-30,FR,France,3.2227
-2017-09-30,GB,United Kingdom,4.6986
+2017-09-30,GB,United Kingdom,4.7431
 2017-09-30,GR,Greece,-0.658
 2017-09-30,HK,Hong Kong SAR,17.6471
-2017-09-30,HR,Croatia,3.7511
+2017-09-30,HR,Croatia,3.7512
 2017-09-30,HU,Hungary,12.2239
 2017-09-30,ID,Indonesia,3.3173
-2017-09-30,IE,Ireland,11.7669
+2017-09-30,IE,Ireland,11.7378
 2017-09-30,IL,Israel,3.716
 2017-09-30,IN,India,7.45
-2017-09-30,IS,Iceland,20.3999
+2017-09-30,IS,Iceland,20.3854
 2017-09-30,IT,Italy,-1.4896
 2017-09-30,JP,Japan,2.4496
-2017-09-30,KR,Korea,1.4932
+2017-09-30,KR,Korea,1.4545
 2017-09-30,LT,Lithuania,8.5411
 2017-09-30,LU,Luxembourg,4.9293
 2017-09-30,LV,Latvia,8.7909
-2017-09-30,MA,Morocco,5.4994
-2017-09-30,MK,North Macedonia,-0.8882
+2017-09-30,MA,Morocco,1.8067
+2017-09-30,MK,North Macedonia,-0.9309
 2017-09-30,MT,Malta,5.0186
 2017-09-30,MX,Mexico,7.8989
 2017-09-30,MY,Malaysia,6.4986
-2017-09-30,NL,Netherlands,7.4039
+2017-09-30,NL,Netherlands,8.1081
 2017-09-30,NO,Norway,2.4748
 2017-09-30,NZ,New Zealand,3.6505
 2017-09-30,PE,Peru,2.4773
@@ -22493,31 +6710,30 @@ date,country_code,country,price
 2017-09-30,PL,Poland,3.6698
 2017-09-30,PT,Portugal,10.4238
 2017-09-30,RO,Romania,5.6604
-2017-09-30,RS,Serbia,-0.8523
+2017-09-30,RS,Serbia,-0.6522
 2017-09-30,RU,Russia,-3.5515
 2017-09-30,SE,Sweden,7.5353
 2017-09-30,SG,Singapore,-0.2175
 2017-09-30,SI,Slovenia,8.1782
-2017-09-30,SK,Slovak Republic,7.271
-2017-09-30,TH,Thailand,3.4019
-2017-09-30,TR,Türkiye,9.2672
-2017-09-30,US,United States,5.9887
-2017-09-30,XM,Euro area,4.3676
-2017-09-30,XW,World,5.2703
-2017-09-30,ZA,South Africa,4.1578
-2017-12-31,4T,Emerging market economies (aggregate),4.5761
-2017-12-31,5R,Advanced economies,5.1945
-2017-12-31,AE,United Arab Emirates,-3.8246
-2017-12-31,AT,Austria,4.7014
+2017-09-30,SK,Slovakia,7.2972
+2017-09-30,TH,Thailand,4.3607
+2017-09-30,TR,Türkiye,10.0284
+2017-09-30,US,United States,5.9948
+2017-09-30,XM,Euro area,4.362
+2017-09-30,XW,World,5.3409
+2017-09-30,ZA,South Africa,4.2046
+2017-12-31,4T,Emerging market economies (aggregate),4.7829
+2017-12-31,5R,Advanced economies,5.056
+2017-12-31,AT,Austria,4.7013
 2017-12-31,AU,Australia,4.9787
-2017-12-31,BE,Belgium,3.5501
+2017-12-31,BE,Belgium,3.1184
 2017-12-31,BG,Bulgaria,8.1524
-2017-12-31,BR,Brazil,-1.1125
-2017-12-31,CA,Canada,13.8819
-2017-12-31,CH,Switzerland,3.3073
-2017-12-31,CL,Chile,9.6744
+2017-12-31,BR,Brazil,-1.1049
+2017-12-31,CA,Canada,13.8726
+2017-12-31,CH,Switzerland,3.3077
+2017-12-31,CL,Chile,9.6774
 2017-12-31,CN,China,4.9908
-2017-12-31,CO,Colombia,7.3057
+2017-12-31,CO,Colombia,6.9029
 2017-12-31,CY,Cyprus,1.7827
 2017-12-31,CZ,Czechia,8.422
 2017-12-31,DE,Germany,6.2645
@@ -22526,28 +6742,28 @@ date,country_code,country,price
 2017-12-31,ES,Spain,7.1942
 2017-12-31,FI,Finland,0.9891
 2017-12-31,FR,France,3.3399
-2017-12-31,GB,United Kingdom,4.7028
-2017-12-31,GR,Greece,-0.4213
+2017-12-31,GB,United Kingdom,4.6113
+2017-12-31,GR,Greece,-0.4214
 2017-12-31,HK,Hong Kong SAR,13.6868
 2017-12-31,HR,Croatia,7.6389
-2017-12-31,HU,Hungary,12.8335
+2017-12-31,HU,Hungary,12.8334
 2017-12-31,ID,Indonesia,3.5057
-2017-12-31,IE,Ireland,11.6642
+2017-12-31,IE,Ireland,11.7227
 2017-12-31,IL,Israel,2.0591
 2017-12-31,IN,India,7.2024
-2017-12-31,IS,Iceland,14.9972
+2017-12-31,IS,Iceland,15.0024
 2017-12-31,IT,Italy,-1.2
 2017-12-31,JP,Japan,1.8102
-2017-12-31,KR,Korea,1.2222
+2017-12-31,KR,Korea,1.2588
 2017-12-31,LT,Lithuania,6.8921
 2017-12-31,LU,Luxembourg,4.2039
 2017-12-31,LV,Latvia,7.9264
-2017-12-31,MA,Morocco,1.5986
-2017-12-31,MK,North Macedonia,-0.3098
+2017-12-31,MA,Morocco,0.0891
+2017-12-31,MK,North Macedonia,-0.5545
 2017-12-31,MT,Malta,4.9505
 2017-12-31,MX,Mexico,8.5656
 2017-12-31,MY,Malaysia,6.1281
-2017-12-31,NL,Netherlands,8.4914
+2017-12-31,NL,Netherlands,8.9333
 2017-12-31,NO,Norway,0.7333
 2017-12-31,NZ,New Zealand,4.0566
 2017-12-31,PE,Peru,0.2096
@@ -22555,31 +6771,30 @@ date,country_code,country,price
 2017-12-31,PL,Poland,3.8513
 2017-12-31,PT,Portugal,10.4864
 2017-12-31,RO,Romania,5.5555
-2017-12-31,RS,Serbia,-1.8359
+2017-12-31,RS,Serbia,-1.2784
 2017-12-31,RU,Russia,-3.0251
 2017-12-31,SE,Sweden,2.7669
 2017-12-31,SG,Singapore,1.0933
 2017-12-31,SI,Slovenia,9.873
-2017-12-31,SK,Slovak Republic,5.8201
-2017-12-31,TH,Thailand,5.1887
-2017-12-31,TR,Türkiye,9.0717
-2017-12-31,US,United States,6.015
-2017-12-31,XM,Euro area,4.6956
-2017-12-31,XW,World,4.8675
-2017-12-31,ZA,South Africa,3.9082
-2018-03-31,4T,Emerging market economies (aggregate),4.5699
-2018-03-31,5R,Advanced economies,4.9568
-2018-03-31,AE,United Arab Emirates,-5.4153
+2017-12-31,SK,Slovakia,5.9292
+2017-12-31,TH,Thailand,4.796
+2017-12-31,TR,Türkiye,9.6707
+2017-12-31,US,United States,6.032
+2017-12-31,XM,Euro area,4.689
+2017-12-31,XW,World,4.922
+2017-12-31,ZA,South Africa,4.2716
+2018-03-31,4T,Emerging market economies (aggregate),4.7216
+2018-03-31,5R,Advanced economies,4.8983
 2018-03-31,AT,Austria,7.3224
 2018-03-31,AU,Australia,2.0181
-2018-03-31,BE,Belgium,2.5331
+2018-03-31,BE,Belgium,2.8842
 2018-03-31,BG,Bulgaria,7.0921
-2018-03-31,BR,Brazil,-0.4447
+2018-03-31,BR,Brazil,-0.4351
 2018-03-31,CA,Canada,7.4423
 2018-03-31,CH,Switzerland,3.0287
-2018-03-31,CL,Chile,8.6332
+2018-03-31,CL,Chile,8.4669
 2018-03-31,CN,China,4.357
-2018-03-31,CO,Colombia,6.9994
+2018-03-31,CO,Colombia,6.4051
 2018-03-31,CY,Cyprus,2.1181
 2018-03-31,CZ,Czechia,7.5731
 2018-03-31,DE,Germany,6.6975
@@ -22588,28 +6803,28 @@ date,country_code,country,price
 2018-03-31,ES,Spain,6.2477
 2018-03-31,FI,Finland,0.9833
 2018-03-31,FR,France,2.9268
-2018-03-31,GB,United Kingdom,4.2478
-2018-03-31,GR,Greece,0.4745
+2018-03-31,GB,United Kingdom,4.3421
+2018-03-31,GR,Greece,0.4744
 2018-03-31,HK,Hong Kong SAR,15.663
-2018-03-31,HR,Croatia,8.4241
-2018-03-31,HU,Hungary,13.3794
+2018-03-31,HR,Croatia,8.4242
+2018-03-31,HU,Hungary,13.3793
 2018-03-31,ID,Indonesia,3.6914
-2018-03-31,IE,Ireland,12.3026
+2018-03-31,IE,Ireland,12.3493
 2018-03-31,IL,Israel,0.3458
 2018-03-31,IN,India,6.7054
-2018-03-31,IS,Iceland,13.18
+2018-03-31,IS,Iceland,13.1793
 2018-03-31,IT,Italy,-0.5045
 2018-03-31,JP,Japan,1.5338
-2018-03-31,KR,Korea,1.6122
+2018-03-31,KR,Korea,1.6199
 2018-03-31,LT,Lithuania,7.8128
 2018-03-31,LU,Luxembourg,6.3752
 2018-03-31,LV,Latvia,11.4158
-2018-03-31,MA,Morocco,-0.0871
-2018-03-31,MK,North Macedonia,4.1457
+2018-03-31,MA,Morocco,-0.2662
+2018-03-31,MK,North Macedonia,4.2665
 2018-03-31,MT,Malta,5.3977
 2018-03-31,MX,Mexico,8.4283
 2018-03-31,MY,Malaysia,4.3099
-2018-03-31,NL,Netherlands,9.328
+2018-03-31,NL,Netherlands,9.1503
 2018-03-31,NO,Norway,-1.0601
 2018-03-31,NZ,New Zealand,3.5831
 2018-03-31,PE,Peru,-0.7507
@@ -22617,31 +6832,30 @@ date,country_code,country,price
 2018-03-31,PL,Poland,5.9518
 2018-03-31,PT,Portugal,12.2352
 2018-03-31,RO,Romania,6.422
-2018-03-31,RS,Serbia,6.1546
+2018-03-31,RS,Serbia,7.7359
 2018-03-31,RU,Russia,0.257
 2018-03-31,SE,Sweden,-0.6849
 2018-03-31,SG,Singapore,5.4134
 2018-03-31,SI,Slovenia,9.6211
-2018-03-31,SK,Slovak Republic,11.6636
-2018-03-31,TH,Thailand,6.962
-2018-03-31,TR,Türkiye,7.9673
-2018-03-31,US,United States,6.2494
-2018-03-31,XM,Euro area,4.9604
-2018-03-31,XW,World,4.7494
-2018-03-31,ZA,South Africa,3.4986
-2018-06-30,4T,Emerging market economies (aggregate),4.3052
-2018-06-30,5R,Advanced economies,4.5731
-2018-06-30,AE,United Arab Emirates,-7.0589
+2018-03-31,SK,Slovakia,11.8982
+2018-03-31,TH,Thailand,6.2952
+2018-03-31,TR,Türkiye,8.138
+2018-03-31,US,United States,6.2414
+2018-03-31,XM,Euro area,4.9526
+2018-03-31,XW,World,4.8077
+2018-03-31,ZA,South Africa,3.9311
+2018-06-30,4T,Emerging market economies (aggregate),4.3999
+2018-06-30,5R,Advanced economies,4.6021
 2018-06-30,AT,Austria,4.9389
 2018-06-30,AU,Australia,-0.6143
-2018-06-30,BE,Belgium,3.8789
+2018-06-30,BE,Belgium,3.8572
 2018-06-30,BG,Bulgaria,7.5063
-2018-06-30,BR,Brazil,0.2146
+2018-06-30,BR,Brazil,0.226
 2018-06-30,CA,Canada,2.9762
 2018-06-30,CH,Switzerland,3.2651
-2018-06-30,CL,Chile,9.8279
+2018-06-30,CL,Chile,9.7117
 2018-06-30,CN,China,3.8279
-2018-06-30,CO,Colombia,7.1067
+2018-06-30,CO,Colombia,7.1837
 2018-06-30,CY,Cyprus,1.7387
 2018-06-30,CZ,Czechia,8.0605
 2018-06-30,DE,Germany,6.6415
@@ -22650,28 +6864,28 @@ date,country_code,country,price
 2018-06-30,ES,Spain,6.8032
 2018-06-30,FI,Finland,0.7752
 2018-06-30,FR,France,2.8019
-2018-06-30,GB,United Kingdom,3.1169
-2018-06-30,GR,Greece,1.2704
-2018-06-30,HK,Hong Kong SAR,15.1385
-2018-06-30,HR,Croatia,4.4932
-2018-06-30,HU,Hungary,13.5609
+2018-06-30,GB,United Kingdom,3.2175
+2018-06-30,GR,Greece,1.2703
+2018-06-30,HK,Hong Kong SAR,15.1846
+2018-06-30,HR,Croatia,4.4933
+2018-06-30,HU,Hungary,13.5608
 2018-06-30,ID,Indonesia,3.0826
-2018-06-30,IE,Ireland,12.5404
+2018-06-30,IE,Ireland,12.6007
 2018-06-30,IL,Israel,-0.3333
 2018-06-30,IN,India,5.3264
-2018-06-30,IS,Iceland,6.906
+2018-06-30,IS,Iceland,6.8932
 2018-06-30,IT,Italy,-0.4016
 2018-06-30,JP,Japan,1.9108
-2018-06-30,KR,Korea,1.9582
+2018-06-30,KR,Korea,1.9803
 2018-06-30,LT,Lithuania,7.4048
 2018-06-30,LU,Luxembourg,5.0802
 2018-06-30,LV,Latvia,8.6851
-2018-06-30,MA,Morocco,0.1752
-2018-06-30,MK,North Macedonia,2.4398
+2018-06-30,MA,Morocco,0
+2018-06-30,MK,North Macedonia,2.4952
 2018-06-30,MT,Malta,6.0606
 2018-06-30,MX,Mexico,8.6693
 2018-06-30,MY,Malaysia,3.65
-2018-06-30,NL,Netherlands,9.2199
+2018-06-30,NL,Netherlands,9.383
 2018-06-30,NO,Norway,1.6594
 2018-06-30,NZ,New Zealand,3.6139
 2018-06-30,PE,Peru,-0.2168
@@ -22679,31 +6893,30 @@ date,country_code,country,price
 2018-06-30,PL,Poland,6.1741
 2018-06-30,PT,Portugal,11.2371
 2018-06-30,RO,Romania,5.2631
-2018-06-30,RS,Serbia,6.3219
+2018-06-30,RS,Serbia,7.573
 2018-06-30,RU,Russia,1.5468
 2018-06-30,SE,Sweden,-1.6675
 2018-06-30,SG,Singapore,9.0776
 2018-06-30,SI,Slovenia,7.7248
-2018-06-30,SK,Slovak Republic,6.929
-2018-06-30,TH,Thailand,5.5857
-2018-06-30,TR,Türkiye,8.7737
-2018-06-30,US,United States,5.9529
-2018-06-30,XM,Euro area,4.9529
-2018-06-30,XW,World,4.4329
-2018-06-30,ZA,South Africa,3.6422
-2018-09-30,4T,Emerging market economies (aggregate),5.1697
-2018-09-30,5R,Advanced economies,4.233
-2018-09-30,AE,United Arab Emirates,-7.9724
+2018-06-30,SK,Slovakia,7.1306
+2018-06-30,TH,Thailand,6.0562
+2018-06-30,TR,Türkiye,8.3902
+2018-06-30,US,United States,5.9625
+2018-06-30,XM,Euro area,4.9352
+2018-06-30,XW,World,4.5031
+2018-06-30,ZA,South Africa,3.4452
+2018-09-30,4T,Emerging market economies (aggregate),5.4375
+2018-09-30,5R,Advanced economies,4.2945
 2018-09-30,AT,Austria,7.9702
 2018-09-30,AU,Australia,-1.9152
-2018-09-30,BE,Belgium,2.5421
-2018-09-30,BG,Bulgaria,6.266
-2018-09-30,BR,Brazil,0.8446
+2018-09-30,BE,Belgium,2.625
+2018-09-30,BG,Bulgaria,6.2659
+2018-09-30,BR,Brazil,0.8561
 2018-09-30,CA,Canada,1.8609
 2018-09-30,CH,Switzerland,1.947
-2018-09-30,CL,Chile,11.7456
+2018-09-30,CL,Chile,11.8001
 2018-09-30,CN,China,5.7805
-2018-09-30,CO,Colombia,4.6462
+2018-09-30,CO,Colombia,4.8566
 2018-09-30,CY,Cyprus,2.0545
 2018-09-30,CZ,Czechia,8.8283
 2018-09-30,DE,Germany,7.0527
@@ -22712,28 +6925,28 @@ date,country_code,country,price
 2018-09-30,ES,Spain,7.16
 2018-09-30,FI,Finland,0.9756
 2018-09-30,FR,France,2.7436
-2018-09-30,GB,United Kingdom,2.7942
+2018-09-30,GB,United Kingdom,2.7673
 2018-09-30,GR,Greece,2.2758
 2018-09-30,HK,Hong Kong SAR,15.7957
-2018-09-30,HR,Croatia,6.8507
+2018-09-30,HR,Croatia,6.8506
 2018-09-30,HU,Hungary,14.8678
 2018-09-30,ID,Indonesia,2.8862
-2018-09-30,IE,Ireland,9.0971
+2018-09-30,IE,Ireland,9.1132
 2018-09-30,IL,Israel,-1.8236
 2018-09-30,IN,India,5.6814
-2018-09-30,IS,Iceland,5.0032
+2018-09-30,IS,Iceland,5.0162
 2018-09-30,IT,Italy,-0.8065
 2018-09-30,JP,Japan,1.7857
-2018-09-30,KR,Korea,2.1203
+2018-09-30,KR,Korea,2.1126
 2018-09-30,LT,Lithuania,6.5918
 2018-09-30,LU,Luxembourg,7.569
 2018-09-30,LV,Latvia,7.2013
-2018-09-30,MA,Morocco,-0.4344
-2018-09-30,MK,North Macedonia,2.9907
+2018-09-30,MA,Morocco,-0.2662
+2018-09-30,MK,North Macedonia,3.2617
 2018-09-30,MT,Malta,5.5752
 2018-09-30,MX,Mexico,9.048
 2018-09-30,MY,Malaysia,2.7354
-2018-09-30,NL,Netherlands,10.1473
+2018-09-30,NL,Netherlands,9.75
 2018-09-30,NO,Norway,2.9517
 2018-09-30,NZ,New Zealand,3.8624
 2018-09-30,PE,Peru,0.417
@@ -22741,31 +6954,30 @@ date,country_code,country,price
 2018-09-30,PL,Poland,6.5071
 2018-09-30,PT,Portugal,8.4615
 2018-09-30,RO,Romania,6.2501
-2018-09-30,RS,Serbia,6.9345
+2018-09-30,RS,Serbia,7.7832
 2018-09-30,RU,Russia,3.1728
 2018-09-30,SE,Sweden,-2.0674
 2018-09-30,SG,Singapore,8.7936
 2018-09-30,SI,Slovenia,9.3608
-2018-09-30,SK,Slovak Republic,4.3515
-2018-09-30,TH,Thailand,5.3558
-2018-09-30,TR,Türkiye,6.3116
-2018-09-30,US,United States,5.3787
-2018-09-30,XM,Euro area,4.9827
-2018-09-30,XW,World,4.7347
-2018-09-30,ZA,South Africa,4.0088
-2018-12-31,4T,Emerging market economies (aggregate),5.6399
-2018-12-31,5R,Advanced economies,3.8854
-2018-12-31,AE,United Arab Emirates,-8.9024
+2018-09-30,SK,Slovakia,4.3661
+2018-09-30,TH,Thailand,5.6657
+2018-09-30,TR,Türkiye,7.9871
+2018-09-30,US,United States,5.404
+2018-09-30,XM,Euro area,4.9821
+2018-09-30,XW,World,4.867
+2018-09-30,ZA,South Africa,3.3214
+2018-12-31,4T,Emerging market economies (aggregate),5.9961
+2018-12-31,5R,Advanced economies,3.9392
 2018-12-31,AT,Austria,7.3957
 2018-12-31,AU,Australia,-5.1491
-2018-12-31,BE,Belgium,2.5179
+2018-12-31,BE,Belgium,2.7254
 2018-12-31,BG,Bulgaria,5.5384
-2018-12-31,BR,Brazil,1.4649
+2018-12-31,BR,Brazil,1.4763
 2018-12-31,CA,Canada,1.7682
 2018-12-31,CH,Switzerland,3.6582
-2018-12-31,CL,Chile,9.7643
+2018-12-31,CL,Chile,10.0024
 2018-12-31,CN,China,7.2033
-2018-12-31,CO,Colombia,3.5648
+2018-12-31,CO,Colombia,3.0369
 2018-12-31,CY,Cyprus,2.5133
 2018-12-31,CZ,Czechia,9.8937
 2018-12-31,DE,Germany,6.2591
@@ -22774,28 +6986,28 @@ date,country_code,country,price
 2018-12-31,ES,Spain,6.6849
 2018-12-31,FI,Finland,1.0774
 2018-12-31,FR,France,3.2319
-2018-12-31,GB,United Kingdom,2.3729
+2018-12-31,GB,United Kingdom,2.3929
 2018-12-31,GR,Greece,3.1991
 2018-12-31,HK,Hong Kong SAR,5.8232
 2018-12-31,HR,Croatia,4.6083
 2018-12-31,HU,Hungary,15.4166
 2018-12-31,ID,Indonesia,2.6918
-2018-12-31,IE,Ireland,7.2522
+2018-12-31,IE,Ireland,7.2437
 2018-12-31,IL,Israel,-1.4746
 2018-12-31,IN,India,5.134
-2018-12-31,IS,Iceland,6.8962
+2018-12-31,IS,Iceland,6.888
 2018-12-31,IT,Italy,-0.5061
 2018-12-31,JP,Japan,2.5138
-2018-12-31,KR,Korea,3.2342
+2018-12-31,KR,Korea,3.1762
 2018-12-31,LT,Lithuania,7.397
 2018-12-31,LU,Luxembourg,9.163
 2018-12-31,LV,Latvia,11.0634
-2018-12-31,MA,Morocco,0.9615
-2018-12-31,MK,North Macedonia,2.0682
+2018-12-31,MA,Morocco,0.8008
+2018-12-31,MK,North Macedonia,2.3054
 2018-12-31,MT,Malta,6.1749
 2018-12-31,MX,Mexico,9.316
 2018-12-31,MY,Malaysia,2.5197
-2018-12-31,NL,Netherlands,9.1213
+2018-12-31,NL,Netherlands,8.9351
 2018-12-31,NO,Norway,2.2748
 2018-12-31,NZ,New Zealand,3.317
 2018-12-31,PE,Peru,1.5335
@@ -22803,31 +7015,30 @@ date,country_code,country,price
 2018-12-31,PL,Poland,7.6487
 2018-12-31,PT,Portugal,9.3177
 2018-12-31,RO,Romania,5.2631
-2018-12-31,RS,Serbia,7.9177
+2018-12-31,RS,Serbia,8.5909
 2018-12-31,RU,Russia,4.9169
 2018-12-31,SE,Sweden,0.7236
 2018-12-31,SG,Singapore,7.8587
 2018-12-31,SI,Slovenia,8.27
-2018-12-31,SK,Slovak Republic,6.8334
-2018-12-31,TH,Thailand,3.2885
-2018-12-31,TR,Türkiye,4.4487
-2018-12-31,US,United States,4.6315
-2018-12-31,XM,Euro area,4.8154
-2018-12-31,XW,World,4.8265
-2018-12-31,ZA,South Africa,4.04
-2019-03-31,4T,Emerging market economies (aggregate),5.6175
-2019-03-31,5R,Advanced economies,3.1649
-2019-03-31,AE,United Arab Emirates,-7.3284
+2018-12-31,SK,Slovakia,6.7669
+2018-12-31,TH,Thailand,2.3907
+2018-12-31,TR,Türkiye,6.8584
+2018-12-31,US,United States,4.6332
+2018-12-31,XM,Euro area,4.8172
+2018-12-31,XW,World,4.9727
+2018-12-31,ZA,South Africa,3.2722
+2019-03-31,4T,Emerging market economies (aggregate),6.0145
+2019-03-31,5R,Advanced economies,3.184
 2019-03-31,AT,Austria,4.9389
 2019-03-31,AU,Australia,-7.367
-2019-03-31,BE,Belgium,3.5943
+2019-03-31,BE,Belgium,3.3808
 2019-03-31,BG,Bulgaria,7.2938
-2019-03-31,BR,Brazil,2.1356
+2019-03-31,BR,Brazil,2.1449
 2019-03-31,CA,Canada,0.5854
 2019-03-31,CH,Switzerland,4.7554
-2019-03-31,CL,Chile,9.4887
+2019-03-31,CL,Chile,9.9837
 2019-03-31,CN,China,7.5963
-2019-03-31,CO,Colombia,5.6339
+2019-03-31,CO,Colombia,5.5003
 2019-03-31,CY,Cyprus,2.6592
 2019-03-31,CZ,Czechia,9.76
 2019-03-31,DE,Germany,5.3391
@@ -22836,60 +7047,59 @@ date,country_code,country,price
 2019-03-31,ES,Spain,6.8894
 2019-03-31,FI,Finland,0.3895
 2019-03-31,FR,France,2.9384
-2019-03-31,GB,United Kingdom,1.3582
-2019-03-31,GR,Greece,5.4974
+2019-03-31,GB,United Kingdom,1.3871
+2019-03-31,GR,Greece,5.4975
 2019-03-31,HK,Hong Kong SAR,1.2627
 2019-03-31,HR,Croatia,7.4954
 2019-03-31,HU,Hungary,19.0476
 2019-03-31,ID,Indonesia,1.6311
-2019-03-31,IE,Ireland,4.4474
+2019-03-31,IE,Ireland,4.4229
 2019-03-31,IL,Israel,0.8205
 2019-03-31,IN,India,3.6286
-2019-03-31,IS,Iceland,4.3766
+2019-03-31,IS,Iceland,4.3767
 2019-03-31,IT,Italy,-0.9128
 2019-03-31,JP,Japan,2.3104
-2019-03-31,KR,Korea,2.6587
+2019-03-31,KR,Korea,2.678
 2019-03-31,LT,Lithuania,7.8644
 2019-03-31,LU,Luxembourg,7.0205
 2019-03-31,LV,Latvia,6.3695
-2019-03-31,MA,Morocco,0
-2019-03-31,MK,North Macedonia,1.7435
+2019-03-31,MA,Morocco,-0.5338
+2019-03-31,MK,North Macedonia,1.6472
 2019-03-31,MT,Malta,6.4691
 2019-03-31,MX,Mexico,9.0328
 2019-03-31,MY,Malaysia,2.5105
-2019-03-31,NL,Netherlands,8.1401
+2019-03-31,NL,Netherlands,8.3832
 2019-03-31,NO,Norway,3.0357
 2019-03-31,NZ,New Zealand,2.5893
 2019-03-31,PE,Peru,2.5701
-2019-03-31,PH,Philippines,3.1987
+2019-03-31,PH,Philippines,3.0447
 2019-03-31,PL,Poland,8.0928
-2019-03-31,PT,Portugal,9.2052
+2019-03-31,PT,Portugal,9.2053
 2019-03-31,RO,Romania,3.4483
-2019-03-31,RS,Serbia,8.9799
+2019-03-31,RS,Serbia,9.6251
 2019-03-31,RU,Russia,7.2274
 2019-03-31,SE,Sweden,1.5225
 2019-03-31,SG,Singapore,3.1228
 2019-03-31,SI,Slovenia,7.5737
-2019-03-31,SK,Slovak Republic,5.749
-2019-03-31,TH,Thailand,2.145
-2019-03-31,TR,Türkiye,3.1221
-2019-03-31,US,United States,3.7959
-2019-03-31,XM,Euro area,4.1769
-2019-03-31,XW,World,4.4787
-2019-03-31,ZA,South Africa,3.6324
-2019-06-30,4T,Emerging market economies (aggregate),5.3343
-2019-06-30,5R,Advanced economies,3.065
-2019-06-30,AE,United Arab Emirates,-9.2561
+2019-03-31,SK,Slovakia,5.6819
+2019-03-31,TH,Thailand,0.953
+2019-03-31,TR,Türkiye,4.0879
+2019-03-31,US,United States,3.8232
+2019-03-31,XM,Euro area,4.1872
+2019-03-31,XW,World,4.6036
+2019-03-31,ZA,South Africa,3.2611
+2019-06-30,4T,Emerging market economies (aggregate),5.8125
+2019-06-30,5R,Advanced economies,3.0565
 2019-06-30,AT,Austria,5.5668
 2019-06-30,AU,Australia,-7.4176
-2019-06-30,BE,Belgium,3.0166
+2019-06-30,BE,Belgium,3.0688
 2019-06-30,BG,Bulgaria,5.023
-2019-06-30,BR,Brazil,2.9456
+2019-06-30,BR,Brazil,2.9473
 2019-06-30,CA,Canada,0.1927
 2019-06-30,CH,Switzerland,3.6557
-2019-06-30,CL,Chile,7.3824
+2019-06-30,CL,Chile,7.8195
 2019-06-30,CN,China,7.4021
-2019-06-30,CO,Colombia,3.3736
+2019-06-30,CO,Colombia,3.1608
 2019-06-30,CY,Cyprus,2.8352
 2019-06-30,CZ,Czechia,9.2463
 2019-06-30,DE,Germany,5.9448
@@ -22898,60 +7108,59 @@ date,country_code,country,price
 2019-06-30,ES,Spain,5.4029
 2019-06-30,FI,Finland,0.6731
 2019-06-30,FR,France,3.1955
-2019-06-30,GB,United Kingdom,1.0076
+2019-06-30,GB,United Kingdom,0.9975
 2019-06-30,GR,Greece,7.5932
-2019-06-30,HK,Hong Kong SAR,2.7616
-2019-06-30,HR,Croatia,10.3386
+2019-06-30,HK,Hong Kong SAR,2.7268
+2019-06-30,HR,Croatia,10.3385
 2019-06-30,HU,Hungary,19.6491
 2019-06-30,ID,Indonesia,1.2613
-2019-06-30,IE,Ireland,2.5224
+2019-06-30,IE,Ireland,2.4783
 2019-06-30,IL,Israel,1.2073
 2019-06-30,IN,India,3.447
-2019-06-30,IS,Iceland,4.1674
+2019-06-30,IS,Iceland,4.1747
 2019-06-30,IT,Italy,-0.1008
 2019-06-30,JP,Japan,1.9345
-2019-06-30,KR,Korea,1.8779
+2019-06-30,KR,Korea,1.8502
 2019-06-30,LT,Lithuania,6.5935
 2019-06-30,LU,Luxembourg,11.3656
 2019-06-30,LV,Latvia,7.9169
-2019-06-30,MA,Morocco,-0.2623
-2019-06-30,MK,North Macedonia,5.515
+2019-06-30,MA,Morocco,-0.6222
+2019-06-30,MK,North Macedonia,5.5884
 2019-06-30,MT,Malta,6.3204
 2019-06-30,MX,Mexico,9.177
 2019-06-30,MY,Malaysia,2.3304
-2019-06-30,NL,Netherlands,8.3265
+2019-06-30,NL,Netherlands,7.7556
 2019-06-30,NO,Norway,1.9759
 2019-06-30,NZ,New Zealand,2.0023
 2019-06-30,PE,Peru,4.7362
-2019-06-30,PH,Philippines,0.8354
+2019-06-30,PH,Philippines,6.1155
 2019-06-30,PL,Poland,8.1733
 2019-06-30,PT,Portugal,9.4638
 2019-06-30,RO,Romania,1.6667
-2019-06-30,RS,Serbia,9.76
+2019-06-30,RS,Serbia,10.8504
 2019-06-30,RU,Russia,6.9115
 2019-06-30,SE,Sweden,2.171
 2019-06-30,SG,Singapore,1.208
 2019-06-30,SI,Slovenia,7.421
-2019-06-30,SK,Slovak Republic,8.32
-2019-06-30,TH,Thailand,0.8082
-2019-06-30,TR,Türkiye,1.7415
-2019-06-30,US,United States,3.6274
-2019-06-30,XM,Euro area,4.3621
-2019-06-30,XW,World,4.2831
-2019-06-30,ZA,South Africa,3.4793
-2019-09-30,4T,Emerging market economies (aggregate),4.8462
-2019-09-30,5R,Advanced economies,3.083
-2019-09-30,AE,United Arab Emirates,-7.4725
+2019-06-30,SK,Slovakia,8.2599
+2019-06-30,TH,Thailand,1.6315
+2019-06-30,TR,Türkiye,2.5203
+2019-06-30,US,United States,3.6612
+2019-06-30,XM,Euro area,4.3774
+2019-06-30,XW,World,4.4414
+2019-06-30,ZA,South Africa,2.6575
+2019-09-30,4T,Emerging market economies (aggregate),5.0975
+2019-09-30,5R,Advanced economies,3.0145
 2019-09-30,AT,Austria,2.2638
 2019-09-30,AU,Australia,-3.696
-2019-09-30,BE,Belgium,4.5344
-2019-09-30,BG,Bulgaria,5.5845
-2019-09-30,BR,Brazil,3.9172
+2019-09-30,BE,Belgium,4.2751
+2019-09-30,BG,Bulgaria,5.5844
+2019-09-30,BR,Brazil,3.9052
 2019-09-30,CA,Canada,0.1923
 2019-09-30,CH,Switzerland,3.148
-2019-09-30,CL,Chile,7.6877
+2019-09-30,CL,Chile,7.9575
 2019-09-30,CN,China,5.2704
-2019-09-30,CO,Colombia,6.408
+2019-09-30,CO,Colombia,5.7733
 2019-09-30,CY,Cyprus,2.8026
 2019-09-30,CZ,Czechia,8.7188
 2019-09-30,DE,Germany,5.2705
@@ -22960,60 +7169,59 @@ date,country_code,country,price
 2019-09-30,ES,Spain,4.7975
 2019-09-30,FI,Finland,0.4831
 2019-09-30,FR,France,3.407
-2019-09-30,GB,United Kingdom,0.7414
-2019-09-30,GR,Greece,8.2864
+2019-09-30,GB,United Kingdom,0.7344
+2019-09-30,GR,Greece,8.2863
 2019-09-30,HK,Hong Kong SAR,-1.3319
-2019-09-30,HR,Croatia,8.1032
+2019-09-30,HR,Croatia,8.1033
 2019-09-30,HU,Hungary,16.633
 2019-09-30,ID,Indonesia,1.2474
-2019-09-30,IE,Ireland,1.7177
+2019-09-30,IE,Ireland,1.7504
 2019-09-30,IL,Israel,1.9557
 2019-09-30,IN,India,3.2504
-2019-09-30,IS,Iceland,3.3261
+2019-09-30,IS,Iceland,3.3258
 2019-09-30,IT,Italy,0.4065
 2019-09-30,JP,Japan,1.2489
-2019-09-30,KR,Korea,1.1017
+2019-09-30,KR,Korea,1.1236
 2019-09-30,LT,Lithuania,6.4415
 2019-09-30,LU,Luxembourg,11.2582
 2019-09-30,LV,Latvia,12.6526
-2019-09-30,MA,Morocco,0.349
-2019-09-30,MK,North Macedonia,1.9394
+2019-09-30,MA,Morocco,0.089
+2019-09-30,MK,North Macedonia,1.6839
 2019-09-30,MT,Malta,5.9514
 2019-09-30,MX,Mexico,8.4429
 2019-09-30,MY,Malaysia,2.1505
-2019-09-30,NL,Netherlands,6.2505
+2019-09-30,NL,Netherlands,6.3781
 2019-09-30,NO,Norway,2.3458
 2019-09-30,NZ,New Zealand,3.095
 2019-09-30,PE,Peru,1.9738
-2019-09-30,PH,Philippines,10.394
+2019-09-30,PH,Philippines,6.9851
 2019-09-30,PL,Poland,8.9571
-2019-09-30,PT,Portugal,10.754
+2019-09-30,PT,Portugal,10.7539
 2019-09-30,RO,Romania,4.2017
-2019-09-30,RS,Serbia,10.1364
+2019-09-30,RS,Serbia,11.7963
 2019-09-30,RU,Russia,8.0942
 2019-09-30,SE,Sweden,2.9387
 2019-09-30,SG,Singapore,2.0708
 2019-09-30,SI,Slovenia,7.0595
-2019-09-30,SK,Slovak Republic,11.4676
-2019-09-30,TH,Thailand,-0.4357
-2019-09-30,TR,Türkiye,6.8646
-2019-09-30,US,United States,3.8391
-2019-09-30,XM,Euro area,4.0783
-2019-09-30,XW,World,4.0318
-2019-09-30,ZA,South Africa,3.6879
-2019-12-31,4T,Emerging market economies (aggregate),4.4484
-2019-12-31,5R,Advanced economies,3.6268
-2019-12-31,AE,United Arab Emirates,-6.0524
+2019-09-30,SK,Slovakia,11.5849
+2019-09-30,TH,Thailand,-1.5416
+2019-09-30,TR,Türkiye,4.7719
+2019-09-30,US,United States,3.8427
+2019-09-30,XM,Euro area,4.0889
+2019-09-30,XW,World,4.0645
+2019-09-30,ZA,South Africa,2.1189
+2019-12-31,4T,Emerging market economies (aggregate),4.6508
+2019-12-31,5R,Advanced economies,3.5339
 2019-12-31,AT,Austria,3.0497
 2019-12-31,AU,Australia,2.5
-2019-12-31,BE,Belgium,4.7761
+2019-12-31,BE,Belgium,4.2341
 2019-12-31,BG,Bulgaria,6.2148
-2019-12-31,BR,Brazil,5.0048
+2019-12-31,BR,Brazil,4.9718
 2019-12-31,CA,Canada,1.6409
 2019-12-31,CH,Switzerland,3.4431
-2019-12-31,CL,Chile,7.948
+2019-12-31,CL,Chile,8.0327
 2019-12-31,CN,China,3.7813
-2019-12-31,CO,Colombia,6.4407
+2019-12-31,CO,Colombia,6.5267
 2019-12-31,CY,Cyprus,2.1519
 2019-12-31,CZ,Czechia,8.9285
 2019-12-31,DE,Germany,6.5068
@@ -23022,60 +7230,59 @@ date,country_code,country,price
 2019-12-31,ES,Spain,3.6951
 2019-12-31,FI,Finland,0.0969
 2019-12-31,FR,France,3.7753
-2019-12-31,GB,United Kingdom,0.8278
+2019-12-31,GB,United Kingdom,0.861
 2019-12-31,GR,Greece,7.4791
 2019-12-31,HK,Hong Kong SAR,3.4211
 2019-12-31,HR,Croatia,10.0441
 2019-12-31,HU,Hungary,12.8693
 2019-12-31,ID,Indonesia,1.2429
-2019-12-31,IE,Ireland,0.8375
+2019-12-31,IE,Ireland,0.7946
 2019-12-31,IL,Israel,3.5691
 2019-12-31,IN,India,2.9735
-2019-12-31,IS,Iceland,4.2851
+2019-12-31,IS,Iceland,4.2847
 2019-12-31,IT,Italy,0.2035
 2019-12-31,JP,Japan,0.9569
-2019-12-31,KR,Korea,0.0835
+2019-12-31,KR,Korea,0.0655
 2019-12-31,LT,Lithuania,6.5133
 2019-12-31,LU,Luxembourg,10.7345
 2019-12-31,LV,Latvia,8.8491
-2019-12-31,MA,Morocco,-0.6926
-2019-12-31,MK,North Macedonia,3.3701
+2019-12-31,MA,Morocco,-0.9709
+2019-12-31,MK,North Macedonia,3.2596
 2019-12-31,MT,Malta,5.7351
 2019-12-31,MX,Mexico,7.6581
 2019-12-31,MY,Malaysia,1.7921
-2019-12-31,NL,Netherlands,6.5127
+2019-12-31,NL,Netherlands,6.5169
 2019-12-31,NO,Norway,2.5801
 2019-12-31,NZ,New Zealand,4.7761
 2019-12-31,PE,Peru,-0.6231
-2019-12-31,PH,Philippines,10.4391
+2019-12-31,PH,Philippines,8.7983
 2019-12-31,PL,Poland,9.4308
 2019-12-31,PT,Portugal,10.3748
 2019-12-31,RO,Romania,4.1667
-2019-12-31,RS,Serbia,9.9805
+2019-12-31,RS,Serbia,11.9696
 2019-12-31,RU,Russia,6.5611
 2019-12-31,SE,Sweden,3.2795
 2019-12-31,SG,Singapore,2.6738
 2019-12-31,SI,Slovenia,4.8348
-2019-12-31,SK,Slovak Republic,10.8424
-2019-12-31,TH,Thailand,1.4472
-2019-12-31,TR,Türkiye,10
-2019-12-31,US,United States,4.4678
-2019-12-31,XM,Euro area,4.3098
-2019-12-31,XW,World,4.072
-2019-12-31,ZA,South Africa,3.3049
-2020-03-31,4T,Emerging market economies (aggregate),4.6282
-2020-03-31,5R,Advanced economies,4.2886
-2020-03-31,AE,United Arab Emirates,-7.6449
+2019-12-31,SK,Slovakia,10.9546
+2019-12-31,TH,Thailand,2.068
+2019-12-31,TR,Türkiye,7.7788
+2019-12-31,US,United States,4.4834
+2019-12-31,XM,Euro area,4.3172
+2019-12-31,XW,World,4.1012
+2019-12-31,ZA,South Africa,1.9911
+2020-03-31,4T,Emerging market economies (aggregate),4.899
+2020-03-31,5R,Advanced economies,4.1945
 2020-03-31,AT,Austria,3.3964
 2020-03-31,AU,Australia,7.3638
-2020-03-31,BE,Belgium,3.5413
-2020-03-31,BG,Bulgaria,4.7046
-2020-03-31,BR,Brazil,6.1733
+2020-03-31,BE,Belgium,3.8198
+2020-03-31,BG,Bulgaria,4.7045
+2020-03-31,BR,Brazil,6.1102
 2020-03-31,CA,Canada,4.2677
 2020-03-31,CH,Switzerland,1.6561
-2020-03-31,CL,Chile,9.0817
+2020-03-31,CL,Chile,8.9676
 2020-03-31,CN,China,2.9911
-2020-03-31,CO,Colombia,5.6809
+2020-03-31,CO,Colombia,5.0609
 2020-03-31,CY,Cyprus,1.8262
 2020-03-31,CZ,Czechia,8.6006
 2020-03-31,DE,Germany,7.3973
@@ -23084,60 +7291,59 @@ date,country_code,country,price
 2020-03-31,ES,Spain,3.2878
 2020-03-31,FI,Finland,1.1639
 2020-03-31,FR,France,4.8803
-2020-03-31,GB,United Kingdom,1.7588
+2020-03-31,GB,United Kingdom,1.7413
 2020-03-31,GR,Greece,6.7295
 2020-03-31,HK,Hong Kong SAR,2.2409
-2020-03-31,HR,Croatia,9.0987
+2020-03-31,HR,Croatia,9.0986
 2020-03-31,HU,Hungary,8.303
 2020-03-31,ID,Indonesia,1.3077
-2020-03-31,IE,Ireland,1.0019
+2020-03-31,IE,Ireland,0.9774
 2020-03-31,IL,Israel,3.4834
 2020-03-31,IN,India,3.9163
-2020-03-31,IS,Iceland,5.5113
+2020-03-31,IS,Iceland,5.513
 2020-03-31,IT,Italy,1.74
 2020-03-31,JP,Japan,-0.4343
-2020-03-31,KR,Korea,1.086
+2020-03-31,KR,Korea,1.0914
 2020-03-31,LT,Lithuania,6.2384
 2020-03-31,LU,Luxembourg,14.16
 2020-03-31,LV,Latvia,8.7514
-2020-03-31,MA,Morocco,-0.7847
-2020-03-31,MK,North Macedonia,2.2091
+2020-03-31,MA,Morocco,-0.6261
+2020-03-31,MK,North Macedonia,2.3122
 2020-03-31,MT,Malta,5.5696
 2020-03-31,MX,Mexico,7.0372
 2020-03-31,MY,Malaysia,1.8878
-2020-03-31,NL,Netherlands,6.3088
+2020-03-31,NL,Netherlands,6.8508
 2020-03-31,NO,Norway,1.9064
 2020-03-31,NZ,New Zealand,7.5561
 2020-03-31,PE,Peru,-0.308
-2020-03-31,PH,Philippines,12.5612
+2020-03-31,PH,Philippines,7.7159
 2020-03-31,PL,Poland,11.2557
 2020-03-31,PT,Portugal,10.595
 2020-03-31,RO,Romania,8.3333
-2020-03-31,RS,Serbia,9.58
+2020-03-31,RS,Serbia,11.85
 2020-03-31,RU,Russia,7.1234
 2020-03-31,SE,Sweden,4.5513
 2020-03-31,SG,Singapore,2.3554
 2020-03-31,SI,Slovenia,4.7331
-2020-03-31,SK,Slovak Republic,13.17
-2020-03-31,TH,Thailand,3.8378
-2020-03-31,TR,Türkiye,15.0459
-2020-03-31,US,United States,5.1608
-2020-03-31,XM,Euro area,5.0972
-2020-03-31,XW,World,4.4713
-2020-03-31,ZA,South Africa,1.9209
-2020-06-30,4T,Emerging market economies (aggregate),4.3951
-2020-06-30,5R,Advanced economies,4.1559
-2020-06-30,AE,United Arab Emirates,-7.0906
+2020-03-31,SK,Slovakia,13.1336
+2020-03-31,TH,Thailand,4.1807
+2020-03-31,TR,Türkiye,14.936
+2020-03-31,US,United States,5.238
+2020-03-31,XM,Euro area,5.1055
+2020-03-31,XW,World,4.5518
+2020-03-31,ZA,South Africa,1.2479
+2020-06-30,4T,Emerging market economies (aggregate),4.3612
+2020-06-30,5R,Advanced economies,4.0689
 2020-06-30,AT,Austria,5.2253
 2020-06-30,AU,Australia,6.2315
-2020-06-30,BE,Belgium,4.4907
+2020-06-30,BE,Belgium,4.265
 2020-06-30,BG,Bulgaria,2.9249
-2020-06-30,BR,Brazil,7.3289
+2020-06-30,BR,Brazil,7.2294
 2020-06-30,CA,Canada,5.6731
 2020-06-30,CH,Switzerland,2.5077
-2020-06-30,CL,Chile,9.4516
+2020-06-30,CL,Chile,9.4696
 2020-06-30,CN,China,2.2618
-2020-06-30,CO,Colombia,1.1406
+2020-06-30,CO,Colombia,1.056
 2020-06-30,CY,Cyprus,2.2288
 2020-06-30,CZ,Czechia,7.7525
 2020-06-30,DE,Germany,6.6132
@@ -23146,60 +7352,59 @@ date,country_code,country,price
 2020-06-30,ES,Spain,2.1807
 2020-06-30,FI,Finland,0.6686
 2020-06-30,FR,France,5.1913
-2020-06-30,GB,United Kingdom,1.2469
+2020-06-30,GB,United Kingdom,1.2346
 2020-06-30,GR,Greece,4.2904
-2020-06-30,HK,Hong Kong SAR,-2.7888
+2020-06-30,HK,Hong Kong SAR,-2.7559
 2020-06-30,HR,Croatia,8.2919
 2020-06-30,HU,Hungary,2.5806
 2020-06-30,ID,Indonesia,1.3642
-2020-06-30,IE,Ireland,0.3426
+2020-06-30,IE,Ireland,0.349
 2020-06-30,IL,Israel,2.2729
 2020-06-30,IN,India,2.8243
 2020-06-30,IS,Iceland,6.6873
 2020-06-30,IT,Italy,3.33
 2020-06-30,JP,Japan,-0.7007
-2020-06-30,KR,Korea,2.4298
+2020-06-30,KR,Korea,2.3927
 2020-06-30,LT,Lithuania,6.9712
 2020-06-30,LU,Luxembourg,13.2521
 2020-06-30,LV,Latvia,1.5016
-2020-06-30,MA,Morocco,-0.8764
-2020-06-30,MK,North Macedonia,1.4346
+2020-06-30,MA,Morocco,-5.4562
+2020-06-30,MK,North Macedonia,1.4434
 2020-06-30,MT,Malta,3.9088
 2020-06-30,MX,Mexico,5.7672
 2020-06-30,MY,Malaysia,1.417
-2020-06-30,NL,Netherlands,7.0719
+2020-06-30,NL,Netherlands,7.9607
 2020-06-30,NO,Norway,2.6959
 2020-06-30,NZ,New Zealand,6.807
 2020-06-30,PE,Peru,-0.17
-2020-06-30,PH,Philippines,26.5949
+2020-06-30,PH,Philippines,8.6407
 2020-06-30,PL,Poland,10.9084
 2020-06-30,PT,Portugal,9.7334
 2020-06-30,RO,Romania,6.5573
-2020-06-30,RS,Serbia,9.1947
+2020-06-30,RS,Serbia,11.5265
 2020-06-30,RU,Russia,8.0776
 2020-06-30,SE,Sweden,3.2499
 2020-06-30,SG,Singapore,1.1937
 2020-06-30,SI,Slovenia,5.224
-2020-06-30,SK,Slovak Republic,9.675
-2020-06-30,TH,Thailand,5.1749
-2020-06-30,TR,Türkiye,25.6757
-2020-06-30,US,United States,4.9537
-2020-06-30,XM,Euro area,5.0918
-2020-06-30,XW,World,4.2862
-2020-06-30,ZA,South Africa,1.4609
-2020-09-30,4T,Emerging market economies (aggregate),4.1827
-2020-09-30,5R,Advanced economies,5.2938
-2020-09-30,AE,United Arab Emirates,-7.6333
+2020-06-30,SK,Slovakia,9.7037
+2020-06-30,TH,Thailand,4.2809
+2020-06-30,TR,Türkiye,19.6078
+2020-06-30,US,United States,5.0658
+2020-06-30,XM,Euro area,5.1034
+2020-06-30,XW,World,4.2169
+2020-06-30,ZA,South Africa,1.2314
+2020-09-30,4T,Emerging market economies (aggregate),4.3262
+2020-09-30,5R,Advanced economies,5.1853
 2020-09-30,AT,Austria,9.4803
 2020-09-30,AU,Australia,4.4895
-2020-09-30,BE,Belgium,3.1563
+2020-09-30,BE,Belgium,3.1897
 2020-09-30,BG,Bulgaria,5.183
-2020-09-30,BR,Brazil,8.3726
+2020-09-30,BR,Brazil,8.2349
 2020-09-30,CA,Canada,6.9098
 2020-09-30,CH,Switzerland,2.5879
-2020-09-30,CL,Chile,3.7979
+2020-09-30,CL,Chile,3.882
 2020-09-30,CN,China,2.2134
-2020-09-30,CO,Colombia,1.3274
+2020-09-30,CO,Colombia,1.2332
 2020-09-30,CY,Cyprus,1.1903
 2020-09-30,CZ,Czechia,8.3682
 2020-09-30,DE,Germany,8.3004
@@ -23208,60 +7413,59 @@ date,country_code,country,price
 2020-09-30,ES,Spain,1.8216
 2020-09-30,FI,Finland,1.7308
 2020-09-30,FR,France,4.8976
-2020-09-30,GB,United Kingdom,2.5348
+2020-09-30,GB,United Kingdom,2.5516
 2020-09-30,GR,Greece,3.8798
 2020-09-30,HK,Hong Kong SAR,-1.0833
-2020-09-30,HR,Croatia,6.9192
+2020-09-30,HR,Croatia,6.9193
 2020-09-30,HU,Hungary,4.8499
 2020-09-30,ID,Indonesia,1.2616
-2020-09-30,IE,Ireland,-0.7983
+2020-09-30,IE,Ireland,-0.7864
 2020-09-30,IL,Israel,2.7849
 2020-09-30,IN,India,1.1038
-2020-09-30,IS,Iceland,7.7494
+2020-09-30,IS,Iceland,7.7484
 2020-09-30,IT,Italy,1.0121
 2020-09-30,JP,Japan,-0.1175
-2020-09-30,KR,Korea,4.5264
+2020-09-30,KR,Korea,4.5225
 2020-09-30,LT,Lithuania,6.4143
 2020-09-30,LU,Luxembourg,13.8393
 2020-09-30,LV,Latvia,1.7284
-2020-09-30,MA,Morocco,-0.8695
-2020-09-30,MK,North Macedonia,2.8898
+2020-09-30,MA,Morocco,-1.2445
+2020-09-30,MK,North Macedonia,3.0241
 2020-09-30,MT,Malta,2.6899
 2020-09-30,MX,Mexico,5.0369
 2020-09-30,MY,Malaysia,0.2005
-2020-09-30,NL,Netherlands,8.3558
+2020-09-30,NL,Netherlands,8.4582
 2020-09-30,NO,Norway,4.9236
 2020-09-30,NZ,New Zealand,9.9876
 2020-09-30,PE,Peru,0.5051
-2020-09-30,PH,Philippines,-0.3797
+2020-09-30,PH,Philippines,6.3196
 2020-09-30,PL,Poland,10.899
 2020-09-30,PT,Portugal,6.9186
 2020-09-30,RO,Romania,1.6129
-2020-09-30,RS,Serbia,8.6604
+2020-09-30,RS,Serbia,11.1268
 2020-09-30,RU,Russia,9.6048
 2020-09-30,SE,Sweden,3.7182
 2020-09-30,SG,Singapore,0.6545
 2020-09-30,SI,Slovenia,3.2895
-2020-09-30,SK,Slovak Republic,8.4892
-2020-09-30,TH,Thailand,5.3975
-2020-09-30,TR,Türkiye,27.3438
-2020-09-30,US,United States,7.1296
-2020-09-30,XM,Euro area,5.2092
-2020-09-30,XW,World,4.6831
-2020-09-30,ZA,South Africa,2.7601
-2020-12-31,4T,Emerging market economies (aggregate),4.6532
-2020-12-31,5R,Advanced economies,7.0241
-2020-12-31,AE,United Arab Emirates,-6.4362
+2020-09-30,SK,Slovakia,8.3634
+2020-09-30,TH,Thailand,4.6971
+2020-09-30,TR,Türkiye,28.4942
+2020-09-30,US,United States,7.1645
+2020-09-30,XM,Euro area,5.2152
+2020-09-30,XW,World,4.7411
+2020-09-30,ZA,South Africa,2.819
+2020-12-31,4T,Emerging market economies (aggregate),4.6467
+2020-12-31,5R,Advanced economies,6.9073
 2020-12-31,AT,Austria,9.9761
 2020-12-31,AU,Australia,3.6237
-2020-12-31,BE,Belgium,5.7261
-2020-12-31,BG,Bulgaria,5.4035
-2020-12-31,BR,Brazil,9.1235
+2020-12-31,BE,Belgium,5.8665
+2020-12-31,BG,Bulgaria,5.4034
+2020-12-31,BR,Brazil,8.9444
 2020-12-31,CA,Canada,8.3571
 2020-12-31,CH,Switzerland,3.1292
-2020-12-31,CL,Chile,4.5766
+2020-12-31,CL,Chile,4.5116
 2020-12-31,CN,China,2.3067
-2020-12-31,CO,Colombia,1.9318
+2020-12-31,CO,Colombia,1.7536
 2020-12-31,CY,Cyprus,0.7659
 2020-12-31,CZ,Czechia,8.9481
 2020-12-31,DE,Germany,8.746
@@ -23270,60 +7474,59 @@ date,country_code,country,price
 2020-12-31,ES,Spain,1.6821
 2020-12-31,FI,Finland,3.5818
 2020-12-31,FR,France,5.8563
-2020-12-31,GB,United Kingdom,5.9113
+2020-12-31,GB,United Kingdom,5.8537
 2020-12-31,GR,Greece,3.1741
 2020-12-31,HK,Hong Kong SAR,-0.0788
-2020-12-31,HR,Croatia,6.4851
+2020-12-31,HR,Croatia,6.4852
 2020-12-31,HU,Hungary,4.1885
 2020-12-31,ID,Indonesia,1.1491
-2020-12-31,IE,Ireland,0.7075
+2020-12-31,IE,Ireland,0.7145
 2020-12-31,IL,Israel,3.6843
 2020-12-31,IN,India,2.1918
-2020-12-31,IS,Iceland,7.763
+2020-12-31,IS,Iceland,7.7638
 2020-12-31,IT,Italy,1.5228
 2020-12-31,JP,Japan,1.5699
-2020-12-31,KR,Korea,7.1369
+2020-12-31,KR,Korea,7.1684
 2020-12-31,LT,Lithuania,9.4042
 2020-12-31,LU,Luxembourg,16.691
 2020-12-31,LV,Latvia,2.2323
-2020-12-31,MA,Morocco,1.2206
-2020-12-31,MK,North Macedonia,1.8282
+2020-12-31,MA,Morocco,1.5151
+2020-12-31,MK,North Macedonia,1.8777
 2020-12-31,MT,Malta,1.6043
 2020-12-31,MX,Mexico,5.3772
 2020-12-31,MY,Malaysia,1.2072
-2020-12-31,NL,Netherlands,8.7476
+2020-12-31,NL,Netherlands,8.6498
 2020-12-31,NO,Norway,7.5455
 2020-12-31,NZ,New Zealand,16.0658
 2020-12-31,PE,Peru,3.8465
-2020-12-31,PH,Philippines,0.8252
+2020-12-31,PH,Philippines,3.9097
 2020-12-31,PL,Poland,8.9406
 2020-12-31,PT,Portugal,7.9551
 2020-12-31,RO,Romania,2.4
-2020-12-31,RS,Serbia,8.4226
+2020-12-31,RS,Serbia,10.947
 2020-12-31,RU,Russia,13.9833
 2020-12-31,SE,Sweden,5.2747
 2020-12-31,SG,Singapore,2.2135
 2020-12-31,SI,Slovenia,5.174
-2020-12-31,SK,Slovak Republic,7.2484
-2020-12-31,TH,Thailand,3.923
-2020-12-31,TR,Türkiye,30.3872
-2020-12-31,US,United States,9.519
-2020-12-31,XM,Euro area,5.9346
-2020-12-31,XW,World,5.7182
-2020-12-31,ZA,South Africa,3.8266
-2021-03-31,4T,Emerging market economies (aggregate),4.98
-2021-03-31,5R,Advanced economies,8.4426
-2021-03-31,AE,United Arab Emirates,-3.4764
+2020-12-31,SK,Slovakia,7.1227
+2020-12-31,TH,Thailand,1.1111
+2020-12-31,TR,Türkiye,31.3392
+2020-12-31,US,United States,9.5373
+2020-12-31,XM,Euro area,5.9414
+2020-12-31,XW,World,5.7388
+2020-12-31,ZA,South Africa,4.1631
+2021-03-31,4T,Emerging market economies (aggregate),4.7683
+2021-03-31,5R,Advanced economies,8.3676
 2021-03-31,AT,Austria,12.3416
 2021-03-31,AU,Australia,7.476
-2021-03-31,BE,Belgium,6.927
+2021-03-31,BE,Belgium,6.2218
 2021-03-31,BG,Bulgaria,7.5107
-2021-03-31,BR,Brazil,9.3358
+2021-03-31,BR,Brazil,9.1204
 2021-03-31,CA,Canada,8.7442
 2021-03-31,CH,Switzerland,3.8598
-2021-03-31,CL,Chile,7.8898
+2021-03-31,CL,Chile,8.1793
 2021-03-31,CN,China,3.0351
-2021-03-31,CO,Colombia,2.1555
+2021-03-31,CO,Colombia,2.219
 2021-03-31,CY,Cyprus,0.9031
 2021-03-31,CZ,Czechia,13.3557
 2021-03-31,DE,Germany,9.3112
@@ -23332,60 +7535,59 @@ date,country_code,country,price
 2021-03-31,ES,Spain,0.9455
 2021-03-31,FI,Finland,4.1227
 2021-03-31,FR,France,5.5312
-2021-03-31,GB,United Kingdom,8.3128
-2021-03-31,GR,Greece,4.5381
+2021-03-31,GB,United Kingdom,7.7017
+2021-03-31,GR,Greece,4.538
 2021-03-31,HK,Hong Kong SAR,2.2006
-2021-03-31,HR,Croatia,4.5985
-2021-03-31,HU,Hungary,9.6811
+2021-03-31,HR,Croatia,4.5986
+2021-03-31,HU,Hungary,9.681
 2021-03-31,ID,Indonesia,0.9584
-2021-03-31,IE,Ireland,3.0068
+2021-03-31,IE,Ireland,3.028
 2021-03-31,IL,Israel,4.6323
 2021-03-31,IN,India,2.6575
-2021-03-31,IS,Iceland,8.548
+2021-03-31,IS,Iceland,8.547
 2021-03-31,IT,Italy,1.7103
 2021-03-31,JP,Japan,3.344
-2021-03-31,KR,Korea,10.2893
+2021-03-31,KR,Korea,10.2499
 2021-03-31,LT,Lithuania,11.97
 2021-03-31,LU,Luxembourg,17.1689
 2021-03-31,LV,Latvia,2.8771
-2021-03-31,MA,Morocco,-0.1757
-2021-03-31,MK,North Macedonia,3.0805
+2021-03-31,MA,Morocco,0.5401
+2021-03-31,MK,North Macedonia,2.956
 2021-03-31,MT,Malta,4.5564
 2021-03-31,MX,Mexico,6.5673
 2021-03-31,MY,Malaysia,0.7011
-2021-03-31,NL,Netherlands,11.2667
+2021-03-31,NL,Netherlands,10.3413
 2021-03-31,NO,Norway,11.1395
 2021-03-31,NZ,New Zealand,22.7404
 2021-03-31,PE,Peru,2.1329
-2021-03-31,PH,Philippines,-4.2029
+2021-03-31,PH,Philippines,4.1098
 2021-03-31,PL,Poland,7.2156
-2021-03-31,PT,Portugal,6.6131
+2021-03-31,PT,Portugal,6.613
 2021-03-31,RO,Romania,0.7692
-2021-03-31,RS,Serbia,8.6695
+2021-03-31,RS,Serbia,11.1667
 2021-03-31,RU,Russia,11.0675
 2021-03-31,SE,Sweden,7.2392
 2021-03-31,SG,Singapore,6.6403
 2021-03-31,SI,Slovenia,7.2636
-2021-03-31,SK,Slovak Republic,1.9621
-2021-03-31,TH,Thailand,0.3487
-2021-03-31,TR,Türkiye,31.9777
-2021-03-31,US,United States,11.4198
-2021-03-31,XM,Euro area,6.2206
-2021-03-31,XW,World,6.5259
-2021-03-31,ZA,South Africa,4.6519
-2021-06-30,4T,Emerging market economies (aggregate),5.666
-2021-06-30,5R,Advanced economies,11.47
-2021-06-30,AE,United Arab Emirates,2.136
+2021-03-31,SK,Slovakia,1.9688
+2021-03-31,TH,Thailand,0.9709
+2021-03-31,TR,Türkiye,31.4781
+2021-03-31,US,United States,11.3366
+2021-03-31,XM,Euro area,6.1827
+2021-03-31,XW,World,6.4921
+2021-03-31,ZA,South Africa,6.309
+2021-06-30,4T,Emerging market economies (aggregate),5.5373
+2021-06-30,5R,Advanced economies,11.2527
 2021-06-30,AT,Austria,11.754
 2021-06-30,AU,Australia,16.7598
-2021-06-30,BE,Belgium,7.4077
+2021-06-30,BE,Belgium,7.0063
 2021-06-30,BG,Bulgaria,9.0699
-2021-06-30,BR,Brazil,8.908
+2021-06-30,BR,Brazil,8.6708
 2021-06-30,CA,Canada,13.4668
 2021-06-30,CH,Switzerland,4.713
-2021-06-30,CL,Chile,10.1604
+2021-06-30,CL,Chile,10.3522
 2021-06-30,CN,China,3.669
-2021-06-30,CO,Colombia,7.947
+2021-06-30,CO,Colombia,7.3254
 2021-06-30,CY,Cyprus,0.2394
 2021-06-30,CZ,Czechia,17.2277
 2021-06-30,DE,Germany,11.4662
@@ -23394,60 +7596,59 @@ date,country_code,country,price
 2021-06-30,ES,Spain,3.284
 2021-06-30,FI,Finland,5.5028
 2021-06-30,FR,France,6.0606
-2021-06-30,GB,United Kingdom,10.0985
-2021-06-30,GR,Greece,6.8715
+2021-06-30,GB,United Kingdom,9.3902
+2021-06-30,GR,Greece,6.8714
 2021-06-30,HK,Hong Kong SAR,2.4863
-2021-06-30,HR,Croatia,6.4318
-2021-06-30,HU,Hungary,16.8667
+2021-06-30,HR,Croatia,6.4319
+2021-06-30,HU,Hungary,16.8668
 2021-06-30,ID,Indonesia,0.9557
-2021-06-30,IE,Ireland,5.6176
+2021-06-30,IE,Ireland,5.5652
 2021-06-30,IL,Israel,7.6838
 2021-06-30,IN,India,1.972
-2021-06-30,IS,Iceland,12.6244
+2021-06-30,IS,Iceland,12.6243
 2021-06-30,IT,Italy,0.3906
 2021-06-30,JP,Japan,5.469
-2021-06-30,KR,Korea,13.0061
+2021-06-30,KR,Korea,13.009
 2021-06-30,LT,Lithuania,13.2763
 2021-06-30,LU,Luxembourg,13.4499
 2021-06-30,LV,Latvia,12.1005
-2021-06-30,MA,Morocco,-4.4209
-2021-06-30,MK,North Macedonia,4.0847
+2021-06-30,MA,Morocco,2.2706
+2021-06-30,MK,North Macedonia,4.1502
 2021-06-30,MT,Malta,5.3291
 2021-06-30,MX,Mexico,7.7463
 2021-06-30,MY,Malaysia,1.0479
-2021-06-30,NL,Netherlands,13.0111
+2021-06-30,NL,Netherlands,12.5253
 2021-06-30,NO,Norway,12.3872
 2021-06-30,NZ,New Zealand,28.5164
 2021-06-30,PE,Peru,1.4367
-2021-06-30,PH,Philippines,-9.3586
+2021-06-30,PH,Philippines,2.3859
 2021-06-30,PL,Poland,8.3314
 2021-06-30,PT,Portugal,7.8139
 2021-06-30,RO,Romania,3.0769
-2021-06-30,RS,Serbia,9.2697
+2021-06-30,RS,Serbia,11.7109
 2021-06-30,RU,Russia,14.3553
 2021-06-30,SE,Sweden,10.9251
 2021-06-30,SG,Singapore,7.1429
 2021-06-30,SI,Slovenia,10.0694
-2021-06-30,SK,Slovak Republic,4.7811
-2021-06-30,TH,Thailand,0.4851
-2021-06-30,TR,Türkiye,29.2473
-2021-06-30,US,United States,15.8881
-2021-06-30,XM,Euro area,7.3731
-2021-06-30,XW,World,8.2378
-2021-06-30,ZA,South Africa,4.7921
-2021-09-30,4T,Emerging market economies (aggregate),5.9915
-2021-09-30,5R,Advanced economies,12.9688
-2021-09-30,AE,United Arab Emirates,7.8032
+2021-06-30,SK,Slovakia,4.7265
+2021-06-30,TH,Thailand,0.8339
+2021-06-30,TR,Türkiye,34.3039
+2021-06-30,US,United States,15.6084
+2021-06-30,XM,Euro area,7.3528
+2021-06-30,XW,World,8.2543
+2021-06-30,ZA,South Africa,7.71
+2021-09-30,4T,Emerging market economies (aggregate),5.4247
+2021-09-30,5R,Advanced economies,12.7236
 2021-09-30,AT,Austria,10.4176
 2021-09-30,AU,Australia,21.6909
-2021-09-30,BE,Belgium,8.1926
+2021-09-30,BE,Belgium,7.5514
 2021-09-30,BG,Bulgaria,8.7097
-2021-09-30,BR,Brazil,7.8576
+2021-09-30,BR,Brazil,7.6236
 2021-09-30,CA,Canada,14.3627
 2021-09-30,CH,Switzerland,6.9456
-2021-09-30,CL,Chile,13.3425
+2021-09-30,CL,Chile,13.3246
 2021-09-30,CN,China,3.0678
-2021-09-30,CO,Colombia,6.8764
+2021-09-30,CO,Colombia,6.3718
 2021-09-30,CY,Cyprus,1.1764
 2021-09-30,CZ,Czechia,22.1364
 2021-09-30,DE,Germany,12.7737
@@ -23456,60 +7657,59 @@ date,country_code,country,price
 2021-09-30,ES,Spain,4.1693
 2021-09-30,FI,Finland,4.8204
 2021-09-30,FR,France,7.1307
-2021-09-30,GB,United Kingdom,9.0909
+2021-09-30,GB,United Kingdom,8.2938
 2021-09-30,GR,Greece,8.7983
 2021-09-30,HK,Hong Kong SAR,3.7462
-2021-09-30,HR,Croatia,8.9369
+2021-09-30,HR,Croatia,8.9368
 2021-09-30,HU,Hungary,16.685
 2021-09-30,ID,Indonesia,1.022
-2021-09-30,IE,Ireland,10.6469
+2021-09-30,IE,Ireland,10.5772
 2021-09-30,IL,Israel,9.6041
 2021-09-30,IN,India,2.3811
-2021-09-30,IS,Iceland,14.6512
+2021-09-30,IS,Iceland,14.6522
 2021-09-30,IT,Italy,4.1082
 2021-09-30,JP,Japan,8.1447
-2021-09-30,KR,Korea,15.1163
+2021-09-30,KR,Korea,15.0808
 2021-09-30,LT,Lithuania,18.8782
 2021-09-30,LU,Luxembourg,13.2026
 2021-09-30,LV,Latvia,12.3955
-2021-09-30,MA,Morocco,-6.0526
-2021-09-30,MK,North Macedonia,5.7871
+2021-09-30,MA,Morocco,-5.4906
+2021-09-30,MK,North Macedonia,5.6609
 2021-09-30,MT,Malta,5.9322
 2021-09-30,MX,Mexico,8.6641
 2021-09-30,MY,Malaysia,1.0505
-2021-09-30,NL,Netherlands,16.7577
+2021-09-30,NL,Netherlands,16.1895
 2021-09-30,NO,Norway,10.4369
 2021-09-30,NZ,New Zealand,28.6702
 2021-09-30,PE,Peru,-0.6733
-2021-09-30,PH,Philippines,6.3262
+2021-09-30,PH,Philippines,5.0121
 2021-09-30,PL,Poland,8.9158
-2021-09-30,PT,Portugal,11.5161
+2021-09-30,PT,Portugal,11.5162
 2021-09-30,RO,Romania,6.3492
-2021-09-30,RS,Serbia,10.2937
+2021-09-30,RS,Serbia,12.7535
 2021-09-30,RU,Russia,14.5636
 2021-09-30,SE,Sweden,11.3378
 2021-09-30,SG,Singapore,7.4772
 2021-09-30,SI,Slovenia,12.9008
-2021-09-30,SK,Slovak Republic,8.0239
-2021-09-30,TH,Thailand,2.0069
-2021-09-30,TR,Türkiye,35.5828
-2021-09-30,US,United States,17.12
-2021-09-30,XM,Euro area,9.2711
-2021-09-30,XW,World,9.0694
-2021-09-30,ZA,South Africa,3.7524
-2021-12-31,4T,Emerging market economies (aggregate),6.6572
-2021-12-31,5R,Advanced economies,12.9788
-2021-12-31,AE,United Arab Emirates,9.7958
+2021-09-30,SK,Slovakia,8.0506
+2021-09-30,TH,Thailand,4.2263
+2021-09-30,TR,Türkiye,33.2964
+2021-09-30,US,United States,16.7353
+2021-09-30,XM,Euro area,9.2141
+2021-09-30,XW,World,8.8738
+2021-09-30,ZA,South Africa,6.9448
+2021-12-31,4T,Emerging market economies (aggregate),5.6267
+2021-12-31,5R,Advanced economies,12.7934
 2021-12-31,AT,Austria,12.5434
 2021-12-31,AU,Australia,23.6718
-2021-12-31,BE,Belgium,6.0378
-2021-12-31,BG,Bulgaria,9.3818
-2021-12-31,BR,Brazil,6.3643
+2021-12-31,BE,Belgium,5.9037
+2021-12-31,BG,Bulgaria,9.3819
+2021-12-31,BR,Brazil,6.1737
 2021-12-31,CA,Canada,13.9351
 2021-12-31,CH,Switzerland,7.314
-2021-12-31,CL,Chile,15.8984
+2021-12-31,CL,Chile,15.4366
 2021-12-31,CN,China,1.6141
-2021-12-31,CO,Colombia,7.0919
+2021-12-31,CO,Colombia,6.5711
 2021-12-31,CY,Cyprus,2.6226
 2021-12-31,CZ,Czechia,25.7681
 2021-12-31,DE,Germany,12.5961
@@ -23518,478 +7718,1013 @@ date,country_code,country,price
 2021-12-31,ES,Spain,6.2956
 2021-12-31,FI,Finland,3.8318
 2021-12-31,FR,France,6.8734
-2021-12-31,GB,United Kingdom,8.2171
+2021-12-31,GB,United Kingdom,7.2581
 2021-12-31,GR,Greece,10.0429
 2021-12-31,HK,Hong Kong SAR,3.6521
 2021-12-31,HR,Croatia,9.0226
-2021-12-31,HU,Hungary,22.7805
+2021-12-31,HU,Hungary,22.7806
 2021-12-31,ID,Indonesia,1.1846
-2021-12-31,IE,Ireland,13.8057
+2021-12-31,IE,Ireland,13.8209
 2021-12-31,IL,Israel,11.7476
 2021-12-31,IN,India,3.1276
-2021-12-31,IS,Iceland,15.8509
+2021-12-31,IS,Iceland,15.851
 2021-12-31,IT,Italy,4
 2021-12-31,JP,Japan,6.8241
-2021-12-31,KR,Korea,15.6993
+2021-12-31,KR,Korea,15.7496
 2021-12-31,LT,Lithuania,19.8223
 2021-12-31,LU,Luxembourg,12.1174
 2021-12-31,LV,Latvia,16.1325
-2021-12-31,MA,Morocco,-7.4074
-2021-12-31,MK,North Macedonia,11.3006
+2021-12-31,MA,Morocco,-7.1115
+2021-12-31,MK,North Macedonia,11.3779
 2021-12-31,MT,Malta,4.5113
 2021-12-31,MX,Mexico,8.5492
 2021-12-31,MY,Malaysia,1.8887
-2021-12-31,NL,Netherlands,18.7195
+2021-12-31,NL,Netherlands,18.5437
 2021-12-31,NO,Norway,7.9839
 2021-12-31,NZ,New Zealand,25.9273
 2021-12-31,PE,Peru,-2.9875
-2021-12-31,PH,Philippines,4.9107
+2021-12-31,PH,Philippines,6.3586
 2021-12-31,PL,Poland,12.0864
 2021-12-31,PT,Portugal,11.586
 2021-12-31,RO,Romania,7.8125
-2021-12-31,RS,Serbia,11.8244
-2021-12-31,RU,Russia,14.9516
+2021-12-31,RS,Serbia,14.2668
+2021-12-31,RU,Russia,14.952
 2021-12-31,SE,Sweden,10.9028
 2021-12-31,SG,Singapore,10.5732
 2021-12-31,SI,Slovenia,15.7697
-2021-12-31,SK,Slovak Republic,10.6955
-2021-12-31,TH,Thailand,2.4022
-2021-12-31,TR,Türkiye,59.7159
-2021-12-31,US,United States,17.4002
-2021-12-31,XM,Euro area,9.5958
-2021-12-31,XW,World,9.4461
-2021-12-31,ZA,South Africa,3.4749
-2022-03-31,4T,Emerging market economies (aggregate),8.1428
-2022-03-31,5R,Advanced economies,14.2936
-2022-03-31,AE,United Arab Emirates,11.9713
-2022-03-31,AT,Austria,12.3643
-2022-03-31,AU,Australia,20.588
-2022-03-31,BE,Belgium,6.4621
+2021-12-31,SK,Slovakia,10.7308
+2021-12-31,TH,Thailand,3.0381
+2021-12-31,TR,Türkiye,49.206
+2021-12-31,US,United States,16.9148
+2021-12-31,XM,Euro area,9.5328
+2021-12-31,XW,World,9.0064
+2021-12-31,ZA,South Africa,5.9606
+2022-03-31,4T,Emerging market economies (aggregate),7.1027
+2022-03-31,5R,Advanced economies,13.6892
+2022-03-31,AT,Austria,12.3642
+2022-03-31,AU,Australia,20.5831
+2022-03-31,BE,Belgium,6.2168
 2022-03-31,BG,Bulgaria,11.529
-2022-03-31,BR,Brazil,4.6679
-2022-03-31,CA,Canada,25.5508
+2022-03-31,BR,Brazil,4.5882
+2022-03-31,CA,Canada,25.4606
 2022-03-31,CH,Switzerland,6.9742
-2022-03-31,CL,Chile,7.9423
+2022-03-31,CL,Chile,7.3935
 2022-03-31,CN,China,-0.1523
-2022-03-31,CO,Colombia,8.5309
+2022-03-31,CO,Colombia,8.007
 2022-03-31,CY,Cyprus,3.1892
 2022-03-31,CZ,Czechia,24.5116
-2022-03-31,DE,Germany,11.6103
+2022-03-31,DE,Germany,12.1937
 2022-03-31,DK,Denmark,4.1481
 2022-03-31,EE,Estonia,20.9877
 2022-03-31,ES,Spain,8.5311
-2022-03-31,FI,Finland,3.3149
+2022-03-31,FI,Finland,3.0387
 2022-03-31,FR,France,6.9884
-2022-03-31,GB,United Kingdom,8.8146
-2022-03-31,GR,Greece,10.0286
+2022-03-31,GB,United Kingdom,8.1725
+2022-03-31,GR,Greece,10.0287
 2022-03-31,HK,Hong Kong SAR,-0.0519
 2022-03-31,HR,Croatia,13.4873
-2022-03-31,HU,Hungary,23.1632
+2022-03-31,HU,Hungary,23.1633
 2022-03-31,ID,Indonesia,1.5789
-2022-03-31,IE,Ireland,14.9564
+2022-03-31,IE,Ireland,14.9362
 2022-03-31,IL,Israel,15.2059
 2022-03-31,IN,India,1.797
 2022-03-31,IS,Iceland,19.0813
 2022-03-31,IT,Italy,4.55
 2022-03-31,JP,Japan,9.0602
-2022-03-31,KR,Korea,12.589
+2022-03-31,KR,Korea,12.6089
 2022-03-31,LT,Lithuania,19.1489
 2022-03-31,LU,Luxembourg,10.2273
 2022-03-31,LV,Latvia,17.3962
-2022-03-31,MA,Morocco,-5.4577
-2022-03-31,MK,North Macedonia,12.3849
+2022-03-31,MA,Morocco,-5.282
+2022-03-31,MK,North Macedonia,12.4547
 2022-03-31,MT,Malta,6.8043
 2022-03-31,MX,Mexico,7.7422
 2022-03-31,MY,Malaysia,2.3869
-2022-03-31,NL,Netherlands,19.3063
+2022-03-31,NL,Netherlands,19.0253
 2022-03-31,NO,Norway,7.192
 2022-03-31,NZ,New Zealand,13.5922
 2022-03-31,PE,Peru,-2.1077
-2022-03-31,PH,Philippines,5.7489
+2022-03-31,PH,Philippines,9.0927
 2022-03-31,PL,Poland,13.5591
 2022-03-31,PT,Portugal,12.9499
 2022-03-31,RO,Romania,6.8702
-2022-03-31,RS,Serbia,13.4279
-2022-03-31,RU,Russia,32.497
-2022-03-31,SE,Sweden,10.3141
+2022-03-31,RS,Serbia,15.7311
+2022-03-31,RU,Russia,32.4969
+2022-03-31,SE,Sweden,10.3136
 2022-03-31,SG,Singapore,7.7682
 2022-03-31,SI,Slovenia,17.0207
-2022-03-31,SK,Slovak Republic,14.1341
-2022-03-31,TH,Thailand,4.1696
-2022-03-31,TR,Türkiye,110.0906
-2022-03-31,US,United States,19.1515
-2022-03-31,XM,Euro area,9.8486
-2022-03-31,XW,World,10.8549
-2022-03-31,ZA,South Africa,4.0023
-2022-06-30,4T,Emerging market economies (aggregate),8.5199
-2022-06-30,5R,Advanced economies,12.6928
-2022-06-30,AE,United Arab Emirates,11.0518
+2022-03-31,SK,Slovakia,14.181
+2022-03-31,TH,Thailand,2.8205
+2022-03-31,TR,Türkiye,92.2426
+2022-03-31,US,United States,18.1091
+2022-03-31,XM,Euro area,9.9897
+2022-03-31,XW,World,10.2114
+2022-03-31,ZA,South Africa,5.1453
+2022-06-30,4T,Emerging market economies (aggregate),7.4914
+2022-06-30,5R,Advanced economies,12.0611
 2022-06-30,AT,Austria,13.1268
-2022-06-30,AU,Australia,13.3381
-2022-06-30,BE,Belgium,5.9343
+2022-06-30,AU,Australia,13.3574
+2022-06-30,BE,Belgium,5.9304
 2022-06-30,BG,Bulgaria,14.6003
-2022-06-30,BR,Brazil,3.0563
-2022-06-30,CA,Canada,15.301
+2022-06-30,BR,Brazil,3.1737
+2022-06-30,CA,Canada,14.5625
 2022-06-30,CH,Switzerland,7.4816
-2022-06-30,CL,Chile,8.6637
+2022-06-30,CL,Chile,7.169
 2022-06-30,CN,China,-2.1837
-2022-06-30,CO,Colombia,7.4046
+2022-06-30,CO,Colombia,6.9599
 2022-06-30,CY,Cyprus,4.6643
 2022-06-30,CZ,Czechia,22.2973
-2022-06-30,DE,Germany,9.6121
+2022-06-30,DE,Germany,10.2305
 2022-06-30,DK,Denmark,2.5918
 2022-06-30,EE,Estonia,27.3313
 2022-06-30,ES,Spain,8.0518
-2022-06-30,FI,Finland,2.3381
+2022-06-30,FI,Finland,2.0683
 2022-06-30,FR,France,6.7755
-2022-06-30,GB,United Kingdom,9.5451
-2022-06-30,GR,Greece,10.8786
+2022-06-30,GB,United Kingdom,8.9186
+2022-06-30,GR,Greece,10.8787
 2022-06-30,HK,Hong Kong SAR,-2.2563
-2022-06-30,HR,Croatia,13.5972
-2022-06-30,HU,Hungary,24.8533
+2022-06-30,HR,Croatia,13.5971
+2022-06-30,HU,Hungary,24.8532
 2022-06-30,ID,Indonesia,1.6518
-2022-06-30,IE,Ireland,14.2521
+2022-06-30,IE,Ireland,14.2857
 2022-06-30,IL,Israel,17.4912
 2022-06-30,IN,India,3.3556
 2022-06-30,IS,Iceland,22.8806
 2022-06-30,IT,Italy,5.1556
 2022-06-30,JP,Japan,9.1999
-2022-06-30,KR,Korea,9.3739
+2022-06-30,KR,Korea,9.3869
 2022-06-30,LT,Lithuania,22.0558
 2022-06-30,LU,Luxembourg,11.6775
 2022-06-30,LV,Latvia,16.325
-2022-06-30,MA,Morocco,-0.37
-2022-06-30,MK,North Macedonia,16.4956
+2022-06-30,MA,Morocco,-1.9426
+2022-06-30,MK,North Macedonia,16.5086
 2022-06-30,MT,Malta,7.5893
 2022-06-30,MX,Mexico,7.9678
 2022-06-30,MY,Malaysia,2.6173
-2022-06-30,NL,Netherlands,18.1664
+2022-06-30,NL,Netherlands,17.5045
 2022-06-30,NO,Norway,6.3504
 2022-06-30,NZ,New Zealand,5.109
 2022-06-30,PE,Peru,-1.6691
-2022-06-30,PH,Philippines,2.5993
+2022-06-30,PH,Philippines,9.6336
 2022-06-30,PL,Poland,12.3712
-2022-06-30,PT,Portugal,13.167
+2022-06-30,PT,Portugal,13.1671
 2022-06-30,RO,Romania,8.2089
-2022-06-30,RS,Serbia,14.7088
-2022-06-30,RU,Russia,29.4496
-2022-06-30,SE,Sweden,7.0547
+2022-06-30,RS,Serbia,16.4848
+2022-06-30,RU,Russia,29.4502
+2022-06-30,SE,Sweden,7.0548
 2022-06-30,SG,Singapore,10.6422
 2022-06-30,SI,Slovenia,15.5619
-2022-06-30,SK,Slovak Republic,16.6452
-2022-06-30,TH,Thailand,5.2414
-2022-06-30,TR,Türkiye,160.6766
-2022-06-30,US,United States,17.0822
-2022-06-30,XM,Euro area,9.2324
-2022-06-30,XW,World,10.3673
-2022-06-30,ZA,South Africa,3.7908
-2022-09-30,4T,Emerging market economies (aggregate),8.4765
-2022-09-30,5R,Advanced economies,8.6461
-2022-09-30,AE,United Arab Emirates,8.998
+2022-06-30,SK,Slovakia,16.6345
+2022-06-30,TH,Thailand,3.5623
+2022-06-30,TR,Türkiye,143.2684
+2022-06-30,US,United States,15.9601
+2022-06-30,XM,Euro area,9.4284
+2022-06-30,XW,World,9.6574
+2022-06-30,ZA,South Africa,4.513
+2022-09-30,4T,Emerging market economies (aggregate),8.1505
+2022-09-30,5R,Advanced economies,8.327
 2022-09-30,AT,Austria,10.7882
-2022-09-30,AU,Australia,4.1694
-2022-09-30,BE,Belgium,5.3469
+2022-09-30,AU,Australia,4.2018
+2022-09-30,BE,Belgium,5.4046
 2022-09-30,BG,Bulgaria,15.5931
-2022-09-30,BR,Brazil,1.7582
-2022-09-30,CA,Canada,2.8227
+2022-09-30,BR,Brazil,2.1966
+2022-09-30,CA,Canada,1.9759
 2022-09-30,CH,Switzerland,6.3144
-2022-09-30,CL,Chile,7.8767
+2022-09-30,CL,Chile,8.1161
 2022-09-30,CN,China,-3.2766
-2022-09-30,CO,Colombia,7.4565
+2022-09-30,CO,Colombia,6.8452
 2022-09-30,CY,Cyprus,6.2757
 2022-09-30,CZ,Czechia,15.5954
-2022-09-30,DE,Germany,4.4229
+2022-09-30,DE,Germany,5.0701
 2022-09-30,DK,Denmark,-2.0655
 2022-09-30,EE,Estonia,24.1895
 2022-09-30,ES,Spain,7.6389
-2022-09-30,FI,Finland,1.3526
+2022-09-30,FI,Finland,1.1722
 2022-09-30,FR,France,6.4184
-2022-09-30,GB,United Kingdom,11.2573
-2022-09-30,GR,Greece,12.6188
+2022-09-30,GB,United Kingdom,10.9409
+2022-09-30,GR,Greece,12.6187
 2022-09-30,HK,Hong Kong SAR,-7.4229
 2022-09-30,HR,Croatia,14.8515
 2022-09-30,HU,Hungary,24.1151
 2022-09-30,ID,Indonesia,1.9367
-2022-09-30,IE,Ireland,11.8601
+2022-09-30,IE,Ireland,11.8728
 2022-09-30,IL,Israel,19.584
-2022-09-30,IN,India,4.5426
+2022-09-30,IN,India,6.6461
 2022-09-30,IS,Iceland,22.6252
 2022-09-30,IT,Italy,2.8874
 2022-09-30,JP,Japan,7.8575
-2022-09-30,KR,Korea,5.2595
+2022-09-30,KR,Korea,5.2668
 2022-09-30,LT,Lithuania,19.2666
 2022-09-30,LU,Luxembourg,11.0277
 2022-09-30,LV,Latvia,13.5997
-2022-09-30,MA,Morocco,1.1205
-2022-09-30,MK,North Macedonia,21.268
+2022-09-30,MA,Morocco,1.5239
+2022-09-30,MK,North Macedonia,21.3739
 2022-09-30,MT,Malta,6.3273
 2022-09-30,MX,Mexico,9.4236
 2022-09-30,MY,Malaysia,5.1485
-2022-09-30,NL,Netherlands,12.149
+2022-09-30,NL,Netherlands,12.0646
 2022-09-30,NO,Norway,4.8352
 2022-09-30,NZ,New Zealand,-3.6451
 2022-09-30,PE,Peru,0.1118
-2022-09-30,PH,Philippines,6.5233
+2022-09-30,PH,Philippines,13.9141
 2022-09-30,PL,Poland,12.1248
-2022-09-30,PT,Portugal,13.1466
+2022-09-30,PT,Portugal,13.1465
 2022-09-30,RO,Romania,6.7164
-2022-09-30,RS,Serbia,15.3748
-2022-09-30,RU,Russia,26.8583
-2022-09-30,SE,Sweden,1.1506
+2022-09-30,RS,Serbia,16.481
+2022-09-30,RU,Russia,26.8587
+2022-09-30,SE,Sweden,1.1507
 2022-09-30,SG,Singapore,13.6116
 2022-09-30,SI,Slovenia,15.1812
-2022-09-30,SK,Slovak Republic,14.5488
-2022-09-30,TH,Thailand,3.5957
-2022-09-30,TR,Türkiye,189.09
-2022-09-30,US,United States,11.2683
-2022-09-30,XM,Euro area,6.7506
-2022-09-30,XW,World,8.5572
-2022-09-30,ZA,South Africa,3.2909
-2022-12-31,4T,Emerging market economies (aggregate),6.9203
-2022-12-31,5R,Advanced economies,4.8929
-2022-12-31,AE,United Arab Emirates,9.5638
+2022-09-30,SK,Slovakia,14.5936
+2022-09-30,TH,Thailand,1.3724
+2022-09-30,TR,Türkiye,180.5053
+2022-09-30,US,United States,10.6532
+2022-09-30,XM,Euro area,6.9812
+2022-09-30,XW,World,8.2422
+2022-09-30,ZA,South Africa,4.1348
+2022-12-31,4T,Emerging market economies (aggregate),7.0677
+2022-12-31,5R,Advanced economies,4.632
 2022-12-31,AT,Austria,5.2449
-2022-12-31,AU,Australia,-3.1009
-2022-12-31,BE,Belgium,4.7682
+2022-12-31,AU,Australia,-3.0743
+2022-12-31,BE,Belgium,4.6105
 2022-12-31,BG,Bulgaria,13.3739
-2022-12-31,BR,Brazil,0.9005
-2022-12-31,CA,Canada,-3.8314
+2022-12-31,BR,Brazil,1.8105
+2022-12-31,CA,Canada,-4.6756
 2022-12-31,CH,Switzerland,4.8076
-2022-12-31,CL,Chile,4.6715
+2022-12-31,CL,Chile,4.8973
 2022-12-31,CN,China,-3.7064
-2022-12-31,CO,Colombia,5.9418
+2022-12-31,CO,Colombia,5.4561
 2022-12-31,CY,Cyprus,6.605
 2022-12-31,CZ,Czechia,6.9292
-2022-12-31,DE,Germany,-3.5714
+2022-12-31,DE,Germany,-2.4685
 2022-12-31,DK,Denmark,-6.468
 2022-12-31,EE,Estonia,16.8552
 2022-12-31,ES,Spain,5.4654
 2022-12-31,FI,Finland,-2.3402
 2022-12-31,FR,France,4.7059
-2022-12-31,GB,United Kingdom,9.0974
-2022-12-31,GR,Greece,13.9785
+2022-12-31,GB,United Kingdom,9.0226
+2022-12-31,GR,Greece,14.2473
 2022-12-31,HK,Hong Kong SAR,-13.553
-2022-12-31,HR,Croatia,17.3104
-2022-12-31,HU,Hungary,17.1896
+2022-12-31,HR,Croatia,17.3103
+2022-12-31,HU,Hungary,17.508
 2022-12-31,ID,Indonesia,2.0055
-2022-12-31,IE,Ireland,8.5615
+2022-12-31,IE,Ireland,8.5966
 2022-12-31,IL,Israel,16.7283
-2022-12-31,IN,India,2.8081
+2022-12-31,IN,India,4.5045
 2022-12-31,IS,Iceland,20.2712
 2022-12-31,IT,Italy,2.6923
 2022-12-31,JP,Japan,7.5348
-2022-12-31,KR,Korea,-0.0673
+2022-12-31,KR,Korea,-0.0902
 2022-12-31,LT,Lithuania,16.0242
 2022-12-31,LU,Luxembourg,5.5153
 2022-12-31,LV,Latvia,8.6296
-2022-12-31,MA,Morocco,0.093
-2022-12-31,MK,North Macedonia,20.5574
+2022-12-31,MA,Morocco,1.0397
+2022-12-31,MK,North Macedonia,20.467
 2022-12-31,MT,Malta,5.8993
 2022-12-31,MX,Mexico,10.4072
 2022-12-31,MY,Malaysia,3.9024
-2022-12-31,NL,Netherlands,5.3531
+2022-12-31,NL,Netherlands,5.6511
 2022-12-31,NO,Norway,2.6139
 2022-12-31,NZ,New Zealand,-10.7876
 2022-12-31,PE,Peru,1.5403
-2022-12-31,PH,Philippines,7.7305
+2022-12-31,PH,Philippines,12.9367
 2022-12-31,PL,Poland,9.3394
 2022-12-31,PT,Portugal,11.3378
 2022-12-31,RO,Romania,6.5218
-2022-12-31,RS,Serbia,15.0234
-2022-12-31,RU,Russia,23.0511
-2022-12-31,SE,Sweden,-3.6969
+2022-12-31,RS,Serbia,15.4603
+2022-12-31,RU,Russia,23.0504
+2022-12-31,SE,Sweden,-3.6968
 2022-12-31,SG,Singapore,8.6405
 2022-12-31,SI,Slovenia,11.5874
-2022-12-31,SK,Slovak Republic,9.7214
-2022-12-31,TH,Thailand,4.7587
-2022-12-31,TR,Türkiye,167.8658
-2022-12-31,US,United States,7.0373
-2022-12-31,XM,Euro area,2.9304
-2022-12-31,XW,World,6.0237
-2022-12-31,ZA,South Africa,3.1511
-2023-03-31,4T,Emerging market economies (aggregate),4.989
-2023-03-31,5R,Advanced economies,1.396
-2023-03-31,AE,United Arab Emirates,13.9651
+2022-12-31,SK,Slovakia,9.6908
+2022-12-31,TH,Thailand,4.266
+2022-12-31,TR,Türkiye,170.4663
+2022-12-31,US,United States,6.8996
+2022-12-31,XM,Euro area,3.2083
+2022-12-31,XW,World,5.9107
+2022-12-31,ZA,South Africa,3.5327
+2023-03-31,4T,Emerging market economies (aggregate),4.8721
+2023-03-31,5R,Advanced economies,1.3104
 2023-03-31,AT,Austria,1.0409
-2023-03-31,AU,Australia,-6.1607
-2023-03-31,BE,Belgium,4.3584
+2023-03-31,AU,Australia,-6.1314
+2023-03-31,BE,Belgium,3.8609
 2023-03-31,BG,Bulgaria,9.4819
-2023-03-31,BR,Brazil,0.499
-2023-03-31,CA,Canada,-14.7059
+2023-03-31,BR,Brazil,2.0564
+2023-03-31,CA,Canada,-15.4497
 2023-03-31,CH,Switzerland,3.924
-2023-03-31,CL,Chile,8.0911
+2023-03-31,CL,Chile,8.3372
 2023-03-31,CN,China,-3.3571
-2023-03-31,CO,Colombia,8.883
+2023-03-31,CO,Colombia,7.8536
 2023-03-31,CY,Cyprus,7.6716
 2023-03-31,CZ,Czechia,0.7133
-2023-03-31,DE,Germany,-6.7956
-2023-03-31,DK,Denmark,-7.8947
+2023-03-31,DE,Germany,-6.3443
+2023-03-31,DK,Denmark,-3.9118
 2023-03-31,EE,Estonia,9.1837
 2023-03-31,ES,Spain,3.5455
-2023-03-31,FI,Finland,-5.0802
+2023-03-31,FI,Finland,-5.4513
 2023-03-31,FR,France,2.8771
-2023-03-31,GB,United Kingdom,3.7709
-2023-03-31,GR,Greece,15.3647
+2023-03-31,GB,United Kingdom,3.9874
+2023-03-31,GR,Greece,15.625
 2023-03-31,HK,Hong Kong SAR,-10.244
 2023-03-31,HR,Croatia,13.9856
-2023-03-31,HU,Hungary,10.3977
+2023-03-31,HU,Hungary,11.3505
 2023-03-31,ID,Indonesia,1.7926
-2023-03-31,IE,Ireland,5.1047
+2023-03-31,IE,Ireland,5.1142
 2023-03-31,IL,Israel,11.2416
-2023-03-31,IN,India,4.5802
+2023-03-31,IN,India,4.3422
 2023-03-31,IS,Iceland,13.3531
 2023-03-31,IT,Italy,1.0407
 2023-03-31,JP,Japan,4.7472
-2023-03-31,KR,Korea,-4.3261
+2023-03-31,KR,Korea,-4.3253
 2023-03-31,LT,Lithuania,13.1389
 2023-03-31,LU,Luxembourg,-1.6821
 2023-03-31,LV,Latvia,5.8689
-2023-03-31,MA,Morocco,0.3724
-2023-03-31,MK,North Macedonia,18.8317
-2023-03-31,MT,Malta,6.5855
+2023-03-31,MA,Morocco,0.6616
+2023-03-31,MK,North Macedonia,19.031
+2023-03-31,MT,Malta,7.3013
 2023-03-31,MX,Mexico,11.6789
 2023-03-31,MY,Malaysia,4.8082
-2023-03-31,NL,Netherlands,-0.1476
+2023-03-31,NL,Netherlands,0.0787
 2023-03-31,NO,Norway,-0.0714
 2023-03-31,NZ,New Zealand,-11.6739
 2023-03-31,PE,Peru,0.723
-2023-03-31,PH,Philippines,10.2289
+2023-03-31,PH,Philippines,10.1177
 2023-03-31,PL,Poland,5.7517
 2023-03-31,PT,Portugal,8.7111
 2023-03-31,RO,Romania,4.2857
-2023-03-31,RS,Serbia,13.319
-2023-03-31,RU,Russia,1.1399
-2023-03-31,SE,Sweden,-6.9125
+2023-03-31,RS,Serbia,13.5997
+2023-03-31,RU,Russia,1.1394
+2023-03-31,SE,Sweden,-6.7202
 2023-03-31,SG,Singapore,11.4417
-2023-03-31,SI,Slovenia,8.824
-2023-03-31,SK,Slovak Republic,7.6163
-2023-03-31,TH,Thailand,4.8032
-2023-03-31,TR,Türkiye,132.8444
-2023-03-31,US,United States,3.4303
-2023-03-31,XM,Euro area,0.429
-2023-03-31,XW,World,3.3905
-2023-03-31,ZA,South Africa,2.6339
-2023-06-30,4T,Emerging market economies (aggregate),4.1
-2023-06-30,5R,Advanced economies,0.0294
-2023-06-30,AE,United Arab Emirates,16.0563
+2023-03-31,SI,Slovenia,9.0037
+2023-03-31,SK,Slovakia,7.4053
+2023-03-31,TH,Thailand,4.7382
+2023-03-31,TR,Türkiye,142.6874
+2023-03-31,US,United States,3.6737
+2023-03-31,XM,Euro area,0.4773
+2023-03-31,XW,World,3.1742
+2023-03-31,ZA,South Africa,2.583
+2023-06-30,4T,Emerging market economies (aggregate),4.0822
+2023-06-30,5R,Advanced economies,-0.0473
 2023-06-30,AT,Austria,-2.2703
-2023-06-30,AU,Australia,-3.864
-2023-06-30,BE,Belgium,1.7346
+2023-06-30,AU,Australia,-3.8022
+2023-06-30,BE,Belgium,1.793
 2023-06-30,BG,Bulgaria,10.6934
-2023-06-30,BR,Brazil,0.3977
-2023-06-30,CA,Canada,-8.6028
+2023-06-30,BR,Brazil,2.7796
+2023-06-30,CA,Canada,-8.8278
 2023-06-30,CH,Switzerland,2.3932
-2023-06-30,CL,Chile,7.851
-2023-06-30,CN,China,-2.6742
-2023-06-30,CO,Colombia,7.1207
+2023-06-30,CL,Chile,8.0369
+2023-06-30,CN,China,-2.6688
+2023-06-30,CO,Colombia,5.9898
 2023-06-30,CY,Cyprus,7.4234
 2023-06-30,CZ,Czechia,-2.7164
-2023-06-30,DE,Germany,-9.641
-2023-06-30,DK,Denmark,-6.5965
+2023-06-30,DE,Germany,-9.434
+2023-06-30,DK,Denmark,-4.7719
 2023-06-30,EE,Estonia,4.9949
 2023-06-30,ES,Spain,3.7118
-2023-06-30,FI,Finland,-5.536
+2023-06-30,FI,Finland,-6.0793
 2023-06-30,FR,France,0.6881
-2023-06-30,GB,United Kingdom,0.8169
-2023-06-30,GR,Greece,14.4655
+2023-06-30,GB,United Kingdom,0.9212
+2023-06-30,GR,Greece,14.8428
 2023-06-30,HK,Hong Kong SAR,-8.713
-2023-06-30,HR,Croatia,13.7428
-2023-06-30,HU,Hungary,4.9373
+2023-06-30,HR,Croatia,13.7429
+2023-06-30,HU,Hungary,6.3871
 2023-06-30,ID,Indonesia,1.9291
-2023-06-30,IE,Ireland,2.7263
+2023-06-30,IE,Ireland,2.7389
 2023-06-30,IL,Israel,5.0517
-2023-06-30,IN,India,5.1482
+2023-06-30,IN,India,3.7212
 2023-06-30,IS,Iceland,7.8848
 2023-06-30,IT,Italy,0.6475
 2023-06-30,JP,Japan,3.2423
-2023-06-30,KR,Korea,-6.8167
+2023-06-30,KR,Korea,-6.7961
 2023-06-30,LT,Lithuania,9.3549
 2023-06-30,LU,Luxembourg,-5.8917
 2023-06-30,LV,Latvia,5.378
-2023-06-30,MA,Morocco,-0.4642
-2023-06-30,MK,North Macedonia,12.9608
-2023-06-30,MT,Malta,4.4952
+2023-06-30,MA,Morocco,0.3773
+2023-06-30,MK,North Macedonia,12.9967
+2023-06-30,MT,Malta,5.2559
 2023-06-30,MX,Mexico,11.5326
 2023-06-30,MY,Malaysia,4.3311
-2023-06-30,NL,Netherlands,-4.3409
+2023-06-30,NL,Netherlands,-4.0489
 2023-06-30,NO,Norway,-0.1373
 2023-06-30,NZ,New Zealand,-8.8957
 2023-06-30,PE,Peru,1.0456
-2023-06-30,PH,Philippines,14.145
+2023-06-30,PH,Philippines,10.5082
 2023-06-30,PL,Poland,7.0336
 2023-06-30,PT,Portugal,8.725
 2023-06-30,RO,Romania,0
-2023-06-30,RS,Serbia,10.7617
-2023-06-30,RU,Russia,0.7922
-2023-06-30,SE,Sweden,-6.7953
+2023-06-30,RS,Serbia,11.4219
+2023-06-30,RU,Russia,0.7918
+2023-06-30,SE,Sweden,-6.7531
 2023-06-30,SG,Singapore,7.4627
-2023-06-30,SI,Slovenia,7.3653
-2023-06-30,SK,Slovak Republic,-1.9284
-2023-06-30,TH,Thailand,3.3421
-2023-06-30,TR,Türkiye,95.9574
-2023-06-30,US,United States,1.6239
-2023-06-30,XM,Euro area,-1.5349
-2023-06-30,XW,World,2.2882
-2023-06-30,ZA,South Africa,1.9785
-2023-09-30,4T,Emerging market economies (aggregate),
-2023-09-30,5R,Advanced economies,1.3954
-2023-09-30,AE,United Arab Emirates,19.5512
+2023-06-30,SI,Slovenia,7.5161
+2023-06-30,SK,Slovakia,-2.1559
+2023-06-30,TH,Thailand,2.887
+2023-06-30,TR,Türkiye,105.4445
+2023-06-30,US,United States,2.2018
+2023-06-30,XM,Euro area,-1.5447
+2023-06-30,XW,World,2.1138
+2023-06-30,ZA,South Africa,1.6043
+2023-09-30,4T,Emerging market economies (aggregate),3.5373
+2023-09-30,5R,Advanced economies,0.8412
 2023-09-30,AT,Austria,-2.9105
-2023-09-30,AU,Australia,2.1583
-2023-09-30,BE,Belgium,1.1589
+2023-09-30,AU,Australia,2.3823
+2023-09-30,BE,Belgium,1.0003
 2023-09-30,BG,Bulgaria,9.2014
-2023-09-30,BR,Brazil,0.4266
-2023-09-30,CA,Canada,-0.0317
+2023-09-30,BR,Brazil,3.7572
+2023-09-30,CA,Canada,-0.3183
 2023-09-30,CH,Switzerland,1.3088
-2023-09-30,CL,Chile,
-2023-09-30,CN,China,-3.1658
-2023-09-30,CO,Colombia,7.0289
+2023-09-30,CL,Chile,7.9387
+2023-09-30,CN,China,-3.1808
+2023-09-30,CO,Colombia,8.3216
 2023-09-30,CY,Cyprus,7.5638
 2023-09-30,CZ,Czechia,-3.5096
-2023-09-30,DE,Germany,-10.2273
-2023-09-30,DK,Denmark,-0.2909
+2023-09-30,DE,Germany,-10.2156
+2023-09-30,DK,Denmark,0.4364
 2023-09-30,EE,Estonia,3.8487
 2023-09-30,ES,Spain,4.53
-2023-09-30,FI,Finland,
-2023-09-30,FR,France,-1.4892
-2023-09-30,GB,United Kingdom,-0.4599
-2023-09-30,GR,Greece,11.9277
-2023-09-30,HK,Hong Kong SAR,-8.5701
+2023-09-30,FI,Finland,-7.754
+2023-09-30,FR,France,-1.5637
+2023-09-30,GB,United Kingdom,-1.0848
+2023-09-30,GR,Greece,12.7711
+2023-09-30,HK,Hong Kong SAR,-8.5882
 2023-09-30,HR,Croatia,10.899
-2023-09-30,HU,Hungary,1.4829
+2023-09-30,HU,Hungary,3.6502
 2023-09-30,ID,Indonesia,1.9565
-2023-09-30,IE,Ireland,1.3753
-2023-09-30,IL,Israel,-0.2383
-2023-09-30,IN,India,
+2023-09-30,IE,Ireland,1.3817
+2023-09-30,IL,Israel,-0.1966
+2023-09-30,IN,India,2.6257
 2023-09-30,IS,Iceland,2.2551
-2023-09-30,IT,Italy,1.7774
-2023-09-30,JP,Japan,2.0923
-2023-09-30,KR,Korea,-7.313
+2023-09-30,IT,Italy,1.6838
+2023-09-30,JP,Japan,2.1427
+2023-09-30,KR,Korea,-7.324
 2023-09-30,LT,Lithuania,8.7381
-2023-09-30,LU,Luxembourg,-13.6245
-2023-09-30,LV,Latvia,3.1491
-2023-09-30,MA,Morocco,-0.1847
-2023-09-30,MK,North Macedonia,10.9778
-2023-09-30,MT,Malta,4.6101
+2023-09-30,LU,Luxembourg,-13.9366
+2023-09-30,LV,Latvia,3.0164
+2023-09-30,MA,Morocco,0.0938
+2023-09-30,MK,North Macedonia,11.1795
+2023-09-30,MT,Malta,5.6772
 2023-09-30,MX,Mexico,10.3813
-2023-09-30,MY,Malaysia,0.0942
-2023-09-30,NL,Netherlands,-3.7659
+2023-09-30,MY,Malaysia,3.2957
+2023-09-30,NL,Netherlands,-3.7149
 2023-09-30,NO,Norway,-1.2579
-2023-09-30,NZ,New Zealand,-4.295
-2023-09-30,PE,Peru,1.7087
-2023-09-30,PH,Philippines,12.8533
+2023-09-30,NZ,New Zealand,-4.0618
+2023-09-30,PE,Peru,1.0934
+2023-09-30,PH,Philippines,7.3471
 2023-09-30,PL,Poland,9.2603
-2023-09-30,PT,Portugal,
-2023-09-30,RO,Romania,
-2023-09-30,RS,Serbia,8.1995
-2023-09-30,RU,Russia,
-2023-09-30,SE,Sweden,-4.2291
+2023-09-30,PT,Portugal,7.5637
+2023-09-30,RO,Romania,4.8951
+2023-09-30,RS,Serbia,9.058
+2023-09-30,RU,Russia,1.7592
+2023-09-30,SE,Sweden,-4.1734
 2023-09-30,SG,Singapore,4.3664
-2023-09-30,SI,Slovenia,5.7143
-2023-09-30,SK,Slovak Republic,-3.805
-2023-09-30,TH,Thailand,3.6018
-2023-09-30,TR,Türkiye,89.2
-2023-09-30,US,United States,4.5706
-2023-09-30,XM,Euro area,-2.1011
-2023-09-30,XW,World,
-2023-09-30,ZA,South Africa,0.8016
+2023-09-30,SI,Slovenia,5.6293
+2023-09-30,SK,Slovakia,-4.0838
+2023-09-30,TH,Thailand,3.2
+2023-09-30,TR,Türkiye,93.7552
+2023-09-30,US,United States,4.663
+2023-09-30,XM,Euro area,-2.2115
+2023-09-30,XW,World,2.2605
+2023-09-30,ZA,South Africa,0.8698
+2023-12-31,4T,Emerging market economies (aggregate),3.3968
+2023-12-31,5R,Advanced economies,1.7175
+2023-12-31,AT,Austria,-2.3452
+2023-12-31,AU,Australia,7.2442
+2023-12-31,BE,Belgium,2.7722
+2023-12-31,BG,Bulgaria,10.0719
+2023-12-31,BR,Brazil,4.7656
+2023-12-31,CA,Canada,0.4671
+2023-12-31,CH,Switzerland,1.2482
+2023-12-31,CL,Chile,7.635
+2023-12-31,CN,China,-3.7182
+2023-12-31,CO,Colombia,4.8717
+2023-12-31,CY,Cyprus,8.3382
+2023-12-31,CZ,Czechia,-1.0256
+2023-12-31,DE,Germany,-7.6467
+2023-12-31,DK,Denmark,9.0132
+2023-12-31,EE,Estonia,5.7763
+2023-12-31,ES,Spain,4.294
+2023-12-31,FI,Finland,-5.53
+2023-12-31,FR,France,-3.5955
+2023-12-31,GB,United Kingdom,-2.4631
+2023-12-31,GR,Greece,12.4706
+2023-12-31,HK,Hong Kong SAR,-7.2525
+2023-12-31,HR,Croatia,9.465
+2023-12-31,HU,Hungary,7.3529
+2023-12-31,ID,Indonesia,1.7404
+2023-12-31,IE,Ireland,3.1269
+2023-12-31,IL,Israel,-1.6204
+2023-12-31,IN,India,2.955
+2023-12-31,IS,Iceland,4.2353
+2023-12-31,IT,Italy,1.779
+2023-12-31,JP,Japan,2.031
+2023-12-31,KR,Korea,-5.5994
+2023-12-31,LT,Lithuania,8.326
+2023-12-31,LU,Luxembourg,-14.4667
+2023-12-31,LV,Latvia,0.8181
+2023-12-31,MA,Morocco,-0.2806
+2023-12-31,MK,North Macedonia,6.8835
+2023-12-31,MT,Malta,6.7256
+2023-12-31,MX,Mexico,10.0616
+2023-12-31,MY,Malaysia,3.8498
+2023-12-31,NL,Netherlands,0.155
+2023-12-31,NO,Norway,-0.7278
+2023-12-31,NZ,New Zealand,-0.615
+2023-12-31,PE,Peru,2.933
+2023-12-31,PH,Philippines,3.2079
+2023-12-31,PL,Poland,13.0158
+2023-12-31,PT,Portugal,7.8403
+2023-12-31,RO,Romania,3.4014
+2023-12-31,RS,Serbia,7.1339
+2023-12-31,RU,Russia,3.2382
+2023-12-31,SE,Sweden,-2.8562
+2023-12-31,SG,Singapore,6.8399
+2023-12-31,SI,Slovenia,6.9116
+2023-12-31,SK,Slovakia,-1.4092
+2023-12-31,TH,Thailand,2.5271
+2023-12-31,TR,Türkiye,87.2631
+2023-12-31,US,United States,5.4939
+2023-12-31,XM,Euro area,-1.2531
+2023-12-31,XW,World,2.6107
+2023-12-31,ZA,South Africa,0.9085
+2024-03-31,4T,Emerging market economies (aggregate),4.1134
+2024-03-31,5R,Advanced economies,2.2524
+2024-03-31,AT,Austria,-2.5754
+2024-03-31,AU,Australia,9.5525
+2024-03-31,BE,Belgium,3.1991
+2024-03-31,BG,Bulgaria,16.0119
+2024-03-31,BR,Brazil,5.6044
+2024-03-31,CA,Canada,0.7336
+2024-03-31,CH,Switzerland,1.478
+2024-03-31,CL,Chile,7.5458
+2024-03-31,CN,China,-5.1579
+2024-03-31,CO,Colombia,7.943
+2024-03-31,CY,Cyprus,7.7944
+2024-03-31,CZ,Czechia,1.1803
+2024-03-31,DE,Germany,-5.1638
+2024-03-31,DK,Denmark,1.1843
+2024-03-31,EE,Estonia,7.8104
+2024-03-31,ES,Spain,6.3898
+2024-03-31,FI,Finland,-4.0643
+2024-03-31,FR,France,-4.7619
+2024-03-31,GB,United Kingdom,-1.3118
+2024-03-31,GR,Greece,10.8108
+2024-03-31,HK,Hong Kong SAR,-11.5288
+2024-03-31,HR,Croatia,9.1014
+2024-03-31,HU,Hungary,11.9792
+2024-03-31,ID,Indonesia,1.883
+2024-03-31,IE,Ireland,6.321
+2024-03-31,IL,Israel,1.0909
+2024-03-31,IN,India,6.8898
+2024-03-31,IS,Iceland,6.9663
+2024-03-31,IT,Italy,1.5918
+2024-03-31,JP,Japan,2.4877
+2024-03-31,KR,Korea,-2.7963
+2024-03-31,LT,Lithuania,9.9044
+2024-03-31,LU,Luxembourg,-11.2031
+2024-03-31,LV,Latvia,3.621
+2024-03-31,MA,Morocco,-0.5634
+2024-03-31,MK,North Macedonia,4.5681
+2024-03-31,MT,Malta,6.7378
+2024-03-31,MX,Mexico,9.6706
+2024-03-31,MY,Malaysia,3.5218
+2024-03-31,NL,Netherlands,3.6979
+2024-03-31,NO,Norway,1.2143
+2024-03-31,NZ,New Zealand,2.0812
+2024-03-31,PE,Peru,1.5312
+2024-03-31,PH,Philippines,7.4123
+2024-03-31,PL,Poland,18.0038
+2024-03-31,PT,Portugal,7.0008
+2024-03-31,RO,Romania,5.4795
+2024-03-31,RS,Serbia,5.8726
+2024-03-31,RU,Russia,18.9628
+2024-03-31,SE,Sweden,-1.5872
+2024-03-31,SG,Singapore,4.8767
+2024-03-31,SI,Slovenia,7.4083
+2024-03-31,SK,Slovakia,-2.9316
+2024-03-31,TH,Thailand,0.5952
+2024-03-31,TR,Türkiye,63.3482
+2024-03-31,US,United States,5.3827
+2024-03-31,XM,Euro area,-0.2515
+2024-03-31,XW,World,3.2459
+2024-03-31,ZA,South Africa,1.0122
+2024-06-30,4T,Emerging market economies (aggregate),2.8615
+2024-06-30,5R,Advanced economies,2.6692
+2024-06-30,AT,Austria,-2.4705
+2024-06-30,AU,Australia,8.8514
+2024-06-30,BE,Belgium,3.2776
+2024-06-30,BG,Bulgaria,15.1105
+2024-06-30,BR,Brazil,6.1376
+2024-06-30,CA,Canada,-2.7937
+2024-06-30,CH,Switzerland,1.3762
+2024-06-30,CL,Chile,7.0951
+2024-06-30,CN,China,-7.382
+2024-06-30,CO,Colombia,7.7446
+2024-06-30,CY,Cyprus,7.9728
+2024-06-30,CZ,Czechia,4.0701
+2024-06-30,DE,Germany,-2.4775
+2024-06-30,DK,Denmark,3.832
+2024-06-30,EE,Estonia,6.686
+2024-06-30,ES,Spain,7.9336
+2024-06-30,FI,Finland,-4.409
+2024-06-30,FR,France,-4.5558
+2024-06-30,GB,United Kingdom,0.4057
+2024-06-30,GR,Greece,9.7575
+2024-06-30,HK,Hong Kong SAR,-12.7674
+2024-06-30,HR,Croatia,9.9666
+2024-06-30,HU,Hungary,12.8913
+2024-06-30,ID,Indonesia,1.7621
+2024-06-30,IE,Ireland,8.4386
+2024-06-30,IL,Israel,4.5063
+2024-06-30,IN,India,7.6201
+2024-06-30,IS,Iceland,6.2825
+2024-06-30,IT,Italy,2.9412
+2024-06-30,JP,Japan,2.7695
+2024-06-30,KR,Korea,-0.9673
+2024-06-30,LT,Lithuania,10.356
+2024-06-30,LU,Luxembourg,-8.4038
+2024-06-30,LV,Latvia,0.715
+2024-06-30,MA,Morocco,-0.2819
+2024-06-30,MK,North Macedonia,11.3866
+2024-06-30,MT,Malta,6.8988
+2024-06-30,MX,Mexico,9.3551
+2024-06-30,MY,Malaysia,4.1052
+2024-06-30,NL,Netherlands,7.6433
+2024-06-30,NO,Norway,1.512
+2024-06-30,NZ,New Zealand,1.2013
+2024-06-30,PE,Peru,0.443
+2024-06-30,PH,Philippines,7.8941
+2024-06-30,PL,Poland,17.6686
+2024-06-30,PT,Portugal,7.8148
+2024-06-30,RO,Romania,6.8966
+2024-06-30,RS,Serbia,5.3027
+2024-06-30,RU,Russia,19.2588
+2024-06-30,SE,Sweden,-0.7635
+2024-06-30,SG,Singapore,6.0185
+2024-06-30,SI,Slovenia,6.9799
+2024-06-30,SK,Slovakia,4.0113
+2024-06-30,TH,Thailand,1.2537
+2024-06-30,TR,Türkiye,49.6847
+2024-06-30,US,United States,4.7901
+2024-06-30,XM,Euro area,1.4016
+2024-06-30,XW,World,2.77
+2024-06-30,ZA,South Africa,0.6101
+2024-09-30,4T,Emerging market economies (aggregate),1.4766
+2024-09-30,5R,Advanced economies,2.7491
+2024-09-30,AT,Austria,-2.2576
+2024-09-30,AU,Australia,7.4356
+2024-09-30,BE,Belgium,3.5581
+2024-09-30,BG,Bulgaria,16.5004
+2024-09-30,BR,Brazil,6.2933
+2024-09-30,CA,Canada,-4.023
+2024-09-30,CH,Switzerland,1.7467
+2024-09-30,CL,Chile,6.7978
+2024-09-30,CN,China,-8.5737
+2024-09-30,CO,Colombia,7.3933
+2024-09-30,CY,Cyprus,6.507
+2024-09-30,CZ,Czechia,6.1407
+2024-09-30,DE,Germany,-0.1715
+2024-09-30,DK,Denmark,5.2136
+2024-09-30,EE,Estonia,6.4454
+2024-09-30,ES,Spain,8.2559
+2024-09-30,FI,Finland,-1.9324
+2024-09-30,FR,France,-3.4796
+2024-09-30,GB,United Kingdom,0.8973
+2024-09-30,GR,Greece,8.5575
+2024-09-30,HK,Hong Kong SAR,-13.1274
+2024-09-30,HR,Croatia,12.271
+2024-09-30,HU,Hungary,13.6464
+2024-09-30,ID,Indonesia,1.4554
+2024-09-30,IE,Ireland,9.9151
+2024-09-30,IL,Israel,6.19
+2024-09-30,IN,India,6.9867
+2024-09-30,IS,Iceland,11.886
+2024-09-30,IT,Italy,3.7718
+2024-09-30,JP,Japan,3.233
+2024-09-30,KR,Korea,-0.3283
+2024-09-30,LT,Lithuania,8.8648
+2024-09-30,LU,Luxembourg,-1.8731
+2024-09-30,LV,Latvia,5.254
+2024-09-30,MA,Morocco,-0.2812
+2024-09-30,MK,North Macedonia,7.9476
+2024-09-30,MT,Malta,6.9644
+2024-09-30,MX,Mexico,9.1864
+2024-09-30,MY,Malaysia,4.33
+2024-09-30,NL,Netherlands,10.3937
+2024-09-30,NO,Norway,3.2555
+2024-09-30,NZ,New Zealand,-0.9932
+2024-09-30,PE,Peru,0.0766
+2024-09-30,PH,Philippines,7.5836
+2024-09-30,PL,Poland,14.392
+2024-09-30,PT,Portugal,9.7899
+2024-09-30,RO,Romania,4
+2024-09-30,RS,Serbia,5.2666
+2024-09-30,RU,Russia,17.7033
+2024-09-30,SE,Sweden,0.2211
+2024-09-30,SG,Singapore,4.4388
+2024-09-30,SI,Slovenia,8.1629
+2024-09-30,SK,Slovakia,6.1624
+2024-09-30,TH,Thailand,3.0411
+2024-09-30,TR,Türkiye,33.2763
+2024-09-30,US,United States,3.7448
+2024-09-30,XM,Euro area,2.7903
+2024-09-30,XW,World,2.0599
+2024-09-30,ZA,South Africa,0.6487
+2024-12-31,4T,Emerging market economies (aggregate),1.1282
+2024-12-31,5R,Advanced economies,3.2315
+2024-12-31,AT,Austria,-1.0882
+2024-12-31,AU,Australia,5.7735
+2024-12-31,BE,Belgium,2.8204
+2024-12-31,BG,Bulgaria,18.2695
+2024-12-31,BR,Brazil,6.0972
+2024-12-31,CA,Canada,-1.8266
+2024-12-31,CH,Switzerland,2.3686
+2024-12-31,CL,Chile,7.4373
+2024-12-31,CN,China,-8.5668
+2024-12-31,CO,Colombia,10.2084
+2024-12-31,CY,Cyprus,4.5323
+2024-12-31,CZ,Czechia,8.4314
+2024-12-31,DE,Germany,1.9242
+2024-12-31,DK,Denmark,3.7063
+2024-12-31,EE,Estonia,3.5669
+2024-12-31,ES,Spain,11.3592
+2024-12-31,FI,Finland,-1.8537
+2024-12-31,FR,France,-1.8648
+2024-12-31,GB,United Kingdom,2.4242
+2024-12-31,GR,Greece,7.4109
+2024-12-31,HK,Hong Kong SAR,-8.1357
+2024-12-31,HR,Croatia,10.0967
+2024-12-31,HU,Hungary,16.1139
+2024-12-31,ID,Indonesia,1.387
+2024-12-31,IE,Ireland,9.3648
+2024-12-31,IL,Israel,7.5252
+2024-12-31,IN,India,6.8763
+2024-12-31,IS,Iceland,8.7089
+2024-12-31,IT,Italy,4.4158
+2024-12-31,JP,Japan,2.7868
+2024-12-31,KR,Korea,-0.1629
+2024-12-31,LT,Lithuania,9.7913
+2024-12-31,LU,Luxembourg,1.4197
+2024-12-31,LV,Latvia,7.3158
+2024-12-31,MA,Morocco,1.6886
+2024-12-31,MK,North Macedonia,10.5808
+2024-12-31,MT,Malta,6.2762
+2024-12-31,MX,Mexico,8.7133
+2024-12-31,MY,Malaysia,4.4304
+2024-12-31,NL,Netherlands,10.8359
+2024-12-31,NO,Norway,4.8387
+2024-12-31,NZ,New Zealand,-1.5909
+2024-12-31,PE,Peru,-1.496
+2024-12-31,PH,Philippines,9.7667
+2024-12-31,PL,Poland,10.3954
+2024-12-31,PT,Portugal,11.5539
+2024-12-31,RO,Romania,3.9474
+2024-12-31,RS,Serbia,5.4184
+2024-12-31,RU,Russia,17.1055
+2024-12-31,SE,Sweden,2.119
+2024-12-31,SG,Singapore,3.9206
+2024-12-31,SI,Slovenia,7.5946
+2024-12-31,SK,Slovakia,7.9714
+2024-12-31,TH,Thailand,2.5822
+2024-12-31,TR,Türkiye,28.5446
+2024-12-31,US,United States,3.4603
+2024-12-31,XM,Euro area,4.1506
+2024-12-31,XW,World,2.0934
+2024-12-31,ZA,South Africa,1.0748
+2025-03-31,4T,Emerging market economies (aggregate),0.9434
+2025-03-31,5R,Advanced economies,3.5823
+2025-03-31,AT,Austria,0.3776
+2025-03-31,AU,Australia,4.4669
+2025-03-31,BE,Belgium,2.6693
+2025-03-31,BG,Bulgaria,15.0809
+2025-03-31,BR,Brazil,5.6751
+2025-03-31,CA,Canada,-1.4896
+2025-03-31,CH,Switzerland,4.1295
+2025-03-31,CL,Chile,6.9132
+2025-03-31,CN,China,-7.5194
+2025-03-31,CO,Colombia,4.1585
+2025-03-31,CY,Cyprus,4.8311
+2025-03-31,CZ,Czechia,9.9394
+2025-03-31,DE,Germany,3.5129
+2025-03-31,DK,Denmark,8.7783
+2025-03-31,EE,Estonia,4.613
+2025-03-31,ES,Spain,12.2862
+2025-03-31,FI,Finland,-1.8719
+2025-03-31,FR,France,0.3968
+2025-03-31,GB,United Kingdom,4.1922
+2025-03-31,GR,Greece,7.4756
+2025-03-31,HK,Hong Kong SAR,-6.5482
+2025-03-31,HR,Croatia,13.094
+2025-03-31,HU,Hungary,17.0432
+2025-03-31,ID,Indonesia,1.0758
+2025-03-31,IE,Ireland,7.9332
+2025-03-31,IL,Israel,5.9294
+2025-03-31,IN,India,3.8341
+2025-03-31,IS,Iceland,7.002
+2025-03-31,IT,Italy,4.424
+2025-03-31,JP,Japan,4.6864
+2025-03-31,KR,Korea,-0.1533
+2025-03-31,LT,Lithuania,8.7791
+2025-03-31,LU,Luxembourg,0.9944
+2025-03-31,LV,Latvia,5.4372
+2025-03-31,MA,Morocco,0.4721
+2025-03-31,MK,North Macedonia,19.4553
+2025-03-31,MT,Malta,5.85
+2025-03-31,MX,Mexico,8.1525
+2025-03-31,MY,Malaysia,3.5363
+2025-03-31,NL,Netherlands,10.7739
+2025-03-31,NO,Norway,6.4926
+2025-03-31,NZ,New Zealand,-1.9046
+2025-03-31,PE,Peru,0.743
+2025-03-31,PH,Philippines,7.5632
+2025-03-31,PL,Poland,6.5787
+2025-03-31,PT,Portugal,16.2862
+2025-03-31,RO,Romania,5.1948
+2025-03-31,RS,Serbia,5.5642
+2025-03-31,RU,Russia,17.0471
+2025-03-31,SE,Sweden,2.1058
+2025-03-31,SG,Singapore,3.3284
+2025-03-31,SI,Slovenia,3.1825
+2025-03-31,SK,Slovakia,13.1991
+2025-03-31,TH,Thailand,3.4911
+2025-03-31,TR,Türkiye,31.8392
+2025-03-31,US,United States,2.6655
+2025-03-31,XM,Euro area,5.3225
+2025-03-31,XW,World,2.1515
+2025-03-31,ZA,South Africa,1.7812
+2025-06-30,4T,Emerging market economies (aggregate),1.3642
+2025-06-30,5R,Advanced economies,2.9339
+2025-06-30,AT,Austria,0
+2025-06-30,AU,Australia,4.0662
+2025-06-30,BE,Belgium,2.8641
+2025-06-30,BG,Bulgaria,15.5107
+2025-06-30,BR,Brazil,5.1711
+2025-06-30,CA,Canada,-2.9066
+2025-06-30,CH,Switzerland,4.9549
+2025-06-30,CL,Chile,6.4835
+2025-06-30,CN,China,-6.4048
+2025-06-30,CO,Colombia,9.9494
+2025-06-30,CY,Cyprus,4.681
+2025-06-30,CZ,Czechia,10.5048
+2025-06-30,DE,Germany,3.1178
+2025-06-30,DK,Denmark,7.3811
+2025-06-30,EE,Estonia,5.5137
+2025-06-30,ES,Spain,12.7719
+2025-06-30,FI,Finland,-1.3739
+2025-06-30,FR,France,0.6364
+2025-06-30,GB,United Kingdom,2.1212
+2025-06-30,GR,Greece,7.9924
+2025-06-30,HK,Hong Kong SAR,-6.3099
+2025-06-30,HR,Croatia,13.2658
+2025-06-30,HU,Hungary,13.8662
+2025-06-30,ID,Indonesia,0.8979
+2025-06-30,IE,Ireland,7.7634
+2025-06-30,IL,Israel,2.6723
+2025-06-30,IN,India,3.6436
+2025-06-30,IS,Iceland,5.845
+2025-06-30,IT,Italy,3.9286
+2025-06-30,JP,Japan,3.6574
+2025-06-30,KR,Korea,0.1084
+2025-06-30,LT,Lithuania,8.7689
+2025-06-30,LU,Luxembourg,4.4951
+2025-06-30,LV,Latvia,6.4667
+2025-06-30,MA,Morocco,0.2827
+2025-06-30,MK,North Macedonia,19.9016
+2025-06-30,MT,Malta,5.6177
+2025-06-30,MX,Mexico,8.7134
+2025-06-30,MY,Malaysia,3.0128
+2025-06-30,NL,Netherlands,9.5414
+2025-06-30,NO,Norway,4.5362
+2025-06-30,NZ,New Zealand,-1.1038
+2025-06-30,PE,Peru,2.2358
+2025-06-30,PH,Philippines,7.5474
+2025-06-30,PL,Poland,4.73
+2025-06-30,PT,Portugal,17.2329
+2025-06-30,RO,Romania,4.5162
+2025-06-30,RS,Serbia,5.6858
+2025-06-30,RU,Russia,16.2494
+2025-06-30,SE,Sweden,0.5823
+2025-06-30,SG,Singapore,3.445
+2025-06-30,SI,Slovenia,5.5362
+2025-06-30,SK,Slovakia,11.2982
+2025-06-30,TH,Thailand,2.8302
+2025-06-30,TR,Türkiye,32.6498
+2025-06-30,US,United States,1.8814
+2025-06-30,XM,Euro area,5.1506
+2025-06-30,XW,World,2.0845
+2025-06-30,ZA,South Africa,3.3058
+2025-09-30,4T,Emerging market economies (aggregate),1.6663
+2025-09-30,5R,Advanced economies,2.8184
+2025-09-30,AT,Austria,1.4767
+2025-09-30,AU,Australia,5.0184
+2025-09-30,BE,Belgium,3.6554
+2025-09-30,BG,Bulgaria,15.3666
+2025-09-30,BR,Brazil,4.7139
+2025-09-30,CA,Canada,-3.1936
+2025-09-30,CH,Switzerland,5.2223
+2025-09-30,CL,Chile,7.1251
+2025-09-30,CN,China,-5.5214
+2025-09-30,CO,Colombia,8.3472
+2025-09-30,CY,Cyprus,5.0313
+2025-09-30,CZ,Czechia,10.8145
+2025-09-30,DE,Germany,3.0928
+2025-09-30,DK,Denmark,6.3317
+2025-09-30,EE,Estonia,5.1771
+2025-09-30,ES,Spain,12.8372
+2025-09-30,FI,Finland,-3.1527
+2025-09-30,FR,France,0.7053
+2025-09-30,GB,United Kingdom,2.4704
+2025-09-30,GR,Greece,8.2531
+2025-09-30,HK,Hong Kong SAR,-0.8205
+2025-09-30,HR,Croatia,13.7982
+2025-09-30,HU,Hungary,20.949
+2025-09-30,ID,Indonesia,0.8406
+2025-09-30,IE,Ireland,7.4753
+2025-09-30,IL,Israel,0.6745
+2025-09-30,IN,India,3.5386
+2025-09-30,IS,Iceland,2.8286
+2025-09-30,IT,Italy,3.7234
+2025-09-30,JP,Japan,4.327
+2025-09-30,KR,Korea,0.3538
+2025-09-30,LT,Lithuania,10.8333
+2025-09-30,LU,Luxembourg,0.8621
+2025-09-30,LV,Latvia,7.9433
+2025-09-30,MA,Morocco,1.9737
+2025-09-30,MK,North Macedonia,25.0908
+2025-09-30,MT,Malta,5.6698
+2025-09-30,MX,Mexico,8.8639
+2025-09-30,MY,Malaysia,2.3154
+2025-09-30,NL,Netherlands,7.7033
+2025-09-30,NO,Norway,5.0034
+2025-09-30,NZ,New Zealand,-0.53
+2025-09-30,PE,Peru,4.065
+2025-09-30,PH,Philippines,1.8897
+2025-09-30,PL,Poland,3.9866
+2025-09-30,PT,Portugal,17.6766
+2025-09-30,RO,Romania,6.4103
+2025-09-30,RS,Serbia,5.7516
+2025-09-30,RU,Russia,16.0114
+2025-09-30,SE,Sweden,0.3156
+2025-09-30,SG,Singapore,5.0806
+2025-09-30,SI,Slovenia,2.724
+2025-09-30,SK,Slovakia,13.4037
+2025-09-30,TH,Thailand,0.4051
+2025-09-30,TR,Türkiye,32.1311
+2025-09-30,US,United States,1.2796
+2025-09-30,XM,Euro area,5.0501
+2025-09-30,XW,World,2.1896
+2025-09-30,ZA,South Africa,4.8894
+2025-12-31,5R,Advanced economies,2.8224
+2025-12-31,AT,Austria,2.1244
+2025-12-31,AU,Australia,7.8211
+2025-12-31,BE,Belgium,3.4604
+2025-12-31,BG,Bulgaria,12.5921
+2025-12-31,BR,Brazil,4.3755
+2025-12-31,CA,Canada,-3.383
+2025-12-31,CH,Switzerland,3.9406
+2025-12-31,CN,China,-5.7407
+2025-12-31,CO,Colombia,12.8865
+2025-12-31,CY,Cyprus,7.0661
+2025-12-31,CZ,Czechia,10.3823
+2025-12-31,DE,Germany,3.032
+2025-12-31,DK,Denmark,7.6289
+2025-12-31,EE,Estonia,5.5471
+2025-12-31,ES,Spain,12.8741
+2025-12-31,FR,France,1.0293
+2025-12-31,GB,United Kingdom,2.4655
+2025-12-31,GR,Greece,7.6202
+2025-12-31,HK,Hong Kong SAR,2.478
+2025-12-31,HR,Croatia,16.0488
+2025-12-31,HU,Hungary,21.2356
+2025-12-31,IE,Ireland,6.9661
+2025-12-31,IL,Israel,-0.1665
+2025-12-31,IN,India,3.5781
+2025-12-31,IS,Iceland,3.6484
+2025-12-31,IT,Italy,4.0529
+2025-12-31,JP,Japan,5.0351
+2025-12-31,KR,Korea,0.703
+2025-12-31,LT,Lithuania,10.8439
+2025-12-31,LU,Luxembourg,0.0609
+2025-12-31,LV,Latvia,10.9559
+2025-12-31,MA,Morocco,0.2767
+2025-12-31,MK,North Macedonia,25.011
+2025-12-31,MX,Mexico,8.9237
+2025-12-31,MY,Malaysia,1.4719
+2025-12-31,NO,Norway,5.9441
+2025-12-31,NZ,New Zealand,-1.2636
+2025-12-31,PE,Peru,6.1028
+2025-12-31,PH,Philippines,1.5676
+2025-12-31,PL,Poland,4.3326
+2025-12-31,PT,Portugal,18.8943
+2025-12-31,RO,Romania,6.962
+2025-12-31,RS,Serbia,5.7005
+2025-12-31,RU,Russia,14.2674
+2025-12-31,SE,Sweden,1.1856
+2025-12-31,SG,Singapore,3.3429
+2025-12-31,SI,Slovenia,5.7654
+2025-12-31,SK,Slovakia,12.7291
+2025-12-31,TH,Thailand,0.6293
+2025-12-31,TR,Türkiye,30.6182
+2025-12-31,US,United States,0.8728
+2025-12-31,XM,Euro area,5.1363
+2025-12-31,ZA,South Africa,5.3748

--- a/data/real_index.csv
+++ b/data/real_index.csv
@@ -1,20694 +1,5176 @@
 date,country_code,country,price
-1927-03-31,4T,Emerging market economies (aggregate),
-1927-03-31,5R,Advanced economies,
-1927-03-31,AE,United Arab Emirates,
-1927-03-31,AT,Austria,
-1927-03-31,AU,Australia,
-1927-03-31,BE,Belgium,
-1927-03-31,BG,Bulgaria,
-1927-03-31,BR,Brazil,
-1927-03-31,CA,Canada,
-1927-03-31,CH,Switzerland,
-1927-03-31,CL,Chile,
-1927-03-31,CN,China,
-1927-03-31,CO,Colombia,
-1927-03-31,CY,Cyprus,
-1927-03-31,CZ,Czechia,
-1927-03-31,DE,Germany,
-1927-03-31,DK,Denmark,
-1927-03-31,EE,Estonia,
-1927-03-31,ES,Spain,
-1927-03-31,FI,Finland,
-1927-03-31,FR,France,
-1927-03-31,GB,United Kingdom,
-1927-03-31,GR,Greece,
-1927-03-31,HK,Hong Kong SAR,
-1927-03-31,HR,Croatia,
-1927-03-31,HU,Hungary,
-1927-03-31,ID,Indonesia,
-1927-03-31,IE,Ireland,
-1927-03-31,IL,Israel,
-1927-03-31,IN,India,
-1927-03-31,IS,Iceland,
-1927-03-31,IT,Italy,
-1927-03-31,JP,Japan,
-1927-03-31,KR,Korea,
-1927-03-31,LT,Lithuania,
-1927-03-31,LU,Luxembourg,
-1927-03-31,LV,Latvia,
-1927-03-31,MA,Morocco,
-1927-03-31,MK,North Macedonia,
-1927-03-31,MT,Malta,
-1927-03-31,MX,Mexico,
-1927-03-31,MY,Malaysia,
-1927-03-31,NL,Netherlands,
-1927-03-31,NO,Norway,
-1927-03-31,NZ,New Zealand,
-1927-03-31,PE,Peru,
-1927-03-31,PH,Philippines,
-1927-03-31,PL,Poland,
-1927-03-31,PT,Portugal,
-1927-03-31,RO,Romania,
-1927-03-31,RS,Serbia,
-1927-03-31,RU,Russia,
-1927-03-31,SE,Sweden,
-1927-03-31,SG,Singapore,
-1927-03-31,SI,Slovenia,
-1927-03-31,SK,Slovak Republic,
-1927-03-31,TH,Thailand,
-1927-03-31,TR,Türkiye,
-1927-03-31,US,United States,
-1927-03-31,XM,Euro area,
-1927-03-31,XW,World,
-1927-03-31,ZA,South Africa,
-1927-06-30,4T,Emerging market economies (aggregate),
-1927-06-30,5R,Advanced economies,
-1927-06-30,AE,United Arab Emirates,
-1927-06-30,AT,Austria,
-1927-06-30,AU,Australia,
-1927-06-30,BE,Belgium,
-1927-06-30,BG,Bulgaria,
-1927-06-30,BR,Brazil,
-1927-06-30,CA,Canada,
-1927-06-30,CH,Switzerland,
-1927-06-30,CL,Chile,
-1927-06-30,CN,China,
-1927-06-30,CO,Colombia,
-1927-06-30,CY,Cyprus,
-1927-06-30,CZ,Czechia,
-1927-06-30,DE,Germany,
-1927-06-30,DK,Denmark,
-1927-06-30,EE,Estonia,
-1927-06-30,ES,Spain,
-1927-06-30,FI,Finland,
-1927-06-30,FR,France,
-1927-06-30,GB,United Kingdom,
-1927-06-30,GR,Greece,
-1927-06-30,HK,Hong Kong SAR,
-1927-06-30,HR,Croatia,
-1927-06-30,HU,Hungary,
-1927-06-30,ID,Indonesia,
-1927-06-30,IE,Ireland,
-1927-06-30,IL,Israel,
-1927-06-30,IN,India,
-1927-06-30,IS,Iceland,
-1927-06-30,IT,Italy,
-1927-06-30,JP,Japan,
-1927-06-30,KR,Korea,
-1927-06-30,LT,Lithuania,
-1927-06-30,LU,Luxembourg,
-1927-06-30,LV,Latvia,
-1927-06-30,MA,Morocco,
-1927-06-30,MK,North Macedonia,
-1927-06-30,MT,Malta,
-1927-06-30,MX,Mexico,
-1927-06-30,MY,Malaysia,
-1927-06-30,NL,Netherlands,
-1927-06-30,NO,Norway,
-1927-06-30,NZ,New Zealand,
-1927-06-30,PE,Peru,
-1927-06-30,PH,Philippines,
-1927-06-30,PL,Poland,
-1927-06-30,PT,Portugal,
-1927-06-30,RO,Romania,
-1927-06-30,RS,Serbia,
-1927-06-30,RU,Russia,
-1927-06-30,SE,Sweden,
-1927-06-30,SG,Singapore,
-1927-06-30,SI,Slovenia,
-1927-06-30,SK,Slovak Republic,
-1927-06-30,TH,Thailand,
-1927-06-30,TR,Türkiye,
-1927-06-30,US,United States,
-1927-06-30,XM,Euro area,
-1927-06-30,XW,World,
-1927-06-30,ZA,South Africa,
-1927-09-30,4T,Emerging market economies (aggregate),
-1927-09-30,5R,Advanced economies,
-1927-09-30,AE,United Arab Emirates,
-1927-09-30,AT,Austria,
-1927-09-30,AU,Australia,
-1927-09-30,BE,Belgium,
-1927-09-30,BG,Bulgaria,
-1927-09-30,BR,Brazil,
-1927-09-30,CA,Canada,
-1927-09-30,CH,Switzerland,
-1927-09-30,CL,Chile,
-1927-09-30,CN,China,
-1927-09-30,CO,Colombia,
-1927-09-30,CY,Cyprus,
-1927-09-30,CZ,Czechia,
-1927-09-30,DE,Germany,
-1927-09-30,DK,Denmark,
-1927-09-30,EE,Estonia,
-1927-09-30,ES,Spain,
-1927-09-30,FI,Finland,
-1927-09-30,FR,France,
-1927-09-30,GB,United Kingdom,
-1927-09-30,GR,Greece,
-1927-09-30,HK,Hong Kong SAR,
-1927-09-30,HR,Croatia,
-1927-09-30,HU,Hungary,
-1927-09-30,ID,Indonesia,
-1927-09-30,IE,Ireland,
-1927-09-30,IL,Israel,
-1927-09-30,IN,India,
-1927-09-30,IS,Iceland,
-1927-09-30,IT,Italy,
-1927-09-30,JP,Japan,
-1927-09-30,KR,Korea,
-1927-09-30,LT,Lithuania,
-1927-09-30,LU,Luxembourg,
-1927-09-30,LV,Latvia,
-1927-09-30,MA,Morocco,
-1927-09-30,MK,North Macedonia,
-1927-09-30,MT,Malta,
-1927-09-30,MX,Mexico,
-1927-09-30,MY,Malaysia,
-1927-09-30,NL,Netherlands,
-1927-09-30,NO,Norway,
-1927-09-30,NZ,New Zealand,
-1927-09-30,PE,Peru,
-1927-09-30,PH,Philippines,
-1927-09-30,PL,Poland,
-1927-09-30,PT,Portugal,
-1927-09-30,RO,Romania,
-1927-09-30,RS,Serbia,
-1927-09-30,RU,Russia,
-1927-09-30,SE,Sweden,
-1927-09-30,SG,Singapore,
-1927-09-30,SI,Slovenia,
-1927-09-30,SK,Slovak Republic,
-1927-09-30,TH,Thailand,
-1927-09-30,TR,Türkiye,
-1927-09-30,US,United States,
-1927-09-30,XM,Euro area,
-1927-09-30,XW,World,
-1927-09-30,ZA,South Africa,
-1927-12-31,4T,Emerging market economies (aggregate),
-1927-12-31,5R,Advanced economies,
-1927-12-31,AE,United Arab Emirates,
-1927-12-31,AT,Austria,
-1927-12-31,AU,Australia,
-1927-12-31,BE,Belgium,
-1927-12-31,BG,Bulgaria,
-1927-12-31,BR,Brazil,
-1927-12-31,CA,Canada,
-1927-12-31,CH,Switzerland,
-1927-12-31,CL,Chile,
-1927-12-31,CN,China,
-1927-12-31,CO,Colombia,
-1927-12-31,CY,Cyprus,
-1927-12-31,CZ,Czechia,
-1927-12-31,DE,Germany,
-1927-12-31,DK,Denmark,
-1927-12-31,EE,Estonia,
-1927-12-31,ES,Spain,
-1927-12-31,FI,Finland,
-1927-12-31,FR,France,
-1927-12-31,GB,United Kingdom,
-1927-12-31,GR,Greece,
-1927-12-31,HK,Hong Kong SAR,
-1927-12-31,HR,Croatia,
-1927-12-31,HU,Hungary,
-1927-12-31,ID,Indonesia,
-1927-12-31,IE,Ireland,
-1927-12-31,IL,Israel,
-1927-12-31,IN,India,
-1927-12-31,IS,Iceland,
-1927-12-31,IT,Italy,
-1927-12-31,JP,Japan,
-1927-12-31,KR,Korea,
-1927-12-31,LT,Lithuania,
-1927-12-31,LU,Luxembourg,
-1927-12-31,LV,Latvia,
-1927-12-31,MA,Morocco,
-1927-12-31,MK,North Macedonia,
-1927-12-31,MT,Malta,
-1927-12-31,MX,Mexico,
-1927-12-31,MY,Malaysia,
-1927-12-31,NL,Netherlands,
-1927-12-31,NO,Norway,
-1927-12-31,NZ,New Zealand,
-1927-12-31,PE,Peru,
-1927-12-31,PH,Philippines,
-1927-12-31,PL,Poland,
-1927-12-31,PT,Portugal,
-1927-12-31,RO,Romania,
-1927-12-31,RS,Serbia,
-1927-12-31,RU,Russia,
-1927-12-31,SE,Sweden,
-1927-12-31,SG,Singapore,
-1927-12-31,SI,Slovenia,
-1927-12-31,SK,Slovak Republic,
-1927-12-31,TH,Thailand,
-1927-12-31,TR,Türkiye,
-1927-12-31,US,United States,
-1927-12-31,XM,Euro area,
-1927-12-31,XW,World,
-1927-12-31,ZA,South Africa,
-1928-03-31,4T,Emerging market economies (aggregate),
-1928-03-31,5R,Advanced economies,
-1928-03-31,AE,United Arab Emirates,
-1928-03-31,AT,Austria,
-1928-03-31,AU,Australia,
-1928-03-31,BE,Belgium,
-1928-03-31,BG,Bulgaria,
-1928-03-31,BR,Brazil,
-1928-03-31,CA,Canada,
-1928-03-31,CH,Switzerland,
-1928-03-31,CL,Chile,
-1928-03-31,CN,China,
-1928-03-31,CO,Colombia,
-1928-03-31,CY,Cyprus,
-1928-03-31,CZ,Czechia,
-1928-03-31,DE,Germany,
-1928-03-31,DK,Denmark,
-1928-03-31,EE,Estonia,
-1928-03-31,ES,Spain,
-1928-03-31,FI,Finland,
-1928-03-31,FR,France,
-1928-03-31,GB,United Kingdom,
-1928-03-31,GR,Greece,
-1928-03-31,HK,Hong Kong SAR,
-1928-03-31,HR,Croatia,
-1928-03-31,HU,Hungary,
-1928-03-31,ID,Indonesia,
-1928-03-31,IE,Ireland,
-1928-03-31,IL,Israel,
-1928-03-31,IN,India,
-1928-03-31,IS,Iceland,
-1928-03-31,IT,Italy,
-1928-03-31,JP,Japan,
-1928-03-31,KR,Korea,
-1928-03-31,LT,Lithuania,
-1928-03-31,LU,Luxembourg,
-1928-03-31,LV,Latvia,
-1928-03-31,MA,Morocco,
-1928-03-31,MK,North Macedonia,
-1928-03-31,MT,Malta,
-1928-03-31,MX,Mexico,
-1928-03-31,MY,Malaysia,
-1928-03-31,NL,Netherlands,
-1928-03-31,NO,Norway,
-1928-03-31,NZ,New Zealand,
-1928-03-31,PE,Peru,
-1928-03-31,PH,Philippines,
-1928-03-31,PL,Poland,
-1928-03-31,PT,Portugal,
-1928-03-31,RO,Romania,
-1928-03-31,RS,Serbia,
-1928-03-31,RU,Russia,
-1928-03-31,SE,Sweden,
-1928-03-31,SG,Singapore,
-1928-03-31,SI,Slovenia,
-1928-03-31,SK,Slovak Republic,
-1928-03-31,TH,Thailand,
-1928-03-31,TR,Türkiye,
-1928-03-31,US,United States,
-1928-03-31,XM,Euro area,
-1928-03-31,XW,World,
-1928-03-31,ZA,South Africa,
-1928-06-30,4T,Emerging market economies (aggregate),
-1928-06-30,5R,Advanced economies,
-1928-06-30,AE,United Arab Emirates,
-1928-06-30,AT,Austria,
-1928-06-30,AU,Australia,
-1928-06-30,BE,Belgium,
-1928-06-30,BG,Bulgaria,
-1928-06-30,BR,Brazil,
-1928-06-30,CA,Canada,
-1928-06-30,CH,Switzerland,
-1928-06-30,CL,Chile,
-1928-06-30,CN,China,
-1928-06-30,CO,Colombia,
-1928-06-30,CY,Cyprus,
-1928-06-30,CZ,Czechia,
-1928-06-30,DE,Germany,
-1928-06-30,DK,Denmark,
-1928-06-30,EE,Estonia,
-1928-06-30,ES,Spain,
-1928-06-30,FI,Finland,
-1928-06-30,FR,France,
-1928-06-30,GB,United Kingdom,
-1928-06-30,GR,Greece,
-1928-06-30,HK,Hong Kong SAR,
-1928-06-30,HR,Croatia,
-1928-06-30,HU,Hungary,
-1928-06-30,ID,Indonesia,
-1928-06-30,IE,Ireland,
-1928-06-30,IL,Israel,
-1928-06-30,IN,India,
-1928-06-30,IS,Iceland,
-1928-06-30,IT,Italy,
-1928-06-30,JP,Japan,
-1928-06-30,KR,Korea,
-1928-06-30,LT,Lithuania,
-1928-06-30,LU,Luxembourg,
-1928-06-30,LV,Latvia,
-1928-06-30,MA,Morocco,
-1928-06-30,MK,North Macedonia,
-1928-06-30,MT,Malta,
-1928-06-30,MX,Mexico,
-1928-06-30,MY,Malaysia,
-1928-06-30,NL,Netherlands,
-1928-06-30,NO,Norway,
-1928-06-30,NZ,New Zealand,
-1928-06-30,PE,Peru,
-1928-06-30,PH,Philippines,
-1928-06-30,PL,Poland,
-1928-06-30,PT,Portugal,
-1928-06-30,RO,Romania,
-1928-06-30,RS,Serbia,
-1928-06-30,RU,Russia,
-1928-06-30,SE,Sweden,
-1928-06-30,SG,Singapore,
-1928-06-30,SI,Slovenia,
-1928-06-30,SK,Slovak Republic,
-1928-06-30,TH,Thailand,
-1928-06-30,TR,Türkiye,
-1928-06-30,US,United States,
-1928-06-30,XM,Euro area,
-1928-06-30,XW,World,
-1928-06-30,ZA,South Africa,
-1928-09-30,4T,Emerging market economies (aggregate),
-1928-09-30,5R,Advanced economies,
-1928-09-30,AE,United Arab Emirates,
-1928-09-30,AT,Austria,
-1928-09-30,AU,Australia,
-1928-09-30,BE,Belgium,
-1928-09-30,BG,Bulgaria,
-1928-09-30,BR,Brazil,
-1928-09-30,CA,Canada,
-1928-09-30,CH,Switzerland,
-1928-09-30,CL,Chile,
-1928-09-30,CN,China,
-1928-09-30,CO,Colombia,
-1928-09-30,CY,Cyprus,
-1928-09-30,CZ,Czechia,
-1928-09-30,DE,Germany,
-1928-09-30,DK,Denmark,
-1928-09-30,EE,Estonia,
-1928-09-30,ES,Spain,
-1928-09-30,FI,Finland,
-1928-09-30,FR,France,
-1928-09-30,GB,United Kingdom,
-1928-09-30,GR,Greece,
-1928-09-30,HK,Hong Kong SAR,
-1928-09-30,HR,Croatia,
-1928-09-30,HU,Hungary,
-1928-09-30,ID,Indonesia,
-1928-09-30,IE,Ireland,
-1928-09-30,IL,Israel,
-1928-09-30,IN,India,
-1928-09-30,IS,Iceland,
-1928-09-30,IT,Italy,
-1928-09-30,JP,Japan,
-1928-09-30,KR,Korea,
-1928-09-30,LT,Lithuania,
-1928-09-30,LU,Luxembourg,
-1928-09-30,LV,Latvia,
-1928-09-30,MA,Morocco,
-1928-09-30,MK,North Macedonia,
-1928-09-30,MT,Malta,
-1928-09-30,MX,Mexico,
-1928-09-30,MY,Malaysia,
-1928-09-30,NL,Netherlands,
-1928-09-30,NO,Norway,
-1928-09-30,NZ,New Zealand,
-1928-09-30,PE,Peru,
-1928-09-30,PH,Philippines,
-1928-09-30,PL,Poland,
-1928-09-30,PT,Portugal,
-1928-09-30,RO,Romania,
-1928-09-30,RS,Serbia,
-1928-09-30,RU,Russia,
-1928-09-30,SE,Sweden,
-1928-09-30,SG,Singapore,
-1928-09-30,SI,Slovenia,
-1928-09-30,SK,Slovak Republic,
-1928-09-30,TH,Thailand,
-1928-09-30,TR,Türkiye,
-1928-09-30,US,United States,
-1928-09-30,XM,Euro area,
-1928-09-30,XW,World,
-1928-09-30,ZA,South Africa,
-1928-12-31,4T,Emerging market economies (aggregate),
-1928-12-31,5R,Advanced economies,
-1928-12-31,AE,United Arab Emirates,
-1928-12-31,AT,Austria,
-1928-12-31,AU,Australia,
-1928-12-31,BE,Belgium,
-1928-12-31,BG,Bulgaria,
-1928-12-31,BR,Brazil,
-1928-12-31,CA,Canada,
-1928-12-31,CH,Switzerland,
-1928-12-31,CL,Chile,
-1928-12-31,CN,China,
-1928-12-31,CO,Colombia,
-1928-12-31,CY,Cyprus,
-1928-12-31,CZ,Czechia,
-1928-12-31,DE,Germany,
-1928-12-31,DK,Denmark,
-1928-12-31,EE,Estonia,
-1928-12-31,ES,Spain,
-1928-12-31,FI,Finland,
-1928-12-31,FR,France,
-1928-12-31,GB,United Kingdom,
-1928-12-31,GR,Greece,
-1928-12-31,HK,Hong Kong SAR,
-1928-12-31,HR,Croatia,
-1928-12-31,HU,Hungary,
-1928-12-31,ID,Indonesia,
-1928-12-31,IE,Ireland,
-1928-12-31,IL,Israel,
-1928-12-31,IN,India,
-1928-12-31,IS,Iceland,
-1928-12-31,IT,Italy,
-1928-12-31,JP,Japan,
-1928-12-31,KR,Korea,
-1928-12-31,LT,Lithuania,
-1928-12-31,LU,Luxembourg,
-1928-12-31,LV,Latvia,
-1928-12-31,MA,Morocco,
-1928-12-31,MK,North Macedonia,
-1928-12-31,MT,Malta,
-1928-12-31,MX,Mexico,
-1928-12-31,MY,Malaysia,
-1928-12-31,NL,Netherlands,
-1928-12-31,NO,Norway,
-1928-12-31,NZ,New Zealand,
-1928-12-31,PE,Peru,
-1928-12-31,PH,Philippines,
-1928-12-31,PL,Poland,
-1928-12-31,PT,Portugal,
-1928-12-31,RO,Romania,
-1928-12-31,RS,Serbia,
-1928-12-31,RU,Russia,
-1928-12-31,SE,Sweden,
-1928-12-31,SG,Singapore,
-1928-12-31,SI,Slovenia,
-1928-12-31,SK,Slovak Republic,
-1928-12-31,TH,Thailand,
-1928-12-31,TR,Türkiye,
-1928-12-31,US,United States,
-1928-12-31,XM,Euro area,
-1928-12-31,XW,World,
-1928-12-31,ZA,South Africa,
-1929-03-31,4T,Emerging market economies (aggregate),
-1929-03-31,5R,Advanced economies,
-1929-03-31,AE,United Arab Emirates,
-1929-03-31,AT,Austria,
-1929-03-31,AU,Australia,
-1929-03-31,BE,Belgium,
-1929-03-31,BG,Bulgaria,
-1929-03-31,BR,Brazil,
-1929-03-31,CA,Canada,
-1929-03-31,CH,Switzerland,
-1929-03-31,CL,Chile,
-1929-03-31,CN,China,
-1929-03-31,CO,Colombia,
-1929-03-31,CY,Cyprus,
-1929-03-31,CZ,Czechia,
-1929-03-31,DE,Germany,
-1929-03-31,DK,Denmark,
-1929-03-31,EE,Estonia,
-1929-03-31,ES,Spain,
-1929-03-31,FI,Finland,
-1929-03-31,FR,France,
-1929-03-31,GB,United Kingdom,
-1929-03-31,GR,Greece,
-1929-03-31,HK,Hong Kong SAR,
-1929-03-31,HR,Croatia,
-1929-03-31,HU,Hungary,
-1929-03-31,ID,Indonesia,
-1929-03-31,IE,Ireland,
-1929-03-31,IL,Israel,
-1929-03-31,IN,India,
-1929-03-31,IS,Iceland,
-1929-03-31,IT,Italy,
-1929-03-31,JP,Japan,
-1929-03-31,KR,Korea,
-1929-03-31,LT,Lithuania,
-1929-03-31,LU,Luxembourg,
-1929-03-31,LV,Latvia,
-1929-03-31,MA,Morocco,
-1929-03-31,MK,North Macedonia,
-1929-03-31,MT,Malta,
-1929-03-31,MX,Mexico,
-1929-03-31,MY,Malaysia,
-1929-03-31,NL,Netherlands,
-1929-03-31,NO,Norway,
-1929-03-31,NZ,New Zealand,
-1929-03-31,PE,Peru,
-1929-03-31,PH,Philippines,
-1929-03-31,PL,Poland,
-1929-03-31,PT,Portugal,
-1929-03-31,RO,Romania,
-1929-03-31,RS,Serbia,
-1929-03-31,RU,Russia,
-1929-03-31,SE,Sweden,
-1929-03-31,SG,Singapore,
-1929-03-31,SI,Slovenia,
-1929-03-31,SK,Slovak Republic,
-1929-03-31,TH,Thailand,
-1929-03-31,TR,Türkiye,
-1929-03-31,US,United States,
-1929-03-31,XM,Euro area,
-1929-03-31,XW,World,
-1929-03-31,ZA,South Africa,
-1929-06-30,4T,Emerging market economies (aggregate),
-1929-06-30,5R,Advanced economies,
-1929-06-30,AE,United Arab Emirates,
-1929-06-30,AT,Austria,
-1929-06-30,AU,Australia,
-1929-06-30,BE,Belgium,
-1929-06-30,BG,Bulgaria,
-1929-06-30,BR,Brazil,
-1929-06-30,CA,Canada,
-1929-06-30,CH,Switzerland,
-1929-06-30,CL,Chile,
-1929-06-30,CN,China,
-1929-06-30,CO,Colombia,
-1929-06-30,CY,Cyprus,
-1929-06-30,CZ,Czechia,
-1929-06-30,DE,Germany,
-1929-06-30,DK,Denmark,
-1929-06-30,EE,Estonia,
-1929-06-30,ES,Spain,
-1929-06-30,FI,Finland,
-1929-06-30,FR,France,
-1929-06-30,GB,United Kingdom,
-1929-06-30,GR,Greece,
-1929-06-30,HK,Hong Kong SAR,
-1929-06-30,HR,Croatia,
-1929-06-30,HU,Hungary,
-1929-06-30,ID,Indonesia,
-1929-06-30,IE,Ireland,
-1929-06-30,IL,Israel,
-1929-06-30,IN,India,
-1929-06-30,IS,Iceland,
-1929-06-30,IT,Italy,
-1929-06-30,JP,Japan,
-1929-06-30,KR,Korea,
-1929-06-30,LT,Lithuania,
-1929-06-30,LU,Luxembourg,
-1929-06-30,LV,Latvia,
-1929-06-30,MA,Morocco,
-1929-06-30,MK,North Macedonia,
-1929-06-30,MT,Malta,
-1929-06-30,MX,Mexico,
-1929-06-30,MY,Malaysia,
-1929-06-30,NL,Netherlands,
-1929-06-30,NO,Norway,
-1929-06-30,NZ,New Zealand,
-1929-06-30,PE,Peru,
-1929-06-30,PH,Philippines,
-1929-06-30,PL,Poland,
-1929-06-30,PT,Portugal,
-1929-06-30,RO,Romania,
-1929-06-30,RS,Serbia,
-1929-06-30,RU,Russia,
-1929-06-30,SE,Sweden,
-1929-06-30,SG,Singapore,
-1929-06-30,SI,Slovenia,
-1929-06-30,SK,Slovak Republic,
-1929-06-30,TH,Thailand,
-1929-06-30,TR,Türkiye,
-1929-06-30,US,United States,
-1929-06-30,XM,Euro area,
-1929-06-30,XW,World,
-1929-06-30,ZA,South Africa,
-1929-09-30,4T,Emerging market economies (aggregate),
-1929-09-30,5R,Advanced economies,
-1929-09-30,AE,United Arab Emirates,
-1929-09-30,AT,Austria,
-1929-09-30,AU,Australia,
-1929-09-30,BE,Belgium,
-1929-09-30,BG,Bulgaria,
-1929-09-30,BR,Brazil,
-1929-09-30,CA,Canada,
-1929-09-30,CH,Switzerland,
-1929-09-30,CL,Chile,
-1929-09-30,CN,China,
-1929-09-30,CO,Colombia,
-1929-09-30,CY,Cyprus,
-1929-09-30,CZ,Czechia,
-1929-09-30,DE,Germany,
-1929-09-30,DK,Denmark,
-1929-09-30,EE,Estonia,
-1929-09-30,ES,Spain,
-1929-09-30,FI,Finland,
-1929-09-30,FR,France,
-1929-09-30,GB,United Kingdom,
-1929-09-30,GR,Greece,
-1929-09-30,HK,Hong Kong SAR,
-1929-09-30,HR,Croatia,
-1929-09-30,HU,Hungary,
-1929-09-30,ID,Indonesia,
-1929-09-30,IE,Ireland,
-1929-09-30,IL,Israel,
-1929-09-30,IN,India,
-1929-09-30,IS,Iceland,
-1929-09-30,IT,Italy,
-1929-09-30,JP,Japan,
-1929-09-30,KR,Korea,
-1929-09-30,LT,Lithuania,
-1929-09-30,LU,Luxembourg,
-1929-09-30,LV,Latvia,
-1929-09-30,MA,Morocco,
-1929-09-30,MK,North Macedonia,
-1929-09-30,MT,Malta,
-1929-09-30,MX,Mexico,
-1929-09-30,MY,Malaysia,
-1929-09-30,NL,Netherlands,
-1929-09-30,NO,Norway,
-1929-09-30,NZ,New Zealand,
-1929-09-30,PE,Peru,
-1929-09-30,PH,Philippines,
-1929-09-30,PL,Poland,
-1929-09-30,PT,Portugal,
-1929-09-30,RO,Romania,
-1929-09-30,RS,Serbia,
-1929-09-30,RU,Russia,
-1929-09-30,SE,Sweden,
-1929-09-30,SG,Singapore,
-1929-09-30,SI,Slovenia,
-1929-09-30,SK,Slovak Republic,
-1929-09-30,TH,Thailand,
-1929-09-30,TR,Türkiye,
-1929-09-30,US,United States,
-1929-09-30,XM,Euro area,
-1929-09-30,XW,World,
-1929-09-30,ZA,South Africa,
-1929-12-31,4T,Emerging market economies (aggregate),
-1929-12-31,5R,Advanced economies,
-1929-12-31,AE,United Arab Emirates,
-1929-12-31,AT,Austria,
-1929-12-31,AU,Australia,
-1929-12-31,BE,Belgium,
-1929-12-31,BG,Bulgaria,
-1929-12-31,BR,Brazil,
-1929-12-31,CA,Canada,
-1929-12-31,CH,Switzerland,
-1929-12-31,CL,Chile,
-1929-12-31,CN,China,
-1929-12-31,CO,Colombia,
-1929-12-31,CY,Cyprus,
-1929-12-31,CZ,Czechia,
-1929-12-31,DE,Germany,
-1929-12-31,DK,Denmark,
-1929-12-31,EE,Estonia,
-1929-12-31,ES,Spain,
-1929-12-31,FI,Finland,
-1929-12-31,FR,France,
-1929-12-31,GB,United Kingdom,
-1929-12-31,GR,Greece,
-1929-12-31,HK,Hong Kong SAR,
-1929-12-31,HR,Croatia,
-1929-12-31,HU,Hungary,
-1929-12-31,ID,Indonesia,
-1929-12-31,IE,Ireland,
-1929-12-31,IL,Israel,
-1929-12-31,IN,India,
-1929-12-31,IS,Iceland,
-1929-12-31,IT,Italy,
-1929-12-31,JP,Japan,
-1929-12-31,KR,Korea,
-1929-12-31,LT,Lithuania,
-1929-12-31,LU,Luxembourg,
-1929-12-31,LV,Latvia,
-1929-12-31,MA,Morocco,
-1929-12-31,MK,North Macedonia,
-1929-12-31,MT,Malta,
-1929-12-31,MX,Mexico,
-1929-12-31,MY,Malaysia,
-1929-12-31,NL,Netherlands,
-1929-12-31,NO,Norway,
-1929-12-31,NZ,New Zealand,
-1929-12-31,PE,Peru,
-1929-12-31,PH,Philippines,
-1929-12-31,PL,Poland,
-1929-12-31,PT,Portugal,
-1929-12-31,RO,Romania,
-1929-12-31,RS,Serbia,
-1929-12-31,RU,Russia,
-1929-12-31,SE,Sweden,
-1929-12-31,SG,Singapore,
-1929-12-31,SI,Slovenia,
-1929-12-31,SK,Slovak Republic,
-1929-12-31,TH,Thailand,
-1929-12-31,TR,Türkiye,
-1929-12-31,US,United States,
-1929-12-31,XM,Euro area,
-1929-12-31,XW,World,
-1929-12-31,ZA,South Africa,
-1930-03-31,4T,Emerging market economies (aggregate),
-1930-03-31,5R,Advanced economies,
-1930-03-31,AE,United Arab Emirates,
-1930-03-31,AT,Austria,
-1930-03-31,AU,Australia,
-1930-03-31,BE,Belgium,
-1930-03-31,BG,Bulgaria,
-1930-03-31,BR,Brazil,
-1930-03-31,CA,Canada,
-1930-03-31,CH,Switzerland,
-1930-03-31,CL,Chile,
-1930-03-31,CN,China,
-1930-03-31,CO,Colombia,
-1930-03-31,CY,Cyprus,
-1930-03-31,CZ,Czechia,
-1930-03-31,DE,Germany,
-1930-03-31,DK,Denmark,
-1930-03-31,EE,Estonia,
-1930-03-31,ES,Spain,
-1930-03-31,FI,Finland,
-1930-03-31,FR,France,
-1930-03-31,GB,United Kingdom,
-1930-03-31,GR,Greece,
-1930-03-31,HK,Hong Kong SAR,
-1930-03-31,HR,Croatia,
-1930-03-31,HU,Hungary,
-1930-03-31,ID,Indonesia,
-1930-03-31,IE,Ireland,
-1930-03-31,IL,Israel,
-1930-03-31,IN,India,
-1930-03-31,IS,Iceland,
-1930-03-31,IT,Italy,
-1930-03-31,JP,Japan,
-1930-03-31,KR,Korea,
-1930-03-31,LT,Lithuania,
-1930-03-31,LU,Luxembourg,
-1930-03-31,LV,Latvia,
-1930-03-31,MA,Morocco,
-1930-03-31,MK,North Macedonia,
-1930-03-31,MT,Malta,
-1930-03-31,MX,Mexico,
-1930-03-31,MY,Malaysia,
-1930-03-31,NL,Netherlands,
-1930-03-31,NO,Norway,
-1930-03-31,NZ,New Zealand,
-1930-03-31,PE,Peru,
-1930-03-31,PH,Philippines,
-1930-03-31,PL,Poland,
-1930-03-31,PT,Portugal,
-1930-03-31,RO,Romania,
-1930-03-31,RS,Serbia,
-1930-03-31,RU,Russia,
-1930-03-31,SE,Sweden,
-1930-03-31,SG,Singapore,
-1930-03-31,SI,Slovenia,
-1930-03-31,SK,Slovak Republic,
-1930-03-31,TH,Thailand,
-1930-03-31,TR,Türkiye,
-1930-03-31,US,United States,
-1930-03-31,XM,Euro area,
-1930-03-31,XW,World,
-1930-03-31,ZA,South Africa,
-1930-06-30,4T,Emerging market economies (aggregate),
-1930-06-30,5R,Advanced economies,
-1930-06-30,AE,United Arab Emirates,
-1930-06-30,AT,Austria,
-1930-06-30,AU,Australia,
-1930-06-30,BE,Belgium,
-1930-06-30,BG,Bulgaria,
-1930-06-30,BR,Brazil,
-1930-06-30,CA,Canada,
-1930-06-30,CH,Switzerland,
-1930-06-30,CL,Chile,
-1930-06-30,CN,China,
-1930-06-30,CO,Colombia,
-1930-06-30,CY,Cyprus,
-1930-06-30,CZ,Czechia,
-1930-06-30,DE,Germany,
-1930-06-30,DK,Denmark,
-1930-06-30,EE,Estonia,
-1930-06-30,ES,Spain,
-1930-06-30,FI,Finland,
-1930-06-30,FR,France,
-1930-06-30,GB,United Kingdom,
-1930-06-30,GR,Greece,
-1930-06-30,HK,Hong Kong SAR,
-1930-06-30,HR,Croatia,
-1930-06-30,HU,Hungary,
-1930-06-30,ID,Indonesia,
-1930-06-30,IE,Ireland,
-1930-06-30,IL,Israel,
-1930-06-30,IN,India,
-1930-06-30,IS,Iceland,
-1930-06-30,IT,Italy,
-1930-06-30,JP,Japan,
-1930-06-30,KR,Korea,
-1930-06-30,LT,Lithuania,
-1930-06-30,LU,Luxembourg,
-1930-06-30,LV,Latvia,
-1930-06-30,MA,Morocco,
-1930-06-30,MK,North Macedonia,
-1930-06-30,MT,Malta,
-1930-06-30,MX,Mexico,
-1930-06-30,MY,Malaysia,
-1930-06-30,NL,Netherlands,
-1930-06-30,NO,Norway,
-1930-06-30,NZ,New Zealand,
-1930-06-30,PE,Peru,
-1930-06-30,PH,Philippines,
-1930-06-30,PL,Poland,
-1930-06-30,PT,Portugal,
-1930-06-30,RO,Romania,
-1930-06-30,RS,Serbia,
-1930-06-30,RU,Russia,
-1930-06-30,SE,Sweden,
-1930-06-30,SG,Singapore,
-1930-06-30,SI,Slovenia,
-1930-06-30,SK,Slovak Republic,
-1930-06-30,TH,Thailand,
-1930-06-30,TR,Türkiye,
-1930-06-30,US,United States,
-1930-06-30,XM,Euro area,
-1930-06-30,XW,World,
-1930-06-30,ZA,South Africa,
-1930-09-30,4T,Emerging market economies (aggregate),
-1930-09-30,5R,Advanced economies,
-1930-09-30,AE,United Arab Emirates,
-1930-09-30,AT,Austria,
-1930-09-30,AU,Australia,
-1930-09-30,BE,Belgium,
-1930-09-30,BG,Bulgaria,
-1930-09-30,BR,Brazil,
-1930-09-30,CA,Canada,
-1930-09-30,CH,Switzerland,
-1930-09-30,CL,Chile,
-1930-09-30,CN,China,
-1930-09-30,CO,Colombia,
-1930-09-30,CY,Cyprus,
-1930-09-30,CZ,Czechia,
-1930-09-30,DE,Germany,
-1930-09-30,DK,Denmark,
-1930-09-30,EE,Estonia,
-1930-09-30,ES,Spain,
-1930-09-30,FI,Finland,
-1930-09-30,FR,France,
-1930-09-30,GB,United Kingdom,
-1930-09-30,GR,Greece,
-1930-09-30,HK,Hong Kong SAR,
-1930-09-30,HR,Croatia,
-1930-09-30,HU,Hungary,
-1930-09-30,ID,Indonesia,
-1930-09-30,IE,Ireland,
-1930-09-30,IL,Israel,
-1930-09-30,IN,India,
-1930-09-30,IS,Iceland,
-1930-09-30,IT,Italy,
-1930-09-30,JP,Japan,
-1930-09-30,KR,Korea,
-1930-09-30,LT,Lithuania,
-1930-09-30,LU,Luxembourg,
-1930-09-30,LV,Latvia,
-1930-09-30,MA,Morocco,
-1930-09-30,MK,North Macedonia,
-1930-09-30,MT,Malta,
-1930-09-30,MX,Mexico,
-1930-09-30,MY,Malaysia,
-1930-09-30,NL,Netherlands,
-1930-09-30,NO,Norway,
-1930-09-30,NZ,New Zealand,
-1930-09-30,PE,Peru,
-1930-09-30,PH,Philippines,
-1930-09-30,PL,Poland,
-1930-09-30,PT,Portugal,
-1930-09-30,RO,Romania,
-1930-09-30,RS,Serbia,
-1930-09-30,RU,Russia,
-1930-09-30,SE,Sweden,
-1930-09-30,SG,Singapore,
-1930-09-30,SI,Slovenia,
-1930-09-30,SK,Slovak Republic,
-1930-09-30,TH,Thailand,
-1930-09-30,TR,Türkiye,
-1930-09-30,US,United States,
-1930-09-30,XM,Euro area,
-1930-09-30,XW,World,
-1930-09-30,ZA,South Africa,
-1930-12-31,4T,Emerging market economies (aggregate),
-1930-12-31,5R,Advanced economies,
-1930-12-31,AE,United Arab Emirates,
-1930-12-31,AT,Austria,
-1930-12-31,AU,Australia,
-1930-12-31,BE,Belgium,
-1930-12-31,BG,Bulgaria,
-1930-12-31,BR,Brazil,
-1930-12-31,CA,Canada,
-1930-12-31,CH,Switzerland,
-1930-12-31,CL,Chile,
-1930-12-31,CN,China,
-1930-12-31,CO,Colombia,
-1930-12-31,CY,Cyprus,
-1930-12-31,CZ,Czechia,
-1930-12-31,DE,Germany,
-1930-12-31,DK,Denmark,
-1930-12-31,EE,Estonia,
-1930-12-31,ES,Spain,
-1930-12-31,FI,Finland,
-1930-12-31,FR,France,
-1930-12-31,GB,United Kingdom,
-1930-12-31,GR,Greece,
-1930-12-31,HK,Hong Kong SAR,
-1930-12-31,HR,Croatia,
-1930-12-31,HU,Hungary,
-1930-12-31,ID,Indonesia,
-1930-12-31,IE,Ireland,
-1930-12-31,IL,Israel,
-1930-12-31,IN,India,
-1930-12-31,IS,Iceland,
-1930-12-31,IT,Italy,
-1930-12-31,JP,Japan,
-1930-12-31,KR,Korea,
-1930-12-31,LT,Lithuania,
-1930-12-31,LU,Luxembourg,
-1930-12-31,LV,Latvia,
-1930-12-31,MA,Morocco,
-1930-12-31,MK,North Macedonia,
-1930-12-31,MT,Malta,
-1930-12-31,MX,Mexico,
-1930-12-31,MY,Malaysia,
-1930-12-31,NL,Netherlands,
-1930-12-31,NO,Norway,
-1930-12-31,NZ,New Zealand,
-1930-12-31,PE,Peru,
-1930-12-31,PH,Philippines,
-1930-12-31,PL,Poland,
-1930-12-31,PT,Portugal,
-1930-12-31,RO,Romania,
-1930-12-31,RS,Serbia,
-1930-12-31,RU,Russia,
-1930-12-31,SE,Sweden,
-1930-12-31,SG,Singapore,
-1930-12-31,SI,Slovenia,
-1930-12-31,SK,Slovak Republic,
-1930-12-31,TH,Thailand,
-1930-12-31,TR,Türkiye,
-1930-12-31,US,United States,
-1930-12-31,XM,Euro area,
-1930-12-31,XW,World,
-1930-12-31,ZA,South Africa,
-1931-03-31,4T,Emerging market economies (aggregate),
-1931-03-31,5R,Advanced economies,
-1931-03-31,AE,United Arab Emirates,
-1931-03-31,AT,Austria,
-1931-03-31,AU,Australia,
-1931-03-31,BE,Belgium,
-1931-03-31,BG,Bulgaria,
-1931-03-31,BR,Brazil,
-1931-03-31,CA,Canada,
-1931-03-31,CH,Switzerland,
-1931-03-31,CL,Chile,
-1931-03-31,CN,China,
-1931-03-31,CO,Colombia,
-1931-03-31,CY,Cyprus,
-1931-03-31,CZ,Czechia,
-1931-03-31,DE,Germany,
-1931-03-31,DK,Denmark,
-1931-03-31,EE,Estonia,
-1931-03-31,ES,Spain,
-1931-03-31,FI,Finland,
-1931-03-31,FR,France,
-1931-03-31,GB,United Kingdom,
-1931-03-31,GR,Greece,
-1931-03-31,HK,Hong Kong SAR,
-1931-03-31,HR,Croatia,
-1931-03-31,HU,Hungary,
-1931-03-31,ID,Indonesia,
-1931-03-31,IE,Ireland,
-1931-03-31,IL,Israel,
-1931-03-31,IN,India,
-1931-03-31,IS,Iceland,
-1931-03-31,IT,Italy,
-1931-03-31,JP,Japan,
-1931-03-31,KR,Korea,
-1931-03-31,LT,Lithuania,
-1931-03-31,LU,Luxembourg,
-1931-03-31,LV,Latvia,
-1931-03-31,MA,Morocco,
-1931-03-31,MK,North Macedonia,
-1931-03-31,MT,Malta,
-1931-03-31,MX,Mexico,
-1931-03-31,MY,Malaysia,
-1931-03-31,NL,Netherlands,
-1931-03-31,NO,Norway,
-1931-03-31,NZ,New Zealand,
-1931-03-31,PE,Peru,
-1931-03-31,PH,Philippines,
-1931-03-31,PL,Poland,
-1931-03-31,PT,Portugal,
-1931-03-31,RO,Romania,
-1931-03-31,RS,Serbia,
-1931-03-31,RU,Russia,
-1931-03-31,SE,Sweden,
-1931-03-31,SG,Singapore,
-1931-03-31,SI,Slovenia,
-1931-03-31,SK,Slovak Republic,
-1931-03-31,TH,Thailand,
-1931-03-31,TR,Türkiye,
-1931-03-31,US,United States,
-1931-03-31,XM,Euro area,
-1931-03-31,XW,World,
-1931-03-31,ZA,South Africa,
-1931-06-30,4T,Emerging market economies (aggregate),
-1931-06-30,5R,Advanced economies,
-1931-06-30,AE,United Arab Emirates,
-1931-06-30,AT,Austria,
-1931-06-30,AU,Australia,
-1931-06-30,BE,Belgium,
-1931-06-30,BG,Bulgaria,
-1931-06-30,BR,Brazil,
-1931-06-30,CA,Canada,
-1931-06-30,CH,Switzerland,
-1931-06-30,CL,Chile,
-1931-06-30,CN,China,
-1931-06-30,CO,Colombia,
-1931-06-30,CY,Cyprus,
-1931-06-30,CZ,Czechia,
-1931-06-30,DE,Germany,
-1931-06-30,DK,Denmark,
-1931-06-30,EE,Estonia,
-1931-06-30,ES,Spain,
-1931-06-30,FI,Finland,
-1931-06-30,FR,France,
-1931-06-30,GB,United Kingdom,
-1931-06-30,GR,Greece,
-1931-06-30,HK,Hong Kong SAR,
-1931-06-30,HR,Croatia,
-1931-06-30,HU,Hungary,
-1931-06-30,ID,Indonesia,
-1931-06-30,IE,Ireland,
-1931-06-30,IL,Israel,
-1931-06-30,IN,India,
-1931-06-30,IS,Iceland,
-1931-06-30,IT,Italy,
-1931-06-30,JP,Japan,
-1931-06-30,KR,Korea,
-1931-06-30,LT,Lithuania,
-1931-06-30,LU,Luxembourg,
-1931-06-30,LV,Latvia,
-1931-06-30,MA,Morocco,
-1931-06-30,MK,North Macedonia,
-1931-06-30,MT,Malta,
-1931-06-30,MX,Mexico,
-1931-06-30,MY,Malaysia,
-1931-06-30,NL,Netherlands,
-1931-06-30,NO,Norway,
-1931-06-30,NZ,New Zealand,
-1931-06-30,PE,Peru,
-1931-06-30,PH,Philippines,
-1931-06-30,PL,Poland,
-1931-06-30,PT,Portugal,
-1931-06-30,RO,Romania,
-1931-06-30,RS,Serbia,
-1931-06-30,RU,Russia,
-1931-06-30,SE,Sweden,
-1931-06-30,SG,Singapore,
-1931-06-30,SI,Slovenia,
-1931-06-30,SK,Slovak Republic,
-1931-06-30,TH,Thailand,
-1931-06-30,TR,Türkiye,
-1931-06-30,US,United States,
-1931-06-30,XM,Euro area,
-1931-06-30,XW,World,
-1931-06-30,ZA,South Africa,
-1931-09-30,4T,Emerging market economies (aggregate),
-1931-09-30,5R,Advanced economies,
-1931-09-30,AE,United Arab Emirates,
-1931-09-30,AT,Austria,
-1931-09-30,AU,Australia,
-1931-09-30,BE,Belgium,
-1931-09-30,BG,Bulgaria,
-1931-09-30,BR,Brazil,
-1931-09-30,CA,Canada,
-1931-09-30,CH,Switzerland,
-1931-09-30,CL,Chile,
-1931-09-30,CN,China,
-1931-09-30,CO,Colombia,
-1931-09-30,CY,Cyprus,
-1931-09-30,CZ,Czechia,
-1931-09-30,DE,Germany,
-1931-09-30,DK,Denmark,
-1931-09-30,EE,Estonia,
-1931-09-30,ES,Spain,
-1931-09-30,FI,Finland,
-1931-09-30,FR,France,
-1931-09-30,GB,United Kingdom,
-1931-09-30,GR,Greece,
-1931-09-30,HK,Hong Kong SAR,
-1931-09-30,HR,Croatia,
-1931-09-30,HU,Hungary,
-1931-09-30,ID,Indonesia,
-1931-09-30,IE,Ireland,
-1931-09-30,IL,Israel,
-1931-09-30,IN,India,
-1931-09-30,IS,Iceland,
-1931-09-30,IT,Italy,
-1931-09-30,JP,Japan,
-1931-09-30,KR,Korea,
-1931-09-30,LT,Lithuania,
-1931-09-30,LU,Luxembourg,
-1931-09-30,LV,Latvia,
-1931-09-30,MA,Morocco,
-1931-09-30,MK,North Macedonia,
-1931-09-30,MT,Malta,
-1931-09-30,MX,Mexico,
-1931-09-30,MY,Malaysia,
-1931-09-30,NL,Netherlands,
-1931-09-30,NO,Norway,
-1931-09-30,NZ,New Zealand,
-1931-09-30,PE,Peru,
-1931-09-30,PH,Philippines,
-1931-09-30,PL,Poland,
-1931-09-30,PT,Portugal,
-1931-09-30,RO,Romania,
-1931-09-30,RS,Serbia,
-1931-09-30,RU,Russia,
-1931-09-30,SE,Sweden,
-1931-09-30,SG,Singapore,
-1931-09-30,SI,Slovenia,
-1931-09-30,SK,Slovak Republic,
-1931-09-30,TH,Thailand,
-1931-09-30,TR,Türkiye,
-1931-09-30,US,United States,
-1931-09-30,XM,Euro area,
-1931-09-30,XW,World,
-1931-09-30,ZA,South Africa,
-1931-12-31,4T,Emerging market economies (aggregate),
-1931-12-31,5R,Advanced economies,
-1931-12-31,AE,United Arab Emirates,
-1931-12-31,AT,Austria,
-1931-12-31,AU,Australia,
-1931-12-31,BE,Belgium,
-1931-12-31,BG,Bulgaria,
-1931-12-31,BR,Brazil,
-1931-12-31,CA,Canada,
-1931-12-31,CH,Switzerland,
-1931-12-31,CL,Chile,
-1931-12-31,CN,China,
-1931-12-31,CO,Colombia,
-1931-12-31,CY,Cyprus,
-1931-12-31,CZ,Czechia,
-1931-12-31,DE,Germany,
-1931-12-31,DK,Denmark,
-1931-12-31,EE,Estonia,
-1931-12-31,ES,Spain,
-1931-12-31,FI,Finland,
-1931-12-31,FR,France,
-1931-12-31,GB,United Kingdom,
-1931-12-31,GR,Greece,
-1931-12-31,HK,Hong Kong SAR,
-1931-12-31,HR,Croatia,
-1931-12-31,HU,Hungary,
-1931-12-31,ID,Indonesia,
-1931-12-31,IE,Ireland,
-1931-12-31,IL,Israel,
-1931-12-31,IN,India,
-1931-12-31,IS,Iceland,
-1931-12-31,IT,Italy,
-1931-12-31,JP,Japan,
-1931-12-31,KR,Korea,
-1931-12-31,LT,Lithuania,
-1931-12-31,LU,Luxembourg,
-1931-12-31,LV,Latvia,
-1931-12-31,MA,Morocco,
-1931-12-31,MK,North Macedonia,
-1931-12-31,MT,Malta,
-1931-12-31,MX,Mexico,
-1931-12-31,MY,Malaysia,
-1931-12-31,NL,Netherlands,
-1931-12-31,NO,Norway,
-1931-12-31,NZ,New Zealand,
-1931-12-31,PE,Peru,
-1931-12-31,PH,Philippines,
-1931-12-31,PL,Poland,
-1931-12-31,PT,Portugal,
-1931-12-31,RO,Romania,
-1931-12-31,RS,Serbia,
-1931-12-31,RU,Russia,
-1931-12-31,SE,Sweden,
-1931-12-31,SG,Singapore,
-1931-12-31,SI,Slovenia,
-1931-12-31,SK,Slovak Republic,
-1931-12-31,TH,Thailand,
-1931-12-31,TR,Türkiye,
-1931-12-31,US,United States,
-1931-12-31,XM,Euro area,
-1931-12-31,XW,World,
-1931-12-31,ZA,South Africa,
-1932-03-31,4T,Emerging market economies (aggregate),
-1932-03-31,5R,Advanced economies,
-1932-03-31,AE,United Arab Emirates,
-1932-03-31,AT,Austria,
-1932-03-31,AU,Australia,
-1932-03-31,BE,Belgium,
-1932-03-31,BG,Bulgaria,
-1932-03-31,BR,Brazil,
-1932-03-31,CA,Canada,
-1932-03-31,CH,Switzerland,
-1932-03-31,CL,Chile,
-1932-03-31,CN,China,
-1932-03-31,CO,Colombia,
-1932-03-31,CY,Cyprus,
-1932-03-31,CZ,Czechia,
-1932-03-31,DE,Germany,
-1932-03-31,DK,Denmark,
-1932-03-31,EE,Estonia,
-1932-03-31,ES,Spain,
-1932-03-31,FI,Finland,
-1932-03-31,FR,France,
-1932-03-31,GB,United Kingdom,
-1932-03-31,GR,Greece,
-1932-03-31,HK,Hong Kong SAR,
-1932-03-31,HR,Croatia,
-1932-03-31,HU,Hungary,
-1932-03-31,ID,Indonesia,
-1932-03-31,IE,Ireland,
-1932-03-31,IL,Israel,
-1932-03-31,IN,India,
-1932-03-31,IS,Iceland,
-1932-03-31,IT,Italy,
-1932-03-31,JP,Japan,
-1932-03-31,KR,Korea,
-1932-03-31,LT,Lithuania,
-1932-03-31,LU,Luxembourg,
-1932-03-31,LV,Latvia,
-1932-03-31,MA,Morocco,
-1932-03-31,MK,North Macedonia,
-1932-03-31,MT,Malta,
-1932-03-31,MX,Mexico,
-1932-03-31,MY,Malaysia,
-1932-03-31,NL,Netherlands,
-1932-03-31,NO,Norway,
-1932-03-31,NZ,New Zealand,
-1932-03-31,PE,Peru,
-1932-03-31,PH,Philippines,
-1932-03-31,PL,Poland,
-1932-03-31,PT,Portugal,
-1932-03-31,RO,Romania,
-1932-03-31,RS,Serbia,
-1932-03-31,RU,Russia,
-1932-03-31,SE,Sweden,
-1932-03-31,SG,Singapore,
-1932-03-31,SI,Slovenia,
-1932-03-31,SK,Slovak Republic,
-1932-03-31,TH,Thailand,
-1932-03-31,TR,Türkiye,
-1932-03-31,US,United States,
-1932-03-31,XM,Euro area,
-1932-03-31,XW,World,
-1932-03-31,ZA,South Africa,
-1932-06-30,4T,Emerging market economies (aggregate),
-1932-06-30,5R,Advanced economies,
-1932-06-30,AE,United Arab Emirates,
-1932-06-30,AT,Austria,
-1932-06-30,AU,Australia,
-1932-06-30,BE,Belgium,
-1932-06-30,BG,Bulgaria,
-1932-06-30,BR,Brazil,
-1932-06-30,CA,Canada,
-1932-06-30,CH,Switzerland,
-1932-06-30,CL,Chile,
-1932-06-30,CN,China,
-1932-06-30,CO,Colombia,
-1932-06-30,CY,Cyprus,
-1932-06-30,CZ,Czechia,
-1932-06-30,DE,Germany,
-1932-06-30,DK,Denmark,
-1932-06-30,EE,Estonia,
-1932-06-30,ES,Spain,
-1932-06-30,FI,Finland,
-1932-06-30,FR,France,
-1932-06-30,GB,United Kingdom,
-1932-06-30,GR,Greece,
-1932-06-30,HK,Hong Kong SAR,
-1932-06-30,HR,Croatia,
-1932-06-30,HU,Hungary,
-1932-06-30,ID,Indonesia,
-1932-06-30,IE,Ireland,
-1932-06-30,IL,Israel,
-1932-06-30,IN,India,
-1932-06-30,IS,Iceland,
-1932-06-30,IT,Italy,
-1932-06-30,JP,Japan,
-1932-06-30,KR,Korea,
-1932-06-30,LT,Lithuania,
-1932-06-30,LU,Luxembourg,
-1932-06-30,LV,Latvia,
-1932-06-30,MA,Morocco,
-1932-06-30,MK,North Macedonia,
-1932-06-30,MT,Malta,
-1932-06-30,MX,Mexico,
-1932-06-30,MY,Malaysia,
-1932-06-30,NL,Netherlands,
-1932-06-30,NO,Norway,
-1932-06-30,NZ,New Zealand,
-1932-06-30,PE,Peru,
-1932-06-30,PH,Philippines,
-1932-06-30,PL,Poland,
-1932-06-30,PT,Portugal,
-1932-06-30,RO,Romania,
-1932-06-30,RS,Serbia,
-1932-06-30,RU,Russia,
-1932-06-30,SE,Sweden,
-1932-06-30,SG,Singapore,
-1932-06-30,SI,Slovenia,
-1932-06-30,SK,Slovak Republic,
-1932-06-30,TH,Thailand,
-1932-06-30,TR,Türkiye,
-1932-06-30,US,United States,
-1932-06-30,XM,Euro area,
-1932-06-30,XW,World,
-1932-06-30,ZA,South Africa,
-1932-09-30,4T,Emerging market economies (aggregate),
-1932-09-30,5R,Advanced economies,
-1932-09-30,AE,United Arab Emirates,
-1932-09-30,AT,Austria,
-1932-09-30,AU,Australia,
-1932-09-30,BE,Belgium,
-1932-09-30,BG,Bulgaria,
-1932-09-30,BR,Brazil,
-1932-09-30,CA,Canada,
-1932-09-30,CH,Switzerland,
-1932-09-30,CL,Chile,
-1932-09-30,CN,China,
-1932-09-30,CO,Colombia,
-1932-09-30,CY,Cyprus,
-1932-09-30,CZ,Czechia,
-1932-09-30,DE,Germany,
-1932-09-30,DK,Denmark,
-1932-09-30,EE,Estonia,
-1932-09-30,ES,Spain,
-1932-09-30,FI,Finland,
-1932-09-30,FR,France,
-1932-09-30,GB,United Kingdom,
-1932-09-30,GR,Greece,
-1932-09-30,HK,Hong Kong SAR,
-1932-09-30,HR,Croatia,
-1932-09-30,HU,Hungary,
-1932-09-30,ID,Indonesia,
-1932-09-30,IE,Ireland,
-1932-09-30,IL,Israel,
-1932-09-30,IN,India,
-1932-09-30,IS,Iceland,
-1932-09-30,IT,Italy,
-1932-09-30,JP,Japan,
-1932-09-30,KR,Korea,
-1932-09-30,LT,Lithuania,
-1932-09-30,LU,Luxembourg,
-1932-09-30,LV,Latvia,
-1932-09-30,MA,Morocco,
-1932-09-30,MK,North Macedonia,
-1932-09-30,MT,Malta,
-1932-09-30,MX,Mexico,
-1932-09-30,MY,Malaysia,
-1932-09-30,NL,Netherlands,
-1932-09-30,NO,Norway,
-1932-09-30,NZ,New Zealand,
-1932-09-30,PE,Peru,
-1932-09-30,PH,Philippines,
-1932-09-30,PL,Poland,
-1932-09-30,PT,Portugal,
-1932-09-30,RO,Romania,
-1932-09-30,RS,Serbia,
-1932-09-30,RU,Russia,
-1932-09-30,SE,Sweden,
-1932-09-30,SG,Singapore,
-1932-09-30,SI,Slovenia,
-1932-09-30,SK,Slovak Republic,
-1932-09-30,TH,Thailand,
-1932-09-30,TR,Türkiye,
-1932-09-30,US,United States,
-1932-09-30,XM,Euro area,
-1932-09-30,XW,World,
-1932-09-30,ZA,South Africa,
-1932-12-31,4T,Emerging market economies (aggregate),
-1932-12-31,5R,Advanced economies,
-1932-12-31,AE,United Arab Emirates,
-1932-12-31,AT,Austria,
-1932-12-31,AU,Australia,
-1932-12-31,BE,Belgium,
-1932-12-31,BG,Bulgaria,
-1932-12-31,BR,Brazil,
-1932-12-31,CA,Canada,
-1932-12-31,CH,Switzerland,
-1932-12-31,CL,Chile,
-1932-12-31,CN,China,
-1932-12-31,CO,Colombia,
-1932-12-31,CY,Cyprus,
-1932-12-31,CZ,Czechia,
-1932-12-31,DE,Germany,
-1932-12-31,DK,Denmark,
-1932-12-31,EE,Estonia,
-1932-12-31,ES,Spain,
-1932-12-31,FI,Finland,
-1932-12-31,FR,France,
-1932-12-31,GB,United Kingdom,
-1932-12-31,GR,Greece,
-1932-12-31,HK,Hong Kong SAR,
-1932-12-31,HR,Croatia,
-1932-12-31,HU,Hungary,
-1932-12-31,ID,Indonesia,
-1932-12-31,IE,Ireland,
-1932-12-31,IL,Israel,
-1932-12-31,IN,India,
-1932-12-31,IS,Iceland,
-1932-12-31,IT,Italy,
-1932-12-31,JP,Japan,
-1932-12-31,KR,Korea,
-1932-12-31,LT,Lithuania,
-1932-12-31,LU,Luxembourg,
-1932-12-31,LV,Latvia,
-1932-12-31,MA,Morocco,
-1932-12-31,MK,North Macedonia,
-1932-12-31,MT,Malta,
-1932-12-31,MX,Mexico,
-1932-12-31,MY,Malaysia,
-1932-12-31,NL,Netherlands,
-1932-12-31,NO,Norway,
-1932-12-31,NZ,New Zealand,
-1932-12-31,PE,Peru,
-1932-12-31,PH,Philippines,
-1932-12-31,PL,Poland,
-1932-12-31,PT,Portugal,
-1932-12-31,RO,Romania,
-1932-12-31,RS,Serbia,
-1932-12-31,RU,Russia,
-1932-12-31,SE,Sweden,
-1932-12-31,SG,Singapore,
-1932-12-31,SI,Slovenia,
-1932-12-31,SK,Slovak Republic,
-1932-12-31,TH,Thailand,
-1932-12-31,TR,Türkiye,
-1932-12-31,US,United States,
-1932-12-31,XM,Euro area,
-1932-12-31,XW,World,
-1932-12-31,ZA,South Africa,
-1933-03-31,4T,Emerging market economies (aggregate),
-1933-03-31,5R,Advanced economies,
-1933-03-31,AE,United Arab Emirates,
-1933-03-31,AT,Austria,
-1933-03-31,AU,Australia,
-1933-03-31,BE,Belgium,
-1933-03-31,BG,Bulgaria,
-1933-03-31,BR,Brazil,
-1933-03-31,CA,Canada,
-1933-03-31,CH,Switzerland,
-1933-03-31,CL,Chile,
-1933-03-31,CN,China,
-1933-03-31,CO,Colombia,
-1933-03-31,CY,Cyprus,
-1933-03-31,CZ,Czechia,
-1933-03-31,DE,Germany,
-1933-03-31,DK,Denmark,
-1933-03-31,EE,Estonia,
-1933-03-31,ES,Spain,
-1933-03-31,FI,Finland,
-1933-03-31,FR,France,
-1933-03-31,GB,United Kingdom,
-1933-03-31,GR,Greece,
-1933-03-31,HK,Hong Kong SAR,
-1933-03-31,HR,Croatia,
-1933-03-31,HU,Hungary,
-1933-03-31,ID,Indonesia,
-1933-03-31,IE,Ireland,
-1933-03-31,IL,Israel,
-1933-03-31,IN,India,
-1933-03-31,IS,Iceland,
-1933-03-31,IT,Italy,
-1933-03-31,JP,Japan,
-1933-03-31,KR,Korea,
-1933-03-31,LT,Lithuania,
-1933-03-31,LU,Luxembourg,
-1933-03-31,LV,Latvia,
-1933-03-31,MA,Morocco,
-1933-03-31,MK,North Macedonia,
-1933-03-31,MT,Malta,
-1933-03-31,MX,Mexico,
-1933-03-31,MY,Malaysia,
-1933-03-31,NL,Netherlands,
-1933-03-31,NO,Norway,
-1933-03-31,NZ,New Zealand,
-1933-03-31,PE,Peru,
-1933-03-31,PH,Philippines,
-1933-03-31,PL,Poland,
-1933-03-31,PT,Portugal,
-1933-03-31,RO,Romania,
-1933-03-31,RS,Serbia,
-1933-03-31,RU,Russia,
-1933-03-31,SE,Sweden,
-1933-03-31,SG,Singapore,
-1933-03-31,SI,Slovenia,
-1933-03-31,SK,Slovak Republic,
-1933-03-31,TH,Thailand,
-1933-03-31,TR,Türkiye,
-1933-03-31,US,United States,
-1933-03-31,XM,Euro area,
-1933-03-31,XW,World,
-1933-03-31,ZA,South Africa,
-1933-06-30,4T,Emerging market economies (aggregate),
-1933-06-30,5R,Advanced economies,
-1933-06-30,AE,United Arab Emirates,
-1933-06-30,AT,Austria,
-1933-06-30,AU,Australia,
-1933-06-30,BE,Belgium,
-1933-06-30,BG,Bulgaria,
-1933-06-30,BR,Brazil,
-1933-06-30,CA,Canada,
-1933-06-30,CH,Switzerland,
-1933-06-30,CL,Chile,
-1933-06-30,CN,China,
-1933-06-30,CO,Colombia,
-1933-06-30,CY,Cyprus,
-1933-06-30,CZ,Czechia,
-1933-06-30,DE,Germany,
-1933-06-30,DK,Denmark,
-1933-06-30,EE,Estonia,
-1933-06-30,ES,Spain,
-1933-06-30,FI,Finland,
-1933-06-30,FR,France,
-1933-06-30,GB,United Kingdom,
-1933-06-30,GR,Greece,
-1933-06-30,HK,Hong Kong SAR,
-1933-06-30,HR,Croatia,
-1933-06-30,HU,Hungary,
-1933-06-30,ID,Indonesia,
-1933-06-30,IE,Ireland,
-1933-06-30,IL,Israel,
-1933-06-30,IN,India,
-1933-06-30,IS,Iceland,
-1933-06-30,IT,Italy,
-1933-06-30,JP,Japan,
-1933-06-30,KR,Korea,
-1933-06-30,LT,Lithuania,
-1933-06-30,LU,Luxembourg,
-1933-06-30,LV,Latvia,
-1933-06-30,MA,Morocco,
-1933-06-30,MK,North Macedonia,
-1933-06-30,MT,Malta,
-1933-06-30,MX,Mexico,
-1933-06-30,MY,Malaysia,
-1933-06-30,NL,Netherlands,
-1933-06-30,NO,Norway,
-1933-06-30,NZ,New Zealand,
-1933-06-30,PE,Peru,
-1933-06-30,PH,Philippines,
-1933-06-30,PL,Poland,
-1933-06-30,PT,Portugal,
-1933-06-30,RO,Romania,
-1933-06-30,RS,Serbia,
-1933-06-30,RU,Russia,
-1933-06-30,SE,Sweden,
-1933-06-30,SG,Singapore,
-1933-06-30,SI,Slovenia,
-1933-06-30,SK,Slovak Republic,
-1933-06-30,TH,Thailand,
-1933-06-30,TR,Türkiye,
-1933-06-30,US,United States,
-1933-06-30,XM,Euro area,
-1933-06-30,XW,World,
-1933-06-30,ZA,South Africa,
-1933-09-30,4T,Emerging market economies (aggregate),
-1933-09-30,5R,Advanced economies,
-1933-09-30,AE,United Arab Emirates,
-1933-09-30,AT,Austria,
-1933-09-30,AU,Australia,
-1933-09-30,BE,Belgium,
-1933-09-30,BG,Bulgaria,
-1933-09-30,BR,Brazil,
-1933-09-30,CA,Canada,
-1933-09-30,CH,Switzerland,
-1933-09-30,CL,Chile,
-1933-09-30,CN,China,
-1933-09-30,CO,Colombia,
-1933-09-30,CY,Cyprus,
-1933-09-30,CZ,Czechia,
-1933-09-30,DE,Germany,
-1933-09-30,DK,Denmark,
-1933-09-30,EE,Estonia,
-1933-09-30,ES,Spain,
-1933-09-30,FI,Finland,
-1933-09-30,FR,France,
-1933-09-30,GB,United Kingdom,
-1933-09-30,GR,Greece,
-1933-09-30,HK,Hong Kong SAR,
-1933-09-30,HR,Croatia,
-1933-09-30,HU,Hungary,
-1933-09-30,ID,Indonesia,
-1933-09-30,IE,Ireland,
-1933-09-30,IL,Israel,
-1933-09-30,IN,India,
-1933-09-30,IS,Iceland,
-1933-09-30,IT,Italy,
-1933-09-30,JP,Japan,
-1933-09-30,KR,Korea,
-1933-09-30,LT,Lithuania,
-1933-09-30,LU,Luxembourg,
-1933-09-30,LV,Latvia,
-1933-09-30,MA,Morocco,
-1933-09-30,MK,North Macedonia,
-1933-09-30,MT,Malta,
-1933-09-30,MX,Mexico,
-1933-09-30,MY,Malaysia,
-1933-09-30,NL,Netherlands,
-1933-09-30,NO,Norway,
-1933-09-30,NZ,New Zealand,
-1933-09-30,PE,Peru,
-1933-09-30,PH,Philippines,
-1933-09-30,PL,Poland,
-1933-09-30,PT,Portugal,
-1933-09-30,RO,Romania,
-1933-09-30,RS,Serbia,
-1933-09-30,RU,Russia,
-1933-09-30,SE,Sweden,
-1933-09-30,SG,Singapore,
-1933-09-30,SI,Slovenia,
-1933-09-30,SK,Slovak Republic,
-1933-09-30,TH,Thailand,
-1933-09-30,TR,Türkiye,
-1933-09-30,US,United States,
-1933-09-30,XM,Euro area,
-1933-09-30,XW,World,
-1933-09-30,ZA,South Africa,
-1933-12-31,4T,Emerging market economies (aggregate),
-1933-12-31,5R,Advanced economies,
-1933-12-31,AE,United Arab Emirates,
-1933-12-31,AT,Austria,
-1933-12-31,AU,Australia,
-1933-12-31,BE,Belgium,
-1933-12-31,BG,Bulgaria,
-1933-12-31,BR,Brazil,
-1933-12-31,CA,Canada,
-1933-12-31,CH,Switzerland,
-1933-12-31,CL,Chile,
-1933-12-31,CN,China,
-1933-12-31,CO,Colombia,
-1933-12-31,CY,Cyprus,
-1933-12-31,CZ,Czechia,
-1933-12-31,DE,Germany,
-1933-12-31,DK,Denmark,
-1933-12-31,EE,Estonia,
-1933-12-31,ES,Spain,
-1933-12-31,FI,Finland,
-1933-12-31,FR,France,
-1933-12-31,GB,United Kingdom,
-1933-12-31,GR,Greece,
-1933-12-31,HK,Hong Kong SAR,
-1933-12-31,HR,Croatia,
-1933-12-31,HU,Hungary,
-1933-12-31,ID,Indonesia,
-1933-12-31,IE,Ireland,
-1933-12-31,IL,Israel,
-1933-12-31,IN,India,
-1933-12-31,IS,Iceland,
-1933-12-31,IT,Italy,
-1933-12-31,JP,Japan,
-1933-12-31,KR,Korea,
-1933-12-31,LT,Lithuania,
-1933-12-31,LU,Luxembourg,
-1933-12-31,LV,Latvia,
-1933-12-31,MA,Morocco,
-1933-12-31,MK,North Macedonia,
-1933-12-31,MT,Malta,
-1933-12-31,MX,Mexico,
-1933-12-31,MY,Malaysia,
-1933-12-31,NL,Netherlands,
-1933-12-31,NO,Norway,
-1933-12-31,NZ,New Zealand,
-1933-12-31,PE,Peru,
-1933-12-31,PH,Philippines,
-1933-12-31,PL,Poland,
-1933-12-31,PT,Portugal,
-1933-12-31,RO,Romania,
-1933-12-31,RS,Serbia,
-1933-12-31,RU,Russia,
-1933-12-31,SE,Sweden,
-1933-12-31,SG,Singapore,
-1933-12-31,SI,Slovenia,
-1933-12-31,SK,Slovak Republic,
-1933-12-31,TH,Thailand,
-1933-12-31,TR,Türkiye,
-1933-12-31,US,United States,
-1933-12-31,XM,Euro area,
-1933-12-31,XW,World,
-1933-12-31,ZA,South Africa,
-1934-03-31,4T,Emerging market economies (aggregate),
-1934-03-31,5R,Advanced economies,
-1934-03-31,AE,United Arab Emirates,
-1934-03-31,AT,Austria,
-1934-03-31,AU,Australia,
-1934-03-31,BE,Belgium,
-1934-03-31,BG,Bulgaria,
-1934-03-31,BR,Brazil,
-1934-03-31,CA,Canada,
-1934-03-31,CH,Switzerland,
-1934-03-31,CL,Chile,
-1934-03-31,CN,China,
-1934-03-31,CO,Colombia,
-1934-03-31,CY,Cyprus,
-1934-03-31,CZ,Czechia,
-1934-03-31,DE,Germany,
-1934-03-31,DK,Denmark,
-1934-03-31,EE,Estonia,
-1934-03-31,ES,Spain,
-1934-03-31,FI,Finland,
-1934-03-31,FR,France,
-1934-03-31,GB,United Kingdom,
-1934-03-31,GR,Greece,
-1934-03-31,HK,Hong Kong SAR,
-1934-03-31,HR,Croatia,
-1934-03-31,HU,Hungary,
-1934-03-31,ID,Indonesia,
-1934-03-31,IE,Ireland,
-1934-03-31,IL,Israel,
-1934-03-31,IN,India,
-1934-03-31,IS,Iceland,
-1934-03-31,IT,Italy,
-1934-03-31,JP,Japan,
-1934-03-31,KR,Korea,
-1934-03-31,LT,Lithuania,
-1934-03-31,LU,Luxembourg,
-1934-03-31,LV,Latvia,
-1934-03-31,MA,Morocco,
-1934-03-31,MK,North Macedonia,
-1934-03-31,MT,Malta,
-1934-03-31,MX,Mexico,
-1934-03-31,MY,Malaysia,
-1934-03-31,NL,Netherlands,
-1934-03-31,NO,Norway,
-1934-03-31,NZ,New Zealand,
-1934-03-31,PE,Peru,
-1934-03-31,PH,Philippines,
-1934-03-31,PL,Poland,
-1934-03-31,PT,Portugal,
-1934-03-31,RO,Romania,
-1934-03-31,RS,Serbia,
-1934-03-31,RU,Russia,
-1934-03-31,SE,Sweden,
-1934-03-31,SG,Singapore,
-1934-03-31,SI,Slovenia,
-1934-03-31,SK,Slovak Republic,
-1934-03-31,TH,Thailand,
-1934-03-31,TR,Türkiye,
-1934-03-31,US,United States,
-1934-03-31,XM,Euro area,
-1934-03-31,XW,World,
-1934-03-31,ZA,South Africa,
-1934-06-30,4T,Emerging market economies (aggregate),
-1934-06-30,5R,Advanced economies,
-1934-06-30,AE,United Arab Emirates,
-1934-06-30,AT,Austria,
-1934-06-30,AU,Australia,
-1934-06-30,BE,Belgium,
-1934-06-30,BG,Bulgaria,
-1934-06-30,BR,Brazil,
-1934-06-30,CA,Canada,
-1934-06-30,CH,Switzerland,
-1934-06-30,CL,Chile,
-1934-06-30,CN,China,
-1934-06-30,CO,Colombia,
-1934-06-30,CY,Cyprus,
-1934-06-30,CZ,Czechia,
-1934-06-30,DE,Germany,
-1934-06-30,DK,Denmark,
-1934-06-30,EE,Estonia,
-1934-06-30,ES,Spain,
-1934-06-30,FI,Finland,
-1934-06-30,FR,France,
-1934-06-30,GB,United Kingdom,
-1934-06-30,GR,Greece,
-1934-06-30,HK,Hong Kong SAR,
-1934-06-30,HR,Croatia,
-1934-06-30,HU,Hungary,
-1934-06-30,ID,Indonesia,
-1934-06-30,IE,Ireland,
-1934-06-30,IL,Israel,
-1934-06-30,IN,India,
-1934-06-30,IS,Iceland,
-1934-06-30,IT,Italy,
-1934-06-30,JP,Japan,
-1934-06-30,KR,Korea,
-1934-06-30,LT,Lithuania,
-1934-06-30,LU,Luxembourg,
-1934-06-30,LV,Latvia,
-1934-06-30,MA,Morocco,
-1934-06-30,MK,North Macedonia,
-1934-06-30,MT,Malta,
-1934-06-30,MX,Mexico,
-1934-06-30,MY,Malaysia,
-1934-06-30,NL,Netherlands,
-1934-06-30,NO,Norway,
-1934-06-30,NZ,New Zealand,
-1934-06-30,PE,Peru,
-1934-06-30,PH,Philippines,
-1934-06-30,PL,Poland,
-1934-06-30,PT,Portugal,
-1934-06-30,RO,Romania,
-1934-06-30,RS,Serbia,
-1934-06-30,RU,Russia,
-1934-06-30,SE,Sweden,
-1934-06-30,SG,Singapore,
-1934-06-30,SI,Slovenia,
-1934-06-30,SK,Slovak Republic,
-1934-06-30,TH,Thailand,
-1934-06-30,TR,Türkiye,
-1934-06-30,US,United States,
-1934-06-30,XM,Euro area,
-1934-06-30,XW,World,
-1934-06-30,ZA,South Africa,
-1934-09-30,4T,Emerging market economies (aggregate),
-1934-09-30,5R,Advanced economies,
-1934-09-30,AE,United Arab Emirates,
-1934-09-30,AT,Austria,
-1934-09-30,AU,Australia,
-1934-09-30,BE,Belgium,
-1934-09-30,BG,Bulgaria,
-1934-09-30,BR,Brazil,
-1934-09-30,CA,Canada,
-1934-09-30,CH,Switzerland,
-1934-09-30,CL,Chile,
-1934-09-30,CN,China,
-1934-09-30,CO,Colombia,
-1934-09-30,CY,Cyprus,
-1934-09-30,CZ,Czechia,
-1934-09-30,DE,Germany,
-1934-09-30,DK,Denmark,
-1934-09-30,EE,Estonia,
-1934-09-30,ES,Spain,
-1934-09-30,FI,Finland,
-1934-09-30,FR,France,
-1934-09-30,GB,United Kingdom,
-1934-09-30,GR,Greece,
-1934-09-30,HK,Hong Kong SAR,
-1934-09-30,HR,Croatia,
-1934-09-30,HU,Hungary,
-1934-09-30,ID,Indonesia,
-1934-09-30,IE,Ireland,
-1934-09-30,IL,Israel,
-1934-09-30,IN,India,
-1934-09-30,IS,Iceland,
-1934-09-30,IT,Italy,
-1934-09-30,JP,Japan,
-1934-09-30,KR,Korea,
-1934-09-30,LT,Lithuania,
-1934-09-30,LU,Luxembourg,
-1934-09-30,LV,Latvia,
-1934-09-30,MA,Morocco,
-1934-09-30,MK,North Macedonia,
-1934-09-30,MT,Malta,
-1934-09-30,MX,Mexico,
-1934-09-30,MY,Malaysia,
-1934-09-30,NL,Netherlands,
-1934-09-30,NO,Norway,
-1934-09-30,NZ,New Zealand,
-1934-09-30,PE,Peru,
-1934-09-30,PH,Philippines,
-1934-09-30,PL,Poland,
-1934-09-30,PT,Portugal,
-1934-09-30,RO,Romania,
-1934-09-30,RS,Serbia,
-1934-09-30,RU,Russia,
-1934-09-30,SE,Sweden,
-1934-09-30,SG,Singapore,
-1934-09-30,SI,Slovenia,
-1934-09-30,SK,Slovak Republic,
-1934-09-30,TH,Thailand,
-1934-09-30,TR,Türkiye,
-1934-09-30,US,United States,
-1934-09-30,XM,Euro area,
-1934-09-30,XW,World,
-1934-09-30,ZA,South Africa,
-1934-12-31,4T,Emerging market economies (aggregate),
-1934-12-31,5R,Advanced economies,
-1934-12-31,AE,United Arab Emirates,
-1934-12-31,AT,Austria,
-1934-12-31,AU,Australia,
-1934-12-31,BE,Belgium,
-1934-12-31,BG,Bulgaria,
-1934-12-31,BR,Brazil,
-1934-12-31,CA,Canada,
-1934-12-31,CH,Switzerland,
-1934-12-31,CL,Chile,
-1934-12-31,CN,China,
-1934-12-31,CO,Colombia,
-1934-12-31,CY,Cyprus,
-1934-12-31,CZ,Czechia,
-1934-12-31,DE,Germany,
-1934-12-31,DK,Denmark,
-1934-12-31,EE,Estonia,
-1934-12-31,ES,Spain,
-1934-12-31,FI,Finland,
-1934-12-31,FR,France,
-1934-12-31,GB,United Kingdom,
-1934-12-31,GR,Greece,
-1934-12-31,HK,Hong Kong SAR,
-1934-12-31,HR,Croatia,
-1934-12-31,HU,Hungary,
-1934-12-31,ID,Indonesia,
-1934-12-31,IE,Ireland,
-1934-12-31,IL,Israel,
-1934-12-31,IN,India,
-1934-12-31,IS,Iceland,
-1934-12-31,IT,Italy,
-1934-12-31,JP,Japan,
-1934-12-31,KR,Korea,
-1934-12-31,LT,Lithuania,
-1934-12-31,LU,Luxembourg,
-1934-12-31,LV,Latvia,
-1934-12-31,MA,Morocco,
-1934-12-31,MK,North Macedonia,
-1934-12-31,MT,Malta,
-1934-12-31,MX,Mexico,
-1934-12-31,MY,Malaysia,
-1934-12-31,NL,Netherlands,
-1934-12-31,NO,Norway,
-1934-12-31,NZ,New Zealand,
-1934-12-31,PE,Peru,
-1934-12-31,PH,Philippines,
-1934-12-31,PL,Poland,
-1934-12-31,PT,Portugal,
-1934-12-31,RO,Romania,
-1934-12-31,RS,Serbia,
-1934-12-31,RU,Russia,
-1934-12-31,SE,Sweden,
-1934-12-31,SG,Singapore,
-1934-12-31,SI,Slovenia,
-1934-12-31,SK,Slovak Republic,
-1934-12-31,TH,Thailand,
-1934-12-31,TR,Türkiye,
-1934-12-31,US,United States,
-1934-12-31,XM,Euro area,
-1934-12-31,XW,World,
-1934-12-31,ZA,South Africa,
-1935-03-31,4T,Emerging market economies (aggregate),
-1935-03-31,5R,Advanced economies,
-1935-03-31,AE,United Arab Emirates,
-1935-03-31,AT,Austria,
-1935-03-31,AU,Australia,
-1935-03-31,BE,Belgium,
-1935-03-31,BG,Bulgaria,
-1935-03-31,BR,Brazil,
-1935-03-31,CA,Canada,
-1935-03-31,CH,Switzerland,
-1935-03-31,CL,Chile,
-1935-03-31,CN,China,
-1935-03-31,CO,Colombia,
-1935-03-31,CY,Cyprus,
-1935-03-31,CZ,Czechia,
-1935-03-31,DE,Germany,
-1935-03-31,DK,Denmark,
-1935-03-31,EE,Estonia,
-1935-03-31,ES,Spain,
-1935-03-31,FI,Finland,
-1935-03-31,FR,France,
-1935-03-31,GB,United Kingdom,
-1935-03-31,GR,Greece,
-1935-03-31,HK,Hong Kong SAR,
-1935-03-31,HR,Croatia,
-1935-03-31,HU,Hungary,
-1935-03-31,ID,Indonesia,
-1935-03-31,IE,Ireland,
-1935-03-31,IL,Israel,
-1935-03-31,IN,India,
-1935-03-31,IS,Iceland,
-1935-03-31,IT,Italy,
-1935-03-31,JP,Japan,
-1935-03-31,KR,Korea,
-1935-03-31,LT,Lithuania,
-1935-03-31,LU,Luxembourg,
-1935-03-31,LV,Latvia,
-1935-03-31,MA,Morocco,
-1935-03-31,MK,North Macedonia,
-1935-03-31,MT,Malta,
-1935-03-31,MX,Mexico,
-1935-03-31,MY,Malaysia,
-1935-03-31,NL,Netherlands,
-1935-03-31,NO,Norway,
-1935-03-31,NZ,New Zealand,
-1935-03-31,PE,Peru,
-1935-03-31,PH,Philippines,
-1935-03-31,PL,Poland,
-1935-03-31,PT,Portugal,
-1935-03-31,RO,Romania,
-1935-03-31,RS,Serbia,
-1935-03-31,RU,Russia,
-1935-03-31,SE,Sweden,
-1935-03-31,SG,Singapore,
-1935-03-31,SI,Slovenia,
-1935-03-31,SK,Slovak Republic,
-1935-03-31,TH,Thailand,
-1935-03-31,TR,Türkiye,
-1935-03-31,US,United States,
-1935-03-31,XM,Euro area,
-1935-03-31,XW,World,
-1935-03-31,ZA,South Africa,
-1935-06-30,4T,Emerging market economies (aggregate),
-1935-06-30,5R,Advanced economies,
-1935-06-30,AE,United Arab Emirates,
-1935-06-30,AT,Austria,
-1935-06-30,AU,Australia,
-1935-06-30,BE,Belgium,
-1935-06-30,BG,Bulgaria,
-1935-06-30,BR,Brazil,
-1935-06-30,CA,Canada,
-1935-06-30,CH,Switzerland,
-1935-06-30,CL,Chile,
-1935-06-30,CN,China,
-1935-06-30,CO,Colombia,
-1935-06-30,CY,Cyprus,
-1935-06-30,CZ,Czechia,
-1935-06-30,DE,Germany,
-1935-06-30,DK,Denmark,
-1935-06-30,EE,Estonia,
-1935-06-30,ES,Spain,
-1935-06-30,FI,Finland,
-1935-06-30,FR,France,
-1935-06-30,GB,United Kingdom,
-1935-06-30,GR,Greece,
-1935-06-30,HK,Hong Kong SAR,
-1935-06-30,HR,Croatia,
-1935-06-30,HU,Hungary,
-1935-06-30,ID,Indonesia,
-1935-06-30,IE,Ireland,
-1935-06-30,IL,Israel,
-1935-06-30,IN,India,
-1935-06-30,IS,Iceland,
-1935-06-30,IT,Italy,
-1935-06-30,JP,Japan,
-1935-06-30,KR,Korea,
-1935-06-30,LT,Lithuania,
-1935-06-30,LU,Luxembourg,
-1935-06-30,LV,Latvia,
-1935-06-30,MA,Morocco,
-1935-06-30,MK,North Macedonia,
-1935-06-30,MT,Malta,
-1935-06-30,MX,Mexico,
-1935-06-30,MY,Malaysia,
-1935-06-30,NL,Netherlands,
-1935-06-30,NO,Norway,
-1935-06-30,NZ,New Zealand,
-1935-06-30,PE,Peru,
-1935-06-30,PH,Philippines,
-1935-06-30,PL,Poland,
-1935-06-30,PT,Portugal,
-1935-06-30,RO,Romania,
-1935-06-30,RS,Serbia,
-1935-06-30,RU,Russia,
-1935-06-30,SE,Sweden,
-1935-06-30,SG,Singapore,
-1935-06-30,SI,Slovenia,
-1935-06-30,SK,Slovak Republic,
-1935-06-30,TH,Thailand,
-1935-06-30,TR,Türkiye,
-1935-06-30,US,United States,
-1935-06-30,XM,Euro area,
-1935-06-30,XW,World,
-1935-06-30,ZA,South Africa,
-1935-09-30,4T,Emerging market economies (aggregate),
-1935-09-30,5R,Advanced economies,
-1935-09-30,AE,United Arab Emirates,
-1935-09-30,AT,Austria,
-1935-09-30,AU,Australia,
-1935-09-30,BE,Belgium,
-1935-09-30,BG,Bulgaria,
-1935-09-30,BR,Brazil,
-1935-09-30,CA,Canada,
-1935-09-30,CH,Switzerland,
-1935-09-30,CL,Chile,
-1935-09-30,CN,China,
-1935-09-30,CO,Colombia,
-1935-09-30,CY,Cyprus,
-1935-09-30,CZ,Czechia,
-1935-09-30,DE,Germany,
-1935-09-30,DK,Denmark,
-1935-09-30,EE,Estonia,
-1935-09-30,ES,Spain,
-1935-09-30,FI,Finland,
-1935-09-30,FR,France,
-1935-09-30,GB,United Kingdom,
-1935-09-30,GR,Greece,
-1935-09-30,HK,Hong Kong SAR,
-1935-09-30,HR,Croatia,
-1935-09-30,HU,Hungary,
-1935-09-30,ID,Indonesia,
-1935-09-30,IE,Ireland,
-1935-09-30,IL,Israel,
-1935-09-30,IN,India,
-1935-09-30,IS,Iceland,
-1935-09-30,IT,Italy,
-1935-09-30,JP,Japan,
-1935-09-30,KR,Korea,
-1935-09-30,LT,Lithuania,
-1935-09-30,LU,Luxembourg,
-1935-09-30,LV,Latvia,
-1935-09-30,MA,Morocco,
-1935-09-30,MK,North Macedonia,
-1935-09-30,MT,Malta,
-1935-09-30,MX,Mexico,
-1935-09-30,MY,Malaysia,
-1935-09-30,NL,Netherlands,
-1935-09-30,NO,Norway,
-1935-09-30,NZ,New Zealand,
-1935-09-30,PE,Peru,
-1935-09-30,PH,Philippines,
-1935-09-30,PL,Poland,
-1935-09-30,PT,Portugal,
-1935-09-30,RO,Romania,
-1935-09-30,RS,Serbia,
-1935-09-30,RU,Russia,
-1935-09-30,SE,Sweden,
-1935-09-30,SG,Singapore,
-1935-09-30,SI,Slovenia,
-1935-09-30,SK,Slovak Republic,
-1935-09-30,TH,Thailand,
-1935-09-30,TR,Türkiye,
-1935-09-30,US,United States,
-1935-09-30,XM,Euro area,
-1935-09-30,XW,World,
-1935-09-30,ZA,South Africa,
-1935-12-31,4T,Emerging market economies (aggregate),
-1935-12-31,5R,Advanced economies,
-1935-12-31,AE,United Arab Emirates,
-1935-12-31,AT,Austria,
-1935-12-31,AU,Australia,
-1935-12-31,BE,Belgium,
-1935-12-31,BG,Bulgaria,
-1935-12-31,BR,Brazil,
-1935-12-31,CA,Canada,
-1935-12-31,CH,Switzerland,
-1935-12-31,CL,Chile,
-1935-12-31,CN,China,
-1935-12-31,CO,Colombia,
-1935-12-31,CY,Cyprus,
-1935-12-31,CZ,Czechia,
-1935-12-31,DE,Germany,
-1935-12-31,DK,Denmark,
-1935-12-31,EE,Estonia,
-1935-12-31,ES,Spain,
-1935-12-31,FI,Finland,
-1935-12-31,FR,France,
-1935-12-31,GB,United Kingdom,
-1935-12-31,GR,Greece,
-1935-12-31,HK,Hong Kong SAR,
-1935-12-31,HR,Croatia,
-1935-12-31,HU,Hungary,
-1935-12-31,ID,Indonesia,
-1935-12-31,IE,Ireland,
-1935-12-31,IL,Israel,
-1935-12-31,IN,India,
-1935-12-31,IS,Iceland,
-1935-12-31,IT,Italy,
-1935-12-31,JP,Japan,
-1935-12-31,KR,Korea,
-1935-12-31,LT,Lithuania,
-1935-12-31,LU,Luxembourg,
-1935-12-31,LV,Latvia,
-1935-12-31,MA,Morocco,
-1935-12-31,MK,North Macedonia,
-1935-12-31,MT,Malta,
-1935-12-31,MX,Mexico,
-1935-12-31,MY,Malaysia,
-1935-12-31,NL,Netherlands,
-1935-12-31,NO,Norway,
-1935-12-31,NZ,New Zealand,
-1935-12-31,PE,Peru,
-1935-12-31,PH,Philippines,
-1935-12-31,PL,Poland,
-1935-12-31,PT,Portugal,
-1935-12-31,RO,Romania,
-1935-12-31,RS,Serbia,
-1935-12-31,RU,Russia,
-1935-12-31,SE,Sweden,
-1935-12-31,SG,Singapore,
-1935-12-31,SI,Slovenia,
-1935-12-31,SK,Slovak Republic,
-1935-12-31,TH,Thailand,
-1935-12-31,TR,Türkiye,
-1935-12-31,US,United States,
-1935-12-31,XM,Euro area,
-1935-12-31,XW,World,
-1935-12-31,ZA,South Africa,
-1936-03-31,4T,Emerging market economies (aggregate),
-1936-03-31,5R,Advanced economies,
-1936-03-31,AE,United Arab Emirates,
-1936-03-31,AT,Austria,
-1936-03-31,AU,Australia,
-1936-03-31,BE,Belgium,
-1936-03-31,BG,Bulgaria,
-1936-03-31,BR,Brazil,
-1936-03-31,CA,Canada,
-1936-03-31,CH,Switzerland,
-1936-03-31,CL,Chile,
-1936-03-31,CN,China,
-1936-03-31,CO,Colombia,
-1936-03-31,CY,Cyprus,
-1936-03-31,CZ,Czechia,
-1936-03-31,DE,Germany,
-1936-03-31,DK,Denmark,
-1936-03-31,EE,Estonia,
-1936-03-31,ES,Spain,
-1936-03-31,FI,Finland,
-1936-03-31,FR,France,
-1936-03-31,GB,United Kingdom,
-1936-03-31,GR,Greece,
-1936-03-31,HK,Hong Kong SAR,
-1936-03-31,HR,Croatia,
-1936-03-31,HU,Hungary,
-1936-03-31,ID,Indonesia,
-1936-03-31,IE,Ireland,
-1936-03-31,IL,Israel,
-1936-03-31,IN,India,
-1936-03-31,IS,Iceland,
-1936-03-31,IT,Italy,
-1936-03-31,JP,Japan,
-1936-03-31,KR,Korea,
-1936-03-31,LT,Lithuania,
-1936-03-31,LU,Luxembourg,
-1936-03-31,LV,Latvia,
-1936-03-31,MA,Morocco,
-1936-03-31,MK,North Macedonia,
-1936-03-31,MT,Malta,
-1936-03-31,MX,Mexico,
-1936-03-31,MY,Malaysia,
-1936-03-31,NL,Netherlands,
-1936-03-31,NO,Norway,
-1936-03-31,NZ,New Zealand,
-1936-03-31,PE,Peru,
-1936-03-31,PH,Philippines,
-1936-03-31,PL,Poland,
-1936-03-31,PT,Portugal,
-1936-03-31,RO,Romania,
-1936-03-31,RS,Serbia,
-1936-03-31,RU,Russia,
-1936-03-31,SE,Sweden,
-1936-03-31,SG,Singapore,
-1936-03-31,SI,Slovenia,
-1936-03-31,SK,Slovak Republic,
-1936-03-31,TH,Thailand,
-1936-03-31,TR,Türkiye,
-1936-03-31,US,United States,
-1936-03-31,XM,Euro area,
-1936-03-31,XW,World,
-1936-03-31,ZA,South Africa,
-1936-06-30,4T,Emerging market economies (aggregate),
-1936-06-30,5R,Advanced economies,
-1936-06-30,AE,United Arab Emirates,
-1936-06-30,AT,Austria,
-1936-06-30,AU,Australia,
-1936-06-30,BE,Belgium,
-1936-06-30,BG,Bulgaria,
-1936-06-30,BR,Brazil,
-1936-06-30,CA,Canada,
-1936-06-30,CH,Switzerland,
-1936-06-30,CL,Chile,
-1936-06-30,CN,China,
-1936-06-30,CO,Colombia,
-1936-06-30,CY,Cyprus,
-1936-06-30,CZ,Czechia,
-1936-06-30,DE,Germany,
-1936-06-30,DK,Denmark,
-1936-06-30,EE,Estonia,
-1936-06-30,ES,Spain,
-1936-06-30,FI,Finland,
-1936-06-30,FR,France,
-1936-06-30,GB,United Kingdom,
-1936-06-30,GR,Greece,
-1936-06-30,HK,Hong Kong SAR,
-1936-06-30,HR,Croatia,
-1936-06-30,HU,Hungary,
-1936-06-30,ID,Indonesia,
-1936-06-30,IE,Ireland,
-1936-06-30,IL,Israel,
-1936-06-30,IN,India,
-1936-06-30,IS,Iceland,
-1936-06-30,IT,Italy,
-1936-06-30,JP,Japan,
-1936-06-30,KR,Korea,
-1936-06-30,LT,Lithuania,
-1936-06-30,LU,Luxembourg,
-1936-06-30,LV,Latvia,
-1936-06-30,MA,Morocco,
-1936-06-30,MK,North Macedonia,
-1936-06-30,MT,Malta,
-1936-06-30,MX,Mexico,
-1936-06-30,MY,Malaysia,
-1936-06-30,NL,Netherlands,
-1936-06-30,NO,Norway,
-1936-06-30,NZ,New Zealand,
-1936-06-30,PE,Peru,
-1936-06-30,PH,Philippines,
-1936-06-30,PL,Poland,
-1936-06-30,PT,Portugal,
-1936-06-30,RO,Romania,
-1936-06-30,RS,Serbia,
-1936-06-30,RU,Russia,
-1936-06-30,SE,Sweden,
-1936-06-30,SG,Singapore,
-1936-06-30,SI,Slovenia,
-1936-06-30,SK,Slovak Republic,
-1936-06-30,TH,Thailand,
-1936-06-30,TR,Türkiye,
-1936-06-30,US,United States,
-1936-06-30,XM,Euro area,
-1936-06-30,XW,World,
-1936-06-30,ZA,South Africa,
-1936-09-30,4T,Emerging market economies (aggregate),
-1936-09-30,5R,Advanced economies,
-1936-09-30,AE,United Arab Emirates,
-1936-09-30,AT,Austria,
-1936-09-30,AU,Australia,
-1936-09-30,BE,Belgium,
-1936-09-30,BG,Bulgaria,
-1936-09-30,BR,Brazil,
-1936-09-30,CA,Canada,
-1936-09-30,CH,Switzerland,
-1936-09-30,CL,Chile,
-1936-09-30,CN,China,
-1936-09-30,CO,Colombia,
-1936-09-30,CY,Cyprus,
-1936-09-30,CZ,Czechia,
-1936-09-30,DE,Germany,
-1936-09-30,DK,Denmark,
-1936-09-30,EE,Estonia,
-1936-09-30,ES,Spain,
-1936-09-30,FI,Finland,
-1936-09-30,FR,France,
-1936-09-30,GB,United Kingdom,
-1936-09-30,GR,Greece,
-1936-09-30,HK,Hong Kong SAR,
-1936-09-30,HR,Croatia,
-1936-09-30,HU,Hungary,
-1936-09-30,ID,Indonesia,
-1936-09-30,IE,Ireland,
-1936-09-30,IL,Israel,
-1936-09-30,IN,India,
-1936-09-30,IS,Iceland,
-1936-09-30,IT,Italy,
-1936-09-30,JP,Japan,
-1936-09-30,KR,Korea,
-1936-09-30,LT,Lithuania,
-1936-09-30,LU,Luxembourg,
-1936-09-30,LV,Latvia,
-1936-09-30,MA,Morocco,
-1936-09-30,MK,North Macedonia,
-1936-09-30,MT,Malta,
-1936-09-30,MX,Mexico,
-1936-09-30,MY,Malaysia,
-1936-09-30,NL,Netherlands,
-1936-09-30,NO,Norway,
-1936-09-30,NZ,New Zealand,
-1936-09-30,PE,Peru,
-1936-09-30,PH,Philippines,
-1936-09-30,PL,Poland,
-1936-09-30,PT,Portugal,
-1936-09-30,RO,Romania,
-1936-09-30,RS,Serbia,
-1936-09-30,RU,Russia,
-1936-09-30,SE,Sweden,
-1936-09-30,SG,Singapore,
-1936-09-30,SI,Slovenia,
-1936-09-30,SK,Slovak Republic,
-1936-09-30,TH,Thailand,
-1936-09-30,TR,Türkiye,
-1936-09-30,US,United States,
-1936-09-30,XM,Euro area,
-1936-09-30,XW,World,
-1936-09-30,ZA,South Africa,
-1936-12-31,4T,Emerging market economies (aggregate),
-1936-12-31,5R,Advanced economies,
-1936-12-31,AE,United Arab Emirates,
-1936-12-31,AT,Austria,
-1936-12-31,AU,Australia,
-1936-12-31,BE,Belgium,
-1936-12-31,BG,Bulgaria,
-1936-12-31,BR,Brazil,
-1936-12-31,CA,Canada,
-1936-12-31,CH,Switzerland,
-1936-12-31,CL,Chile,
-1936-12-31,CN,China,
-1936-12-31,CO,Colombia,
-1936-12-31,CY,Cyprus,
-1936-12-31,CZ,Czechia,
-1936-12-31,DE,Germany,
-1936-12-31,DK,Denmark,
-1936-12-31,EE,Estonia,
-1936-12-31,ES,Spain,
-1936-12-31,FI,Finland,
-1936-12-31,FR,France,
-1936-12-31,GB,United Kingdom,
-1936-12-31,GR,Greece,
-1936-12-31,HK,Hong Kong SAR,
-1936-12-31,HR,Croatia,
-1936-12-31,HU,Hungary,
-1936-12-31,ID,Indonesia,
-1936-12-31,IE,Ireland,
-1936-12-31,IL,Israel,
-1936-12-31,IN,India,
-1936-12-31,IS,Iceland,
-1936-12-31,IT,Italy,
-1936-12-31,JP,Japan,
-1936-12-31,KR,Korea,
-1936-12-31,LT,Lithuania,
-1936-12-31,LU,Luxembourg,
-1936-12-31,LV,Latvia,
-1936-12-31,MA,Morocco,
-1936-12-31,MK,North Macedonia,
-1936-12-31,MT,Malta,
-1936-12-31,MX,Mexico,
-1936-12-31,MY,Malaysia,
-1936-12-31,NL,Netherlands,
-1936-12-31,NO,Norway,
-1936-12-31,NZ,New Zealand,
-1936-12-31,PE,Peru,
-1936-12-31,PH,Philippines,
-1936-12-31,PL,Poland,
-1936-12-31,PT,Portugal,
-1936-12-31,RO,Romania,
-1936-12-31,RS,Serbia,
-1936-12-31,RU,Russia,
-1936-12-31,SE,Sweden,
-1936-12-31,SG,Singapore,
-1936-12-31,SI,Slovenia,
-1936-12-31,SK,Slovak Republic,
-1936-12-31,TH,Thailand,
-1936-12-31,TR,Türkiye,
-1936-12-31,US,United States,
-1936-12-31,XM,Euro area,
-1936-12-31,XW,World,
-1936-12-31,ZA,South Africa,
-1937-03-31,4T,Emerging market economies (aggregate),
-1937-03-31,5R,Advanced economies,
-1937-03-31,AE,United Arab Emirates,
-1937-03-31,AT,Austria,
-1937-03-31,AU,Australia,
-1937-03-31,BE,Belgium,
-1937-03-31,BG,Bulgaria,
-1937-03-31,BR,Brazil,
-1937-03-31,CA,Canada,
-1937-03-31,CH,Switzerland,
-1937-03-31,CL,Chile,
-1937-03-31,CN,China,
-1937-03-31,CO,Colombia,
-1937-03-31,CY,Cyprus,
-1937-03-31,CZ,Czechia,
-1937-03-31,DE,Germany,
-1937-03-31,DK,Denmark,
-1937-03-31,EE,Estonia,
-1937-03-31,ES,Spain,
-1937-03-31,FI,Finland,
-1937-03-31,FR,France,
-1937-03-31,GB,United Kingdom,
-1937-03-31,GR,Greece,
-1937-03-31,HK,Hong Kong SAR,
-1937-03-31,HR,Croatia,
-1937-03-31,HU,Hungary,
-1937-03-31,ID,Indonesia,
-1937-03-31,IE,Ireland,
-1937-03-31,IL,Israel,
-1937-03-31,IN,India,
-1937-03-31,IS,Iceland,
-1937-03-31,IT,Italy,
-1937-03-31,JP,Japan,
-1937-03-31,KR,Korea,
-1937-03-31,LT,Lithuania,
-1937-03-31,LU,Luxembourg,
-1937-03-31,LV,Latvia,
-1937-03-31,MA,Morocco,
-1937-03-31,MK,North Macedonia,
-1937-03-31,MT,Malta,
-1937-03-31,MX,Mexico,
-1937-03-31,MY,Malaysia,
-1937-03-31,NL,Netherlands,
-1937-03-31,NO,Norway,
-1937-03-31,NZ,New Zealand,
-1937-03-31,PE,Peru,
-1937-03-31,PH,Philippines,
-1937-03-31,PL,Poland,
-1937-03-31,PT,Portugal,
-1937-03-31,RO,Romania,
-1937-03-31,RS,Serbia,
-1937-03-31,RU,Russia,
-1937-03-31,SE,Sweden,
-1937-03-31,SG,Singapore,
-1937-03-31,SI,Slovenia,
-1937-03-31,SK,Slovak Republic,
-1937-03-31,TH,Thailand,
-1937-03-31,TR,Türkiye,
-1937-03-31,US,United States,
-1937-03-31,XM,Euro area,
-1937-03-31,XW,World,
-1937-03-31,ZA,South Africa,
-1937-06-30,4T,Emerging market economies (aggregate),
-1937-06-30,5R,Advanced economies,
-1937-06-30,AE,United Arab Emirates,
-1937-06-30,AT,Austria,
-1937-06-30,AU,Australia,
-1937-06-30,BE,Belgium,
-1937-06-30,BG,Bulgaria,
-1937-06-30,BR,Brazil,
-1937-06-30,CA,Canada,
-1937-06-30,CH,Switzerland,
-1937-06-30,CL,Chile,
-1937-06-30,CN,China,
-1937-06-30,CO,Colombia,
-1937-06-30,CY,Cyprus,
-1937-06-30,CZ,Czechia,
-1937-06-30,DE,Germany,
-1937-06-30,DK,Denmark,
-1937-06-30,EE,Estonia,
-1937-06-30,ES,Spain,
-1937-06-30,FI,Finland,
-1937-06-30,FR,France,
-1937-06-30,GB,United Kingdom,
-1937-06-30,GR,Greece,
-1937-06-30,HK,Hong Kong SAR,
-1937-06-30,HR,Croatia,
-1937-06-30,HU,Hungary,
-1937-06-30,ID,Indonesia,
-1937-06-30,IE,Ireland,
-1937-06-30,IL,Israel,
-1937-06-30,IN,India,
-1937-06-30,IS,Iceland,
-1937-06-30,IT,Italy,
-1937-06-30,JP,Japan,
-1937-06-30,KR,Korea,
-1937-06-30,LT,Lithuania,
-1937-06-30,LU,Luxembourg,
-1937-06-30,LV,Latvia,
-1937-06-30,MA,Morocco,
-1937-06-30,MK,North Macedonia,
-1937-06-30,MT,Malta,
-1937-06-30,MX,Mexico,
-1937-06-30,MY,Malaysia,
-1937-06-30,NL,Netherlands,
-1937-06-30,NO,Norway,
-1937-06-30,NZ,New Zealand,
-1937-06-30,PE,Peru,
-1937-06-30,PH,Philippines,
-1937-06-30,PL,Poland,
-1937-06-30,PT,Portugal,
-1937-06-30,RO,Romania,
-1937-06-30,RS,Serbia,
-1937-06-30,RU,Russia,
-1937-06-30,SE,Sweden,
-1937-06-30,SG,Singapore,
-1937-06-30,SI,Slovenia,
-1937-06-30,SK,Slovak Republic,
-1937-06-30,TH,Thailand,
-1937-06-30,TR,Türkiye,
-1937-06-30,US,United States,
-1937-06-30,XM,Euro area,
-1937-06-30,XW,World,
-1937-06-30,ZA,South Africa,
-1937-09-30,4T,Emerging market economies (aggregate),
-1937-09-30,5R,Advanced economies,
-1937-09-30,AE,United Arab Emirates,
-1937-09-30,AT,Austria,
-1937-09-30,AU,Australia,
-1937-09-30,BE,Belgium,
-1937-09-30,BG,Bulgaria,
-1937-09-30,BR,Brazil,
-1937-09-30,CA,Canada,
-1937-09-30,CH,Switzerland,
-1937-09-30,CL,Chile,
-1937-09-30,CN,China,
-1937-09-30,CO,Colombia,
-1937-09-30,CY,Cyprus,
-1937-09-30,CZ,Czechia,
-1937-09-30,DE,Germany,
-1937-09-30,DK,Denmark,
-1937-09-30,EE,Estonia,
-1937-09-30,ES,Spain,
-1937-09-30,FI,Finland,
-1937-09-30,FR,France,
-1937-09-30,GB,United Kingdom,
-1937-09-30,GR,Greece,
-1937-09-30,HK,Hong Kong SAR,
-1937-09-30,HR,Croatia,
-1937-09-30,HU,Hungary,
-1937-09-30,ID,Indonesia,
-1937-09-30,IE,Ireland,
-1937-09-30,IL,Israel,
-1937-09-30,IN,India,
-1937-09-30,IS,Iceland,
-1937-09-30,IT,Italy,
-1937-09-30,JP,Japan,
-1937-09-30,KR,Korea,
-1937-09-30,LT,Lithuania,
-1937-09-30,LU,Luxembourg,
-1937-09-30,LV,Latvia,
-1937-09-30,MA,Morocco,
-1937-09-30,MK,North Macedonia,
-1937-09-30,MT,Malta,
-1937-09-30,MX,Mexico,
-1937-09-30,MY,Malaysia,
-1937-09-30,NL,Netherlands,
-1937-09-30,NO,Norway,
-1937-09-30,NZ,New Zealand,
-1937-09-30,PE,Peru,
-1937-09-30,PH,Philippines,
-1937-09-30,PL,Poland,
-1937-09-30,PT,Portugal,
-1937-09-30,RO,Romania,
-1937-09-30,RS,Serbia,
-1937-09-30,RU,Russia,
-1937-09-30,SE,Sweden,
-1937-09-30,SG,Singapore,
-1937-09-30,SI,Slovenia,
-1937-09-30,SK,Slovak Republic,
-1937-09-30,TH,Thailand,
-1937-09-30,TR,Türkiye,
-1937-09-30,US,United States,
-1937-09-30,XM,Euro area,
-1937-09-30,XW,World,
-1937-09-30,ZA,South Africa,
-1937-12-31,4T,Emerging market economies (aggregate),
-1937-12-31,5R,Advanced economies,
-1937-12-31,AE,United Arab Emirates,
-1937-12-31,AT,Austria,
-1937-12-31,AU,Australia,
-1937-12-31,BE,Belgium,
-1937-12-31,BG,Bulgaria,
-1937-12-31,BR,Brazil,
-1937-12-31,CA,Canada,
-1937-12-31,CH,Switzerland,
-1937-12-31,CL,Chile,
-1937-12-31,CN,China,
-1937-12-31,CO,Colombia,
-1937-12-31,CY,Cyprus,
-1937-12-31,CZ,Czechia,
-1937-12-31,DE,Germany,
-1937-12-31,DK,Denmark,
-1937-12-31,EE,Estonia,
-1937-12-31,ES,Spain,
-1937-12-31,FI,Finland,
-1937-12-31,FR,France,
-1937-12-31,GB,United Kingdom,
-1937-12-31,GR,Greece,
-1937-12-31,HK,Hong Kong SAR,
-1937-12-31,HR,Croatia,
-1937-12-31,HU,Hungary,
-1937-12-31,ID,Indonesia,
-1937-12-31,IE,Ireland,
-1937-12-31,IL,Israel,
-1937-12-31,IN,India,
-1937-12-31,IS,Iceland,
-1937-12-31,IT,Italy,
-1937-12-31,JP,Japan,
-1937-12-31,KR,Korea,
-1937-12-31,LT,Lithuania,
-1937-12-31,LU,Luxembourg,
-1937-12-31,LV,Latvia,
-1937-12-31,MA,Morocco,
-1937-12-31,MK,North Macedonia,
-1937-12-31,MT,Malta,
-1937-12-31,MX,Mexico,
-1937-12-31,MY,Malaysia,
-1937-12-31,NL,Netherlands,
-1937-12-31,NO,Norway,
-1937-12-31,NZ,New Zealand,
-1937-12-31,PE,Peru,
-1937-12-31,PH,Philippines,
-1937-12-31,PL,Poland,
-1937-12-31,PT,Portugal,
-1937-12-31,RO,Romania,
-1937-12-31,RS,Serbia,
-1937-12-31,RU,Russia,
-1937-12-31,SE,Sweden,
-1937-12-31,SG,Singapore,
-1937-12-31,SI,Slovenia,
-1937-12-31,SK,Slovak Republic,
-1937-12-31,TH,Thailand,
-1937-12-31,TR,Türkiye,
-1937-12-31,US,United States,
-1937-12-31,XM,Euro area,
-1937-12-31,XW,World,
-1937-12-31,ZA,South Africa,
-1938-03-31,4T,Emerging market economies (aggregate),
-1938-03-31,5R,Advanced economies,
-1938-03-31,AE,United Arab Emirates,
-1938-03-31,AT,Austria,
-1938-03-31,AU,Australia,
-1938-03-31,BE,Belgium,
-1938-03-31,BG,Bulgaria,
-1938-03-31,BR,Brazil,
-1938-03-31,CA,Canada,
-1938-03-31,CH,Switzerland,
-1938-03-31,CL,Chile,
-1938-03-31,CN,China,
-1938-03-31,CO,Colombia,
-1938-03-31,CY,Cyprus,
-1938-03-31,CZ,Czechia,
-1938-03-31,DE,Germany,
-1938-03-31,DK,Denmark,
-1938-03-31,EE,Estonia,
-1938-03-31,ES,Spain,
-1938-03-31,FI,Finland,
-1938-03-31,FR,France,
-1938-03-31,GB,United Kingdom,
-1938-03-31,GR,Greece,
-1938-03-31,HK,Hong Kong SAR,
-1938-03-31,HR,Croatia,
-1938-03-31,HU,Hungary,
-1938-03-31,ID,Indonesia,
-1938-03-31,IE,Ireland,
-1938-03-31,IL,Israel,
-1938-03-31,IN,India,
-1938-03-31,IS,Iceland,
-1938-03-31,IT,Italy,
-1938-03-31,JP,Japan,
-1938-03-31,KR,Korea,
-1938-03-31,LT,Lithuania,
-1938-03-31,LU,Luxembourg,
-1938-03-31,LV,Latvia,
-1938-03-31,MA,Morocco,
-1938-03-31,MK,North Macedonia,
-1938-03-31,MT,Malta,
-1938-03-31,MX,Mexico,
-1938-03-31,MY,Malaysia,
-1938-03-31,NL,Netherlands,
-1938-03-31,NO,Norway,
-1938-03-31,NZ,New Zealand,
-1938-03-31,PE,Peru,
-1938-03-31,PH,Philippines,
-1938-03-31,PL,Poland,
-1938-03-31,PT,Portugal,
-1938-03-31,RO,Romania,
-1938-03-31,RS,Serbia,
-1938-03-31,RU,Russia,
-1938-03-31,SE,Sweden,
-1938-03-31,SG,Singapore,
-1938-03-31,SI,Slovenia,
-1938-03-31,SK,Slovak Republic,
-1938-03-31,TH,Thailand,
-1938-03-31,TR,Türkiye,
-1938-03-31,US,United States,
-1938-03-31,XM,Euro area,
-1938-03-31,XW,World,
-1938-03-31,ZA,South Africa,
-1938-06-30,4T,Emerging market economies (aggregate),
-1938-06-30,5R,Advanced economies,
-1938-06-30,AE,United Arab Emirates,
-1938-06-30,AT,Austria,
-1938-06-30,AU,Australia,
-1938-06-30,BE,Belgium,
-1938-06-30,BG,Bulgaria,
-1938-06-30,BR,Brazil,
-1938-06-30,CA,Canada,
-1938-06-30,CH,Switzerland,
-1938-06-30,CL,Chile,
-1938-06-30,CN,China,
-1938-06-30,CO,Colombia,
-1938-06-30,CY,Cyprus,
-1938-06-30,CZ,Czechia,
-1938-06-30,DE,Germany,
-1938-06-30,DK,Denmark,
-1938-06-30,EE,Estonia,
-1938-06-30,ES,Spain,
-1938-06-30,FI,Finland,
-1938-06-30,FR,France,
-1938-06-30,GB,United Kingdom,
-1938-06-30,GR,Greece,
-1938-06-30,HK,Hong Kong SAR,
-1938-06-30,HR,Croatia,
-1938-06-30,HU,Hungary,
-1938-06-30,ID,Indonesia,
-1938-06-30,IE,Ireland,
-1938-06-30,IL,Israel,
-1938-06-30,IN,India,
-1938-06-30,IS,Iceland,
-1938-06-30,IT,Italy,
-1938-06-30,JP,Japan,
-1938-06-30,KR,Korea,
-1938-06-30,LT,Lithuania,
-1938-06-30,LU,Luxembourg,
-1938-06-30,LV,Latvia,
-1938-06-30,MA,Morocco,
-1938-06-30,MK,North Macedonia,
-1938-06-30,MT,Malta,
-1938-06-30,MX,Mexico,
-1938-06-30,MY,Malaysia,
-1938-06-30,NL,Netherlands,
-1938-06-30,NO,Norway,
-1938-06-30,NZ,New Zealand,
-1938-06-30,PE,Peru,
-1938-06-30,PH,Philippines,
-1938-06-30,PL,Poland,
-1938-06-30,PT,Portugal,
-1938-06-30,RO,Romania,
-1938-06-30,RS,Serbia,
-1938-06-30,RU,Russia,
-1938-06-30,SE,Sweden,
-1938-06-30,SG,Singapore,
-1938-06-30,SI,Slovenia,
-1938-06-30,SK,Slovak Republic,
-1938-06-30,TH,Thailand,
-1938-06-30,TR,Türkiye,
-1938-06-30,US,United States,
-1938-06-30,XM,Euro area,
-1938-06-30,XW,World,
-1938-06-30,ZA,South Africa,
-1938-09-30,4T,Emerging market economies (aggregate),
-1938-09-30,5R,Advanced economies,
-1938-09-30,AE,United Arab Emirates,
-1938-09-30,AT,Austria,
-1938-09-30,AU,Australia,
-1938-09-30,BE,Belgium,
-1938-09-30,BG,Bulgaria,
-1938-09-30,BR,Brazil,
-1938-09-30,CA,Canada,
-1938-09-30,CH,Switzerland,
-1938-09-30,CL,Chile,
-1938-09-30,CN,China,
-1938-09-30,CO,Colombia,
-1938-09-30,CY,Cyprus,
-1938-09-30,CZ,Czechia,
-1938-09-30,DE,Germany,
-1938-09-30,DK,Denmark,
-1938-09-30,EE,Estonia,
-1938-09-30,ES,Spain,
-1938-09-30,FI,Finland,
-1938-09-30,FR,France,
-1938-09-30,GB,United Kingdom,
-1938-09-30,GR,Greece,
-1938-09-30,HK,Hong Kong SAR,
-1938-09-30,HR,Croatia,
-1938-09-30,HU,Hungary,
-1938-09-30,ID,Indonesia,
-1938-09-30,IE,Ireland,
-1938-09-30,IL,Israel,
-1938-09-30,IN,India,
-1938-09-30,IS,Iceland,
-1938-09-30,IT,Italy,
-1938-09-30,JP,Japan,
-1938-09-30,KR,Korea,
-1938-09-30,LT,Lithuania,
-1938-09-30,LU,Luxembourg,
-1938-09-30,LV,Latvia,
-1938-09-30,MA,Morocco,
-1938-09-30,MK,North Macedonia,
-1938-09-30,MT,Malta,
-1938-09-30,MX,Mexico,
-1938-09-30,MY,Malaysia,
-1938-09-30,NL,Netherlands,
-1938-09-30,NO,Norway,
-1938-09-30,NZ,New Zealand,
-1938-09-30,PE,Peru,
-1938-09-30,PH,Philippines,
-1938-09-30,PL,Poland,
-1938-09-30,PT,Portugal,
-1938-09-30,RO,Romania,
-1938-09-30,RS,Serbia,
-1938-09-30,RU,Russia,
-1938-09-30,SE,Sweden,
-1938-09-30,SG,Singapore,
-1938-09-30,SI,Slovenia,
-1938-09-30,SK,Slovak Republic,
-1938-09-30,TH,Thailand,
-1938-09-30,TR,Türkiye,
-1938-09-30,US,United States,
-1938-09-30,XM,Euro area,
-1938-09-30,XW,World,
-1938-09-30,ZA,South Africa,
-1938-12-31,4T,Emerging market economies (aggregate),
-1938-12-31,5R,Advanced economies,
-1938-12-31,AE,United Arab Emirates,
-1938-12-31,AT,Austria,
-1938-12-31,AU,Australia,
-1938-12-31,BE,Belgium,
-1938-12-31,BG,Bulgaria,
-1938-12-31,BR,Brazil,
-1938-12-31,CA,Canada,
-1938-12-31,CH,Switzerland,
-1938-12-31,CL,Chile,
-1938-12-31,CN,China,
-1938-12-31,CO,Colombia,
-1938-12-31,CY,Cyprus,
-1938-12-31,CZ,Czechia,
-1938-12-31,DE,Germany,
-1938-12-31,DK,Denmark,
-1938-12-31,EE,Estonia,
-1938-12-31,ES,Spain,
-1938-12-31,FI,Finland,
-1938-12-31,FR,France,
-1938-12-31,GB,United Kingdom,
-1938-12-31,GR,Greece,
-1938-12-31,HK,Hong Kong SAR,
-1938-12-31,HR,Croatia,
-1938-12-31,HU,Hungary,
-1938-12-31,ID,Indonesia,
-1938-12-31,IE,Ireland,
-1938-12-31,IL,Israel,
-1938-12-31,IN,India,
-1938-12-31,IS,Iceland,
-1938-12-31,IT,Italy,
-1938-12-31,JP,Japan,
-1938-12-31,KR,Korea,
-1938-12-31,LT,Lithuania,
-1938-12-31,LU,Luxembourg,
-1938-12-31,LV,Latvia,
-1938-12-31,MA,Morocco,
-1938-12-31,MK,North Macedonia,
-1938-12-31,MT,Malta,
-1938-12-31,MX,Mexico,
-1938-12-31,MY,Malaysia,
-1938-12-31,NL,Netherlands,
-1938-12-31,NO,Norway,
-1938-12-31,NZ,New Zealand,
-1938-12-31,PE,Peru,
-1938-12-31,PH,Philippines,
-1938-12-31,PL,Poland,
-1938-12-31,PT,Portugal,
-1938-12-31,RO,Romania,
-1938-12-31,RS,Serbia,
-1938-12-31,RU,Russia,
-1938-12-31,SE,Sweden,
-1938-12-31,SG,Singapore,
-1938-12-31,SI,Slovenia,
-1938-12-31,SK,Slovak Republic,
-1938-12-31,TH,Thailand,
-1938-12-31,TR,Türkiye,
-1938-12-31,US,United States,
-1938-12-31,XM,Euro area,
-1938-12-31,XW,World,
-1938-12-31,ZA,South Africa,
-1939-03-31,4T,Emerging market economies (aggregate),
-1939-03-31,5R,Advanced economies,
-1939-03-31,AE,United Arab Emirates,
-1939-03-31,AT,Austria,
-1939-03-31,AU,Australia,
-1939-03-31,BE,Belgium,
-1939-03-31,BG,Bulgaria,
-1939-03-31,BR,Brazil,
-1939-03-31,CA,Canada,
-1939-03-31,CH,Switzerland,
-1939-03-31,CL,Chile,
-1939-03-31,CN,China,
-1939-03-31,CO,Colombia,
-1939-03-31,CY,Cyprus,
-1939-03-31,CZ,Czechia,
-1939-03-31,DE,Germany,
-1939-03-31,DK,Denmark,
-1939-03-31,EE,Estonia,
-1939-03-31,ES,Spain,
-1939-03-31,FI,Finland,
-1939-03-31,FR,France,
-1939-03-31,GB,United Kingdom,
-1939-03-31,GR,Greece,
-1939-03-31,HK,Hong Kong SAR,
-1939-03-31,HR,Croatia,
-1939-03-31,HU,Hungary,
-1939-03-31,ID,Indonesia,
-1939-03-31,IE,Ireland,
-1939-03-31,IL,Israel,
-1939-03-31,IN,India,
-1939-03-31,IS,Iceland,
-1939-03-31,IT,Italy,
-1939-03-31,JP,Japan,
-1939-03-31,KR,Korea,
-1939-03-31,LT,Lithuania,
-1939-03-31,LU,Luxembourg,
-1939-03-31,LV,Latvia,
-1939-03-31,MA,Morocco,
-1939-03-31,MK,North Macedonia,
-1939-03-31,MT,Malta,
-1939-03-31,MX,Mexico,
-1939-03-31,MY,Malaysia,
-1939-03-31,NL,Netherlands,
-1939-03-31,NO,Norway,
-1939-03-31,NZ,New Zealand,
-1939-03-31,PE,Peru,
-1939-03-31,PH,Philippines,
-1939-03-31,PL,Poland,
-1939-03-31,PT,Portugal,
-1939-03-31,RO,Romania,
-1939-03-31,RS,Serbia,
-1939-03-31,RU,Russia,
-1939-03-31,SE,Sweden,
-1939-03-31,SG,Singapore,
-1939-03-31,SI,Slovenia,
-1939-03-31,SK,Slovak Republic,
-1939-03-31,TH,Thailand,
-1939-03-31,TR,Türkiye,
-1939-03-31,US,United States,
-1939-03-31,XM,Euro area,
-1939-03-31,XW,World,
-1939-03-31,ZA,South Africa,
-1939-06-30,4T,Emerging market economies (aggregate),
-1939-06-30,5R,Advanced economies,
-1939-06-30,AE,United Arab Emirates,
-1939-06-30,AT,Austria,
-1939-06-30,AU,Australia,
-1939-06-30,BE,Belgium,
-1939-06-30,BG,Bulgaria,
-1939-06-30,BR,Brazil,
-1939-06-30,CA,Canada,
-1939-06-30,CH,Switzerland,
-1939-06-30,CL,Chile,
-1939-06-30,CN,China,
-1939-06-30,CO,Colombia,
-1939-06-30,CY,Cyprus,
-1939-06-30,CZ,Czechia,
-1939-06-30,DE,Germany,
-1939-06-30,DK,Denmark,
-1939-06-30,EE,Estonia,
-1939-06-30,ES,Spain,
-1939-06-30,FI,Finland,
-1939-06-30,FR,France,
-1939-06-30,GB,United Kingdom,
-1939-06-30,GR,Greece,
-1939-06-30,HK,Hong Kong SAR,
-1939-06-30,HR,Croatia,
-1939-06-30,HU,Hungary,
-1939-06-30,ID,Indonesia,
-1939-06-30,IE,Ireland,
-1939-06-30,IL,Israel,
-1939-06-30,IN,India,
-1939-06-30,IS,Iceland,
-1939-06-30,IT,Italy,
-1939-06-30,JP,Japan,
-1939-06-30,KR,Korea,
-1939-06-30,LT,Lithuania,
-1939-06-30,LU,Luxembourg,
-1939-06-30,LV,Latvia,
-1939-06-30,MA,Morocco,
-1939-06-30,MK,North Macedonia,
-1939-06-30,MT,Malta,
-1939-06-30,MX,Mexico,
-1939-06-30,MY,Malaysia,
-1939-06-30,NL,Netherlands,
-1939-06-30,NO,Norway,
-1939-06-30,NZ,New Zealand,
-1939-06-30,PE,Peru,
-1939-06-30,PH,Philippines,
-1939-06-30,PL,Poland,
-1939-06-30,PT,Portugal,
-1939-06-30,RO,Romania,
-1939-06-30,RS,Serbia,
-1939-06-30,RU,Russia,
-1939-06-30,SE,Sweden,
-1939-06-30,SG,Singapore,
-1939-06-30,SI,Slovenia,
-1939-06-30,SK,Slovak Republic,
-1939-06-30,TH,Thailand,
-1939-06-30,TR,Türkiye,
-1939-06-30,US,United States,
-1939-06-30,XM,Euro area,
-1939-06-30,XW,World,
-1939-06-30,ZA,South Africa,
-1939-09-30,4T,Emerging market economies (aggregate),
-1939-09-30,5R,Advanced economies,
-1939-09-30,AE,United Arab Emirates,
-1939-09-30,AT,Austria,
-1939-09-30,AU,Australia,
-1939-09-30,BE,Belgium,
-1939-09-30,BG,Bulgaria,
-1939-09-30,BR,Brazil,
-1939-09-30,CA,Canada,
-1939-09-30,CH,Switzerland,
-1939-09-30,CL,Chile,
-1939-09-30,CN,China,
-1939-09-30,CO,Colombia,
-1939-09-30,CY,Cyprus,
-1939-09-30,CZ,Czechia,
-1939-09-30,DE,Germany,
-1939-09-30,DK,Denmark,
-1939-09-30,EE,Estonia,
-1939-09-30,ES,Spain,
-1939-09-30,FI,Finland,
-1939-09-30,FR,France,
-1939-09-30,GB,United Kingdom,
-1939-09-30,GR,Greece,
-1939-09-30,HK,Hong Kong SAR,
-1939-09-30,HR,Croatia,
-1939-09-30,HU,Hungary,
-1939-09-30,ID,Indonesia,
-1939-09-30,IE,Ireland,
-1939-09-30,IL,Israel,
-1939-09-30,IN,India,
-1939-09-30,IS,Iceland,
-1939-09-30,IT,Italy,
-1939-09-30,JP,Japan,
-1939-09-30,KR,Korea,
-1939-09-30,LT,Lithuania,
-1939-09-30,LU,Luxembourg,
-1939-09-30,LV,Latvia,
-1939-09-30,MA,Morocco,
-1939-09-30,MK,North Macedonia,
-1939-09-30,MT,Malta,
-1939-09-30,MX,Mexico,
-1939-09-30,MY,Malaysia,
-1939-09-30,NL,Netherlands,
-1939-09-30,NO,Norway,
-1939-09-30,NZ,New Zealand,
-1939-09-30,PE,Peru,
-1939-09-30,PH,Philippines,
-1939-09-30,PL,Poland,
-1939-09-30,PT,Portugal,
-1939-09-30,RO,Romania,
-1939-09-30,RS,Serbia,
-1939-09-30,RU,Russia,
-1939-09-30,SE,Sweden,
-1939-09-30,SG,Singapore,
-1939-09-30,SI,Slovenia,
-1939-09-30,SK,Slovak Republic,
-1939-09-30,TH,Thailand,
-1939-09-30,TR,Türkiye,
-1939-09-30,US,United States,
-1939-09-30,XM,Euro area,
-1939-09-30,XW,World,
-1939-09-30,ZA,South Africa,
-1939-12-31,4T,Emerging market economies (aggregate),
-1939-12-31,5R,Advanced economies,
-1939-12-31,AE,United Arab Emirates,
-1939-12-31,AT,Austria,
-1939-12-31,AU,Australia,
-1939-12-31,BE,Belgium,
-1939-12-31,BG,Bulgaria,
-1939-12-31,BR,Brazil,
-1939-12-31,CA,Canada,
-1939-12-31,CH,Switzerland,
-1939-12-31,CL,Chile,
-1939-12-31,CN,China,
-1939-12-31,CO,Colombia,
-1939-12-31,CY,Cyprus,
-1939-12-31,CZ,Czechia,
-1939-12-31,DE,Germany,
-1939-12-31,DK,Denmark,
-1939-12-31,EE,Estonia,
-1939-12-31,ES,Spain,
-1939-12-31,FI,Finland,
-1939-12-31,FR,France,
-1939-12-31,GB,United Kingdom,
-1939-12-31,GR,Greece,
-1939-12-31,HK,Hong Kong SAR,
-1939-12-31,HR,Croatia,
-1939-12-31,HU,Hungary,
-1939-12-31,ID,Indonesia,
-1939-12-31,IE,Ireland,
-1939-12-31,IL,Israel,
-1939-12-31,IN,India,
-1939-12-31,IS,Iceland,
-1939-12-31,IT,Italy,
-1939-12-31,JP,Japan,
-1939-12-31,KR,Korea,
-1939-12-31,LT,Lithuania,
-1939-12-31,LU,Luxembourg,
-1939-12-31,LV,Latvia,
-1939-12-31,MA,Morocco,
-1939-12-31,MK,North Macedonia,
-1939-12-31,MT,Malta,
-1939-12-31,MX,Mexico,
-1939-12-31,MY,Malaysia,
-1939-12-31,NL,Netherlands,
-1939-12-31,NO,Norway,
-1939-12-31,NZ,New Zealand,
-1939-12-31,PE,Peru,
-1939-12-31,PH,Philippines,
-1939-12-31,PL,Poland,
-1939-12-31,PT,Portugal,
-1939-12-31,RO,Romania,
-1939-12-31,RS,Serbia,
-1939-12-31,RU,Russia,
-1939-12-31,SE,Sweden,
-1939-12-31,SG,Singapore,
-1939-12-31,SI,Slovenia,
-1939-12-31,SK,Slovak Republic,
-1939-12-31,TH,Thailand,
-1939-12-31,TR,Türkiye,
-1939-12-31,US,United States,
-1939-12-31,XM,Euro area,
-1939-12-31,XW,World,
-1939-12-31,ZA,South Africa,
-1940-03-31,4T,Emerging market economies (aggregate),
-1940-03-31,5R,Advanced economies,
-1940-03-31,AE,United Arab Emirates,
-1940-03-31,AT,Austria,
-1940-03-31,AU,Australia,
-1940-03-31,BE,Belgium,
-1940-03-31,BG,Bulgaria,
-1940-03-31,BR,Brazil,
-1940-03-31,CA,Canada,
-1940-03-31,CH,Switzerland,
-1940-03-31,CL,Chile,
-1940-03-31,CN,China,
-1940-03-31,CO,Colombia,
-1940-03-31,CY,Cyprus,
-1940-03-31,CZ,Czechia,
-1940-03-31,DE,Germany,
-1940-03-31,DK,Denmark,
-1940-03-31,EE,Estonia,
-1940-03-31,ES,Spain,
-1940-03-31,FI,Finland,
-1940-03-31,FR,France,
-1940-03-31,GB,United Kingdom,
-1940-03-31,GR,Greece,
-1940-03-31,HK,Hong Kong SAR,
-1940-03-31,HR,Croatia,
-1940-03-31,HU,Hungary,
-1940-03-31,ID,Indonesia,
-1940-03-31,IE,Ireland,
-1940-03-31,IL,Israel,
-1940-03-31,IN,India,
-1940-03-31,IS,Iceland,
-1940-03-31,IT,Italy,
-1940-03-31,JP,Japan,
-1940-03-31,KR,Korea,
-1940-03-31,LT,Lithuania,
-1940-03-31,LU,Luxembourg,
-1940-03-31,LV,Latvia,
-1940-03-31,MA,Morocco,
-1940-03-31,MK,North Macedonia,
-1940-03-31,MT,Malta,
-1940-03-31,MX,Mexico,
-1940-03-31,MY,Malaysia,
-1940-03-31,NL,Netherlands,
-1940-03-31,NO,Norway,
-1940-03-31,NZ,New Zealand,
-1940-03-31,PE,Peru,
-1940-03-31,PH,Philippines,
-1940-03-31,PL,Poland,
-1940-03-31,PT,Portugal,
-1940-03-31,RO,Romania,
-1940-03-31,RS,Serbia,
-1940-03-31,RU,Russia,
-1940-03-31,SE,Sweden,
-1940-03-31,SG,Singapore,
-1940-03-31,SI,Slovenia,
-1940-03-31,SK,Slovak Republic,
-1940-03-31,TH,Thailand,
-1940-03-31,TR,Türkiye,
-1940-03-31,US,United States,
-1940-03-31,XM,Euro area,
-1940-03-31,XW,World,
-1940-03-31,ZA,South Africa,
-1940-06-30,4T,Emerging market economies (aggregate),
-1940-06-30,5R,Advanced economies,
-1940-06-30,AE,United Arab Emirates,
-1940-06-30,AT,Austria,
-1940-06-30,AU,Australia,
-1940-06-30,BE,Belgium,
-1940-06-30,BG,Bulgaria,
-1940-06-30,BR,Brazil,
-1940-06-30,CA,Canada,
-1940-06-30,CH,Switzerland,
-1940-06-30,CL,Chile,
-1940-06-30,CN,China,
-1940-06-30,CO,Colombia,
-1940-06-30,CY,Cyprus,
-1940-06-30,CZ,Czechia,
-1940-06-30,DE,Germany,
-1940-06-30,DK,Denmark,
-1940-06-30,EE,Estonia,
-1940-06-30,ES,Spain,
-1940-06-30,FI,Finland,
-1940-06-30,FR,France,
-1940-06-30,GB,United Kingdom,
-1940-06-30,GR,Greece,
-1940-06-30,HK,Hong Kong SAR,
-1940-06-30,HR,Croatia,
-1940-06-30,HU,Hungary,
-1940-06-30,ID,Indonesia,
-1940-06-30,IE,Ireland,
-1940-06-30,IL,Israel,
-1940-06-30,IN,India,
-1940-06-30,IS,Iceland,
-1940-06-30,IT,Italy,
-1940-06-30,JP,Japan,
-1940-06-30,KR,Korea,
-1940-06-30,LT,Lithuania,
-1940-06-30,LU,Luxembourg,
-1940-06-30,LV,Latvia,
-1940-06-30,MA,Morocco,
-1940-06-30,MK,North Macedonia,
-1940-06-30,MT,Malta,
-1940-06-30,MX,Mexico,
-1940-06-30,MY,Malaysia,
-1940-06-30,NL,Netherlands,
-1940-06-30,NO,Norway,
-1940-06-30,NZ,New Zealand,
-1940-06-30,PE,Peru,
-1940-06-30,PH,Philippines,
-1940-06-30,PL,Poland,
-1940-06-30,PT,Portugal,
-1940-06-30,RO,Romania,
-1940-06-30,RS,Serbia,
-1940-06-30,RU,Russia,
-1940-06-30,SE,Sweden,
-1940-06-30,SG,Singapore,
-1940-06-30,SI,Slovenia,
-1940-06-30,SK,Slovak Republic,
-1940-06-30,TH,Thailand,
-1940-06-30,TR,Türkiye,
-1940-06-30,US,United States,
-1940-06-30,XM,Euro area,
-1940-06-30,XW,World,
-1940-06-30,ZA,South Africa,
-1940-09-30,4T,Emerging market economies (aggregate),
-1940-09-30,5R,Advanced economies,
-1940-09-30,AE,United Arab Emirates,
-1940-09-30,AT,Austria,
-1940-09-30,AU,Australia,
-1940-09-30,BE,Belgium,
-1940-09-30,BG,Bulgaria,
-1940-09-30,BR,Brazil,
-1940-09-30,CA,Canada,
-1940-09-30,CH,Switzerland,
-1940-09-30,CL,Chile,
-1940-09-30,CN,China,
-1940-09-30,CO,Colombia,
-1940-09-30,CY,Cyprus,
-1940-09-30,CZ,Czechia,
-1940-09-30,DE,Germany,
-1940-09-30,DK,Denmark,
-1940-09-30,EE,Estonia,
-1940-09-30,ES,Spain,
-1940-09-30,FI,Finland,
-1940-09-30,FR,France,
-1940-09-30,GB,United Kingdom,
-1940-09-30,GR,Greece,
-1940-09-30,HK,Hong Kong SAR,
-1940-09-30,HR,Croatia,
-1940-09-30,HU,Hungary,
-1940-09-30,ID,Indonesia,
-1940-09-30,IE,Ireland,
-1940-09-30,IL,Israel,
-1940-09-30,IN,India,
-1940-09-30,IS,Iceland,
-1940-09-30,IT,Italy,
-1940-09-30,JP,Japan,
-1940-09-30,KR,Korea,
-1940-09-30,LT,Lithuania,
-1940-09-30,LU,Luxembourg,
-1940-09-30,LV,Latvia,
-1940-09-30,MA,Morocco,
-1940-09-30,MK,North Macedonia,
-1940-09-30,MT,Malta,
-1940-09-30,MX,Mexico,
-1940-09-30,MY,Malaysia,
-1940-09-30,NL,Netherlands,
-1940-09-30,NO,Norway,
-1940-09-30,NZ,New Zealand,
-1940-09-30,PE,Peru,
-1940-09-30,PH,Philippines,
-1940-09-30,PL,Poland,
-1940-09-30,PT,Portugal,
-1940-09-30,RO,Romania,
-1940-09-30,RS,Serbia,
-1940-09-30,RU,Russia,
-1940-09-30,SE,Sweden,
-1940-09-30,SG,Singapore,
-1940-09-30,SI,Slovenia,
-1940-09-30,SK,Slovak Republic,
-1940-09-30,TH,Thailand,
-1940-09-30,TR,Türkiye,
-1940-09-30,US,United States,
-1940-09-30,XM,Euro area,
-1940-09-30,XW,World,
-1940-09-30,ZA,South Africa,
-1940-12-31,4T,Emerging market economies (aggregate),
-1940-12-31,5R,Advanced economies,
-1940-12-31,AE,United Arab Emirates,
-1940-12-31,AT,Austria,
-1940-12-31,AU,Australia,
-1940-12-31,BE,Belgium,
-1940-12-31,BG,Bulgaria,
-1940-12-31,BR,Brazil,
-1940-12-31,CA,Canada,
-1940-12-31,CH,Switzerland,
-1940-12-31,CL,Chile,
-1940-12-31,CN,China,
-1940-12-31,CO,Colombia,
-1940-12-31,CY,Cyprus,
-1940-12-31,CZ,Czechia,
-1940-12-31,DE,Germany,
-1940-12-31,DK,Denmark,
-1940-12-31,EE,Estonia,
-1940-12-31,ES,Spain,
-1940-12-31,FI,Finland,
-1940-12-31,FR,France,
-1940-12-31,GB,United Kingdom,
-1940-12-31,GR,Greece,
-1940-12-31,HK,Hong Kong SAR,
-1940-12-31,HR,Croatia,
-1940-12-31,HU,Hungary,
-1940-12-31,ID,Indonesia,
-1940-12-31,IE,Ireland,
-1940-12-31,IL,Israel,
-1940-12-31,IN,India,
-1940-12-31,IS,Iceland,
-1940-12-31,IT,Italy,
-1940-12-31,JP,Japan,
-1940-12-31,KR,Korea,
-1940-12-31,LT,Lithuania,
-1940-12-31,LU,Luxembourg,
-1940-12-31,LV,Latvia,
-1940-12-31,MA,Morocco,
-1940-12-31,MK,North Macedonia,
-1940-12-31,MT,Malta,
-1940-12-31,MX,Mexico,
-1940-12-31,MY,Malaysia,
-1940-12-31,NL,Netherlands,
-1940-12-31,NO,Norway,
-1940-12-31,NZ,New Zealand,
-1940-12-31,PE,Peru,
-1940-12-31,PH,Philippines,
-1940-12-31,PL,Poland,
-1940-12-31,PT,Portugal,
-1940-12-31,RO,Romania,
-1940-12-31,RS,Serbia,
-1940-12-31,RU,Russia,
-1940-12-31,SE,Sweden,
-1940-12-31,SG,Singapore,
-1940-12-31,SI,Slovenia,
-1940-12-31,SK,Slovak Republic,
-1940-12-31,TH,Thailand,
-1940-12-31,TR,Türkiye,
-1940-12-31,US,United States,
-1940-12-31,XM,Euro area,
-1940-12-31,XW,World,
-1940-12-31,ZA,South Africa,
-1941-03-31,4T,Emerging market economies (aggregate),
-1941-03-31,5R,Advanced economies,
-1941-03-31,AE,United Arab Emirates,
-1941-03-31,AT,Austria,
-1941-03-31,AU,Australia,
-1941-03-31,BE,Belgium,
-1941-03-31,BG,Bulgaria,
-1941-03-31,BR,Brazil,
-1941-03-31,CA,Canada,
-1941-03-31,CH,Switzerland,
-1941-03-31,CL,Chile,
-1941-03-31,CN,China,
-1941-03-31,CO,Colombia,
-1941-03-31,CY,Cyprus,
-1941-03-31,CZ,Czechia,
-1941-03-31,DE,Germany,
-1941-03-31,DK,Denmark,
-1941-03-31,EE,Estonia,
-1941-03-31,ES,Spain,
-1941-03-31,FI,Finland,
-1941-03-31,FR,France,
-1941-03-31,GB,United Kingdom,
-1941-03-31,GR,Greece,
-1941-03-31,HK,Hong Kong SAR,
-1941-03-31,HR,Croatia,
-1941-03-31,HU,Hungary,
-1941-03-31,ID,Indonesia,
-1941-03-31,IE,Ireland,
-1941-03-31,IL,Israel,
-1941-03-31,IN,India,
-1941-03-31,IS,Iceland,
-1941-03-31,IT,Italy,
-1941-03-31,JP,Japan,
-1941-03-31,KR,Korea,
-1941-03-31,LT,Lithuania,
-1941-03-31,LU,Luxembourg,
-1941-03-31,LV,Latvia,
-1941-03-31,MA,Morocco,
-1941-03-31,MK,North Macedonia,
-1941-03-31,MT,Malta,
-1941-03-31,MX,Mexico,
-1941-03-31,MY,Malaysia,
-1941-03-31,NL,Netherlands,
-1941-03-31,NO,Norway,
-1941-03-31,NZ,New Zealand,
-1941-03-31,PE,Peru,
-1941-03-31,PH,Philippines,
-1941-03-31,PL,Poland,
-1941-03-31,PT,Portugal,
-1941-03-31,RO,Romania,
-1941-03-31,RS,Serbia,
-1941-03-31,RU,Russia,
-1941-03-31,SE,Sweden,
-1941-03-31,SG,Singapore,
-1941-03-31,SI,Slovenia,
-1941-03-31,SK,Slovak Republic,
-1941-03-31,TH,Thailand,
-1941-03-31,TR,Türkiye,
-1941-03-31,US,United States,
-1941-03-31,XM,Euro area,
-1941-03-31,XW,World,
-1941-03-31,ZA,South Africa,
-1941-06-30,4T,Emerging market economies (aggregate),
-1941-06-30,5R,Advanced economies,
-1941-06-30,AE,United Arab Emirates,
-1941-06-30,AT,Austria,
-1941-06-30,AU,Australia,
-1941-06-30,BE,Belgium,
-1941-06-30,BG,Bulgaria,
-1941-06-30,BR,Brazil,
-1941-06-30,CA,Canada,
-1941-06-30,CH,Switzerland,
-1941-06-30,CL,Chile,
-1941-06-30,CN,China,
-1941-06-30,CO,Colombia,
-1941-06-30,CY,Cyprus,
-1941-06-30,CZ,Czechia,
-1941-06-30,DE,Germany,
-1941-06-30,DK,Denmark,
-1941-06-30,EE,Estonia,
-1941-06-30,ES,Spain,
-1941-06-30,FI,Finland,
-1941-06-30,FR,France,
-1941-06-30,GB,United Kingdom,
-1941-06-30,GR,Greece,
-1941-06-30,HK,Hong Kong SAR,
-1941-06-30,HR,Croatia,
-1941-06-30,HU,Hungary,
-1941-06-30,ID,Indonesia,
-1941-06-30,IE,Ireland,
-1941-06-30,IL,Israel,
-1941-06-30,IN,India,
-1941-06-30,IS,Iceland,
-1941-06-30,IT,Italy,
-1941-06-30,JP,Japan,
-1941-06-30,KR,Korea,
-1941-06-30,LT,Lithuania,
-1941-06-30,LU,Luxembourg,
-1941-06-30,LV,Latvia,
-1941-06-30,MA,Morocco,
-1941-06-30,MK,North Macedonia,
-1941-06-30,MT,Malta,
-1941-06-30,MX,Mexico,
-1941-06-30,MY,Malaysia,
-1941-06-30,NL,Netherlands,
-1941-06-30,NO,Norway,
-1941-06-30,NZ,New Zealand,
-1941-06-30,PE,Peru,
-1941-06-30,PH,Philippines,
-1941-06-30,PL,Poland,
-1941-06-30,PT,Portugal,
-1941-06-30,RO,Romania,
-1941-06-30,RS,Serbia,
-1941-06-30,RU,Russia,
-1941-06-30,SE,Sweden,
-1941-06-30,SG,Singapore,
-1941-06-30,SI,Slovenia,
-1941-06-30,SK,Slovak Republic,
-1941-06-30,TH,Thailand,
-1941-06-30,TR,Türkiye,
-1941-06-30,US,United States,
-1941-06-30,XM,Euro area,
-1941-06-30,XW,World,
-1941-06-30,ZA,South Africa,
-1941-09-30,4T,Emerging market economies (aggregate),
-1941-09-30,5R,Advanced economies,
-1941-09-30,AE,United Arab Emirates,
-1941-09-30,AT,Austria,
-1941-09-30,AU,Australia,
-1941-09-30,BE,Belgium,
-1941-09-30,BG,Bulgaria,
-1941-09-30,BR,Brazil,
-1941-09-30,CA,Canada,
-1941-09-30,CH,Switzerland,
-1941-09-30,CL,Chile,
-1941-09-30,CN,China,
-1941-09-30,CO,Colombia,
-1941-09-30,CY,Cyprus,
-1941-09-30,CZ,Czechia,
-1941-09-30,DE,Germany,
-1941-09-30,DK,Denmark,
-1941-09-30,EE,Estonia,
-1941-09-30,ES,Spain,
-1941-09-30,FI,Finland,
-1941-09-30,FR,France,
-1941-09-30,GB,United Kingdom,
-1941-09-30,GR,Greece,
-1941-09-30,HK,Hong Kong SAR,
-1941-09-30,HR,Croatia,
-1941-09-30,HU,Hungary,
-1941-09-30,ID,Indonesia,
-1941-09-30,IE,Ireland,
-1941-09-30,IL,Israel,
-1941-09-30,IN,India,
-1941-09-30,IS,Iceland,
-1941-09-30,IT,Italy,
-1941-09-30,JP,Japan,
-1941-09-30,KR,Korea,
-1941-09-30,LT,Lithuania,
-1941-09-30,LU,Luxembourg,
-1941-09-30,LV,Latvia,
-1941-09-30,MA,Morocco,
-1941-09-30,MK,North Macedonia,
-1941-09-30,MT,Malta,
-1941-09-30,MX,Mexico,
-1941-09-30,MY,Malaysia,
-1941-09-30,NL,Netherlands,
-1941-09-30,NO,Norway,
-1941-09-30,NZ,New Zealand,
-1941-09-30,PE,Peru,
-1941-09-30,PH,Philippines,
-1941-09-30,PL,Poland,
-1941-09-30,PT,Portugal,
-1941-09-30,RO,Romania,
-1941-09-30,RS,Serbia,
-1941-09-30,RU,Russia,
-1941-09-30,SE,Sweden,
-1941-09-30,SG,Singapore,
-1941-09-30,SI,Slovenia,
-1941-09-30,SK,Slovak Republic,
-1941-09-30,TH,Thailand,
-1941-09-30,TR,Türkiye,
-1941-09-30,US,United States,
-1941-09-30,XM,Euro area,
-1941-09-30,XW,World,
-1941-09-30,ZA,South Africa,
-1941-12-31,4T,Emerging market economies (aggregate),
-1941-12-31,5R,Advanced economies,
-1941-12-31,AE,United Arab Emirates,
-1941-12-31,AT,Austria,
-1941-12-31,AU,Australia,
-1941-12-31,BE,Belgium,
-1941-12-31,BG,Bulgaria,
-1941-12-31,BR,Brazil,
-1941-12-31,CA,Canada,
-1941-12-31,CH,Switzerland,
-1941-12-31,CL,Chile,
-1941-12-31,CN,China,
-1941-12-31,CO,Colombia,
-1941-12-31,CY,Cyprus,
-1941-12-31,CZ,Czechia,
-1941-12-31,DE,Germany,
-1941-12-31,DK,Denmark,
-1941-12-31,EE,Estonia,
-1941-12-31,ES,Spain,
-1941-12-31,FI,Finland,
-1941-12-31,FR,France,
-1941-12-31,GB,United Kingdom,
-1941-12-31,GR,Greece,
-1941-12-31,HK,Hong Kong SAR,
-1941-12-31,HR,Croatia,
-1941-12-31,HU,Hungary,
-1941-12-31,ID,Indonesia,
-1941-12-31,IE,Ireland,
-1941-12-31,IL,Israel,
-1941-12-31,IN,India,
-1941-12-31,IS,Iceland,
-1941-12-31,IT,Italy,
-1941-12-31,JP,Japan,
-1941-12-31,KR,Korea,
-1941-12-31,LT,Lithuania,
-1941-12-31,LU,Luxembourg,
-1941-12-31,LV,Latvia,
-1941-12-31,MA,Morocco,
-1941-12-31,MK,North Macedonia,
-1941-12-31,MT,Malta,
-1941-12-31,MX,Mexico,
-1941-12-31,MY,Malaysia,
-1941-12-31,NL,Netherlands,
-1941-12-31,NO,Norway,
-1941-12-31,NZ,New Zealand,
-1941-12-31,PE,Peru,
-1941-12-31,PH,Philippines,
-1941-12-31,PL,Poland,
-1941-12-31,PT,Portugal,
-1941-12-31,RO,Romania,
-1941-12-31,RS,Serbia,
-1941-12-31,RU,Russia,
-1941-12-31,SE,Sweden,
-1941-12-31,SG,Singapore,
-1941-12-31,SI,Slovenia,
-1941-12-31,SK,Slovak Republic,
-1941-12-31,TH,Thailand,
-1941-12-31,TR,Türkiye,
-1941-12-31,US,United States,
-1941-12-31,XM,Euro area,
-1941-12-31,XW,World,
-1941-12-31,ZA,South Africa,
-1942-03-31,4T,Emerging market economies (aggregate),
-1942-03-31,5R,Advanced economies,
-1942-03-31,AE,United Arab Emirates,
-1942-03-31,AT,Austria,
-1942-03-31,AU,Australia,
-1942-03-31,BE,Belgium,
-1942-03-31,BG,Bulgaria,
-1942-03-31,BR,Brazil,
-1942-03-31,CA,Canada,
-1942-03-31,CH,Switzerland,
-1942-03-31,CL,Chile,
-1942-03-31,CN,China,
-1942-03-31,CO,Colombia,
-1942-03-31,CY,Cyprus,
-1942-03-31,CZ,Czechia,
-1942-03-31,DE,Germany,
-1942-03-31,DK,Denmark,
-1942-03-31,EE,Estonia,
-1942-03-31,ES,Spain,
-1942-03-31,FI,Finland,
-1942-03-31,FR,France,
-1942-03-31,GB,United Kingdom,
-1942-03-31,GR,Greece,
-1942-03-31,HK,Hong Kong SAR,
-1942-03-31,HR,Croatia,
-1942-03-31,HU,Hungary,
-1942-03-31,ID,Indonesia,
-1942-03-31,IE,Ireland,
-1942-03-31,IL,Israel,
-1942-03-31,IN,India,
-1942-03-31,IS,Iceland,
-1942-03-31,IT,Italy,
-1942-03-31,JP,Japan,
-1942-03-31,KR,Korea,
-1942-03-31,LT,Lithuania,
-1942-03-31,LU,Luxembourg,
-1942-03-31,LV,Latvia,
-1942-03-31,MA,Morocco,
-1942-03-31,MK,North Macedonia,
-1942-03-31,MT,Malta,
-1942-03-31,MX,Mexico,
-1942-03-31,MY,Malaysia,
-1942-03-31,NL,Netherlands,
-1942-03-31,NO,Norway,
-1942-03-31,NZ,New Zealand,
-1942-03-31,PE,Peru,
-1942-03-31,PH,Philippines,
-1942-03-31,PL,Poland,
-1942-03-31,PT,Portugal,
-1942-03-31,RO,Romania,
-1942-03-31,RS,Serbia,
-1942-03-31,RU,Russia,
-1942-03-31,SE,Sweden,
-1942-03-31,SG,Singapore,
-1942-03-31,SI,Slovenia,
-1942-03-31,SK,Slovak Republic,
-1942-03-31,TH,Thailand,
-1942-03-31,TR,Türkiye,
-1942-03-31,US,United States,
-1942-03-31,XM,Euro area,
-1942-03-31,XW,World,
-1942-03-31,ZA,South Africa,
-1942-06-30,4T,Emerging market economies (aggregate),
-1942-06-30,5R,Advanced economies,
-1942-06-30,AE,United Arab Emirates,
-1942-06-30,AT,Austria,
-1942-06-30,AU,Australia,
-1942-06-30,BE,Belgium,
-1942-06-30,BG,Bulgaria,
-1942-06-30,BR,Brazil,
-1942-06-30,CA,Canada,
-1942-06-30,CH,Switzerland,
-1942-06-30,CL,Chile,
-1942-06-30,CN,China,
-1942-06-30,CO,Colombia,
-1942-06-30,CY,Cyprus,
-1942-06-30,CZ,Czechia,
-1942-06-30,DE,Germany,
-1942-06-30,DK,Denmark,
-1942-06-30,EE,Estonia,
-1942-06-30,ES,Spain,
-1942-06-30,FI,Finland,
-1942-06-30,FR,France,
-1942-06-30,GB,United Kingdom,
-1942-06-30,GR,Greece,
-1942-06-30,HK,Hong Kong SAR,
-1942-06-30,HR,Croatia,
-1942-06-30,HU,Hungary,
-1942-06-30,ID,Indonesia,
-1942-06-30,IE,Ireland,
-1942-06-30,IL,Israel,
-1942-06-30,IN,India,
-1942-06-30,IS,Iceland,
-1942-06-30,IT,Italy,
-1942-06-30,JP,Japan,
-1942-06-30,KR,Korea,
-1942-06-30,LT,Lithuania,
-1942-06-30,LU,Luxembourg,
-1942-06-30,LV,Latvia,
-1942-06-30,MA,Morocco,
-1942-06-30,MK,North Macedonia,
-1942-06-30,MT,Malta,
-1942-06-30,MX,Mexico,
-1942-06-30,MY,Malaysia,
-1942-06-30,NL,Netherlands,
-1942-06-30,NO,Norway,
-1942-06-30,NZ,New Zealand,
-1942-06-30,PE,Peru,
-1942-06-30,PH,Philippines,
-1942-06-30,PL,Poland,
-1942-06-30,PT,Portugal,
-1942-06-30,RO,Romania,
-1942-06-30,RS,Serbia,
-1942-06-30,RU,Russia,
-1942-06-30,SE,Sweden,
-1942-06-30,SG,Singapore,
-1942-06-30,SI,Slovenia,
-1942-06-30,SK,Slovak Republic,
-1942-06-30,TH,Thailand,
-1942-06-30,TR,Türkiye,
-1942-06-30,US,United States,
-1942-06-30,XM,Euro area,
-1942-06-30,XW,World,
-1942-06-30,ZA,South Africa,
-1942-09-30,4T,Emerging market economies (aggregate),
-1942-09-30,5R,Advanced economies,
-1942-09-30,AE,United Arab Emirates,
-1942-09-30,AT,Austria,
-1942-09-30,AU,Australia,
-1942-09-30,BE,Belgium,
-1942-09-30,BG,Bulgaria,
-1942-09-30,BR,Brazil,
-1942-09-30,CA,Canada,
-1942-09-30,CH,Switzerland,
-1942-09-30,CL,Chile,
-1942-09-30,CN,China,
-1942-09-30,CO,Colombia,
-1942-09-30,CY,Cyprus,
-1942-09-30,CZ,Czechia,
-1942-09-30,DE,Germany,
-1942-09-30,DK,Denmark,
-1942-09-30,EE,Estonia,
-1942-09-30,ES,Spain,
-1942-09-30,FI,Finland,
-1942-09-30,FR,France,
-1942-09-30,GB,United Kingdom,
-1942-09-30,GR,Greece,
-1942-09-30,HK,Hong Kong SAR,
-1942-09-30,HR,Croatia,
-1942-09-30,HU,Hungary,
-1942-09-30,ID,Indonesia,
-1942-09-30,IE,Ireland,
-1942-09-30,IL,Israel,
-1942-09-30,IN,India,
-1942-09-30,IS,Iceland,
-1942-09-30,IT,Italy,
-1942-09-30,JP,Japan,
-1942-09-30,KR,Korea,
-1942-09-30,LT,Lithuania,
-1942-09-30,LU,Luxembourg,
-1942-09-30,LV,Latvia,
-1942-09-30,MA,Morocco,
-1942-09-30,MK,North Macedonia,
-1942-09-30,MT,Malta,
-1942-09-30,MX,Mexico,
-1942-09-30,MY,Malaysia,
-1942-09-30,NL,Netherlands,
-1942-09-30,NO,Norway,
-1942-09-30,NZ,New Zealand,
-1942-09-30,PE,Peru,
-1942-09-30,PH,Philippines,
-1942-09-30,PL,Poland,
-1942-09-30,PT,Portugal,
-1942-09-30,RO,Romania,
-1942-09-30,RS,Serbia,
-1942-09-30,RU,Russia,
-1942-09-30,SE,Sweden,
-1942-09-30,SG,Singapore,
-1942-09-30,SI,Slovenia,
-1942-09-30,SK,Slovak Republic,
-1942-09-30,TH,Thailand,
-1942-09-30,TR,Türkiye,
-1942-09-30,US,United States,
-1942-09-30,XM,Euro area,
-1942-09-30,XW,World,
-1942-09-30,ZA,South Africa,
-1942-12-31,4T,Emerging market economies (aggregate),
-1942-12-31,5R,Advanced economies,
-1942-12-31,AE,United Arab Emirates,
-1942-12-31,AT,Austria,
-1942-12-31,AU,Australia,
-1942-12-31,BE,Belgium,
-1942-12-31,BG,Bulgaria,
-1942-12-31,BR,Brazil,
-1942-12-31,CA,Canada,
-1942-12-31,CH,Switzerland,
-1942-12-31,CL,Chile,
-1942-12-31,CN,China,
-1942-12-31,CO,Colombia,
-1942-12-31,CY,Cyprus,
-1942-12-31,CZ,Czechia,
-1942-12-31,DE,Germany,
-1942-12-31,DK,Denmark,
-1942-12-31,EE,Estonia,
-1942-12-31,ES,Spain,
-1942-12-31,FI,Finland,
-1942-12-31,FR,France,
-1942-12-31,GB,United Kingdom,
-1942-12-31,GR,Greece,
-1942-12-31,HK,Hong Kong SAR,
-1942-12-31,HR,Croatia,
-1942-12-31,HU,Hungary,
-1942-12-31,ID,Indonesia,
-1942-12-31,IE,Ireland,
-1942-12-31,IL,Israel,
-1942-12-31,IN,India,
-1942-12-31,IS,Iceland,
-1942-12-31,IT,Italy,
-1942-12-31,JP,Japan,
-1942-12-31,KR,Korea,
-1942-12-31,LT,Lithuania,
-1942-12-31,LU,Luxembourg,
-1942-12-31,LV,Latvia,
-1942-12-31,MA,Morocco,
-1942-12-31,MK,North Macedonia,
-1942-12-31,MT,Malta,
-1942-12-31,MX,Mexico,
-1942-12-31,MY,Malaysia,
-1942-12-31,NL,Netherlands,
-1942-12-31,NO,Norway,
-1942-12-31,NZ,New Zealand,
-1942-12-31,PE,Peru,
-1942-12-31,PH,Philippines,
-1942-12-31,PL,Poland,
-1942-12-31,PT,Portugal,
-1942-12-31,RO,Romania,
-1942-12-31,RS,Serbia,
-1942-12-31,RU,Russia,
-1942-12-31,SE,Sweden,
-1942-12-31,SG,Singapore,
-1942-12-31,SI,Slovenia,
-1942-12-31,SK,Slovak Republic,
-1942-12-31,TH,Thailand,
-1942-12-31,TR,Türkiye,
-1942-12-31,US,United States,
-1942-12-31,XM,Euro area,
-1942-12-31,XW,World,
-1942-12-31,ZA,South Africa,
-1943-03-31,4T,Emerging market economies (aggregate),
-1943-03-31,5R,Advanced economies,
-1943-03-31,AE,United Arab Emirates,
-1943-03-31,AT,Austria,
-1943-03-31,AU,Australia,
-1943-03-31,BE,Belgium,
-1943-03-31,BG,Bulgaria,
-1943-03-31,BR,Brazil,
-1943-03-31,CA,Canada,
-1943-03-31,CH,Switzerland,
-1943-03-31,CL,Chile,
-1943-03-31,CN,China,
-1943-03-31,CO,Colombia,
-1943-03-31,CY,Cyprus,
-1943-03-31,CZ,Czechia,
-1943-03-31,DE,Germany,
-1943-03-31,DK,Denmark,
-1943-03-31,EE,Estonia,
-1943-03-31,ES,Spain,
-1943-03-31,FI,Finland,
-1943-03-31,FR,France,
-1943-03-31,GB,United Kingdom,
-1943-03-31,GR,Greece,
-1943-03-31,HK,Hong Kong SAR,
-1943-03-31,HR,Croatia,
-1943-03-31,HU,Hungary,
-1943-03-31,ID,Indonesia,
-1943-03-31,IE,Ireland,
-1943-03-31,IL,Israel,
-1943-03-31,IN,India,
-1943-03-31,IS,Iceland,
-1943-03-31,IT,Italy,
-1943-03-31,JP,Japan,
-1943-03-31,KR,Korea,
-1943-03-31,LT,Lithuania,
-1943-03-31,LU,Luxembourg,
-1943-03-31,LV,Latvia,
-1943-03-31,MA,Morocco,
-1943-03-31,MK,North Macedonia,
-1943-03-31,MT,Malta,
-1943-03-31,MX,Mexico,
-1943-03-31,MY,Malaysia,
-1943-03-31,NL,Netherlands,
-1943-03-31,NO,Norway,
-1943-03-31,NZ,New Zealand,
-1943-03-31,PE,Peru,
-1943-03-31,PH,Philippines,
-1943-03-31,PL,Poland,
-1943-03-31,PT,Portugal,
-1943-03-31,RO,Romania,
-1943-03-31,RS,Serbia,
-1943-03-31,RU,Russia,
-1943-03-31,SE,Sweden,
-1943-03-31,SG,Singapore,
-1943-03-31,SI,Slovenia,
-1943-03-31,SK,Slovak Republic,
-1943-03-31,TH,Thailand,
-1943-03-31,TR,Türkiye,
-1943-03-31,US,United States,
-1943-03-31,XM,Euro area,
-1943-03-31,XW,World,
-1943-03-31,ZA,South Africa,
-1943-06-30,4T,Emerging market economies (aggregate),
-1943-06-30,5R,Advanced economies,
-1943-06-30,AE,United Arab Emirates,
-1943-06-30,AT,Austria,
-1943-06-30,AU,Australia,
-1943-06-30,BE,Belgium,
-1943-06-30,BG,Bulgaria,
-1943-06-30,BR,Brazil,
-1943-06-30,CA,Canada,
-1943-06-30,CH,Switzerland,
-1943-06-30,CL,Chile,
-1943-06-30,CN,China,
-1943-06-30,CO,Colombia,
-1943-06-30,CY,Cyprus,
-1943-06-30,CZ,Czechia,
-1943-06-30,DE,Germany,
-1943-06-30,DK,Denmark,
-1943-06-30,EE,Estonia,
-1943-06-30,ES,Spain,
-1943-06-30,FI,Finland,
-1943-06-30,FR,France,
-1943-06-30,GB,United Kingdom,
-1943-06-30,GR,Greece,
-1943-06-30,HK,Hong Kong SAR,
-1943-06-30,HR,Croatia,
-1943-06-30,HU,Hungary,
-1943-06-30,ID,Indonesia,
-1943-06-30,IE,Ireland,
-1943-06-30,IL,Israel,
-1943-06-30,IN,India,
-1943-06-30,IS,Iceland,
-1943-06-30,IT,Italy,
-1943-06-30,JP,Japan,
-1943-06-30,KR,Korea,
-1943-06-30,LT,Lithuania,
-1943-06-30,LU,Luxembourg,
-1943-06-30,LV,Latvia,
-1943-06-30,MA,Morocco,
-1943-06-30,MK,North Macedonia,
-1943-06-30,MT,Malta,
-1943-06-30,MX,Mexico,
-1943-06-30,MY,Malaysia,
-1943-06-30,NL,Netherlands,
-1943-06-30,NO,Norway,
-1943-06-30,NZ,New Zealand,
-1943-06-30,PE,Peru,
-1943-06-30,PH,Philippines,
-1943-06-30,PL,Poland,
-1943-06-30,PT,Portugal,
-1943-06-30,RO,Romania,
-1943-06-30,RS,Serbia,
-1943-06-30,RU,Russia,
-1943-06-30,SE,Sweden,
-1943-06-30,SG,Singapore,
-1943-06-30,SI,Slovenia,
-1943-06-30,SK,Slovak Republic,
-1943-06-30,TH,Thailand,
-1943-06-30,TR,Türkiye,
-1943-06-30,US,United States,
-1943-06-30,XM,Euro area,
-1943-06-30,XW,World,
-1943-06-30,ZA,South Africa,
-1943-09-30,4T,Emerging market economies (aggregate),
-1943-09-30,5R,Advanced economies,
-1943-09-30,AE,United Arab Emirates,
-1943-09-30,AT,Austria,
-1943-09-30,AU,Australia,
-1943-09-30,BE,Belgium,
-1943-09-30,BG,Bulgaria,
-1943-09-30,BR,Brazil,
-1943-09-30,CA,Canada,
-1943-09-30,CH,Switzerland,
-1943-09-30,CL,Chile,
-1943-09-30,CN,China,
-1943-09-30,CO,Colombia,
-1943-09-30,CY,Cyprus,
-1943-09-30,CZ,Czechia,
-1943-09-30,DE,Germany,
-1943-09-30,DK,Denmark,
-1943-09-30,EE,Estonia,
-1943-09-30,ES,Spain,
-1943-09-30,FI,Finland,
-1943-09-30,FR,France,
-1943-09-30,GB,United Kingdom,
-1943-09-30,GR,Greece,
-1943-09-30,HK,Hong Kong SAR,
-1943-09-30,HR,Croatia,
-1943-09-30,HU,Hungary,
-1943-09-30,ID,Indonesia,
-1943-09-30,IE,Ireland,
-1943-09-30,IL,Israel,
-1943-09-30,IN,India,
-1943-09-30,IS,Iceland,
-1943-09-30,IT,Italy,
-1943-09-30,JP,Japan,
-1943-09-30,KR,Korea,
-1943-09-30,LT,Lithuania,
-1943-09-30,LU,Luxembourg,
-1943-09-30,LV,Latvia,
-1943-09-30,MA,Morocco,
-1943-09-30,MK,North Macedonia,
-1943-09-30,MT,Malta,
-1943-09-30,MX,Mexico,
-1943-09-30,MY,Malaysia,
-1943-09-30,NL,Netherlands,
-1943-09-30,NO,Norway,
-1943-09-30,NZ,New Zealand,
-1943-09-30,PE,Peru,
-1943-09-30,PH,Philippines,
-1943-09-30,PL,Poland,
-1943-09-30,PT,Portugal,
-1943-09-30,RO,Romania,
-1943-09-30,RS,Serbia,
-1943-09-30,RU,Russia,
-1943-09-30,SE,Sweden,
-1943-09-30,SG,Singapore,
-1943-09-30,SI,Slovenia,
-1943-09-30,SK,Slovak Republic,
-1943-09-30,TH,Thailand,
-1943-09-30,TR,Türkiye,
-1943-09-30,US,United States,
-1943-09-30,XM,Euro area,
-1943-09-30,XW,World,
-1943-09-30,ZA,South Africa,
-1943-12-31,4T,Emerging market economies (aggregate),
-1943-12-31,5R,Advanced economies,
-1943-12-31,AE,United Arab Emirates,
-1943-12-31,AT,Austria,
-1943-12-31,AU,Australia,
-1943-12-31,BE,Belgium,
-1943-12-31,BG,Bulgaria,
-1943-12-31,BR,Brazil,
-1943-12-31,CA,Canada,
-1943-12-31,CH,Switzerland,
-1943-12-31,CL,Chile,
-1943-12-31,CN,China,
-1943-12-31,CO,Colombia,
-1943-12-31,CY,Cyprus,
-1943-12-31,CZ,Czechia,
-1943-12-31,DE,Germany,
-1943-12-31,DK,Denmark,
-1943-12-31,EE,Estonia,
-1943-12-31,ES,Spain,
-1943-12-31,FI,Finland,
-1943-12-31,FR,France,
-1943-12-31,GB,United Kingdom,
-1943-12-31,GR,Greece,
-1943-12-31,HK,Hong Kong SAR,
-1943-12-31,HR,Croatia,
-1943-12-31,HU,Hungary,
-1943-12-31,ID,Indonesia,
-1943-12-31,IE,Ireland,
-1943-12-31,IL,Israel,
-1943-12-31,IN,India,
-1943-12-31,IS,Iceland,
-1943-12-31,IT,Italy,
-1943-12-31,JP,Japan,
-1943-12-31,KR,Korea,
-1943-12-31,LT,Lithuania,
-1943-12-31,LU,Luxembourg,
-1943-12-31,LV,Latvia,
-1943-12-31,MA,Morocco,
-1943-12-31,MK,North Macedonia,
-1943-12-31,MT,Malta,
-1943-12-31,MX,Mexico,
-1943-12-31,MY,Malaysia,
-1943-12-31,NL,Netherlands,
-1943-12-31,NO,Norway,
-1943-12-31,NZ,New Zealand,
-1943-12-31,PE,Peru,
-1943-12-31,PH,Philippines,
-1943-12-31,PL,Poland,
-1943-12-31,PT,Portugal,
-1943-12-31,RO,Romania,
-1943-12-31,RS,Serbia,
-1943-12-31,RU,Russia,
-1943-12-31,SE,Sweden,
-1943-12-31,SG,Singapore,
-1943-12-31,SI,Slovenia,
-1943-12-31,SK,Slovak Republic,
-1943-12-31,TH,Thailand,
-1943-12-31,TR,Türkiye,
-1943-12-31,US,United States,
-1943-12-31,XM,Euro area,
-1943-12-31,XW,World,
-1943-12-31,ZA,South Africa,
-1944-03-31,4T,Emerging market economies (aggregate),
-1944-03-31,5R,Advanced economies,
-1944-03-31,AE,United Arab Emirates,
-1944-03-31,AT,Austria,
-1944-03-31,AU,Australia,
-1944-03-31,BE,Belgium,
-1944-03-31,BG,Bulgaria,
-1944-03-31,BR,Brazil,
-1944-03-31,CA,Canada,
-1944-03-31,CH,Switzerland,
-1944-03-31,CL,Chile,
-1944-03-31,CN,China,
-1944-03-31,CO,Colombia,
-1944-03-31,CY,Cyprus,
-1944-03-31,CZ,Czechia,
-1944-03-31,DE,Germany,
-1944-03-31,DK,Denmark,
-1944-03-31,EE,Estonia,
-1944-03-31,ES,Spain,
-1944-03-31,FI,Finland,
-1944-03-31,FR,France,
-1944-03-31,GB,United Kingdom,
-1944-03-31,GR,Greece,
-1944-03-31,HK,Hong Kong SAR,
-1944-03-31,HR,Croatia,
-1944-03-31,HU,Hungary,
-1944-03-31,ID,Indonesia,
-1944-03-31,IE,Ireland,
-1944-03-31,IL,Israel,
-1944-03-31,IN,India,
-1944-03-31,IS,Iceland,
-1944-03-31,IT,Italy,
-1944-03-31,JP,Japan,
-1944-03-31,KR,Korea,
-1944-03-31,LT,Lithuania,
-1944-03-31,LU,Luxembourg,
-1944-03-31,LV,Latvia,
-1944-03-31,MA,Morocco,
-1944-03-31,MK,North Macedonia,
-1944-03-31,MT,Malta,
-1944-03-31,MX,Mexico,
-1944-03-31,MY,Malaysia,
-1944-03-31,NL,Netherlands,
-1944-03-31,NO,Norway,
-1944-03-31,NZ,New Zealand,
-1944-03-31,PE,Peru,
-1944-03-31,PH,Philippines,
-1944-03-31,PL,Poland,
-1944-03-31,PT,Portugal,
-1944-03-31,RO,Romania,
-1944-03-31,RS,Serbia,
-1944-03-31,RU,Russia,
-1944-03-31,SE,Sweden,
-1944-03-31,SG,Singapore,
-1944-03-31,SI,Slovenia,
-1944-03-31,SK,Slovak Republic,
-1944-03-31,TH,Thailand,
-1944-03-31,TR,Türkiye,
-1944-03-31,US,United States,
-1944-03-31,XM,Euro area,
-1944-03-31,XW,World,
-1944-03-31,ZA,South Africa,
-1944-06-30,4T,Emerging market economies (aggregate),
-1944-06-30,5R,Advanced economies,
-1944-06-30,AE,United Arab Emirates,
-1944-06-30,AT,Austria,
-1944-06-30,AU,Australia,
-1944-06-30,BE,Belgium,
-1944-06-30,BG,Bulgaria,
-1944-06-30,BR,Brazil,
-1944-06-30,CA,Canada,
-1944-06-30,CH,Switzerland,
-1944-06-30,CL,Chile,
-1944-06-30,CN,China,
-1944-06-30,CO,Colombia,
-1944-06-30,CY,Cyprus,
-1944-06-30,CZ,Czechia,
-1944-06-30,DE,Germany,
-1944-06-30,DK,Denmark,
-1944-06-30,EE,Estonia,
-1944-06-30,ES,Spain,
-1944-06-30,FI,Finland,
-1944-06-30,FR,France,
-1944-06-30,GB,United Kingdom,
-1944-06-30,GR,Greece,
-1944-06-30,HK,Hong Kong SAR,
-1944-06-30,HR,Croatia,
-1944-06-30,HU,Hungary,
-1944-06-30,ID,Indonesia,
-1944-06-30,IE,Ireland,
-1944-06-30,IL,Israel,
-1944-06-30,IN,India,
-1944-06-30,IS,Iceland,
-1944-06-30,IT,Italy,
-1944-06-30,JP,Japan,
-1944-06-30,KR,Korea,
-1944-06-30,LT,Lithuania,
-1944-06-30,LU,Luxembourg,
-1944-06-30,LV,Latvia,
-1944-06-30,MA,Morocco,
-1944-06-30,MK,North Macedonia,
-1944-06-30,MT,Malta,
-1944-06-30,MX,Mexico,
-1944-06-30,MY,Malaysia,
-1944-06-30,NL,Netherlands,
-1944-06-30,NO,Norway,
-1944-06-30,NZ,New Zealand,
-1944-06-30,PE,Peru,
-1944-06-30,PH,Philippines,
-1944-06-30,PL,Poland,
-1944-06-30,PT,Portugal,
-1944-06-30,RO,Romania,
-1944-06-30,RS,Serbia,
-1944-06-30,RU,Russia,
-1944-06-30,SE,Sweden,
-1944-06-30,SG,Singapore,
-1944-06-30,SI,Slovenia,
-1944-06-30,SK,Slovak Republic,
-1944-06-30,TH,Thailand,
-1944-06-30,TR,Türkiye,
-1944-06-30,US,United States,
-1944-06-30,XM,Euro area,
-1944-06-30,XW,World,
-1944-06-30,ZA,South Africa,
-1944-09-30,4T,Emerging market economies (aggregate),
-1944-09-30,5R,Advanced economies,
-1944-09-30,AE,United Arab Emirates,
-1944-09-30,AT,Austria,
-1944-09-30,AU,Australia,
-1944-09-30,BE,Belgium,
-1944-09-30,BG,Bulgaria,
-1944-09-30,BR,Brazil,
-1944-09-30,CA,Canada,
-1944-09-30,CH,Switzerland,
-1944-09-30,CL,Chile,
-1944-09-30,CN,China,
-1944-09-30,CO,Colombia,
-1944-09-30,CY,Cyprus,
-1944-09-30,CZ,Czechia,
-1944-09-30,DE,Germany,
-1944-09-30,DK,Denmark,
-1944-09-30,EE,Estonia,
-1944-09-30,ES,Spain,
-1944-09-30,FI,Finland,
-1944-09-30,FR,France,
-1944-09-30,GB,United Kingdom,
-1944-09-30,GR,Greece,
-1944-09-30,HK,Hong Kong SAR,
-1944-09-30,HR,Croatia,
-1944-09-30,HU,Hungary,
-1944-09-30,ID,Indonesia,
-1944-09-30,IE,Ireland,
-1944-09-30,IL,Israel,
-1944-09-30,IN,India,
-1944-09-30,IS,Iceland,
-1944-09-30,IT,Italy,
-1944-09-30,JP,Japan,
-1944-09-30,KR,Korea,
-1944-09-30,LT,Lithuania,
-1944-09-30,LU,Luxembourg,
-1944-09-30,LV,Latvia,
-1944-09-30,MA,Morocco,
-1944-09-30,MK,North Macedonia,
-1944-09-30,MT,Malta,
-1944-09-30,MX,Mexico,
-1944-09-30,MY,Malaysia,
-1944-09-30,NL,Netherlands,
-1944-09-30,NO,Norway,
-1944-09-30,NZ,New Zealand,
-1944-09-30,PE,Peru,
-1944-09-30,PH,Philippines,
-1944-09-30,PL,Poland,
-1944-09-30,PT,Portugal,
-1944-09-30,RO,Romania,
-1944-09-30,RS,Serbia,
-1944-09-30,RU,Russia,
-1944-09-30,SE,Sweden,
-1944-09-30,SG,Singapore,
-1944-09-30,SI,Slovenia,
-1944-09-30,SK,Slovak Republic,
-1944-09-30,TH,Thailand,
-1944-09-30,TR,Türkiye,
-1944-09-30,US,United States,
-1944-09-30,XM,Euro area,
-1944-09-30,XW,World,
-1944-09-30,ZA,South Africa,
-1944-12-31,4T,Emerging market economies (aggregate),
-1944-12-31,5R,Advanced economies,
-1944-12-31,AE,United Arab Emirates,
-1944-12-31,AT,Austria,
-1944-12-31,AU,Australia,
-1944-12-31,BE,Belgium,
-1944-12-31,BG,Bulgaria,
-1944-12-31,BR,Brazil,
-1944-12-31,CA,Canada,
-1944-12-31,CH,Switzerland,
-1944-12-31,CL,Chile,
-1944-12-31,CN,China,
-1944-12-31,CO,Colombia,
-1944-12-31,CY,Cyprus,
-1944-12-31,CZ,Czechia,
-1944-12-31,DE,Germany,
-1944-12-31,DK,Denmark,
-1944-12-31,EE,Estonia,
-1944-12-31,ES,Spain,
-1944-12-31,FI,Finland,
-1944-12-31,FR,France,
-1944-12-31,GB,United Kingdom,
-1944-12-31,GR,Greece,
-1944-12-31,HK,Hong Kong SAR,
-1944-12-31,HR,Croatia,
-1944-12-31,HU,Hungary,
-1944-12-31,ID,Indonesia,
-1944-12-31,IE,Ireland,
-1944-12-31,IL,Israel,
-1944-12-31,IN,India,
-1944-12-31,IS,Iceland,
-1944-12-31,IT,Italy,
-1944-12-31,JP,Japan,
-1944-12-31,KR,Korea,
-1944-12-31,LT,Lithuania,
-1944-12-31,LU,Luxembourg,
-1944-12-31,LV,Latvia,
-1944-12-31,MA,Morocco,
-1944-12-31,MK,North Macedonia,
-1944-12-31,MT,Malta,
-1944-12-31,MX,Mexico,
-1944-12-31,MY,Malaysia,
-1944-12-31,NL,Netherlands,
-1944-12-31,NO,Norway,
-1944-12-31,NZ,New Zealand,
-1944-12-31,PE,Peru,
-1944-12-31,PH,Philippines,
-1944-12-31,PL,Poland,
-1944-12-31,PT,Portugal,
-1944-12-31,RO,Romania,
-1944-12-31,RS,Serbia,
-1944-12-31,RU,Russia,
-1944-12-31,SE,Sweden,
-1944-12-31,SG,Singapore,
-1944-12-31,SI,Slovenia,
-1944-12-31,SK,Slovak Republic,
-1944-12-31,TH,Thailand,
-1944-12-31,TR,Türkiye,
-1944-12-31,US,United States,
-1944-12-31,XM,Euro area,
-1944-12-31,XW,World,
-1944-12-31,ZA,South Africa,
-1945-03-31,4T,Emerging market economies (aggregate),
-1945-03-31,5R,Advanced economies,
-1945-03-31,AE,United Arab Emirates,
-1945-03-31,AT,Austria,
-1945-03-31,AU,Australia,
-1945-03-31,BE,Belgium,
-1945-03-31,BG,Bulgaria,
-1945-03-31,BR,Brazil,
-1945-03-31,CA,Canada,
-1945-03-31,CH,Switzerland,
-1945-03-31,CL,Chile,
-1945-03-31,CN,China,
-1945-03-31,CO,Colombia,
-1945-03-31,CY,Cyprus,
-1945-03-31,CZ,Czechia,
-1945-03-31,DE,Germany,
-1945-03-31,DK,Denmark,
-1945-03-31,EE,Estonia,
-1945-03-31,ES,Spain,
-1945-03-31,FI,Finland,
-1945-03-31,FR,France,
-1945-03-31,GB,United Kingdom,
-1945-03-31,GR,Greece,
-1945-03-31,HK,Hong Kong SAR,
-1945-03-31,HR,Croatia,
-1945-03-31,HU,Hungary,
-1945-03-31,ID,Indonesia,
-1945-03-31,IE,Ireland,
-1945-03-31,IL,Israel,
-1945-03-31,IN,India,
-1945-03-31,IS,Iceland,
-1945-03-31,IT,Italy,
-1945-03-31,JP,Japan,
-1945-03-31,KR,Korea,
-1945-03-31,LT,Lithuania,
-1945-03-31,LU,Luxembourg,
-1945-03-31,LV,Latvia,
-1945-03-31,MA,Morocco,
-1945-03-31,MK,North Macedonia,
-1945-03-31,MT,Malta,
-1945-03-31,MX,Mexico,
-1945-03-31,MY,Malaysia,
-1945-03-31,NL,Netherlands,
-1945-03-31,NO,Norway,
-1945-03-31,NZ,New Zealand,
-1945-03-31,PE,Peru,
-1945-03-31,PH,Philippines,
-1945-03-31,PL,Poland,
-1945-03-31,PT,Portugal,
-1945-03-31,RO,Romania,
-1945-03-31,RS,Serbia,
-1945-03-31,RU,Russia,
-1945-03-31,SE,Sweden,
-1945-03-31,SG,Singapore,
-1945-03-31,SI,Slovenia,
-1945-03-31,SK,Slovak Republic,
-1945-03-31,TH,Thailand,
-1945-03-31,TR,Türkiye,
-1945-03-31,US,United States,
-1945-03-31,XM,Euro area,
-1945-03-31,XW,World,
-1945-03-31,ZA,South Africa,
-1945-06-30,4T,Emerging market economies (aggregate),
-1945-06-30,5R,Advanced economies,
-1945-06-30,AE,United Arab Emirates,
-1945-06-30,AT,Austria,
-1945-06-30,AU,Australia,
-1945-06-30,BE,Belgium,
-1945-06-30,BG,Bulgaria,
-1945-06-30,BR,Brazil,
-1945-06-30,CA,Canada,
-1945-06-30,CH,Switzerland,
-1945-06-30,CL,Chile,
-1945-06-30,CN,China,
-1945-06-30,CO,Colombia,
-1945-06-30,CY,Cyprus,
-1945-06-30,CZ,Czechia,
-1945-06-30,DE,Germany,
-1945-06-30,DK,Denmark,
-1945-06-30,EE,Estonia,
-1945-06-30,ES,Spain,
-1945-06-30,FI,Finland,
-1945-06-30,FR,France,
-1945-06-30,GB,United Kingdom,
-1945-06-30,GR,Greece,
-1945-06-30,HK,Hong Kong SAR,
-1945-06-30,HR,Croatia,
-1945-06-30,HU,Hungary,
-1945-06-30,ID,Indonesia,
-1945-06-30,IE,Ireland,
-1945-06-30,IL,Israel,
-1945-06-30,IN,India,
-1945-06-30,IS,Iceland,
-1945-06-30,IT,Italy,
-1945-06-30,JP,Japan,
-1945-06-30,KR,Korea,
-1945-06-30,LT,Lithuania,
-1945-06-30,LU,Luxembourg,
-1945-06-30,LV,Latvia,
-1945-06-30,MA,Morocco,
-1945-06-30,MK,North Macedonia,
-1945-06-30,MT,Malta,
-1945-06-30,MX,Mexico,
-1945-06-30,MY,Malaysia,
-1945-06-30,NL,Netherlands,
-1945-06-30,NO,Norway,
-1945-06-30,NZ,New Zealand,
-1945-06-30,PE,Peru,
-1945-06-30,PH,Philippines,
-1945-06-30,PL,Poland,
-1945-06-30,PT,Portugal,
-1945-06-30,RO,Romania,
-1945-06-30,RS,Serbia,
-1945-06-30,RU,Russia,
-1945-06-30,SE,Sweden,
-1945-06-30,SG,Singapore,
-1945-06-30,SI,Slovenia,
-1945-06-30,SK,Slovak Republic,
-1945-06-30,TH,Thailand,
-1945-06-30,TR,Türkiye,
-1945-06-30,US,United States,
-1945-06-30,XM,Euro area,
-1945-06-30,XW,World,
-1945-06-30,ZA,South Africa,
-1945-09-30,4T,Emerging market economies (aggregate),
-1945-09-30,5R,Advanced economies,
-1945-09-30,AE,United Arab Emirates,
-1945-09-30,AT,Austria,
-1945-09-30,AU,Australia,
-1945-09-30,BE,Belgium,
-1945-09-30,BG,Bulgaria,
-1945-09-30,BR,Brazil,
-1945-09-30,CA,Canada,
-1945-09-30,CH,Switzerland,
-1945-09-30,CL,Chile,
-1945-09-30,CN,China,
-1945-09-30,CO,Colombia,
-1945-09-30,CY,Cyprus,
-1945-09-30,CZ,Czechia,
-1945-09-30,DE,Germany,
-1945-09-30,DK,Denmark,
-1945-09-30,EE,Estonia,
-1945-09-30,ES,Spain,
-1945-09-30,FI,Finland,
-1945-09-30,FR,France,
-1945-09-30,GB,United Kingdom,
-1945-09-30,GR,Greece,
-1945-09-30,HK,Hong Kong SAR,
-1945-09-30,HR,Croatia,
-1945-09-30,HU,Hungary,
-1945-09-30,ID,Indonesia,
-1945-09-30,IE,Ireland,
-1945-09-30,IL,Israel,
-1945-09-30,IN,India,
-1945-09-30,IS,Iceland,
-1945-09-30,IT,Italy,
-1945-09-30,JP,Japan,
-1945-09-30,KR,Korea,
-1945-09-30,LT,Lithuania,
-1945-09-30,LU,Luxembourg,
-1945-09-30,LV,Latvia,
-1945-09-30,MA,Morocco,
-1945-09-30,MK,North Macedonia,
-1945-09-30,MT,Malta,
-1945-09-30,MX,Mexico,
-1945-09-30,MY,Malaysia,
-1945-09-30,NL,Netherlands,
-1945-09-30,NO,Norway,
-1945-09-30,NZ,New Zealand,
-1945-09-30,PE,Peru,
-1945-09-30,PH,Philippines,
-1945-09-30,PL,Poland,
-1945-09-30,PT,Portugal,
-1945-09-30,RO,Romania,
-1945-09-30,RS,Serbia,
-1945-09-30,RU,Russia,
-1945-09-30,SE,Sweden,
-1945-09-30,SG,Singapore,
-1945-09-30,SI,Slovenia,
-1945-09-30,SK,Slovak Republic,
-1945-09-30,TH,Thailand,
-1945-09-30,TR,Türkiye,
-1945-09-30,US,United States,
-1945-09-30,XM,Euro area,
-1945-09-30,XW,World,
-1945-09-30,ZA,South Africa,
-1945-12-31,4T,Emerging market economies (aggregate),
-1945-12-31,5R,Advanced economies,
-1945-12-31,AE,United Arab Emirates,
-1945-12-31,AT,Austria,
-1945-12-31,AU,Australia,
-1945-12-31,BE,Belgium,
-1945-12-31,BG,Bulgaria,
-1945-12-31,BR,Brazil,
-1945-12-31,CA,Canada,
-1945-12-31,CH,Switzerland,
-1945-12-31,CL,Chile,
-1945-12-31,CN,China,
-1945-12-31,CO,Colombia,
-1945-12-31,CY,Cyprus,
-1945-12-31,CZ,Czechia,
-1945-12-31,DE,Germany,
-1945-12-31,DK,Denmark,
-1945-12-31,EE,Estonia,
-1945-12-31,ES,Spain,
-1945-12-31,FI,Finland,
-1945-12-31,FR,France,
-1945-12-31,GB,United Kingdom,
-1945-12-31,GR,Greece,
-1945-12-31,HK,Hong Kong SAR,
-1945-12-31,HR,Croatia,
-1945-12-31,HU,Hungary,
-1945-12-31,ID,Indonesia,
-1945-12-31,IE,Ireland,
-1945-12-31,IL,Israel,
-1945-12-31,IN,India,
-1945-12-31,IS,Iceland,
-1945-12-31,IT,Italy,
-1945-12-31,JP,Japan,
-1945-12-31,KR,Korea,
-1945-12-31,LT,Lithuania,
-1945-12-31,LU,Luxembourg,
-1945-12-31,LV,Latvia,
-1945-12-31,MA,Morocco,
-1945-12-31,MK,North Macedonia,
-1945-12-31,MT,Malta,
-1945-12-31,MX,Mexico,
-1945-12-31,MY,Malaysia,
-1945-12-31,NL,Netherlands,
-1945-12-31,NO,Norway,
-1945-12-31,NZ,New Zealand,
-1945-12-31,PE,Peru,
-1945-12-31,PH,Philippines,
-1945-12-31,PL,Poland,
-1945-12-31,PT,Portugal,
-1945-12-31,RO,Romania,
-1945-12-31,RS,Serbia,
-1945-12-31,RU,Russia,
-1945-12-31,SE,Sweden,
-1945-12-31,SG,Singapore,
-1945-12-31,SI,Slovenia,
-1945-12-31,SK,Slovak Republic,
-1945-12-31,TH,Thailand,
-1945-12-31,TR,Türkiye,
-1945-12-31,US,United States,
-1945-12-31,XM,Euro area,
-1945-12-31,XW,World,
-1945-12-31,ZA,South Africa,
-1946-03-31,4T,Emerging market economies (aggregate),
-1946-03-31,5R,Advanced economies,
-1946-03-31,AE,United Arab Emirates,
-1946-03-31,AT,Austria,
-1946-03-31,AU,Australia,
-1946-03-31,BE,Belgium,
-1946-03-31,BG,Bulgaria,
-1946-03-31,BR,Brazil,
-1946-03-31,CA,Canada,
-1946-03-31,CH,Switzerland,
-1946-03-31,CL,Chile,
-1946-03-31,CN,China,
-1946-03-31,CO,Colombia,
-1946-03-31,CY,Cyprus,
-1946-03-31,CZ,Czechia,
-1946-03-31,DE,Germany,
-1946-03-31,DK,Denmark,
-1946-03-31,EE,Estonia,
-1946-03-31,ES,Spain,
-1946-03-31,FI,Finland,
-1946-03-31,FR,France,
-1946-03-31,GB,United Kingdom,
-1946-03-31,GR,Greece,
-1946-03-31,HK,Hong Kong SAR,
-1946-03-31,HR,Croatia,
-1946-03-31,HU,Hungary,
-1946-03-31,ID,Indonesia,
-1946-03-31,IE,Ireland,
-1946-03-31,IL,Israel,
-1946-03-31,IN,India,
-1946-03-31,IS,Iceland,
-1946-03-31,IT,Italy,
-1946-03-31,JP,Japan,
-1946-03-31,KR,Korea,
-1946-03-31,LT,Lithuania,
-1946-03-31,LU,Luxembourg,
-1946-03-31,LV,Latvia,
-1946-03-31,MA,Morocco,
-1946-03-31,MK,North Macedonia,
-1946-03-31,MT,Malta,
-1946-03-31,MX,Mexico,
-1946-03-31,MY,Malaysia,
-1946-03-31,NL,Netherlands,
-1946-03-31,NO,Norway,
-1946-03-31,NZ,New Zealand,
-1946-03-31,PE,Peru,
-1946-03-31,PH,Philippines,
-1946-03-31,PL,Poland,
-1946-03-31,PT,Portugal,
-1946-03-31,RO,Romania,
-1946-03-31,RS,Serbia,
-1946-03-31,RU,Russia,
-1946-03-31,SE,Sweden,
-1946-03-31,SG,Singapore,
-1946-03-31,SI,Slovenia,
-1946-03-31,SK,Slovak Republic,
-1946-03-31,TH,Thailand,
-1946-03-31,TR,Türkiye,
-1946-03-31,US,United States,
-1946-03-31,XM,Euro area,
-1946-03-31,XW,World,
-1946-03-31,ZA,South Africa,
-1946-06-30,4T,Emerging market economies (aggregate),
-1946-06-30,5R,Advanced economies,
-1946-06-30,AE,United Arab Emirates,
-1946-06-30,AT,Austria,
-1946-06-30,AU,Australia,
-1946-06-30,BE,Belgium,
-1946-06-30,BG,Bulgaria,
-1946-06-30,BR,Brazil,
-1946-06-30,CA,Canada,
-1946-06-30,CH,Switzerland,
-1946-06-30,CL,Chile,
-1946-06-30,CN,China,
-1946-06-30,CO,Colombia,
-1946-06-30,CY,Cyprus,
-1946-06-30,CZ,Czechia,
-1946-06-30,DE,Germany,
-1946-06-30,DK,Denmark,
-1946-06-30,EE,Estonia,
-1946-06-30,ES,Spain,
-1946-06-30,FI,Finland,
-1946-06-30,FR,France,
-1946-06-30,GB,United Kingdom,
-1946-06-30,GR,Greece,
-1946-06-30,HK,Hong Kong SAR,
-1946-06-30,HR,Croatia,
-1946-06-30,HU,Hungary,
-1946-06-30,ID,Indonesia,
-1946-06-30,IE,Ireland,
-1946-06-30,IL,Israel,
-1946-06-30,IN,India,
-1946-06-30,IS,Iceland,
-1946-06-30,IT,Italy,
-1946-06-30,JP,Japan,
-1946-06-30,KR,Korea,
-1946-06-30,LT,Lithuania,
-1946-06-30,LU,Luxembourg,
-1946-06-30,LV,Latvia,
-1946-06-30,MA,Morocco,
-1946-06-30,MK,North Macedonia,
-1946-06-30,MT,Malta,
-1946-06-30,MX,Mexico,
-1946-06-30,MY,Malaysia,
-1946-06-30,NL,Netherlands,
-1946-06-30,NO,Norway,
-1946-06-30,NZ,New Zealand,
-1946-06-30,PE,Peru,
-1946-06-30,PH,Philippines,
-1946-06-30,PL,Poland,
-1946-06-30,PT,Portugal,
-1946-06-30,RO,Romania,
-1946-06-30,RS,Serbia,
-1946-06-30,RU,Russia,
-1946-06-30,SE,Sweden,
-1946-06-30,SG,Singapore,
-1946-06-30,SI,Slovenia,
-1946-06-30,SK,Slovak Republic,
-1946-06-30,TH,Thailand,
-1946-06-30,TR,Türkiye,
-1946-06-30,US,United States,
-1946-06-30,XM,Euro area,
-1946-06-30,XW,World,
-1946-06-30,ZA,South Africa,
-1946-09-30,4T,Emerging market economies (aggregate),
-1946-09-30,5R,Advanced economies,
-1946-09-30,AE,United Arab Emirates,
-1946-09-30,AT,Austria,
-1946-09-30,AU,Australia,
-1946-09-30,BE,Belgium,
-1946-09-30,BG,Bulgaria,
-1946-09-30,BR,Brazil,
-1946-09-30,CA,Canada,
-1946-09-30,CH,Switzerland,
-1946-09-30,CL,Chile,
-1946-09-30,CN,China,
-1946-09-30,CO,Colombia,
-1946-09-30,CY,Cyprus,
-1946-09-30,CZ,Czechia,
-1946-09-30,DE,Germany,
-1946-09-30,DK,Denmark,
-1946-09-30,EE,Estonia,
-1946-09-30,ES,Spain,
-1946-09-30,FI,Finland,
-1946-09-30,FR,France,
-1946-09-30,GB,United Kingdom,
-1946-09-30,GR,Greece,
-1946-09-30,HK,Hong Kong SAR,
-1946-09-30,HR,Croatia,
-1946-09-30,HU,Hungary,
-1946-09-30,ID,Indonesia,
-1946-09-30,IE,Ireland,
-1946-09-30,IL,Israel,
-1946-09-30,IN,India,
-1946-09-30,IS,Iceland,
-1946-09-30,IT,Italy,
-1946-09-30,JP,Japan,
-1946-09-30,KR,Korea,
-1946-09-30,LT,Lithuania,
-1946-09-30,LU,Luxembourg,
-1946-09-30,LV,Latvia,
-1946-09-30,MA,Morocco,
-1946-09-30,MK,North Macedonia,
-1946-09-30,MT,Malta,
-1946-09-30,MX,Mexico,
-1946-09-30,MY,Malaysia,
-1946-09-30,NL,Netherlands,
-1946-09-30,NO,Norway,
-1946-09-30,NZ,New Zealand,
-1946-09-30,PE,Peru,
-1946-09-30,PH,Philippines,
-1946-09-30,PL,Poland,
-1946-09-30,PT,Portugal,
-1946-09-30,RO,Romania,
-1946-09-30,RS,Serbia,
-1946-09-30,RU,Russia,
-1946-09-30,SE,Sweden,
-1946-09-30,SG,Singapore,
-1946-09-30,SI,Slovenia,
-1946-09-30,SK,Slovak Republic,
-1946-09-30,TH,Thailand,
-1946-09-30,TR,Türkiye,
-1946-09-30,US,United States,
-1946-09-30,XM,Euro area,
-1946-09-30,XW,World,
-1946-09-30,ZA,South Africa,
-1946-12-31,4T,Emerging market economies (aggregate),
-1946-12-31,5R,Advanced economies,
-1946-12-31,AE,United Arab Emirates,
-1946-12-31,AT,Austria,
-1946-12-31,AU,Australia,
-1946-12-31,BE,Belgium,
-1946-12-31,BG,Bulgaria,
-1946-12-31,BR,Brazil,
-1946-12-31,CA,Canada,
-1946-12-31,CH,Switzerland,
-1946-12-31,CL,Chile,
-1946-12-31,CN,China,
-1946-12-31,CO,Colombia,
-1946-12-31,CY,Cyprus,
-1946-12-31,CZ,Czechia,
-1946-12-31,DE,Germany,
-1946-12-31,DK,Denmark,
-1946-12-31,EE,Estonia,
-1946-12-31,ES,Spain,
-1946-12-31,FI,Finland,
-1946-12-31,FR,France,
-1946-12-31,GB,United Kingdom,
-1946-12-31,GR,Greece,
-1946-12-31,HK,Hong Kong SAR,
-1946-12-31,HR,Croatia,
-1946-12-31,HU,Hungary,
-1946-12-31,ID,Indonesia,
-1946-12-31,IE,Ireland,
-1946-12-31,IL,Israel,
-1946-12-31,IN,India,
-1946-12-31,IS,Iceland,
-1946-12-31,IT,Italy,
-1946-12-31,JP,Japan,
-1946-12-31,KR,Korea,
-1946-12-31,LT,Lithuania,
-1946-12-31,LU,Luxembourg,
-1946-12-31,LV,Latvia,
-1946-12-31,MA,Morocco,
-1946-12-31,MK,North Macedonia,
-1946-12-31,MT,Malta,
-1946-12-31,MX,Mexico,
-1946-12-31,MY,Malaysia,
-1946-12-31,NL,Netherlands,
-1946-12-31,NO,Norway,
-1946-12-31,NZ,New Zealand,
-1946-12-31,PE,Peru,
-1946-12-31,PH,Philippines,
-1946-12-31,PL,Poland,
-1946-12-31,PT,Portugal,
-1946-12-31,RO,Romania,
-1946-12-31,RS,Serbia,
-1946-12-31,RU,Russia,
-1946-12-31,SE,Sweden,
-1946-12-31,SG,Singapore,
-1946-12-31,SI,Slovenia,
-1946-12-31,SK,Slovak Republic,
-1946-12-31,TH,Thailand,
-1946-12-31,TR,Türkiye,
-1946-12-31,US,United States,
-1946-12-31,XM,Euro area,
-1946-12-31,XW,World,
-1946-12-31,ZA,South Africa,
-1947-03-31,4T,Emerging market economies (aggregate),
-1947-03-31,5R,Advanced economies,
-1947-03-31,AE,United Arab Emirates,
-1947-03-31,AT,Austria,
-1947-03-31,AU,Australia,
-1947-03-31,BE,Belgium,
-1947-03-31,BG,Bulgaria,
-1947-03-31,BR,Brazil,
-1947-03-31,CA,Canada,
-1947-03-31,CH,Switzerland,
-1947-03-31,CL,Chile,
-1947-03-31,CN,China,
-1947-03-31,CO,Colombia,
-1947-03-31,CY,Cyprus,
-1947-03-31,CZ,Czechia,
-1947-03-31,DE,Germany,
-1947-03-31,DK,Denmark,
-1947-03-31,EE,Estonia,
-1947-03-31,ES,Spain,
-1947-03-31,FI,Finland,
-1947-03-31,FR,France,
-1947-03-31,GB,United Kingdom,
-1947-03-31,GR,Greece,
-1947-03-31,HK,Hong Kong SAR,
-1947-03-31,HR,Croatia,
-1947-03-31,HU,Hungary,
-1947-03-31,ID,Indonesia,
-1947-03-31,IE,Ireland,
-1947-03-31,IL,Israel,
-1947-03-31,IN,India,
-1947-03-31,IS,Iceland,
-1947-03-31,IT,Italy,34.2782
-1947-03-31,JP,Japan,
-1947-03-31,KR,Korea,
-1947-03-31,LT,Lithuania,
-1947-03-31,LU,Luxembourg,
-1947-03-31,LV,Latvia,
-1947-03-31,MA,Morocco,
-1947-03-31,MK,North Macedonia,
-1947-03-31,MT,Malta,
-1947-03-31,MX,Mexico,
-1947-03-31,MY,Malaysia,
-1947-03-31,NL,Netherlands,
-1947-03-31,NO,Norway,
-1947-03-31,NZ,New Zealand,
-1947-03-31,PE,Peru,
-1947-03-31,PH,Philippines,
-1947-03-31,PL,Poland,
-1947-03-31,PT,Portugal,
-1947-03-31,RO,Romania,
-1947-03-31,RS,Serbia,
-1947-03-31,RU,Russia,
-1947-03-31,SE,Sweden,
-1947-03-31,SG,Singapore,
-1947-03-31,SI,Slovenia,
-1947-03-31,SK,Slovak Republic,
-1947-03-31,TH,Thailand,
-1947-03-31,TR,Türkiye,
-1947-03-31,US,United States,
-1947-03-31,XM,Euro area,
-1947-03-31,XW,World,
-1947-03-31,ZA,South Africa,
-1947-06-30,4T,Emerging market economies (aggregate),
-1947-06-30,5R,Advanced economies,
-1947-06-30,AE,United Arab Emirates,
-1947-06-30,AT,Austria,
-1947-06-30,AU,Australia,
-1947-06-30,BE,Belgium,
-1947-06-30,BG,Bulgaria,
-1947-06-30,BR,Brazil,
-1947-06-30,CA,Canada,
-1947-06-30,CH,Switzerland,
-1947-06-30,CL,Chile,
-1947-06-30,CN,China,
-1947-06-30,CO,Colombia,
-1947-06-30,CY,Cyprus,
-1947-06-30,CZ,Czechia,
-1947-06-30,DE,Germany,
-1947-06-30,DK,Denmark,
-1947-06-30,EE,Estonia,
-1947-06-30,ES,Spain,
-1947-06-30,FI,Finland,
-1947-06-30,FR,France,
-1947-06-30,GB,United Kingdom,
-1947-06-30,GR,Greece,
-1947-06-30,HK,Hong Kong SAR,
-1947-06-30,HR,Croatia,
-1947-06-30,HU,Hungary,
-1947-06-30,ID,Indonesia,
-1947-06-30,IE,Ireland,
-1947-06-30,IL,Israel,
-1947-06-30,IN,India,
-1947-06-30,IS,Iceland,
-1947-06-30,IT,Italy,32.0206
-1947-06-30,JP,Japan,
-1947-06-30,KR,Korea,
-1947-06-30,LT,Lithuania,
-1947-06-30,LU,Luxembourg,
-1947-06-30,LV,Latvia,
-1947-06-30,MA,Morocco,
-1947-06-30,MK,North Macedonia,
-1947-06-30,MT,Malta,
-1947-06-30,MX,Mexico,
-1947-06-30,MY,Malaysia,
-1947-06-30,NL,Netherlands,
-1947-06-30,NO,Norway,
-1947-06-30,NZ,New Zealand,
-1947-06-30,PE,Peru,
-1947-06-30,PH,Philippines,
-1947-06-30,PL,Poland,
-1947-06-30,PT,Portugal,
-1947-06-30,RO,Romania,
-1947-06-30,RS,Serbia,
-1947-06-30,RU,Russia,
-1947-06-30,SE,Sweden,
-1947-06-30,SG,Singapore,
-1947-06-30,SI,Slovenia,
-1947-06-30,SK,Slovak Republic,
-1947-06-30,TH,Thailand,
-1947-06-30,TR,Türkiye,
-1947-06-30,US,United States,
-1947-06-30,XM,Euro area,
-1947-06-30,XW,World,
-1947-06-30,ZA,South Africa,
-1947-09-30,4T,Emerging market economies (aggregate),
-1947-09-30,5R,Advanced economies,
-1947-09-30,AE,United Arab Emirates,
-1947-09-30,AT,Austria,
-1947-09-30,AU,Australia,
-1947-09-30,BE,Belgium,
-1947-09-30,BG,Bulgaria,
-1947-09-30,BR,Brazil,
-1947-09-30,CA,Canada,
-1947-09-30,CH,Switzerland,
-1947-09-30,CL,Chile,
-1947-09-30,CN,China,
-1947-09-30,CO,Colombia,
-1947-09-30,CY,Cyprus,
-1947-09-30,CZ,Czechia,
-1947-09-30,DE,Germany,
-1947-09-30,DK,Denmark,
-1947-09-30,EE,Estonia,
-1947-09-30,ES,Spain,
-1947-09-30,FI,Finland,
-1947-09-30,FR,France,
-1947-09-30,GB,United Kingdom,
-1947-09-30,GR,Greece,
-1947-09-30,HK,Hong Kong SAR,
-1947-09-30,HR,Croatia,
-1947-09-30,HU,Hungary,
-1947-09-30,ID,Indonesia,
-1947-09-30,IE,Ireland,
-1947-09-30,IL,Israel,
-1947-09-30,IN,India,
-1947-09-30,IS,Iceland,
-1947-09-30,IT,Italy,29.861
-1947-09-30,JP,Japan,
-1947-09-30,KR,Korea,
-1947-09-30,LT,Lithuania,
-1947-09-30,LU,Luxembourg,
-1947-09-30,LV,Latvia,
-1947-09-30,MA,Morocco,
-1947-09-30,MK,North Macedonia,
-1947-09-30,MT,Malta,
-1947-09-30,MX,Mexico,
-1947-09-30,MY,Malaysia,
-1947-09-30,NL,Netherlands,
-1947-09-30,NO,Norway,
-1947-09-30,NZ,New Zealand,
-1947-09-30,PE,Peru,
-1947-09-30,PH,Philippines,
-1947-09-30,PL,Poland,
-1947-09-30,PT,Portugal,
-1947-09-30,RO,Romania,
-1947-09-30,RS,Serbia,
-1947-09-30,RU,Russia,
-1947-09-30,SE,Sweden,
-1947-09-30,SG,Singapore,
-1947-09-30,SI,Slovenia,
-1947-09-30,SK,Slovak Republic,
-1947-09-30,TH,Thailand,
-1947-09-30,TR,Türkiye,
-1947-09-30,US,United States,
-1947-09-30,XM,Euro area,
-1947-09-30,XW,World,
-1947-09-30,ZA,South Africa,
-1947-12-31,4T,Emerging market economies (aggregate),
-1947-12-31,5R,Advanced economies,
-1947-12-31,AE,United Arab Emirates,
-1947-12-31,AT,Austria,
-1947-12-31,AU,Australia,
-1947-12-31,BE,Belgium,
-1947-12-31,BG,Bulgaria,
-1947-12-31,BR,Brazil,
-1947-12-31,CA,Canada,
-1947-12-31,CH,Switzerland,
-1947-12-31,CL,Chile,
-1947-12-31,CN,China,
-1947-12-31,CO,Colombia,
-1947-12-31,CY,Cyprus,
-1947-12-31,CZ,Czechia,
-1947-12-31,DE,Germany,
-1947-12-31,DK,Denmark,
-1947-12-31,EE,Estonia,
-1947-12-31,ES,Spain,
-1947-12-31,FI,Finland,
-1947-12-31,FR,France,
-1947-12-31,GB,United Kingdom,
-1947-12-31,GR,Greece,
-1947-12-31,HK,Hong Kong SAR,
-1947-12-31,HR,Croatia,
-1947-12-31,HU,Hungary,
-1947-12-31,ID,Indonesia,
-1947-12-31,IE,Ireland,
-1947-12-31,IL,Israel,
-1947-12-31,IN,India,
-1947-12-31,IS,Iceland,
-1947-12-31,IT,Italy,31.1537
-1947-12-31,JP,Japan,
-1947-12-31,KR,Korea,
-1947-12-31,LT,Lithuania,
-1947-12-31,LU,Luxembourg,
-1947-12-31,LV,Latvia,
-1947-12-31,MA,Morocco,
-1947-12-31,MK,North Macedonia,
-1947-12-31,MT,Malta,
-1947-12-31,MX,Mexico,
-1947-12-31,MY,Malaysia,
-1947-12-31,NL,Netherlands,
-1947-12-31,NO,Norway,
-1947-12-31,NZ,New Zealand,
-1947-12-31,PE,Peru,
-1947-12-31,PH,Philippines,
-1947-12-31,PL,Poland,
-1947-12-31,PT,Portugal,
-1947-12-31,RO,Romania,
-1947-12-31,RS,Serbia,
-1947-12-31,RU,Russia,
-1947-12-31,SE,Sweden,
-1947-12-31,SG,Singapore,
-1947-12-31,SI,Slovenia,
-1947-12-31,SK,Slovak Republic,
-1947-12-31,TH,Thailand,
-1947-12-31,TR,Türkiye,
-1947-12-31,US,United States,
-1947-12-31,XM,Euro area,
-1947-12-31,XW,World,
-1947-12-31,ZA,South Africa,
-1948-03-31,4T,Emerging market economies (aggregate),
-1948-03-31,5R,Advanced economies,
-1948-03-31,AE,United Arab Emirates,
-1948-03-31,AT,Austria,
-1948-03-31,AU,Australia,
-1948-03-31,BE,Belgium,
-1948-03-31,BG,Bulgaria,
-1948-03-31,BR,Brazil,
-1948-03-31,CA,Canada,
-1948-03-31,CH,Switzerland,
-1948-03-31,CL,Chile,
-1948-03-31,CN,China,
-1948-03-31,CO,Colombia,
-1948-03-31,CY,Cyprus,
-1948-03-31,CZ,Czechia,
-1948-03-31,DE,Germany,
-1948-03-31,DK,Denmark,
-1948-03-31,EE,Estonia,
-1948-03-31,ES,Spain,
-1948-03-31,FI,Finland,
-1948-03-31,FR,France,
-1948-03-31,GB,United Kingdom,
-1948-03-31,GR,Greece,
-1948-03-31,HK,Hong Kong SAR,
-1948-03-31,HR,Croatia,
-1948-03-31,HU,Hungary,
-1948-03-31,ID,Indonesia,
-1948-03-31,IE,Ireland,
-1948-03-31,IL,Israel,
-1948-03-31,IN,India,
-1948-03-31,IS,Iceland,
-1948-03-31,IT,Italy,36.0605
-1948-03-31,JP,Japan,
-1948-03-31,KR,Korea,
-1948-03-31,LT,Lithuania,
-1948-03-31,LU,Luxembourg,
-1948-03-31,LV,Latvia,
-1948-03-31,MA,Morocco,
-1948-03-31,MK,North Macedonia,
-1948-03-31,MT,Malta,
-1948-03-31,MX,Mexico,
-1948-03-31,MY,Malaysia,
-1948-03-31,NL,Netherlands,
-1948-03-31,NO,Norway,
-1948-03-31,NZ,New Zealand,
-1948-03-31,PE,Peru,
-1948-03-31,PH,Philippines,
-1948-03-31,PL,Poland,
-1948-03-31,PT,Portugal,
-1948-03-31,RO,Romania,
-1948-03-31,RS,Serbia,
-1948-03-31,RU,Russia,
-1948-03-31,SE,Sweden,
-1948-03-31,SG,Singapore,
-1948-03-31,SI,Slovenia,
-1948-03-31,SK,Slovak Republic,
-1948-03-31,TH,Thailand,
-1948-03-31,TR,Türkiye,
-1948-03-31,US,United States,
-1948-03-31,XM,Euro area,
-1948-03-31,XW,World,
-1948-03-31,ZA,South Africa,
-1948-06-30,4T,Emerging market economies (aggregate),
-1948-06-30,5R,Advanced economies,
-1948-06-30,AE,United Arab Emirates,
-1948-06-30,AT,Austria,
-1948-06-30,AU,Australia,
-1948-06-30,BE,Belgium,
-1948-06-30,BG,Bulgaria,
-1948-06-30,BR,Brazil,
-1948-06-30,CA,Canada,
-1948-06-30,CH,Switzerland,
-1948-06-30,CL,Chile,
-1948-06-30,CN,China,
-1948-06-30,CO,Colombia,
-1948-06-30,CY,Cyprus,
-1948-06-30,CZ,Czechia,
-1948-06-30,DE,Germany,
-1948-06-30,DK,Denmark,
-1948-06-30,EE,Estonia,
-1948-06-30,ES,Spain,
-1948-06-30,FI,Finland,
-1948-06-30,FR,France,
-1948-06-30,GB,United Kingdom,
-1948-06-30,GR,Greece,
-1948-06-30,HK,Hong Kong SAR,
-1948-06-30,HR,Croatia,
-1948-06-30,HU,Hungary,
-1948-06-30,ID,Indonesia,
-1948-06-30,IE,Ireland,
-1948-06-30,IL,Israel,
-1948-06-30,IN,India,
-1948-06-30,IS,Iceland,
-1948-06-30,IT,Italy,36.8426
-1948-06-30,JP,Japan,
-1948-06-30,KR,Korea,
-1948-06-30,LT,Lithuania,
-1948-06-30,LU,Luxembourg,
-1948-06-30,LV,Latvia,
-1948-06-30,MA,Morocco,
-1948-06-30,MK,North Macedonia,
-1948-06-30,MT,Malta,
-1948-06-30,MX,Mexico,
-1948-06-30,MY,Malaysia,
-1948-06-30,NL,Netherlands,
-1948-06-30,NO,Norway,
-1948-06-30,NZ,New Zealand,
-1948-06-30,PE,Peru,
-1948-06-30,PH,Philippines,
-1948-06-30,PL,Poland,
-1948-06-30,PT,Portugal,
-1948-06-30,RO,Romania,
-1948-06-30,RS,Serbia,
-1948-06-30,RU,Russia,
-1948-06-30,SE,Sweden,
-1948-06-30,SG,Singapore,
-1948-06-30,SI,Slovenia,
-1948-06-30,SK,Slovak Republic,
-1948-06-30,TH,Thailand,
-1948-06-30,TR,Türkiye,
-1948-06-30,US,United States,
-1948-06-30,XM,Euro area,
-1948-06-30,XW,World,
-1948-06-30,ZA,South Africa,
-1948-09-30,4T,Emerging market economies (aggregate),
-1948-09-30,5R,Advanced economies,
-1948-09-30,AE,United Arab Emirates,
-1948-09-30,AT,Austria,
-1948-09-30,AU,Australia,
-1948-09-30,BE,Belgium,
-1948-09-30,BG,Bulgaria,
-1948-09-30,BR,Brazil,
-1948-09-30,CA,Canada,
-1948-09-30,CH,Switzerland,
-1948-09-30,CL,Chile,
-1948-09-30,CN,China,
-1948-09-30,CO,Colombia,
-1948-09-30,CY,Cyprus,
-1948-09-30,CZ,Czechia,
-1948-09-30,DE,Germany,
-1948-09-30,DK,Denmark,
-1948-09-30,EE,Estonia,
-1948-09-30,ES,Spain,
-1948-09-30,FI,Finland,
-1948-09-30,FR,France,
-1948-09-30,GB,United Kingdom,
-1948-09-30,GR,Greece,
-1948-09-30,HK,Hong Kong SAR,
-1948-09-30,HR,Croatia,
-1948-09-30,HU,Hungary,
-1948-09-30,ID,Indonesia,
-1948-09-30,IE,Ireland,
-1948-09-30,IL,Israel,
-1948-09-30,IN,India,
-1948-09-30,IS,Iceland,
-1948-09-30,IT,Italy,34.9951
-1948-09-30,JP,Japan,
-1948-09-30,KR,Korea,
-1948-09-30,LT,Lithuania,
-1948-09-30,LU,Luxembourg,
-1948-09-30,LV,Latvia,
-1948-09-30,MA,Morocco,
-1948-09-30,MK,North Macedonia,
-1948-09-30,MT,Malta,
-1948-09-30,MX,Mexico,
-1948-09-30,MY,Malaysia,
-1948-09-30,NL,Netherlands,
-1948-09-30,NO,Norway,
-1948-09-30,NZ,New Zealand,
-1948-09-30,PE,Peru,
-1948-09-30,PH,Philippines,
-1948-09-30,PL,Poland,
-1948-09-30,PT,Portugal,
-1948-09-30,RO,Romania,
-1948-09-30,RS,Serbia,
-1948-09-30,RU,Russia,
-1948-09-30,SE,Sweden,
-1948-09-30,SG,Singapore,
-1948-09-30,SI,Slovenia,
-1948-09-30,SK,Slovak Republic,
-1948-09-30,TH,Thailand,
-1948-09-30,TR,Türkiye,
-1948-09-30,US,United States,
-1948-09-30,XM,Euro area,
-1948-09-30,XW,World,
-1948-09-30,ZA,South Africa,
-1948-12-31,4T,Emerging market economies (aggregate),
-1948-12-31,5R,Advanced economies,
-1948-12-31,AE,United Arab Emirates,
-1948-12-31,AT,Austria,
-1948-12-31,AU,Australia,
-1948-12-31,BE,Belgium,
-1948-12-31,BG,Bulgaria,
-1948-12-31,BR,Brazil,
-1948-12-31,CA,Canada,
-1948-12-31,CH,Switzerland,
-1948-12-31,CL,Chile,
-1948-12-31,CN,China,
-1948-12-31,CO,Colombia,
-1948-12-31,CY,Cyprus,
-1948-12-31,CZ,Czechia,
-1948-12-31,DE,Germany,
-1948-12-31,DK,Denmark,
-1948-12-31,EE,Estonia,
-1948-12-31,ES,Spain,
-1948-12-31,FI,Finland,
-1948-12-31,FR,France,
-1948-12-31,GB,United Kingdom,
-1948-12-31,GR,Greece,
-1948-12-31,HK,Hong Kong SAR,
-1948-12-31,HR,Croatia,
-1948-12-31,HU,Hungary,
-1948-12-31,ID,Indonesia,
-1948-12-31,IE,Ireland,
-1948-12-31,IL,Israel,
-1948-12-31,IN,India,
-1948-12-31,IS,Iceland,
-1948-12-31,IT,Italy,35.2351
-1948-12-31,JP,Japan,
-1948-12-31,KR,Korea,
-1948-12-31,LT,Lithuania,
-1948-12-31,LU,Luxembourg,
-1948-12-31,LV,Latvia,
-1948-12-31,MA,Morocco,
-1948-12-31,MK,North Macedonia,
-1948-12-31,MT,Malta,
-1948-12-31,MX,Mexico,
-1948-12-31,MY,Malaysia,
-1948-12-31,NL,Netherlands,
-1948-12-31,NO,Norway,
-1948-12-31,NZ,New Zealand,
-1948-12-31,PE,Peru,
-1948-12-31,PH,Philippines,
-1948-12-31,PL,Poland,
-1948-12-31,PT,Portugal,
-1948-12-31,RO,Romania,
-1948-12-31,RS,Serbia,
-1948-12-31,RU,Russia,
-1948-12-31,SE,Sweden,
-1948-12-31,SG,Singapore,
-1948-12-31,SI,Slovenia,
-1948-12-31,SK,Slovak Republic,
-1948-12-31,TH,Thailand,
-1948-12-31,TR,Türkiye,
-1948-12-31,US,United States,
-1948-12-31,XM,Euro area,
-1948-12-31,XW,World,
-1948-12-31,ZA,South Africa,
-1949-03-31,4T,Emerging market economies (aggregate),
-1949-03-31,5R,Advanced economies,
-1949-03-31,AE,United Arab Emirates,
-1949-03-31,AT,Austria,
-1949-03-31,AU,Australia,
-1949-03-31,BE,Belgium,
-1949-03-31,BG,Bulgaria,
-1949-03-31,BR,Brazil,
-1949-03-31,CA,Canada,
-1949-03-31,CH,Switzerland,
-1949-03-31,CL,Chile,
-1949-03-31,CN,China,
-1949-03-31,CO,Colombia,
-1949-03-31,CY,Cyprus,
-1949-03-31,CZ,Czechia,
-1949-03-31,DE,Germany,
-1949-03-31,DK,Denmark,
-1949-03-31,EE,Estonia,
-1949-03-31,ES,Spain,
-1949-03-31,FI,Finland,
-1949-03-31,FR,France,
-1949-03-31,GB,United Kingdom,
-1949-03-31,GR,Greece,
-1949-03-31,HK,Hong Kong SAR,
-1949-03-31,HR,Croatia,
-1949-03-31,HU,Hungary,
-1949-03-31,ID,Indonesia,
-1949-03-31,IE,Ireland,
-1949-03-31,IL,Israel,
-1949-03-31,IN,India,
-1949-03-31,IS,Iceland,
-1949-03-31,IT,Italy,35.404
-1949-03-31,JP,Japan,
-1949-03-31,KR,Korea,
-1949-03-31,LT,Lithuania,
-1949-03-31,LU,Luxembourg,
-1949-03-31,LV,Latvia,
-1949-03-31,MA,Morocco,
-1949-03-31,MK,North Macedonia,
-1949-03-31,MT,Malta,
-1949-03-31,MX,Mexico,
-1949-03-31,MY,Malaysia,
-1949-03-31,NL,Netherlands,
-1949-03-31,NO,Norway,
-1949-03-31,NZ,New Zealand,
-1949-03-31,PE,Peru,
-1949-03-31,PH,Philippines,
-1949-03-31,PL,Poland,
-1949-03-31,PT,Portugal,
-1949-03-31,RO,Romania,
-1949-03-31,RS,Serbia,
-1949-03-31,RU,Russia,
-1949-03-31,SE,Sweden,
-1949-03-31,SG,Singapore,
-1949-03-31,SI,Slovenia,
-1949-03-31,SK,Slovak Republic,
-1949-03-31,TH,Thailand,
-1949-03-31,TR,Türkiye,
-1949-03-31,US,United States,
-1949-03-31,XM,Euro area,
-1949-03-31,XW,World,
-1949-03-31,ZA,South Africa,
-1949-06-30,4T,Emerging market economies (aggregate),
-1949-06-30,5R,Advanced economies,
-1949-06-30,AE,United Arab Emirates,
-1949-06-30,AT,Austria,
-1949-06-30,AU,Australia,
-1949-06-30,BE,Belgium,
-1949-06-30,BG,Bulgaria,
-1949-06-30,BR,Brazil,
-1949-06-30,CA,Canada,
-1949-06-30,CH,Switzerland,
-1949-06-30,CL,Chile,
-1949-06-30,CN,China,
-1949-06-30,CO,Colombia,
-1949-06-30,CY,Cyprus,
-1949-06-30,CZ,Czechia,
-1949-06-30,DE,Germany,
-1949-06-30,DK,Denmark,
-1949-06-30,EE,Estonia,
-1949-06-30,ES,Spain,
-1949-06-30,FI,Finland,
-1949-06-30,FR,France,
-1949-06-30,GB,United Kingdom,
-1949-06-30,GR,Greece,
-1949-06-30,HK,Hong Kong SAR,
-1949-06-30,HR,Croatia,
-1949-06-30,HU,Hungary,
-1949-06-30,ID,Indonesia,
-1949-06-30,IE,Ireland,
-1949-06-30,IL,Israel,
-1949-06-30,IN,India,
-1949-06-30,IS,Iceland,
-1949-06-30,IT,Italy,35.072
-1949-06-30,JP,Japan,
-1949-06-30,KR,Korea,
-1949-06-30,LT,Lithuania,
-1949-06-30,LU,Luxembourg,
-1949-06-30,LV,Latvia,
-1949-06-30,MA,Morocco,
-1949-06-30,MK,North Macedonia,
-1949-06-30,MT,Malta,
-1949-06-30,MX,Mexico,
-1949-06-30,MY,Malaysia,
-1949-06-30,NL,Netherlands,
-1949-06-30,NO,Norway,
-1949-06-30,NZ,New Zealand,
-1949-06-30,PE,Peru,
-1949-06-30,PH,Philippines,
-1949-06-30,PL,Poland,
-1949-06-30,PT,Portugal,
-1949-06-30,RO,Romania,
-1949-06-30,RS,Serbia,
-1949-06-30,RU,Russia,
-1949-06-30,SE,Sweden,
-1949-06-30,SG,Singapore,
-1949-06-30,SI,Slovenia,
-1949-06-30,SK,Slovak Republic,
-1949-06-30,TH,Thailand,
-1949-06-30,TR,Türkiye,
-1949-06-30,US,United States,
-1949-06-30,XM,Euro area,
-1949-06-30,XW,World,
-1949-06-30,ZA,South Africa,
-1949-09-30,4T,Emerging market economies (aggregate),
-1949-09-30,5R,Advanced economies,
-1949-09-30,AE,United Arab Emirates,
-1949-09-30,AT,Austria,
-1949-09-30,AU,Australia,
-1949-09-30,BE,Belgium,
-1949-09-30,BG,Bulgaria,
-1949-09-30,BR,Brazil,
-1949-09-30,CA,Canada,
-1949-09-30,CH,Switzerland,
-1949-09-30,CL,Chile,
-1949-09-30,CN,China,
-1949-09-30,CO,Colombia,
-1949-09-30,CY,Cyprus,
-1949-09-30,CZ,Czechia,
-1949-09-30,DE,Germany,
-1949-09-30,DK,Denmark,
-1949-09-30,EE,Estonia,
-1949-09-30,ES,Spain,
-1949-09-30,FI,Finland,
-1949-09-30,FR,France,
-1949-09-30,GB,United Kingdom,
-1949-09-30,GR,Greece,
-1949-09-30,HK,Hong Kong SAR,
-1949-09-30,HR,Croatia,
-1949-09-30,HU,Hungary,
-1949-09-30,ID,Indonesia,
-1949-09-30,IE,Ireland,
-1949-09-30,IL,Israel,
-1949-09-30,IN,India,
-1949-09-30,IS,Iceland,
-1949-09-30,IT,Italy,33.1123
-1949-09-30,JP,Japan,
-1949-09-30,KR,Korea,
-1949-09-30,LT,Lithuania,
-1949-09-30,LU,Luxembourg,
-1949-09-30,LV,Latvia,
-1949-09-30,MA,Morocco,
-1949-09-30,MK,North Macedonia,
-1949-09-30,MT,Malta,
-1949-09-30,MX,Mexico,
-1949-09-30,MY,Malaysia,
-1949-09-30,NL,Netherlands,
-1949-09-30,NO,Norway,
-1949-09-30,NZ,New Zealand,
-1949-09-30,PE,Peru,
-1949-09-30,PH,Philippines,
-1949-09-30,PL,Poland,
-1949-09-30,PT,Portugal,
-1949-09-30,RO,Romania,
-1949-09-30,RS,Serbia,
-1949-09-30,RU,Russia,
-1949-09-30,SE,Sweden,
-1949-09-30,SG,Singapore,
-1949-09-30,SI,Slovenia,
-1949-09-30,SK,Slovak Republic,
-1949-09-30,TH,Thailand,
-1949-09-30,TR,Türkiye,
-1949-09-30,US,United States,
-1949-09-30,XM,Euro area,
-1949-09-30,XW,World,
-1949-09-30,ZA,South Africa,
-1949-12-31,4T,Emerging market economies (aggregate),
-1949-12-31,5R,Advanced economies,
-1949-12-31,AE,United Arab Emirates,
-1949-12-31,AT,Austria,
-1949-12-31,AU,Australia,
-1949-12-31,BE,Belgium,
-1949-12-31,BG,Bulgaria,
-1949-12-31,BR,Brazil,
-1949-12-31,CA,Canada,
-1949-12-31,CH,Switzerland,
-1949-12-31,CL,Chile,
-1949-12-31,CN,China,
-1949-12-31,CO,Colombia,
-1949-12-31,CY,Cyprus,
-1949-12-31,CZ,Czechia,
-1949-12-31,DE,Germany,
-1949-12-31,DK,Denmark,
-1949-12-31,EE,Estonia,
-1949-12-31,ES,Spain,
-1949-12-31,FI,Finland,
-1949-12-31,FR,France,
-1949-12-31,GB,United Kingdom,
-1949-12-31,GR,Greece,
-1949-12-31,HK,Hong Kong SAR,
-1949-12-31,HR,Croatia,
-1949-12-31,HU,Hungary,
-1949-12-31,ID,Indonesia,
-1949-12-31,IE,Ireland,
-1949-12-31,IL,Israel,
-1949-12-31,IN,India,
-1949-12-31,IS,Iceland,
-1949-12-31,IT,Italy,32.5878
-1949-12-31,JP,Japan,
-1949-12-31,KR,Korea,
-1949-12-31,LT,Lithuania,
-1949-12-31,LU,Luxembourg,
-1949-12-31,LV,Latvia,
-1949-12-31,MA,Morocco,
-1949-12-31,MK,North Macedonia,
-1949-12-31,MT,Malta,
-1949-12-31,MX,Mexico,
-1949-12-31,MY,Malaysia,
-1949-12-31,NL,Netherlands,
-1949-12-31,NO,Norway,
-1949-12-31,NZ,New Zealand,
-1949-12-31,PE,Peru,
-1949-12-31,PH,Philippines,
-1949-12-31,PL,Poland,
-1949-12-31,PT,Portugal,
-1949-12-31,RO,Romania,
-1949-12-31,RS,Serbia,
-1949-12-31,RU,Russia,
-1949-12-31,SE,Sweden,
-1949-12-31,SG,Singapore,
-1949-12-31,SI,Slovenia,
-1949-12-31,SK,Slovak Republic,
-1949-12-31,TH,Thailand,
-1949-12-31,TR,Türkiye,
-1949-12-31,US,United States,
-1949-12-31,XM,Euro area,
-1949-12-31,XW,World,
-1949-12-31,ZA,South Africa,
-1950-03-31,4T,Emerging market economies (aggregate),
-1950-03-31,5R,Advanced economies,
-1950-03-31,AE,United Arab Emirates,
-1950-03-31,AT,Austria,
-1950-03-31,AU,Australia,
-1950-03-31,BE,Belgium,
-1950-03-31,BG,Bulgaria,
-1950-03-31,BR,Brazil,
-1950-03-31,CA,Canada,
-1950-03-31,CH,Switzerland,
-1950-03-31,CL,Chile,
-1950-03-31,CN,China,
-1950-03-31,CO,Colombia,
-1950-03-31,CY,Cyprus,
-1950-03-31,CZ,Czechia,
-1950-03-31,DE,Germany,
-1950-03-31,DK,Denmark,
-1950-03-31,EE,Estonia,
-1950-03-31,ES,Spain,
-1950-03-31,FI,Finland,
-1950-03-31,FR,France,
-1950-03-31,GB,United Kingdom,
-1950-03-31,GR,Greece,
-1950-03-31,HK,Hong Kong SAR,
-1950-03-31,HR,Croatia,
-1950-03-31,HU,Hungary,
-1950-03-31,ID,Indonesia,
-1950-03-31,IE,Ireland,
-1950-03-31,IL,Israel,
-1950-03-31,IN,India,
-1950-03-31,IS,Iceland,
-1950-03-31,IT,Italy,32.8344
-1950-03-31,JP,Japan,
-1950-03-31,KR,Korea,
-1950-03-31,LT,Lithuania,
-1950-03-31,LU,Luxembourg,
-1950-03-31,LV,Latvia,
-1950-03-31,MA,Morocco,
-1950-03-31,MK,North Macedonia,
-1950-03-31,MT,Malta,
-1950-03-31,MX,Mexico,
-1950-03-31,MY,Malaysia,
-1950-03-31,NL,Netherlands,
-1950-03-31,NO,Norway,
-1950-03-31,NZ,New Zealand,
-1950-03-31,PE,Peru,
-1950-03-31,PH,Philippines,
-1950-03-31,PL,Poland,
-1950-03-31,PT,Portugal,
-1950-03-31,RO,Romania,
-1950-03-31,RS,Serbia,
-1950-03-31,RU,Russia,
-1950-03-31,SE,Sweden,
-1950-03-31,SG,Singapore,
-1950-03-31,SI,Slovenia,
-1950-03-31,SK,Slovak Republic,
-1950-03-31,TH,Thailand,
-1950-03-31,TR,Türkiye,
-1950-03-31,US,United States,
-1950-03-31,XM,Euro area,
-1950-03-31,XW,World,
-1950-03-31,ZA,South Africa,
-1950-06-30,4T,Emerging market economies (aggregate),
-1950-06-30,5R,Advanced economies,
-1950-06-30,AE,United Arab Emirates,
-1950-06-30,AT,Austria,
-1950-06-30,AU,Australia,
-1950-06-30,BE,Belgium,
-1950-06-30,BG,Bulgaria,
-1950-06-30,BR,Brazil,
-1950-06-30,CA,Canada,
-1950-06-30,CH,Switzerland,
-1950-06-30,CL,Chile,
-1950-06-30,CN,China,
-1950-06-30,CO,Colombia,
-1950-06-30,CY,Cyprus,
-1950-06-30,CZ,Czechia,
-1950-06-30,DE,Germany,
-1950-06-30,DK,Denmark,
-1950-06-30,EE,Estonia,
-1950-06-30,ES,Spain,
-1950-06-30,FI,Finland,
-1950-06-30,FR,France,
-1950-06-30,GB,United Kingdom,
-1950-06-30,GR,Greece,
-1950-06-30,HK,Hong Kong SAR,
-1950-06-30,HR,Croatia,
-1950-06-30,HU,Hungary,
-1950-06-30,ID,Indonesia,
-1950-06-30,IE,Ireland,
-1950-06-30,IL,Israel,
-1950-06-30,IN,India,
-1950-06-30,IS,Iceland,
-1950-06-30,IT,Italy,34.5702
-1950-06-30,JP,Japan,
-1950-06-30,KR,Korea,
-1950-06-30,LT,Lithuania,
-1950-06-30,LU,Luxembourg,
-1950-06-30,LV,Latvia,
-1950-06-30,MA,Morocco,
-1950-06-30,MK,North Macedonia,
-1950-06-30,MT,Malta,
-1950-06-30,MX,Mexico,
-1950-06-30,MY,Malaysia,
-1950-06-30,NL,Netherlands,
-1950-06-30,NO,Norway,
-1950-06-30,NZ,New Zealand,
-1950-06-30,PE,Peru,
-1950-06-30,PH,Philippines,
-1950-06-30,PL,Poland,
-1950-06-30,PT,Portugal,
-1950-06-30,RO,Romania,
-1950-06-30,RS,Serbia,
-1950-06-30,RU,Russia,
-1950-06-30,SE,Sweden,
-1950-06-30,SG,Singapore,
-1950-06-30,SI,Slovenia,
-1950-06-30,SK,Slovak Republic,
-1950-06-30,TH,Thailand,
-1950-06-30,TR,Türkiye,
-1950-06-30,US,United States,
-1950-06-30,XM,Euro area,
-1950-06-30,XW,World,
-1950-06-30,ZA,South Africa,
-1950-09-30,4T,Emerging market economies (aggregate),
-1950-09-30,5R,Advanced economies,
-1950-09-30,AE,United Arab Emirates,
-1950-09-30,AT,Austria,
-1950-09-30,AU,Australia,
-1950-09-30,BE,Belgium,
-1950-09-30,BG,Bulgaria,
-1950-09-30,BR,Brazil,
-1950-09-30,CA,Canada,
-1950-09-30,CH,Switzerland,
-1950-09-30,CL,Chile,
-1950-09-30,CN,China,
-1950-09-30,CO,Colombia,
-1950-09-30,CY,Cyprus,
-1950-09-30,CZ,Czechia,
-1950-09-30,DE,Germany,
-1950-09-30,DK,Denmark,
-1950-09-30,EE,Estonia,
-1950-09-30,ES,Spain,
-1950-09-30,FI,Finland,
-1950-09-30,FR,France,
-1950-09-30,GB,United Kingdom,
-1950-09-30,GR,Greece,
-1950-09-30,HK,Hong Kong SAR,
-1950-09-30,HR,Croatia,
-1950-09-30,HU,Hungary,
-1950-09-30,ID,Indonesia,
-1950-09-30,IE,Ireland,
-1950-09-30,IL,Israel,
-1950-09-30,IN,India,
-1950-09-30,IS,Iceland,
-1950-09-30,IT,Italy,36.2324
-1950-09-30,JP,Japan,
-1950-09-30,KR,Korea,
-1950-09-30,LT,Lithuania,
-1950-09-30,LU,Luxembourg,
-1950-09-30,LV,Latvia,
-1950-09-30,MA,Morocco,
-1950-09-30,MK,North Macedonia,
-1950-09-30,MT,Malta,
-1950-09-30,MX,Mexico,
-1950-09-30,MY,Malaysia,
-1950-09-30,NL,Netherlands,
-1950-09-30,NO,Norway,
-1950-09-30,NZ,New Zealand,
-1950-09-30,PE,Peru,
-1950-09-30,PH,Philippines,
-1950-09-30,PL,Poland,
-1950-09-30,PT,Portugal,
-1950-09-30,RO,Romania,
-1950-09-30,RS,Serbia,
-1950-09-30,RU,Russia,
-1950-09-30,SE,Sweden,
-1950-09-30,SG,Singapore,
-1950-09-30,SI,Slovenia,
-1950-09-30,SK,Slovak Republic,
-1950-09-30,TH,Thailand,
-1950-09-30,TR,Türkiye,
-1950-09-30,US,United States,
-1950-09-30,XM,Euro area,
-1950-09-30,XW,World,
-1950-09-30,ZA,South Africa,
-1950-12-31,4T,Emerging market economies (aggregate),
-1950-12-31,5R,Advanced economies,
-1950-12-31,AE,United Arab Emirates,
-1950-12-31,AT,Austria,
-1950-12-31,AU,Australia,
-1950-12-31,BE,Belgium,
-1950-12-31,BG,Bulgaria,
-1950-12-31,BR,Brazil,
-1950-12-31,CA,Canada,
-1950-12-31,CH,Switzerland,
-1950-12-31,CL,Chile,
-1950-12-31,CN,China,
-1950-12-31,CO,Colombia,
-1950-12-31,CY,Cyprus,
-1950-12-31,CZ,Czechia,
-1950-12-31,DE,Germany,
-1950-12-31,DK,Denmark,
-1950-12-31,EE,Estonia,
-1950-12-31,ES,Spain,
-1950-12-31,FI,Finland,
-1950-12-31,FR,France,
-1950-12-31,GB,United Kingdom,
-1950-12-31,GR,Greece,
-1950-12-31,HK,Hong Kong SAR,
-1950-12-31,HR,Croatia,
-1950-12-31,HU,Hungary,
-1950-12-31,ID,Indonesia,
-1950-12-31,IE,Ireland,
-1950-12-31,IL,Israel,
-1950-12-31,IN,India,
-1950-12-31,IS,Iceland,
-1950-12-31,IT,Italy,36.2328
-1950-12-31,JP,Japan,
-1950-12-31,KR,Korea,
-1950-12-31,LT,Lithuania,
-1950-12-31,LU,Luxembourg,
-1950-12-31,LV,Latvia,
-1950-12-31,MA,Morocco,
-1950-12-31,MK,North Macedonia,
-1950-12-31,MT,Malta,
-1950-12-31,MX,Mexico,
-1950-12-31,MY,Malaysia,
-1950-12-31,NL,Netherlands,
-1950-12-31,NO,Norway,
-1950-12-31,NZ,New Zealand,
-1950-12-31,PE,Peru,
-1950-12-31,PH,Philippines,
-1950-12-31,PL,Poland,
-1950-12-31,PT,Portugal,
-1950-12-31,RO,Romania,
-1950-12-31,RS,Serbia,
-1950-12-31,RU,Russia,
-1950-12-31,SE,Sweden,
-1950-12-31,SG,Singapore,
-1950-12-31,SI,Slovenia,
-1950-12-31,SK,Slovak Republic,
-1950-12-31,TH,Thailand,
-1950-12-31,TR,Türkiye,
-1950-12-31,US,United States,
-1950-12-31,XM,Euro area,
-1950-12-31,XW,World,
-1950-12-31,ZA,South Africa,
-1951-03-31,4T,Emerging market economies (aggregate),
-1951-03-31,5R,Advanced economies,
-1951-03-31,AE,United Arab Emirates,
-1951-03-31,AT,Austria,
-1951-03-31,AU,Australia,
-1951-03-31,BE,Belgium,
-1951-03-31,BG,Bulgaria,
-1951-03-31,BR,Brazil,
-1951-03-31,CA,Canada,
-1951-03-31,CH,Switzerland,
-1951-03-31,CL,Chile,
-1951-03-31,CN,China,
-1951-03-31,CO,Colombia,
-1951-03-31,CY,Cyprus,
-1951-03-31,CZ,Czechia,
-1951-03-31,DE,Germany,
-1951-03-31,DK,Denmark,
-1951-03-31,EE,Estonia,
-1951-03-31,ES,Spain,
-1951-03-31,FI,Finland,
-1951-03-31,FR,France,
-1951-03-31,GB,United Kingdom,
-1951-03-31,GR,Greece,
-1951-03-31,HK,Hong Kong SAR,
-1951-03-31,HR,Croatia,
-1951-03-31,HU,Hungary,
-1951-03-31,ID,Indonesia,
-1951-03-31,IE,Ireland,
-1951-03-31,IL,Israel,
-1951-03-31,IN,India,
-1951-03-31,IS,Iceland,
-1951-03-31,IT,Italy,37.2777
-1951-03-31,JP,Japan,
-1951-03-31,KR,Korea,
-1951-03-31,LT,Lithuania,
-1951-03-31,LU,Luxembourg,
-1951-03-31,LV,Latvia,
-1951-03-31,MA,Morocco,
-1951-03-31,MK,North Macedonia,
-1951-03-31,MT,Malta,
-1951-03-31,MX,Mexico,
-1951-03-31,MY,Malaysia,
-1951-03-31,NL,Netherlands,
-1951-03-31,NO,Norway,
-1951-03-31,NZ,New Zealand,
-1951-03-31,PE,Peru,
-1951-03-31,PH,Philippines,
-1951-03-31,PL,Poland,
-1951-03-31,PT,Portugal,
-1951-03-31,RO,Romania,
-1951-03-31,RS,Serbia,
-1951-03-31,RU,Russia,
-1951-03-31,SE,Sweden,
-1951-03-31,SG,Singapore,
-1951-03-31,SI,Slovenia,
-1951-03-31,SK,Slovak Republic,
-1951-03-31,TH,Thailand,
-1951-03-31,TR,Türkiye,
-1951-03-31,US,United States,
-1951-03-31,XM,Euro area,
-1951-03-31,XW,World,
-1951-03-31,ZA,South Africa,
-1951-06-30,4T,Emerging market economies (aggregate),
-1951-06-30,5R,Advanced economies,
-1951-06-30,AE,United Arab Emirates,
-1951-06-30,AT,Austria,
-1951-06-30,AU,Australia,
-1951-06-30,BE,Belgium,
-1951-06-30,BG,Bulgaria,
-1951-06-30,BR,Brazil,
-1951-06-30,CA,Canada,
-1951-06-30,CH,Switzerland,
-1951-06-30,CL,Chile,
-1951-06-30,CN,China,
-1951-06-30,CO,Colombia,
-1951-06-30,CY,Cyprus,
-1951-06-30,CZ,Czechia,
-1951-06-30,DE,Germany,
-1951-06-30,DK,Denmark,
-1951-06-30,EE,Estonia,
-1951-06-30,ES,Spain,
-1951-06-30,FI,Finland,
-1951-06-30,FR,France,
-1951-06-30,GB,United Kingdom,
-1951-06-30,GR,Greece,
-1951-06-30,HK,Hong Kong SAR,
-1951-06-30,HR,Croatia,
-1951-06-30,HU,Hungary,
-1951-06-30,ID,Indonesia,
-1951-06-30,IE,Ireland,
-1951-06-30,IL,Israel,
-1951-06-30,IN,India,
-1951-06-30,IS,Iceland,
-1951-06-30,IT,Italy,38.5187
-1951-06-30,JP,Japan,
-1951-06-30,KR,Korea,
-1951-06-30,LT,Lithuania,
-1951-06-30,LU,Luxembourg,
-1951-06-30,LV,Latvia,
-1951-06-30,MA,Morocco,
-1951-06-30,MK,North Macedonia,
-1951-06-30,MT,Malta,
-1951-06-30,MX,Mexico,
-1951-06-30,MY,Malaysia,
-1951-06-30,NL,Netherlands,
-1951-06-30,NO,Norway,
-1951-06-30,NZ,New Zealand,
-1951-06-30,PE,Peru,
-1951-06-30,PH,Philippines,
-1951-06-30,PL,Poland,
-1951-06-30,PT,Portugal,
-1951-06-30,RO,Romania,
-1951-06-30,RS,Serbia,
-1951-06-30,RU,Russia,
-1951-06-30,SE,Sweden,
-1951-06-30,SG,Singapore,
-1951-06-30,SI,Slovenia,
-1951-06-30,SK,Slovak Republic,
-1951-06-30,TH,Thailand,
-1951-06-30,TR,Türkiye,
-1951-06-30,US,United States,
-1951-06-30,XM,Euro area,
-1951-06-30,XW,World,
-1951-06-30,ZA,South Africa,
-1951-09-30,4T,Emerging market economies (aggregate),
-1951-09-30,5R,Advanced economies,
-1951-09-30,AE,United Arab Emirates,
-1951-09-30,AT,Austria,
-1951-09-30,AU,Australia,
-1951-09-30,BE,Belgium,
-1951-09-30,BG,Bulgaria,
-1951-09-30,BR,Brazil,
-1951-09-30,CA,Canada,
-1951-09-30,CH,Switzerland,
-1951-09-30,CL,Chile,
-1951-09-30,CN,China,
-1951-09-30,CO,Colombia,
-1951-09-30,CY,Cyprus,
-1951-09-30,CZ,Czechia,
-1951-09-30,DE,Germany,
-1951-09-30,DK,Denmark,
-1951-09-30,EE,Estonia,
-1951-09-30,ES,Spain,
-1951-09-30,FI,Finland,
-1951-09-30,FR,France,
-1951-09-30,GB,United Kingdom,
-1951-09-30,GR,Greece,
-1951-09-30,HK,Hong Kong SAR,
-1951-09-30,HR,Croatia,
-1951-09-30,HU,Hungary,
-1951-09-30,ID,Indonesia,
-1951-09-30,IE,Ireland,
-1951-09-30,IL,Israel,
-1951-09-30,IN,India,
-1951-09-30,IS,Iceland,
-1951-09-30,IT,Italy,38.0331
-1951-09-30,JP,Japan,
-1951-09-30,KR,Korea,
-1951-09-30,LT,Lithuania,
-1951-09-30,LU,Luxembourg,
-1951-09-30,LV,Latvia,
-1951-09-30,MA,Morocco,
-1951-09-30,MK,North Macedonia,
-1951-09-30,MT,Malta,
-1951-09-30,MX,Mexico,
-1951-09-30,MY,Malaysia,
-1951-09-30,NL,Netherlands,
-1951-09-30,NO,Norway,
-1951-09-30,NZ,New Zealand,
-1951-09-30,PE,Peru,
-1951-09-30,PH,Philippines,
-1951-09-30,PL,Poland,
-1951-09-30,PT,Portugal,
-1951-09-30,RO,Romania,
-1951-09-30,RS,Serbia,
-1951-09-30,RU,Russia,
-1951-09-30,SE,Sweden,
-1951-09-30,SG,Singapore,
-1951-09-30,SI,Slovenia,
-1951-09-30,SK,Slovak Republic,
-1951-09-30,TH,Thailand,
-1951-09-30,TR,Türkiye,
-1951-09-30,US,United States,
-1951-09-30,XM,Euro area,
-1951-09-30,XW,World,
-1951-09-30,ZA,South Africa,
-1951-12-31,4T,Emerging market economies (aggregate),
-1951-12-31,5R,Advanced economies,
-1951-12-31,AE,United Arab Emirates,
-1951-12-31,AT,Austria,
-1951-12-31,AU,Australia,
-1951-12-31,BE,Belgium,
-1951-12-31,BG,Bulgaria,
-1951-12-31,BR,Brazil,
-1951-12-31,CA,Canada,
-1951-12-31,CH,Switzerland,
-1951-12-31,CL,Chile,
-1951-12-31,CN,China,
-1951-12-31,CO,Colombia,
-1951-12-31,CY,Cyprus,
-1951-12-31,CZ,Czechia,
-1951-12-31,DE,Germany,
-1951-12-31,DK,Denmark,
-1951-12-31,EE,Estonia,
-1951-12-31,ES,Spain,
-1951-12-31,FI,Finland,
-1951-12-31,FR,France,
-1951-12-31,GB,United Kingdom,
-1951-12-31,GR,Greece,
-1951-12-31,HK,Hong Kong SAR,
-1951-12-31,HR,Croatia,
-1951-12-31,HU,Hungary,
-1951-12-31,ID,Indonesia,
-1951-12-31,IE,Ireland,
-1951-12-31,IL,Israel,
-1951-12-31,IN,India,
-1951-12-31,IS,Iceland,
-1951-12-31,IT,Italy,37.4074
-1951-12-31,JP,Japan,
-1951-12-31,KR,Korea,
-1951-12-31,LT,Lithuania,
-1951-12-31,LU,Luxembourg,
-1951-12-31,LV,Latvia,
-1951-12-31,MA,Morocco,
-1951-12-31,MK,North Macedonia,
-1951-12-31,MT,Malta,
-1951-12-31,MX,Mexico,
-1951-12-31,MY,Malaysia,
-1951-12-31,NL,Netherlands,
-1951-12-31,NO,Norway,
-1951-12-31,NZ,New Zealand,
-1951-12-31,PE,Peru,
-1951-12-31,PH,Philippines,
-1951-12-31,PL,Poland,
-1951-12-31,PT,Portugal,
-1951-12-31,RO,Romania,
-1951-12-31,RS,Serbia,
-1951-12-31,RU,Russia,
-1951-12-31,SE,Sweden,
-1951-12-31,SG,Singapore,
-1951-12-31,SI,Slovenia,
-1951-12-31,SK,Slovak Republic,
-1951-12-31,TH,Thailand,
-1951-12-31,TR,Türkiye,
-1951-12-31,US,United States,
-1951-12-31,XM,Euro area,
-1951-12-31,XW,World,
-1951-12-31,ZA,South Africa,
-1952-03-31,4T,Emerging market economies (aggregate),
-1952-03-31,5R,Advanced economies,
-1952-03-31,AE,United Arab Emirates,
-1952-03-31,AT,Austria,
-1952-03-31,AU,Australia,
-1952-03-31,BE,Belgium,
-1952-03-31,BG,Bulgaria,
-1952-03-31,BR,Brazil,
-1952-03-31,CA,Canada,
-1952-03-31,CH,Switzerland,
-1952-03-31,CL,Chile,
-1952-03-31,CN,China,
-1952-03-31,CO,Colombia,
-1952-03-31,CY,Cyprus,
-1952-03-31,CZ,Czechia,
-1952-03-31,DE,Germany,
-1952-03-31,DK,Denmark,
-1952-03-31,EE,Estonia,
-1952-03-31,ES,Spain,
-1952-03-31,FI,Finland,
-1952-03-31,FR,France,
-1952-03-31,GB,United Kingdom,
-1952-03-31,GR,Greece,
-1952-03-31,HK,Hong Kong SAR,
-1952-03-31,HR,Croatia,
-1952-03-31,HU,Hungary,
-1952-03-31,ID,Indonesia,
-1952-03-31,IE,Ireland,
-1952-03-31,IL,Israel,
-1952-03-31,IN,India,
-1952-03-31,IS,Iceland,
-1952-03-31,IT,Italy,36.9859
-1952-03-31,JP,Japan,
-1952-03-31,KR,Korea,
-1952-03-31,LT,Lithuania,
-1952-03-31,LU,Luxembourg,
-1952-03-31,LV,Latvia,
-1952-03-31,MA,Morocco,
-1952-03-31,MK,North Macedonia,
-1952-03-31,MT,Malta,
-1952-03-31,MX,Mexico,
-1952-03-31,MY,Malaysia,
-1952-03-31,NL,Netherlands,
-1952-03-31,NO,Norway,
-1952-03-31,NZ,New Zealand,
-1952-03-31,PE,Peru,
-1952-03-31,PH,Philippines,
-1952-03-31,PL,Poland,
-1952-03-31,PT,Portugal,
-1952-03-31,RO,Romania,
-1952-03-31,RS,Serbia,
-1952-03-31,RU,Russia,
-1952-03-31,SE,Sweden,
-1952-03-31,SG,Singapore,
-1952-03-31,SI,Slovenia,
-1952-03-31,SK,Slovak Republic,
-1952-03-31,TH,Thailand,
-1952-03-31,TR,Türkiye,
-1952-03-31,US,United States,
-1952-03-31,XM,Euro area,
-1952-03-31,XW,World,
-1952-03-31,ZA,South Africa,
-1952-06-30,4T,Emerging market economies (aggregate),
-1952-06-30,5R,Advanced economies,
-1952-06-30,AE,United Arab Emirates,
-1952-06-30,AT,Austria,
-1952-06-30,AU,Australia,
-1952-06-30,BE,Belgium,
-1952-06-30,BG,Bulgaria,
-1952-06-30,BR,Brazil,
-1952-06-30,CA,Canada,
-1952-06-30,CH,Switzerland,
-1952-06-30,CL,Chile,
-1952-06-30,CN,China,
-1952-06-30,CO,Colombia,
-1952-06-30,CY,Cyprus,
-1952-06-30,CZ,Czechia,
-1952-06-30,DE,Germany,
-1952-06-30,DK,Denmark,
-1952-06-30,EE,Estonia,
-1952-06-30,ES,Spain,
-1952-06-30,FI,Finland,
-1952-06-30,FR,France,
-1952-06-30,GB,United Kingdom,
-1952-06-30,GR,Greece,
-1952-06-30,HK,Hong Kong SAR,
-1952-06-30,HR,Croatia,
-1952-06-30,HU,Hungary,
-1952-06-30,ID,Indonesia,
-1952-06-30,IE,Ireland,
-1952-06-30,IL,Israel,
-1952-06-30,IN,India,
-1952-06-30,IS,Iceland,
-1952-06-30,IT,Italy,36.9596
-1952-06-30,JP,Japan,
-1952-06-30,KR,Korea,
-1952-06-30,LT,Lithuania,
-1952-06-30,LU,Luxembourg,
-1952-06-30,LV,Latvia,
-1952-06-30,MA,Morocco,
-1952-06-30,MK,North Macedonia,
-1952-06-30,MT,Malta,
-1952-06-30,MX,Mexico,
-1952-06-30,MY,Malaysia,
-1952-06-30,NL,Netherlands,
-1952-06-30,NO,Norway,
-1952-06-30,NZ,New Zealand,
-1952-06-30,PE,Peru,
-1952-06-30,PH,Philippines,
-1952-06-30,PL,Poland,
-1952-06-30,PT,Portugal,
-1952-06-30,RO,Romania,
-1952-06-30,RS,Serbia,
-1952-06-30,RU,Russia,
-1952-06-30,SE,Sweden,
-1952-06-30,SG,Singapore,
-1952-06-30,SI,Slovenia,
-1952-06-30,SK,Slovak Republic,
-1952-06-30,TH,Thailand,
-1952-06-30,TR,Türkiye,
-1952-06-30,US,United States,
-1952-06-30,XM,Euro area,
-1952-06-30,XW,World,
-1952-06-30,ZA,South Africa,
-1952-09-30,4T,Emerging market economies (aggregate),
-1952-09-30,5R,Advanced economies,
-1952-09-30,AE,United Arab Emirates,
-1952-09-30,AT,Austria,
-1952-09-30,AU,Australia,
-1952-09-30,BE,Belgium,
-1952-09-30,BG,Bulgaria,
-1952-09-30,BR,Brazil,
-1952-09-30,CA,Canada,
-1952-09-30,CH,Switzerland,
-1952-09-30,CL,Chile,
-1952-09-30,CN,China,
-1952-09-30,CO,Colombia,
-1952-09-30,CY,Cyprus,
-1952-09-30,CZ,Czechia,
-1952-09-30,DE,Germany,
-1952-09-30,DK,Denmark,
-1952-09-30,EE,Estonia,
-1952-09-30,ES,Spain,
-1952-09-30,FI,Finland,
-1952-09-30,FR,France,
-1952-09-30,GB,United Kingdom,
-1952-09-30,GR,Greece,
-1952-09-30,HK,Hong Kong SAR,
-1952-09-30,HR,Croatia,
-1952-09-30,HU,Hungary,
-1952-09-30,ID,Indonesia,
-1952-09-30,IE,Ireland,
-1952-09-30,IL,Israel,
-1952-09-30,IN,India,
-1952-09-30,IS,Iceland,
-1952-09-30,IT,Italy,36.994
-1952-09-30,JP,Japan,
-1952-09-30,KR,Korea,
-1952-09-30,LT,Lithuania,
-1952-09-30,LU,Luxembourg,
-1952-09-30,LV,Latvia,
-1952-09-30,MA,Morocco,
-1952-09-30,MK,North Macedonia,
-1952-09-30,MT,Malta,
-1952-09-30,MX,Mexico,
-1952-09-30,MY,Malaysia,
-1952-09-30,NL,Netherlands,
-1952-09-30,NO,Norway,
-1952-09-30,NZ,New Zealand,
-1952-09-30,PE,Peru,
-1952-09-30,PH,Philippines,
-1952-09-30,PL,Poland,
-1952-09-30,PT,Portugal,
-1952-09-30,RO,Romania,
-1952-09-30,RS,Serbia,
-1952-09-30,RU,Russia,
-1952-09-30,SE,Sweden,
-1952-09-30,SG,Singapore,
-1952-09-30,SI,Slovenia,
-1952-09-30,SK,Slovak Republic,
-1952-09-30,TH,Thailand,
-1952-09-30,TR,Türkiye,
-1952-09-30,US,United States,
-1952-09-30,XM,Euro area,
-1952-09-30,XW,World,
-1952-09-30,ZA,South Africa,
-1952-12-31,4T,Emerging market economies (aggregate),
-1952-12-31,5R,Advanced economies,
-1952-12-31,AE,United Arab Emirates,
-1952-12-31,AT,Austria,
-1952-12-31,AU,Australia,
-1952-12-31,BE,Belgium,
-1952-12-31,BG,Bulgaria,
-1952-12-31,BR,Brazil,
-1952-12-31,CA,Canada,
-1952-12-31,CH,Switzerland,
-1952-12-31,CL,Chile,
-1952-12-31,CN,China,
-1952-12-31,CO,Colombia,
-1952-12-31,CY,Cyprus,
-1952-12-31,CZ,Czechia,
-1952-12-31,DE,Germany,
-1952-12-31,DK,Denmark,
-1952-12-31,EE,Estonia,
-1952-12-31,ES,Spain,
-1952-12-31,FI,Finland,
-1952-12-31,FR,France,
-1952-12-31,GB,United Kingdom,
-1952-12-31,GR,Greece,
-1952-12-31,HK,Hong Kong SAR,
-1952-12-31,HR,Croatia,
-1952-12-31,HU,Hungary,
-1952-12-31,ID,Indonesia,
-1952-12-31,IE,Ireland,
-1952-12-31,IL,Israel,
-1952-12-31,IN,India,
-1952-12-31,IS,Iceland,
-1952-12-31,IT,Italy,37.0361
-1952-12-31,JP,Japan,
-1952-12-31,KR,Korea,
-1952-12-31,LT,Lithuania,
-1952-12-31,LU,Luxembourg,
-1952-12-31,LV,Latvia,
-1952-12-31,MA,Morocco,
-1952-12-31,MK,North Macedonia,
-1952-12-31,MT,Malta,
-1952-12-31,MX,Mexico,
-1952-12-31,MY,Malaysia,
-1952-12-31,NL,Netherlands,
-1952-12-31,NO,Norway,
-1952-12-31,NZ,New Zealand,
-1952-12-31,PE,Peru,
-1952-12-31,PH,Philippines,
-1952-12-31,PL,Poland,
-1952-12-31,PT,Portugal,
-1952-12-31,RO,Romania,
-1952-12-31,RS,Serbia,
-1952-12-31,RU,Russia,
-1952-12-31,SE,Sweden,
-1952-12-31,SG,Singapore,
-1952-12-31,SI,Slovenia,
-1952-12-31,SK,Slovak Republic,
-1952-12-31,TH,Thailand,
-1952-12-31,TR,Türkiye,
-1952-12-31,US,United States,
-1952-12-31,XM,Euro area,
-1952-12-31,XW,World,
-1952-12-31,ZA,South Africa,
-1953-03-31,4T,Emerging market economies (aggregate),
-1953-03-31,5R,Advanced economies,
-1953-03-31,AE,United Arab Emirates,
-1953-03-31,AT,Austria,
-1953-03-31,AU,Australia,
-1953-03-31,BE,Belgium,
-1953-03-31,BG,Bulgaria,
-1953-03-31,BR,Brazil,
-1953-03-31,CA,Canada,
-1953-03-31,CH,Switzerland,
-1953-03-31,CL,Chile,
-1953-03-31,CN,China,
-1953-03-31,CO,Colombia,
-1953-03-31,CY,Cyprus,
-1953-03-31,CZ,Czechia,
-1953-03-31,DE,Germany,
-1953-03-31,DK,Denmark,
-1953-03-31,EE,Estonia,
-1953-03-31,ES,Spain,
-1953-03-31,FI,Finland,
-1953-03-31,FR,France,
-1953-03-31,GB,United Kingdom,
-1953-03-31,GR,Greece,
-1953-03-31,HK,Hong Kong SAR,
-1953-03-31,HR,Croatia,
-1953-03-31,HU,Hungary,
-1953-03-31,ID,Indonesia,
-1953-03-31,IE,Ireland,
-1953-03-31,IL,Israel,
-1953-03-31,IN,India,
-1953-03-31,IS,Iceland,
-1953-03-31,IT,Italy,36.5813
-1953-03-31,JP,Japan,
-1953-03-31,KR,Korea,
-1953-03-31,LT,Lithuania,
-1953-03-31,LU,Luxembourg,
-1953-03-31,LV,Latvia,
-1953-03-31,MA,Morocco,
-1953-03-31,MK,North Macedonia,
-1953-03-31,MT,Malta,
-1953-03-31,MX,Mexico,
-1953-03-31,MY,Malaysia,
-1953-03-31,NL,Netherlands,
-1953-03-31,NO,Norway,
-1953-03-31,NZ,New Zealand,
-1953-03-31,PE,Peru,
-1953-03-31,PH,Philippines,
-1953-03-31,PL,Poland,
-1953-03-31,PT,Portugal,
-1953-03-31,RO,Romania,
-1953-03-31,RS,Serbia,
-1953-03-31,RU,Russia,
-1953-03-31,SE,Sweden,
-1953-03-31,SG,Singapore,
-1953-03-31,SI,Slovenia,
-1953-03-31,SK,Slovak Republic,
-1953-03-31,TH,Thailand,
-1953-03-31,TR,Türkiye,
-1953-03-31,US,United States,
-1953-03-31,XM,Euro area,
-1953-03-31,XW,World,
-1953-03-31,ZA,South Africa,
-1953-06-30,4T,Emerging market economies (aggregate),
-1953-06-30,5R,Advanced economies,
-1953-06-30,AE,United Arab Emirates,
-1953-06-30,AT,Austria,
-1953-06-30,AU,Australia,
-1953-06-30,BE,Belgium,
-1953-06-30,BG,Bulgaria,
-1953-06-30,BR,Brazil,
-1953-06-30,CA,Canada,
-1953-06-30,CH,Switzerland,
-1953-06-30,CL,Chile,
-1953-06-30,CN,China,
-1953-06-30,CO,Colombia,
-1953-06-30,CY,Cyprus,
-1953-06-30,CZ,Czechia,
-1953-06-30,DE,Germany,
-1953-06-30,DK,Denmark,
-1953-06-30,EE,Estonia,
-1953-06-30,ES,Spain,
-1953-06-30,FI,Finland,
-1953-06-30,FR,France,
-1953-06-30,GB,United Kingdom,
-1953-06-30,GR,Greece,
-1953-06-30,HK,Hong Kong SAR,
-1953-06-30,HR,Croatia,
-1953-06-30,HU,Hungary,
-1953-06-30,ID,Indonesia,
-1953-06-30,IE,Ireland,
-1953-06-30,IL,Israel,
-1953-06-30,IN,India,
-1953-06-30,IS,Iceland,
-1953-06-30,IT,Italy,37.1279
-1953-06-30,JP,Japan,
-1953-06-30,KR,Korea,
-1953-06-30,LT,Lithuania,
-1953-06-30,LU,Luxembourg,
-1953-06-30,LV,Latvia,
-1953-06-30,MA,Morocco,
-1953-06-30,MK,North Macedonia,
-1953-06-30,MT,Malta,
-1953-06-30,MX,Mexico,
-1953-06-30,MY,Malaysia,
-1953-06-30,NL,Netherlands,
-1953-06-30,NO,Norway,
-1953-06-30,NZ,New Zealand,
-1953-06-30,PE,Peru,
-1953-06-30,PH,Philippines,
-1953-06-30,PL,Poland,
-1953-06-30,PT,Portugal,
-1953-06-30,RO,Romania,
-1953-06-30,RS,Serbia,
-1953-06-30,RU,Russia,
-1953-06-30,SE,Sweden,
-1953-06-30,SG,Singapore,
-1953-06-30,SI,Slovenia,
-1953-06-30,SK,Slovak Republic,
-1953-06-30,TH,Thailand,
-1953-06-30,TR,Türkiye,
-1953-06-30,US,United States,
-1953-06-30,XM,Euro area,
-1953-06-30,XW,World,
-1953-06-30,ZA,South Africa,
-1953-09-30,4T,Emerging market economies (aggregate),
-1953-09-30,5R,Advanced economies,
-1953-09-30,AE,United Arab Emirates,
-1953-09-30,AT,Austria,
-1953-09-30,AU,Australia,
-1953-09-30,BE,Belgium,
-1953-09-30,BG,Bulgaria,
-1953-09-30,BR,Brazil,
-1953-09-30,CA,Canada,
-1953-09-30,CH,Switzerland,
-1953-09-30,CL,Chile,
-1953-09-30,CN,China,
-1953-09-30,CO,Colombia,
-1953-09-30,CY,Cyprus,
-1953-09-30,CZ,Czechia,
-1953-09-30,DE,Germany,
-1953-09-30,DK,Denmark,
-1953-09-30,EE,Estonia,
-1953-09-30,ES,Spain,
-1953-09-30,FI,Finland,
-1953-09-30,FR,France,
-1953-09-30,GB,United Kingdom,
-1953-09-30,GR,Greece,
-1953-09-30,HK,Hong Kong SAR,
-1953-09-30,HR,Croatia,
-1953-09-30,HU,Hungary,
-1953-09-30,ID,Indonesia,
-1953-09-30,IE,Ireland,
-1953-09-30,IL,Israel,
-1953-09-30,IN,India,
-1953-09-30,IS,Iceland,
-1953-09-30,IT,Italy,36.1573
-1953-09-30,JP,Japan,
-1953-09-30,KR,Korea,
-1953-09-30,LT,Lithuania,
-1953-09-30,LU,Luxembourg,
-1953-09-30,LV,Latvia,
-1953-09-30,MA,Morocco,
-1953-09-30,MK,North Macedonia,
-1953-09-30,MT,Malta,
-1953-09-30,MX,Mexico,
-1953-09-30,MY,Malaysia,
-1953-09-30,NL,Netherlands,
-1953-09-30,NO,Norway,
-1953-09-30,NZ,New Zealand,
-1953-09-30,PE,Peru,
-1953-09-30,PH,Philippines,
-1953-09-30,PL,Poland,
-1953-09-30,PT,Portugal,
-1953-09-30,RO,Romania,
-1953-09-30,RS,Serbia,
-1953-09-30,RU,Russia,
-1953-09-30,SE,Sweden,
-1953-09-30,SG,Singapore,
-1953-09-30,SI,Slovenia,
-1953-09-30,SK,Slovak Republic,
-1953-09-30,TH,Thailand,
-1953-09-30,TR,Türkiye,
-1953-09-30,US,United States,
-1953-09-30,XM,Euro area,
-1953-09-30,XW,World,
-1953-09-30,ZA,South Africa,
-1953-12-31,4T,Emerging market economies (aggregate),
-1953-12-31,5R,Advanced economies,
-1953-12-31,AE,United Arab Emirates,
-1953-12-31,AT,Austria,
-1953-12-31,AU,Australia,
-1953-12-31,BE,Belgium,
-1953-12-31,BG,Bulgaria,
-1953-12-31,BR,Brazil,
-1953-12-31,CA,Canada,
-1953-12-31,CH,Switzerland,
-1953-12-31,CL,Chile,
-1953-12-31,CN,China,
-1953-12-31,CO,Colombia,
-1953-12-31,CY,Cyprus,
-1953-12-31,CZ,Czechia,
-1953-12-31,DE,Germany,
-1953-12-31,DK,Denmark,
-1953-12-31,EE,Estonia,
-1953-12-31,ES,Spain,
-1953-12-31,FI,Finland,
-1953-12-31,FR,France,
-1953-12-31,GB,United Kingdom,
-1953-12-31,GR,Greece,
-1953-12-31,HK,Hong Kong SAR,
-1953-12-31,HR,Croatia,
-1953-12-31,HU,Hungary,
-1953-12-31,ID,Indonesia,
-1953-12-31,IE,Ireland,
-1953-12-31,IL,Israel,
-1953-12-31,IN,India,
-1953-12-31,IS,Iceland,
-1953-12-31,IT,Italy,36.4839
-1953-12-31,JP,Japan,
-1953-12-31,KR,Korea,
-1953-12-31,LT,Lithuania,
-1953-12-31,LU,Luxembourg,
-1953-12-31,LV,Latvia,
-1953-12-31,MA,Morocco,
-1953-12-31,MK,North Macedonia,
-1953-12-31,MT,Malta,
-1953-12-31,MX,Mexico,
-1953-12-31,MY,Malaysia,
-1953-12-31,NL,Netherlands,
-1953-12-31,NO,Norway,
-1953-12-31,NZ,New Zealand,
-1953-12-31,PE,Peru,
-1953-12-31,PH,Philippines,
-1953-12-31,PL,Poland,
-1953-12-31,PT,Portugal,
-1953-12-31,RO,Romania,
-1953-12-31,RS,Serbia,
-1953-12-31,RU,Russia,
-1953-12-31,SE,Sweden,
-1953-12-31,SG,Singapore,
-1953-12-31,SI,Slovenia,
-1953-12-31,SK,Slovak Republic,
-1953-12-31,TH,Thailand,
-1953-12-31,TR,Türkiye,
-1953-12-31,US,United States,
-1953-12-31,XM,Euro area,
-1953-12-31,XW,World,
-1953-12-31,ZA,South Africa,
-1954-03-31,4T,Emerging market economies (aggregate),
-1954-03-31,5R,Advanced economies,
-1954-03-31,AE,United Arab Emirates,
-1954-03-31,AT,Austria,
-1954-03-31,AU,Australia,
-1954-03-31,BE,Belgium,
-1954-03-31,BG,Bulgaria,
-1954-03-31,BR,Brazil,
-1954-03-31,CA,Canada,
-1954-03-31,CH,Switzerland,
-1954-03-31,CL,Chile,
-1954-03-31,CN,China,
-1954-03-31,CO,Colombia,
-1954-03-31,CY,Cyprus,
-1954-03-31,CZ,Czechia,
-1954-03-31,DE,Germany,
-1954-03-31,DK,Denmark,
-1954-03-31,EE,Estonia,
-1954-03-31,ES,Spain,
-1954-03-31,FI,Finland,
-1954-03-31,FR,France,
-1954-03-31,GB,United Kingdom,
-1954-03-31,GR,Greece,
-1954-03-31,HK,Hong Kong SAR,
-1954-03-31,HR,Croatia,
-1954-03-31,HU,Hungary,
-1954-03-31,ID,Indonesia,
-1954-03-31,IE,Ireland,
-1954-03-31,IL,Israel,
-1954-03-31,IN,India,
-1954-03-31,IS,Iceland,
-1954-03-31,IT,Italy,36.4362
-1954-03-31,JP,Japan,
-1954-03-31,KR,Korea,
-1954-03-31,LT,Lithuania,
-1954-03-31,LU,Luxembourg,
-1954-03-31,LV,Latvia,
-1954-03-31,MA,Morocco,
-1954-03-31,MK,North Macedonia,
-1954-03-31,MT,Malta,
-1954-03-31,MX,Mexico,
-1954-03-31,MY,Malaysia,
-1954-03-31,NL,Netherlands,
-1954-03-31,NO,Norway,
-1954-03-31,NZ,New Zealand,
-1954-03-31,PE,Peru,
-1954-03-31,PH,Philippines,
-1954-03-31,PL,Poland,
-1954-03-31,PT,Portugal,
-1954-03-31,RO,Romania,
-1954-03-31,RS,Serbia,
-1954-03-31,RU,Russia,
-1954-03-31,SE,Sweden,
-1954-03-31,SG,Singapore,
-1954-03-31,SI,Slovenia,
-1954-03-31,SK,Slovak Republic,
-1954-03-31,TH,Thailand,
-1954-03-31,TR,Türkiye,
-1954-03-31,US,United States,
-1954-03-31,XM,Euro area,
-1954-03-31,XW,World,
-1954-03-31,ZA,South Africa,
-1954-06-30,4T,Emerging market economies (aggregate),
-1954-06-30,5R,Advanced economies,
-1954-06-30,AE,United Arab Emirates,
-1954-06-30,AT,Austria,
-1954-06-30,AU,Australia,
-1954-06-30,BE,Belgium,
-1954-06-30,BG,Bulgaria,
-1954-06-30,BR,Brazil,
-1954-06-30,CA,Canada,
-1954-06-30,CH,Switzerland,
-1954-06-30,CL,Chile,
-1954-06-30,CN,China,
-1954-06-30,CO,Colombia,
-1954-06-30,CY,Cyprus,
-1954-06-30,CZ,Czechia,
-1954-06-30,DE,Germany,
-1954-06-30,DK,Denmark,
-1954-06-30,EE,Estonia,
-1954-06-30,ES,Spain,
-1954-06-30,FI,Finland,
-1954-06-30,FR,France,
-1954-06-30,GB,United Kingdom,
-1954-06-30,GR,Greece,
-1954-06-30,HK,Hong Kong SAR,
-1954-06-30,HR,Croatia,
-1954-06-30,HU,Hungary,
-1954-06-30,ID,Indonesia,
-1954-06-30,IE,Ireland,
-1954-06-30,IL,Israel,
-1954-06-30,IN,India,
-1954-06-30,IS,Iceland,
-1954-06-30,IT,Italy,37.2462
-1954-06-30,JP,Japan,
-1954-06-30,KR,Korea,
-1954-06-30,LT,Lithuania,
-1954-06-30,LU,Luxembourg,
-1954-06-30,LV,Latvia,
-1954-06-30,MA,Morocco,
-1954-06-30,MK,North Macedonia,
-1954-06-30,MT,Malta,
-1954-06-30,MX,Mexico,
-1954-06-30,MY,Malaysia,
-1954-06-30,NL,Netherlands,
-1954-06-30,NO,Norway,
-1954-06-30,NZ,New Zealand,
-1954-06-30,PE,Peru,
-1954-06-30,PH,Philippines,
-1954-06-30,PL,Poland,
-1954-06-30,PT,Portugal,
-1954-06-30,RO,Romania,
-1954-06-30,RS,Serbia,
-1954-06-30,RU,Russia,
-1954-06-30,SE,Sweden,
-1954-06-30,SG,Singapore,
-1954-06-30,SI,Slovenia,
-1954-06-30,SK,Slovak Republic,
-1954-06-30,TH,Thailand,
-1954-06-30,TR,Türkiye,
-1954-06-30,US,United States,
-1954-06-30,XM,Euro area,
-1954-06-30,XW,World,
-1954-06-30,ZA,South Africa,
-1954-09-30,4T,Emerging market economies (aggregate),
-1954-09-30,5R,Advanced economies,
-1954-09-30,AE,United Arab Emirates,
-1954-09-30,AT,Austria,
-1954-09-30,AU,Australia,
-1954-09-30,BE,Belgium,
-1954-09-30,BG,Bulgaria,
-1954-09-30,BR,Brazil,
-1954-09-30,CA,Canada,
-1954-09-30,CH,Switzerland,
-1954-09-30,CL,Chile,
-1954-09-30,CN,China,
-1954-09-30,CO,Colombia,
-1954-09-30,CY,Cyprus,
-1954-09-30,CZ,Czechia,
-1954-09-30,DE,Germany,
-1954-09-30,DK,Denmark,
-1954-09-30,EE,Estonia,
-1954-09-30,ES,Spain,
-1954-09-30,FI,Finland,
-1954-09-30,FR,France,
-1954-09-30,GB,United Kingdom,
-1954-09-30,GR,Greece,
-1954-09-30,HK,Hong Kong SAR,
-1954-09-30,HR,Croatia,
-1954-09-30,HU,Hungary,
-1954-09-30,ID,Indonesia,
-1954-09-30,IE,Ireland,
-1954-09-30,IL,Israel,
-1954-09-30,IN,India,
-1954-09-30,IS,Iceland,
-1954-09-30,IT,Italy,37.6194
-1954-09-30,JP,Japan,
-1954-09-30,KR,Korea,
-1954-09-30,LT,Lithuania,
-1954-09-30,LU,Luxembourg,
-1954-09-30,LV,Latvia,
-1954-09-30,MA,Morocco,
-1954-09-30,MK,North Macedonia,
-1954-09-30,MT,Malta,
-1954-09-30,MX,Mexico,
-1954-09-30,MY,Malaysia,
-1954-09-30,NL,Netherlands,
-1954-09-30,NO,Norway,
-1954-09-30,NZ,New Zealand,
-1954-09-30,PE,Peru,
-1954-09-30,PH,Philippines,
-1954-09-30,PL,Poland,
-1954-09-30,PT,Portugal,
-1954-09-30,RO,Romania,
-1954-09-30,RS,Serbia,
-1954-09-30,RU,Russia,
-1954-09-30,SE,Sweden,
-1954-09-30,SG,Singapore,
-1954-09-30,SI,Slovenia,
-1954-09-30,SK,Slovak Republic,
-1954-09-30,TH,Thailand,
-1954-09-30,TR,Türkiye,
-1954-09-30,US,United States,
-1954-09-30,XM,Euro area,
-1954-09-30,XW,World,
-1954-09-30,ZA,South Africa,
-1954-12-31,4T,Emerging market economies (aggregate),
-1954-12-31,5R,Advanced economies,
-1954-12-31,AE,United Arab Emirates,
-1954-12-31,AT,Austria,
-1954-12-31,AU,Australia,
-1954-12-31,BE,Belgium,
-1954-12-31,BG,Bulgaria,
-1954-12-31,BR,Brazil,
-1954-12-31,CA,Canada,
-1954-12-31,CH,Switzerland,
-1954-12-31,CL,Chile,
-1954-12-31,CN,China,
-1954-12-31,CO,Colombia,
-1954-12-31,CY,Cyprus,
-1954-12-31,CZ,Czechia,
-1954-12-31,DE,Germany,
-1954-12-31,DK,Denmark,
-1954-12-31,EE,Estonia,
-1954-12-31,ES,Spain,
-1954-12-31,FI,Finland,
-1954-12-31,FR,France,
-1954-12-31,GB,United Kingdom,
-1954-12-31,GR,Greece,
-1954-12-31,HK,Hong Kong SAR,
-1954-12-31,HR,Croatia,
-1954-12-31,HU,Hungary,
-1954-12-31,ID,Indonesia,
-1954-12-31,IE,Ireland,
-1954-12-31,IL,Israel,
-1954-12-31,IN,India,
-1954-12-31,IS,Iceland,
-1954-12-31,IT,Italy,37.2784
-1954-12-31,JP,Japan,
-1954-12-31,KR,Korea,
-1954-12-31,LT,Lithuania,
-1954-12-31,LU,Luxembourg,
-1954-12-31,LV,Latvia,
-1954-12-31,MA,Morocco,
-1954-12-31,MK,North Macedonia,
-1954-12-31,MT,Malta,
-1954-12-31,MX,Mexico,
-1954-12-31,MY,Malaysia,
-1954-12-31,NL,Netherlands,
-1954-12-31,NO,Norway,
-1954-12-31,NZ,New Zealand,
-1954-12-31,PE,Peru,
-1954-12-31,PH,Philippines,
-1954-12-31,PL,Poland,
-1954-12-31,PT,Portugal,
-1954-12-31,RO,Romania,
-1954-12-31,RS,Serbia,
-1954-12-31,RU,Russia,
-1954-12-31,SE,Sweden,
-1954-12-31,SG,Singapore,
-1954-12-31,SI,Slovenia,
-1954-12-31,SK,Slovak Republic,
-1954-12-31,TH,Thailand,
-1954-12-31,TR,Türkiye,
-1954-12-31,US,United States,
-1954-12-31,XM,Euro area,
-1954-12-31,XW,World,
-1954-12-31,ZA,South Africa,
-1955-03-31,4T,Emerging market economies (aggregate),
-1955-03-31,5R,Advanced economies,
-1955-03-31,AE,United Arab Emirates,
-1955-03-31,AT,Austria,
-1955-03-31,AU,Australia,
-1955-03-31,BE,Belgium,
-1955-03-31,BG,Bulgaria,
-1955-03-31,BR,Brazil,
-1955-03-31,CA,Canada,
-1955-03-31,CH,Switzerland,
-1955-03-31,CL,Chile,
-1955-03-31,CN,China,
-1955-03-31,CO,Colombia,
-1955-03-31,CY,Cyprus,
-1955-03-31,CZ,Czechia,
-1955-03-31,DE,Germany,
-1955-03-31,DK,Denmark,
-1955-03-31,EE,Estonia,
-1955-03-31,ES,Spain,
-1955-03-31,FI,Finland,
-1955-03-31,FR,France,
-1955-03-31,GB,United Kingdom,
-1955-03-31,GR,Greece,
-1955-03-31,HK,Hong Kong SAR,
-1955-03-31,HR,Croatia,
-1955-03-31,HU,Hungary,
-1955-03-31,ID,Indonesia,
-1955-03-31,IE,Ireland,
-1955-03-31,IL,Israel,
-1955-03-31,IN,India,
-1955-03-31,IS,Iceland,
-1955-03-31,IT,Italy,37.001
+1947-03-31,IT,Italy,32.0595
+1947-06-30,IT,Italy,29.948
+1947-09-30,IT,Italy,27.9281
+1947-12-31,IT,Italy,29.1372
+1948-03-31,IT,Italy,33.8444
+1948-06-30,IT,Italy,34.5275
+1948-09-30,IT,Italy,32.577
+1948-12-31,IT,Italy,32.9188
+1949-03-31,IT,Italy,33.1816
+1949-06-30,IT,Italy,32.92
+1949-09-30,IT,Italy,30.9141
+1949-12-31,IT,Italy,30.3407
+1950-03-31,IT,Italy,30.5676
+1950-06-30,IT,Italy,32.3429
+1950-09-30,IT,Italy,34.0027
+1950-12-31,IT,Italy,33.8948
+1951-03-31,IT,Italy,34.8824
+1951-06-30,IT,Italy,36.0824
+1951-09-30,IT,Italy,35.5473
+1951-12-31,IT,Italy,34.9377
+1952-03-31,IT,Italy,34.5411
+1952-06-30,IT,Italy,34.5564
+1952-09-30,IT,Italy,34.6202
+1952-12-31,IT,Italy,34.6775
+1953-03-31,IT,Italy,34.2159
+1953-06-30,IT,Italy,34.799
+1953-09-30,IT,Italy,33.7771
+1953-12-31,IT,Italy,34.0857
+1954-03-31,IT,Italy,34.5664
+1954-06-30,IT,Italy,34.5157
+1954-09-30,IT,Italy,34.8124
+1954-12-31,IT,Italy,35.0863
+1955-03-31,IT,Italy,35.1457
 1955-03-31,JP,Japan,12.6625
-1955-03-31,KR,Korea,
-1955-03-31,LT,Lithuania,
-1955-03-31,LU,Luxembourg,
-1955-03-31,LV,Latvia,
-1955-03-31,MA,Morocco,
-1955-03-31,MK,North Macedonia,
-1955-03-31,MT,Malta,
-1955-03-31,MX,Mexico,
-1955-03-31,MY,Malaysia,
-1955-03-31,NL,Netherlands,
-1955-03-31,NO,Norway,
-1955-03-31,NZ,New Zealand,
-1955-03-31,PE,Peru,
-1955-03-31,PH,Philippines,
-1955-03-31,PL,Poland,
-1955-03-31,PT,Portugal,
-1955-03-31,RO,Romania,
-1955-03-31,RS,Serbia,
-1955-03-31,RU,Russia,
-1955-03-31,SE,Sweden,
-1955-03-31,SG,Singapore,
-1955-03-31,SI,Slovenia,
-1955-03-31,SK,Slovak Republic,
-1955-03-31,TH,Thailand,
-1955-03-31,TR,Türkiye,
-1955-03-31,US,United States,
-1955-03-31,XM,Euro area,
-1955-03-31,XW,World,
-1955-03-31,ZA,South Africa,
-1955-06-30,4T,Emerging market economies (aggregate),
-1955-06-30,5R,Advanced economies,
-1955-06-30,AE,United Arab Emirates,
-1955-06-30,AT,Austria,
-1955-06-30,AU,Australia,
-1955-06-30,BE,Belgium,
-1955-06-30,BG,Bulgaria,
-1955-06-30,BR,Brazil,
-1955-06-30,CA,Canada,
-1955-06-30,CH,Switzerland,
-1955-06-30,CL,Chile,
-1955-06-30,CN,China,
-1955-06-30,CO,Colombia,
-1955-06-30,CY,Cyprus,
-1955-06-30,CZ,Czechia,
-1955-06-30,DE,Germany,
-1955-06-30,DK,Denmark,
-1955-06-30,EE,Estonia,
-1955-06-30,ES,Spain,
-1955-06-30,FI,Finland,
-1955-06-30,FR,France,
-1955-06-30,GB,United Kingdom,
-1955-06-30,GR,Greece,
-1955-06-30,HK,Hong Kong SAR,
-1955-06-30,HR,Croatia,
-1955-06-30,HU,Hungary,
-1955-06-30,ID,Indonesia,
-1955-06-30,IE,Ireland,
-1955-06-30,IL,Israel,
-1955-06-30,IN,India,
-1955-06-30,IS,Iceland,
-1955-06-30,IT,Italy,37.7289
+1955-06-30,IT,Italy,34.9224
 1955-06-30,JP,Japan,13.0947
-1955-06-30,KR,Korea,
-1955-06-30,LT,Lithuania,
-1955-06-30,LU,Luxembourg,
-1955-06-30,LV,Latvia,
-1955-06-30,MA,Morocco,
-1955-06-30,MK,North Macedonia,
-1955-06-30,MT,Malta,
-1955-06-30,MX,Mexico,
-1955-06-30,MY,Malaysia,
-1955-06-30,NL,Netherlands,
-1955-06-30,NO,Norway,
-1955-06-30,NZ,New Zealand,
-1955-06-30,PE,Peru,
-1955-06-30,PH,Philippines,
-1955-06-30,PL,Poland,
-1955-06-30,PT,Portugal,
-1955-06-30,RO,Romania,
-1955-06-30,RS,Serbia,
-1955-06-30,RU,Russia,
-1955-06-30,SE,Sweden,
-1955-06-30,SG,Singapore,
-1955-06-30,SI,Slovenia,
-1955-06-30,SK,Slovak Republic,
-1955-06-30,TH,Thailand,
-1955-06-30,TR,Türkiye,
-1955-06-30,US,United States,
-1955-06-30,XM,Euro area,
-1955-06-30,XW,World,
-1955-06-30,ZA,South Africa,
-1955-09-30,4T,Emerging market economies (aggregate),
-1955-09-30,5R,Advanced economies,
-1955-09-30,AE,United Arab Emirates,
-1955-09-30,AT,Austria,
-1955-09-30,AU,Australia,
-1955-09-30,BE,Belgium,
-1955-09-30,BG,Bulgaria,
-1955-09-30,BR,Brazil,
-1955-09-30,CA,Canada,
-1955-09-30,CH,Switzerland,
-1955-09-30,CL,Chile,
-1955-09-30,CN,China,
-1955-09-30,CO,Colombia,
-1955-09-30,CY,Cyprus,
-1955-09-30,CZ,Czechia,
-1955-09-30,DE,Germany,
-1955-09-30,DK,Denmark,
-1955-09-30,EE,Estonia,
-1955-09-30,ES,Spain,
-1955-09-30,FI,Finland,
-1955-09-30,FR,France,
-1955-09-30,GB,United Kingdom,
-1955-09-30,GR,Greece,
-1955-09-30,HK,Hong Kong SAR,
-1955-09-30,HR,Croatia,
-1955-09-30,HU,Hungary,
-1955-09-30,ID,Indonesia,
-1955-09-30,IE,Ireland,
-1955-09-30,IL,Israel,
-1955-09-30,IN,India,
-1955-09-30,IS,Iceland,
-1955-09-30,IT,Italy,37.1473
+1955-09-30,IT,Italy,34.6376
 1955-09-30,JP,Japan,13.509
-1955-09-30,KR,Korea,
-1955-09-30,LT,Lithuania,
-1955-09-30,LU,Luxembourg,
-1955-09-30,LV,Latvia,
-1955-09-30,MA,Morocco,
-1955-09-30,MK,North Macedonia,
-1955-09-30,MT,Malta,
-1955-09-30,MX,Mexico,
-1955-09-30,MY,Malaysia,
-1955-09-30,NL,Netherlands,
-1955-09-30,NO,Norway,
-1955-09-30,NZ,New Zealand,
-1955-09-30,PE,Peru,
-1955-09-30,PH,Philippines,
-1955-09-30,PL,Poland,
-1955-09-30,PT,Portugal,
-1955-09-30,RO,Romania,
-1955-09-30,RS,Serbia,
-1955-09-30,RU,Russia,
-1955-09-30,SE,Sweden,
-1955-09-30,SG,Singapore,
-1955-09-30,SI,Slovenia,
-1955-09-30,SK,Slovak Republic,
-1955-09-30,TH,Thailand,
-1955-09-30,TR,Türkiye,
-1955-09-30,US,United States,
-1955-09-30,XM,Euro area,
-1955-09-30,XW,World,
-1955-09-30,ZA,South Africa,
-1955-12-31,4T,Emerging market economies (aggregate),
-1955-12-31,5R,Advanced economies,
-1955-12-31,AE,United Arab Emirates,
-1955-12-31,AT,Austria,
-1955-12-31,AU,Australia,
-1955-12-31,BE,Belgium,
-1955-12-31,BG,Bulgaria,
-1955-12-31,BR,Brazil,
-1955-12-31,CA,Canada,
-1955-12-31,CH,Switzerland,
-1955-12-31,CL,Chile,
-1955-12-31,CN,China,
-1955-12-31,CO,Colombia,
-1955-12-31,CY,Cyprus,
-1955-12-31,CZ,Czechia,
-1955-12-31,DE,Germany,
-1955-12-31,DK,Denmark,
-1955-12-31,EE,Estonia,
-1955-12-31,ES,Spain,
-1955-12-31,FI,Finland,
-1955-12-31,FR,France,
-1955-12-31,GB,United Kingdom,
-1955-12-31,GR,Greece,
-1955-12-31,HK,Hong Kong SAR,
-1955-12-31,HR,Croatia,
-1955-12-31,HU,Hungary,
-1955-12-31,ID,Indonesia,
-1955-12-31,IE,Ireland,
-1955-12-31,IL,Israel,
-1955-12-31,IN,India,
-1955-12-31,IS,Iceland,
-1955-12-31,IT,Italy,36.1765
+1955-12-31,IT,Italy,34.3534
 1955-12-31,JP,Japan,14.1134
-1955-12-31,KR,Korea,
-1955-12-31,LT,Lithuania,
-1955-12-31,LU,Luxembourg,
-1955-12-31,LV,Latvia,
-1955-12-31,MA,Morocco,
-1955-12-31,MK,North Macedonia,
-1955-12-31,MT,Malta,
-1955-12-31,MX,Mexico,
-1955-12-31,MY,Malaysia,
-1955-12-31,NL,Netherlands,
-1955-12-31,NO,Norway,
-1955-12-31,NZ,New Zealand,
-1955-12-31,PE,Peru,
-1955-12-31,PH,Philippines,
-1955-12-31,PL,Poland,
-1955-12-31,PT,Portugal,
-1955-12-31,RO,Romania,
-1955-12-31,RS,Serbia,
-1955-12-31,RU,Russia,
-1955-12-31,SE,Sweden,
-1955-12-31,SG,Singapore,
-1955-12-31,SI,Slovenia,
-1955-12-31,SK,Slovak Republic,
-1955-12-31,TH,Thailand,
-1955-12-31,TR,Türkiye,
-1955-12-31,US,United States,
-1955-12-31,XM,Euro area,
-1955-12-31,XW,World,
-1955-12-31,ZA,South Africa,
-1956-03-31,4T,Emerging market economies (aggregate),
-1956-03-31,5R,Advanced economies,
-1956-03-31,AE,United Arab Emirates,
-1956-03-31,AT,Austria,
-1956-03-31,AU,Australia,
-1956-03-31,BE,Belgium,
-1956-03-31,BG,Bulgaria,
-1956-03-31,BR,Brazil,
-1956-03-31,CA,Canada,
-1956-03-31,CH,Switzerland,
-1956-03-31,CL,Chile,
-1956-03-31,CN,China,
-1956-03-31,CO,Colombia,
-1956-03-31,CY,Cyprus,
-1956-03-31,CZ,Czechia,
-1956-03-31,DE,Germany,
-1956-03-31,DK,Denmark,
-1956-03-31,EE,Estonia,
-1956-03-31,ES,Spain,
-1956-03-31,FI,Finland,
-1956-03-31,FR,France,
-1956-03-31,GB,United Kingdom,
-1956-03-31,GR,Greece,
-1956-03-31,HK,Hong Kong SAR,
-1956-03-31,HR,Croatia,
-1956-03-31,HU,Hungary,
-1956-03-31,ID,Indonesia,
-1956-03-31,IE,Ireland,
-1956-03-31,IL,Israel,
-1956-03-31,IN,India,
-1956-03-31,IS,Iceland,
-1956-03-31,IT,Italy,36.5082
+1956-03-31,IT,Italy,34.7094
 1956-03-31,JP,Japan,14.5879
-1956-03-31,KR,Korea,
-1956-03-31,LT,Lithuania,
-1956-03-31,LU,Luxembourg,
-1956-03-31,LV,Latvia,
-1956-03-31,MA,Morocco,
-1956-03-31,MK,North Macedonia,
-1956-03-31,MT,Malta,
-1956-03-31,MX,Mexico,
-1956-03-31,MY,Malaysia,
-1956-03-31,NL,Netherlands,
-1956-03-31,NO,Norway,
-1956-03-31,NZ,New Zealand,
-1956-03-31,PE,Peru,
-1956-03-31,PH,Philippines,
-1956-03-31,PL,Poland,
-1956-03-31,PT,Portugal,
-1956-03-31,RO,Romania,
-1956-03-31,RS,Serbia,
-1956-03-31,RU,Russia,
-1956-03-31,SE,Sweden,
-1956-03-31,SG,Singapore,
-1956-03-31,SI,Slovenia,
-1956-03-31,SK,Slovak Republic,
-1956-03-31,TH,Thailand,
-1956-03-31,TR,Türkiye,
-1956-03-31,US,United States,
-1956-03-31,XM,Euro area,
-1956-03-31,XW,World,
-1956-03-31,ZA,South Africa,
-1956-06-30,4T,Emerging market economies (aggregate),
-1956-06-30,5R,Advanced economies,
-1956-06-30,AE,United Arab Emirates,
-1956-06-30,AT,Austria,
-1956-06-30,AU,Australia,
-1956-06-30,BE,Belgium,
-1956-06-30,BG,Bulgaria,
-1956-06-30,BR,Brazil,
-1956-06-30,CA,Canada,
-1956-06-30,CH,Switzerland,
-1956-06-30,CL,Chile,
-1956-06-30,CN,China,
-1956-06-30,CO,Colombia,
-1956-06-30,CY,Cyprus,
-1956-06-30,CZ,Czechia,
-1956-06-30,DE,Germany,
-1956-06-30,DK,Denmark,
-1956-06-30,EE,Estonia,
-1956-06-30,ES,Spain,
-1956-06-30,FI,Finland,
-1956-06-30,FR,France,
-1956-06-30,GB,United Kingdom,
-1956-06-30,GR,Greece,
-1956-06-30,HK,Hong Kong SAR,
-1956-06-30,HR,Croatia,
-1956-06-30,HU,Hungary,
-1956-06-30,ID,Indonesia,
-1956-06-30,IE,Ireland,
-1956-06-30,IL,Israel,
-1956-06-30,IN,India,
-1956-06-30,IS,Iceland,
-1956-06-30,IT,Italy,36.6065
+1956-06-30,IT,Italy,34.6464
 1956-06-30,JP,Japan,15.2501
-1956-06-30,KR,Korea,
-1956-06-30,LT,Lithuania,
-1956-06-30,LU,Luxembourg,
-1956-06-30,LV,Latvia,
-1956-06-30,MA,Morocco,
-1956-06-30,MK,North Macedonia,
-1956-06-30,MT,Malta,
-1956-06-30,MX,Mexico,
-1956-06-30,MY,Malaysia,
-1956-06-30,NL,Netherlands,
-1956-06-30,NO,Norway,
-1956-06-30,NZ,New Zealand,
-1956-06-30,PE,Peru,
-1956-06-30,PH,Philippines,
-1956-06-30,PL,Poland,
-1956-06-30,PT,Portugal,
-1956-06-30,RO,Romania,
-1956-06-30,RS,Serbia,
-1956-06-30,RU,Russia,
-1956-06-30,SE,Sweden,
-1956-06-30,SG,Singapore,
-1956-06-30,SI,Slovenia,
-1956-06-30,SK,Slovak Republic,
-1956-06-30,TH,Thailand,
-1956-06-30,TR,Türkiye,
-1956-06-30,US,United States,
-1956-06-30,XM,Euro area,
-1956-06-30,XW,World,
-1956-06-30,ZA,South Africa,
-1956-09-30,4T,Emerging market economies (aggregate),
-1956-09-30,5R,Advanced economies,
-1956-09-30,AE,United Arab Emirates,
-1956-09-30,AT,Austria,
-1956-09-30,AU,Australia,
-1956-09-30,BE,Belgium,
-1956-09-30,BG,Bulgaria,
-1956-09-30,BR,Brazil,
-1956-09-30,CA,Canada,
-1956-09-30,CH,Switzerland,
-1956-09-30,CL,Chile,
-1956-09-30,CN,China,
-1956-09-30,CO,Colombia,
-1956-09-30,CY,Cyprus,
-1956-09-30,CZ,Czechia,
-1956-09-30,DE,Germany,
-1956-09-30,DK,Denmark,
-1956-09-30,EE,Estonia,
-1956-09-30,ES,Spain,
-1956-09-30,FI,Finland,
-1956-09-30,FR,France,
-1956-09-30,GB,United Kingdom,
-1956-09-30,GR,Greece,
-1956-09-30,HK,Hong Kong SAR,
-1956-09-30,HR,Croatia,
-1956-09-30,HU,Hungary,
-1956-09-30,ID,Indonesia,
-1956-09-30,IE,Ireland,
-1956-09-30,IL,Israel,
-1956-09-30,IN,India,
-1956-09-30,IS,Iceland,
-1956-09-30,IT,Italy,35.9775
+1956-09-30,IT,Italy,34.3695
 1956-09-30,JP,Japan,16.106
-1956-09-30,KR,Korea,
-1956-09-30,LT,Lithuania,
-1956-09-30,LU,Luxembourg,
-1956-09-30,LV,Latvia,
-1956-09-30,MA,Morocco,
-1956-09-30,MK,North Macedonia,
-1956-09-30,MT,Malta,
-1956-09-30,MX,Mexico,
-1956-09-30,MY,Malaysia,
-1956-09-30,NL,Netherlands,
-1956-09-30,NO,Norway,
-1956-09-30,NZ,New Zealand,
-1956-09-30,PE,Peru,
-1956-09-30,PH,Philippines,
-1956-09-30,PL,Poland,
-1956-09-30,PT,Portugal,
-1956-09-30,RO,Romania,
-1956-09-30,RS,Serbia,
-1956-09-30,RU,Russia,
-1956-09-30,SE,Sweden,
-1956-09-30,SG,Singapore,
-1956-09-30,SI,Slovenia,
-1956-09-30,SK,Slovak Republic,
-1956-09-30,TH,Thailand,
-1956-09-30,TR,Türkiye,
-1956-09-30,US,United States,
-1956-09-30,XM,Euro area,
-1956-09-30,XW,World,
-1956-09-30,ZA,South Africa,
-1956-12-31,4T,Emerging market economies (aggregate),
-1956-12-31,5R,Advanced economies,
-1956-12-31,AE,United Arab Emirates,
-1956-12-31,AT,Austria,
-1956-12-31,AU,Australia,
-1956-12-31,BE,Belgium,
-1956-12-31,BG,Bulgaria,
-1956-12-31,BR,Brazil,
-1956-12-31,CA,Canada,
-1956-12-31,CH,Switzerland,
-1956-12-31,CL,Chile,
-1956-12-31,CN,China,
-1956-12-31,CO,Colombia,
-1956-12-31,CY,Cyprus,
-1956-12-31,CZ,Czechia,
-1956-12-31,DE,Germany,
-1956-12-31,DK,Denmark,
-1956-12-31,EE,Estonia,
-1956-12-31,ES,Spain,
-1956-12-31,FI,Finland,
-1956-12-31,FR,France,
-1956-12-31,GB,United Kingdom,
-1956-12-31,GR,Greece,
-1956-12-31,HK,Hong Kong SAR,
-1956-12-31,HR,Croatia,
-1956-12-31,HU,Hungary,
-1956-12-31,ID,Indonesia,
-1956-12-31,IE,Ireland,
-1956-12-31,IL,Israel,
-1956-12-31,IN,India,
-1956-12-31,IS,Iceland,
-1956-12-31,IT,Italy,35.997
+1956-12-31,IT,Italy,34.7229
 1956-12-31,JP,Japan,17.1175
-1956-12-31,KR,Korea,
-1956-12-31,LT,Lithuania,
-1956-12-31,LU,Luxembourg,
-1956-12-31,LV,Latvia,
-1956-12-31,MA,Morocco,
-1956-12-31,MK,North Macedonia,
-1956-12-31,MT,Malta,
-1956-12-31,MX,Mexico,
-1956-12-31,MY,Malaysia,
-1956-12-31,NL,Netherlands,
-1956-12-31,NO,Norway,
-1956-12-31,NZ,New Zealand,
-1956-12-31,PE,Peru,
-1956-12-31,PH,Philippines,
-1956-12-31,PL,Poland,
-1956-12-31,PT,Portugal,
-1956-12-31,RO,Romania,
-1956-12-31,RS,Serbia,
-1956-12-31,RU,Russia,
-1956-12-31,SE,Sweden,
-1956-12-31,SG,Singapore,
-1956-12-31,SI,Slovenia,
-1956-12-31,SK,Slovak Republic,
-1956-12-31,TH,Thailand,
-1956-12-31,TR,Türkiye,
-1956-12-31,US,United States,
-1956-12-31,XM,Euro area,
-1956-12-31,XW,World,
-1956-12-31,ZA,South Africa,
-1957-03-31,4T,Emerging market economies (aggregate),
-1957-03-31,5R,Advanced economies,
-1957-03-31,AE,United Arab Emirates,
-1957-03-31,AT,Austria,
-1957-03-31,AU,Australia,
-1957-03-31,BE,Belgium,
-1957-03-31,BG,Bulgaria,
-1957-03-31,BR,Brazil,
-1957-03-31,CA,Canada,
-1957-03-31,CH,Switzerland,
-1957-03-31,CL,Chile,
-1957-03-31,CN,China,
-1957-03-31,CO,Colombia,
-1957-03-31,CY,Cyprus,
-1957-03-31,CZ,Czechia,
-1957-03-31,DE,Germany,
-1957-03-31,DK,Denmark,
-1957-03-31,EE,Estonia,
-1957-03-31,ES,Spain,
-1957-03-31,FI,Finland,
-1957-03-31,FR,France,
-1957-03-31,GB,United Kingdom,
-1957-03-31,GR,Greece,
-1957-03-31,HK,Hong Kong SAR,
-1957-03-31,HR,Croatia,
-1957-03-31,HU,Hungary,
-1957-03-31,ID,Indonesia,
-1957-03-31,IE,Ireland,
-1957-03-31,IL,Israel,
-1957-03-31,IN,India,
-1957-03-31,IS,Iceland,
-1957-03-31,IT,Italy,36.6905
+1957-03-31,IT,Italy,35.1404
 1957-03-31,JP,Japan,17.9545
-1957-03-31,KR,Korea,
-1957-03-31,LT,Lithuania,
-1957-03-31,LU,Luxembourg,
-1957-03-31,LV,Latvia,
-1957-03-31,MA,Morocco,
-1957-03-31,MK,North Macedonia,
-1957-03-31,MT,Malta,
-1957-03-31,MX,Mexico,
-1957-03-31,MY,Malaysia,
-1957-03-31,NL,Netherlands,
-1957-03-31,NO,Norway,
-1957-03-31,NZ,New Zealand,
-1957-03-31,PE,Peru,
-1957-03-31,PH,Philippines,
-1957-03-31,PL,Poland,
-1957-03-31,PT,Portugal,
-1957-03-31,RO,Romania,
-1957-03-31,RS,Serbia,
-1957-03-31,RU,Russia,
-1957-03-31,SE,Sweden,
-1957-03-31,SG,Singapore,
-1957-03-31,SI,Slovenia,
-1957-03-31,SK,Slovak Republic,
-1957-03-31,TH,Thailand,
-1957-03-31,TR,Türkiye,
-1957-03-31,US,United States,
-1957-03-31,XM,Euro area,
-1957-03-31,XW,World,
-1957-03-31,ZA,South Africa,
-1957-06-30,4T,Emerging market economies (aggregate),
-1957-06-30,5R,Advanced economies,
-1957-06-30,AE,United Arab Emirates,
-1957-06-30,AT,Austria,
-1957-06-30,AU,Australia,
-1957-06-30,BE,Belgium,
-1957-06-30,BG,Bulgaria,
-1957-06-30,BR,Brazil,
-1957-06-30,CA,Canada,
-1957-06-30,CH,Switzerland,
-1957-06-30,CL,Chile,
-1957-06-30,CN,China,
-1957-06-30,CO,Colombia,
-1957-06-30,CY,Cyprus,
-1957-06-30,CZ,Czechia,
-1957-06-30,DE,Germany,
-1957-06-30,DK,Denmark,
-1957-06-30,EE,Estonia,
-1957-06-30,ES,Spain,
-1957-06-30,FI,Finland,
-1957-06-30,FR,France,
-1957-06-30,GB,United Kingdom,
-1957-06-30,GR,Greece,
-1957-06-30,HK,Hong Kong SAR,
-1957-06-30,HR,Croatia,
-1957-06-30,HU,Hungary,
-1957-06-30,ID,Indonesia,
-1957-06-30,IE,Ireland,
-1957-06-30,IL,Israel,
-1957-06-30,IN,India,
-1957-06-30,IS,Iceland,
-1957-06-30,IT,Italy,36.6533
+1957-06-30,IT,Italy,35.0801
 1957-06-30,JP,Japan,18.692
-1957-06-30,KR,Korea,
-1957-06-30,LT,Lithuania,
-1957-06-30,LU,Luxembourg,
-1957-06-30,LV,Latvia,
-1957-06-30,MA,Morocco,
-1957-06-30,MK,North Macedonia,
-1957-06-30,MT,Malta,
-1957-06-30,MX,Mexico,
-1957-06-30,MY,Malaysia,
-1957-06-30,NL,Netherlands,
-1957-06-30,NO,Norway,
-1957-06-30,NZ,New Zealand,
-1957-06-30,PE,Peru,
-1957-06-30,PH,Philippines,
-1957-06-30,PL,Poland,
-1957-06-30,PT,Portugal,
-1957-06-30,RO,Romania,
-1957-06-30,RS,Serbia,
-1957-06-30,RU,Russia,
-1957-06-30,SE,Sweden,
-1957-06-30,SG,Singapore,
-1957-06-30,SI,Slovenia,
-1957-06-30,SK,Slovak Republic,
-1957-06-30,TH,Thailand,
-1957-06-30,TR,Türkiye,
-1957-06-30,US,United States,
-1957-06-30,XM,Euro area,
-1957-06-30,XW,World,
-1957-06-30,ZA,South Africa,
-1957-09-30,4T,Emerging market economies (aggregate),
-1957-09-30,5R,Advanced economies,
-1957-09-30,AE,United Arab Emirates,
-1957-09-30,AT,Austria,
-1957-09-30,AU,Australia,
-1957-09-30,BE,Belgium,
-1957-09-30,BG,Bulgaria,
-1957-09-30,BR,Brazil,
-1957-09-30,CA,Canada,
-1957-09-30,CH,Switzerland,
-1957-09-30,CL,Chile,
-1957-09-30,CN,China,
-1957-09-30,CO,Colombia,
-1957-09-30,CY,Cyprus,
-1957-09-30,CZ,Czechia,
-1957-09-30,DE,Germany,
-1957-09-30,DK,Denmark,
-1957-09-30,EE,Estonia,
-1957-09-30,ES,Spain,
-1957-09-30,FI,Finland,
-1957-09-30,FR,France,
-1957-09-30,GB,United Kingdom,
-1957-09-30,GR,Greece,
-1957-09-30,HK,Hong Kong SAR,
-1957-09-30,HR,Croatia,
-1957-09-30,HU,Hungary,
-1957-09-30,ID,Indonesia,
-1957-09-30,IE,Ireland,
-1957-09-30,IL,Israel,
-1957-09-30,IN,India,
-1957-09-30,IS,Iceland,
-1957-09-30,IT,Italy,36.5783
+1957-09-30,IT,Italy,35.034
 1957-09-30,JP,Japan,19.3889
-1957-09-30,KR,Korea,
-1957-09-30,LT,Lithuania,
-1957-09-30,LU,Luxembourg,
-1957-09-30,LV,Latvia,
-1957-09-30,MA,Morocco,
-1957-09-30,MK,North Macedonia,
-1957-09-30,MT,Malta,
-1957-09-30,MX,Mexico,
-1957-09-30,MY,Malaysia,
-1957-09-30,NL,Netherlands,
-1957-09-30,NO,Norway,
-1957-09-30,NZ,New Zealand,
-1957-09-30,PE,Peru,
-1957-09-30,PH,Philippines,
-1957-09-30,PL,Poland,
-1957-09-30,PT,Portugal,
-1957-09-30,RO,Romania,
-1957-09-30,RS,Serbia,
-1957-09-30,RU,Russia,
-1957-09-30,SE,Sweden,
-1957-09-30,SG,Singapore,
-1957-09-30,SI,Slovenia,
-1957-09-30,SK,Slovak Republic,
-1957-09-30,TH,Thailand,
-1957-09-30,TR,Türkiye,
-1957-09-30,US,United States,
-1957-09-30,XM,Euro area,
-1957-09-30,XW,World,
-1957-09-30,ZA,South Africa,
-1957-12-31,4T,Emerging market economies (aggregate),
-1957-12-31,5R,Advanced economies,
-1957-12-31,AE,United Arab Emirates,
-1957-12-31,AT,Austria,
-1957-12-31,AU,Australia,
-1957-12-31,BE,Belgium,
-1957-12-31,BG,Bulgaria,
-1957-12-31,BR,Brazil,
-1957-12-31,CA,Canada,
-1957-12-31,CH,Switzerland,
-1957-12-31,CL,Chile,
-1957-12-31,CN,China,
-1957-12-31,CO,Colombia,
-1957-12-31,CY,Cyprus,
-1957-12-31,CZ,Czechia,
-1957-12-31,DE,Germany,
-1957-12-31,DK,Denmark,
-1957-12-31,EE,Estonia,
-1957-12-31,ES,Spain,
-1957-12-31,FI,Finland,
-1957-12-31,FR,France,
-1957-12-31,GB,United Kingdom,
-1957-12-31,GR,Greece,
-1957-12-31,HK,Hong Kong SAR,
-1957-12-31,HR,Croatia,
-1957-12-31,HU,Hungary,
-1957-12-31,ID,Indonesia,
-1957-12-31,IE,Ireland,
-1957-12-31,IL,Israel,
-1957-12-31,IN,India,
-1957-12-31,IS,Iceland,
-1957-12-31,IT,Italy,36.0888
+1957-12-31,IT,Italy,34.9676
 1957-12-31,JP,Japan,20.7359
-1957-12-31,KR,Korea,
-1957-12-31,LT,Lithuania,
-1957-12-31,LU,Luxembourg,
-1957-12-31,LV,Latvia,
-1957-12-31,MA,Morocco,
-1957-12-31,MK,North Macedonia,
-1957-12-31,MT,Malta,
-1957-12-31,MX,Mexico,
-1957-12-31,MY,Malaysia,
-1957-12-31,NL,Netherlands,
-1957-12-31,NO,Norway,
-1957-12-31,NZ,New Zealand,
-1957-12-31,PE,Peru,
-1957-12-31,PH,Philippines,
-1957-12-31,PL,Poland,
-1957-12-31,PT,Portugal,
-1957-12-31,RO,Romania,
-1957-12-31,RS,Serbia,
-1957-12-31,RU,Russia,
-1957-12-31,SE,Sweden,
-1957-12-31,SG,Singapore,
-1957-12-31,SI,Slovenia,
-1957-12-31,SK,Slovak Republic,
-1957-12-31,TH,Thailand,
-1957-12-31,TR,Türkiye,
-1957-12-31,US,United States,
-1957-12-31,XM,Euro area,
-1957-12-31,XW,World,
-1957-12-31,ZA,South Africa,
-1958-03-31,4T,Emerging market economies (aggregate),
-1958-03-31,5R,Advanced economies,
-1958-03-31,AE,United Arab Emirates,
-1958-03-31,AT,Austria,
-1958-03-31,AU,Australia,
-1958-03-31,BE,Belgium,
-1958-03-31,BG,Bulgaria,
-1958-03-31,BR,Brazil,
-1958-03-31,CA,Canada,
-1958-03-31,CH,Switzerland,
-1958-03-31,CL,Chile,
-1958-03-31,CN,China,
-1958-03-31,CO,Colombia,
-1958-03-31,CY,Cyprus,
-1958-03-31,CZ,Czechia,
-1958-03-31,DE,Germany,
-1958-03-31,DK,Denmark,
-1958-03-31,EE,Estonia,
-1958-03-31,ES,Spain,
-1958-03-31,FI,Finland,
-1958-03-31,FR,France,
-1958-03-31,GB,United Kingdom,
-1958-03-31,GR,Greece,
-1958-03-31,HK,Hong Kong SAR,
-1958-03-31,HR,Croatia,
-1958-03-31,HU,Hungary,
-1958-03-31,ID,Indonesia,
-1958-03-31,IE,Ireland,
-1958-03-31,IL,Israel,
-1958-03-31,IN,India,
-1958-03-31,IS,Iceland,
-1958-03-31,IT,Italy,35.4142
+1958-03-31,IT,Italy,34.4472
 1958-03-31,JP,Japan,22.077
-1958-03-31,KR,Korea,
-1958-03-31,LT,Lithuania,
-1958-03-31,LU,Luxembourg,
-1958-03-31,LV,Latvia,
-1958-03-31,MA,Morocco,
-1958-03-31,MK,North Macedonia,
-1958-03-31,MT,Malta,
-1958-03-31,MX,Mexico,
-1958-03-31,MY,Malaysia,
-1958-03-31,NL,Netherlands,
-1958-03-31,NO,Norway,
-1958-03-31,NZ,New Zealand,
-1958-03-31,PE,Peru,
-1958-03-31,PH,Philippines,
-1958-03-31,PL,Poland,
-1958-03-31,PT,Portugal,
-1958-03-31,RO,Romania,
-1958-03-31,RS,Serbia,
-1958-03-31,RU,Russia,
-1958-03-31,SE,Sweden,
-1958-03-31,SG,Singapore,
-1958-03-31,SI,Slovenia,
-1958-03-31,SK,Slovak Republic,
-1958-03-31,TH,Thailand,
-1958-03-31,TR,Türkiye,
-1958-03-31,US,United States,
-1958-03-31,XM,Euro area,
-1958-03-31,XW,World,
-1958-03-31,ZA,South Africa,
-1958-06-30,4T,Emerging market economies (aggregate),
-1958-06-30,5R,Advanced economies,
-1958-06-30,AE,United Arab Emirates,
-1958-06-30,AT,Austria,
-1958-06-30,AU,Australia,
-1958-06-30,BE,Belgium,
-1958-06-30,BG,Bulgaria,
-1958-06-30,BR,Brazil,
-1958-06-30,CA,Canada,
-1958-06-30,CH,Switzerland,
-1958-06-30,CL,Chile,
-1958-06-30,CN,China,
-1958-06-30,CO,Colombia,
-1958-06-30,CY,Cyprus,
-1958-06-30,CZ,Czechia,
-1958-06-30,DE,Germany,
-1958-06-30,DK,Denmark,
-1958-06-30,EE,Estonia,
-1958-06-30,ES,Spain,
-1958-06-30,FI,Finland,
-1958-06-30,FR,France,
-1958-06-30,GB,United Kingdom,
-1958-06-30,GR,Greece,
-1958-06-30,HK,Hong Kong SAR,
-1958-06-30,HR,Croatia,
-1958-06-30,HU,Hungary,
-1958-06-30,ID,Indonesia,
-1958-06-30,IE,Ireland,
-1958-06-30,IL,Israel,
-1958-06-30,IN,India,
-1958-06-30,IS,Iceland,
-1958-06-30,IT,Italy,35.4665
+1958-06-30,IT,Italy,34.4713
 1958-06-30,JP,Japan,23.3128
-1958-06-30,KR,Korea,
-1958-06-30,LT,Lithuania,
-1958-06-30,LU,Luxembourg,
-1958-06-30,LV,Latvia,
-1958-06-30,MA,Morocco,
-1958-06-30,MK,North Macedonia,
-1958-06-30,MT,Malta,
-1958-06-30,MX,Mexico,
-1958-06-30,MY,Malaysia,
-1958-06-30,NL,Netherlands,
-1958-06-30,NO,Norway,
-1958-06-30,NZ,New Zealand,
-1958-06-30,PE,Peru,
-1958-06-30,PH,Philippines,
-1958-06-30,PL,Poland,
-1958-06-30,PT,Portugal,
-1958-06-30,RO,Romania,
-1958-06-30,RS,Serbia,
-1958-06-30,RU,Russia,
-1958-06-30,SE,Sweden,
-1958-06-30,SG,Singapore,
-1958-06-30,SI,Slovenia,
-1958-06-30,SK,Slovak Republic,
-1958-06-30,TH,Thailand,
-1958-06-30,TR,Türkiye,
-1958-06-30,US,United States,
-1958-06-30,XM,Euro area,
-1958-06-30,XW,World,
-1958-06-30,ZA,South Africa,
-1958-09-30,4T,Emerging market economies (aggregate),
-1958-09-30,5R,Advanced economies,
-1958-09-30,AE,United Arab Emirates,
-1958-09-30,AT,Austria,
-1958-09-30,AU,Australia,
-1958-09-30,BE,Belgium,
-1958-09-30,BG,Bulgaria,
-1958-09-30,BR,Brazil,
-1958-09-30,CA,Canada,
-1958-09-30,CH,Switzerland,
-1958-09-30,CL,Chile,
-1958-09-30,CN,China,
-1958-09-30,CO,Colombia,
-1958-09-30,CY,Cyprus,
-1958-09-30,CZ,Czechia,
-1958-09-30,DE,Germany,
-1958-09-30,DK,Denmark,
-1958-09-30,EE,Estonia,
-1958-09-30,ES,Spain,
-1958-09-30,FI,Finland,
-1958-09-30,FR,France,
-1958-09-30,GB,United Kingdom,
-1958-09-30,GR,Greece,
-1958-09-30,HK,Hong Kong SAR,
-1958-09-30,HR,Croatia,
-1958-09-30,HU,Hungary,
-1958-09-30,ID,Indonesia,
-1958-09-30,IE,Ireland,
-1958-09-30,IL,Israel,
-1958-09-30,IN,India,
-1958-09-30,IS,Iceland,
-1958-09-30,IT,Italy,34.9744
+1958-09-30,IT,Italy,34.1807
 1958-09-30,JP,Japan,24.4646
-1958-09-30,KR,Korea,
-1958-09-30,LT,Lithuania,
-1958-09-30,LU,Luxembourg,
-1958-09-30,LV,Latvia,
-1958-09-30,MA,Morocco,
-1958-09-30,MK,North Macedonia,
-1958-09-30,MT,Malta,
-1958-09-30,MX,Mexico,
-1958-09-30,MY,Malaysia,
-1958-09-30,NL,Netherlands,
-1958-09-30,NO,Norway,
-1958-09-30,NZ,New Zealand,
-1958-09-30,PE,Peru,
-1958-09-30,PH,Philippines,
-1958-09-30,PL,Poland,
-1958-09-30,PT,Portugal,
-1958-09-30,RO,Romania,
-1958-09-30,RS,Serbia,
-1958-09-30,RU,Russia,
-1958-09-30,SE,Sweden,
-1958-09-30,SG,Singapore,
-1958-09-30,SI,Slovenia,
-1958-09-30,SK,Slovak Republic,
-1958-09-30,TH,Thailand,
-1958-09-30,TR,Türkiye,
-1958-09-30,US,United States,
-1958-09-30,XM,Euro area,
-1958-09-30,XW,World,
-1958-09-30,ZA,South Africa,
-1958-12-31,4T,Emerging market economies (aggregate),
-1958-12-31,5R,Advanced economies,
-1958-12-31,AE,United Arab Emirates,
-1958-12-31,AT,Austria,
-1958-12-31,AU,Australia,
-1958-12-31,BE,Belgium,
-1958-12-31,BG,Bulgaria,
-1958-12-31,BR,Brazil,
-1958-12-31,CA,Canada,
-1958-12-31,CH,Switzerland,
-1958-12-31,CL,Chile,
-1958-12-31,CN,China,
-1958-12-31,CO,Colombia,
-1958-12-31,CY,Cyprus,
-1958-12-31,CZ,Czechia,
-1958-12-31,DE,Germany,
-1958-12-31,DK,Denmark,
-1958-12-31,EE,Estonia,
-1958-12-31,ES,Spain,
-1958-12-31,FI,Finland,
-1958-12-31,FR,France,
-1958-12-31,GB,United Kingdom,
-1958-12-31,GR,Greece,
-1958-12-31,HK,Hong Kong SAR,
-1958-12-31,HR,Croatia,
-1958-12-31,HU,Hungary,
-1958-12-31,ID,Indonesia,
-1958-12-31,IE,Ireland,
-1958-12-31,IL,Israel,
-1958-12-31,IN,India,
-1958-12-31,IS,Iceland,
-1958-12-31,IT,Italy,34.3068
+1958-12-31,IT,Italy,33.947
 1958-12-31,JP,Japan,25.7054
-1958-12-31,KR,Korea,
-1958-12-31,LT,Lithuania,
-1958-12-31,LU,Luxembourg,
-1958-12-31,LV,Latvia,
-1958-12-31,MA,Morocco,
-1958-12-31,MK,North Macedonia,
-1958-12-31,MT,Malta,
-1958-12-31,MX,Mexico,
-1958-12-31,MY,Malaysia,
-1958-12-31,NL,Netherlands,
-1958-12-31,NO,Norway,
-1958-12-31,NZ,New Zealand,
-1958-12-31,PE,Peru,
-1958-12-31,PH,Philippines,
-1958-12-31,PL,Poland,
-1958-12-31,PT,Portugal,
-1958-12-31,RO,Romania,
-1958-12-31,RS,Serbia,
-1958-12-31,RU,Russia,
-1958-12-31,SE,Sweden,
-1958-12-31,SG,Singapore,
-1958-12-31,SI,Slovenia,
-1958-12-31,SK,Slovak Republic,
-1958-12-31,TH,Thailand,
-1958-12-31,TR,Türkiye,
-1958-12-31,US,United States,
-1958-12-31,XM,Euro area,
-1958-12-31,XW,World,
-1958-12-31,ZA,South Africa,
-1959-03-31,4T,Emerging market economies (aggregate),
-1959-03-31,5R,Advanced economies,
-1959-03-31,AE,United Arab Emirates,
-1959-03-31,AT,Austria,
-1959-03-31,AU,Australia,
-1959-03-31,BE,Belgium,
-1959-03-31,BG,Bulgaria,
-1959-03-31,BR,Brazil,
-1959-03-31,CA,Canada,
-1959-03-31,CH,Switzerland,
-1959-03-31,CL,Chile,
-1959-03-31,CN,China,
-1959-03-31,CO,Colombia,
-1959-03-31,CY,Cyprus,
-1959-03-31,CZ,Czechia,
-1959-03-31,DE,Germany,
-1959-03-31,DK,Denmark,
-1959-03-31,EE,Estonia,
-1959-03-31,ES,Spain,
-1959-03-31,FI,Finland,
-1959-03-31,FR,France,
-1959-03-31,GB,United Kingdom,
-1959-03-31,GR,Greece,
-1959-03-31,HK,Hong Kong SAR,
-1959-03-31,HR,Croatia,
-1959-03-31,HU,Hungary,
-1959-03-31,ID,Indonesia,
-1959-03-31,IE,Ireland,
-1959-03-31,IL,Israel,
-1959-03-31,IN,India,
-1959-03-31,IS,Iceland,
-1959-03-31,IT,Italy,34.5624
+1959-03-31,IT,Italy,33.9087
 1959-03-31,JP,Japan,27.1387
-1959-03-31,KR,Korea,
-1959-03-31,LT,Lithuania,
-1959-03-31,LU,Luxembourg,
-1959-03-31,LV,Latvia,
-1959-03-31,MA,Morocco,
-1959-03-31,MK,North Macedonia,
-1959-03-31,MT,Malta,
-1959-03-31,MX,Mexico,
-1959-03-31,MY,Malaysia,
-1959-03-31,NL,Netherlands,
-1959-03-31,NO,Norway,
-1959-03-31,NZ,New Zealand,
-1959-03-31,PE,Peru,
-1959-03-31,PH,Philippines,
-1959-03-31,PL,Poland,
-1959-03-31,PT,Portugal,
-1959-03-31,RO,Romania,
-1959-03-31,RS,Serbia,
-1959-03-31,RU,Russia,
-1959-03-31,SE,Sweden,
-1959-03-31,SG,Singapore,
-1959-03-31,SI,Slovenia,
-1959-03-31,SK,Slovak Republic,
-1959-03-31,TH,Thailand,
-1959-03-31,TR,Türkiye,
-1959-03-31,US,United States,
-1959-03-31,XM,Euro area,
-1959-03-31,XW,World,
-1959-03-31,ZA,South Africa,
-1959-06-30,4T,Emerging market economies (aggregate),
-1959-06-30,5R,Advanced economies,
-1959-06-30,AE,United Arab Emirates,
-1959-06-30,AT,Austria,
-1959-06-30,AU,Australia,
-1959-06-30,BE,Belgium,
-1959-06-30,BG,Bulgaria,
-1959-06-30,BR,Brazil,
-1959-06-30,CA,Canada,
-1959-06-30,CH,Switzerland,
-1959-06-30,CL,Chile,
-1959-06-30,CN,China,
-1959-06-30,CO,Colombia,
-1959-06-30,CY,Cyprus,
-1959-06-30,CZ,Czechia,
-1959-06-30,DE,Germany,
-1959-06-30,DK,Denmark,
-1959-06-30,EE,Estonia,
-1959-06-30,ES,Spain,
-1959-06-30,FI,Finland,
-1959-06-30,FR,France,
-1959-06-30,GB,United Kingdom,
-1959-06-30,GR,Greece,
-1959-06-30,HK,Hong Kong SAR,
-1959-06-30,HR,Croatia,
-1959-06-30,HU,Hungary,
-1959-06-30,ID,Indonesia,
-1959-06-30,IE,Ireland,
-1959-06-30,IL,Israel,
-1959-06-30,IN,India,
-1959-06-30,IS,Iceland,
-1959-06-30,IT,Italy,35.0366
+1959-06-30,IT,Italy,34.2743
 1959-06-30,JP,Japan,28.5884
-1959-06-30,KR,Korea,
-1959-06-30,LT,Lithuania,
-1959-06-30,LU,Luxembourg,
-1959-06-30,LV,Latvia,
-1959-06-30,MA,Morocco,
-1959-06-30,MK,North Macedonia,
-1959-06-30,MT,Malta,
-1959-06-30,MX,Mexico,
-1959-06-30,MY,Malaysia,
-1959-06-30,NL,Netherlands,
-1959-06-30,NO,Norway,
-1959-06-30,NZ,New Zealand,
-1959-06-30,PE,Peru,
-1959-06-30,PH,Philippines,
-1959-06-30,PL,Poland,
-1959-06-30,PT,Portugal,
-1959-06-30,RO,Romania,
-1959-06-30,RS,Serbia,
-1959-06-30,RU,Russia,
-1959-06-30,SE,Sweden,
-1959-06-30,SG,Singapore,
-1959-06-30,SI,Slovenia,
-1959-06-30,SK,Slovak Republic,
-1959-06-30,TH,Thailand,
-1959-06-30,TR,Türkiye,
-1959-06-30,US,United States,
-1959-06-30,XM,Euro area,
-1959-06-30,XW,World,
-1959-06-30,ZA,South Africa,
-1959-09-30,4T,Emerging market economies (aggregate),
-1959-09-30,5R,Advanced economies,
-1959-09-30,AE,United Arab Emirates,
-1959-09-30,AT,Austria,
-1959-09-30,AU,Australia,
-1959-09-30,BE,Belgium,
-1959-09-30,BG,Bulgaria,
-1959-09-30,BR,Brazil,
-1959-09-30,CA,Canada,
-1959-09-30,CH,Switzerland,
-1959-09-30,CL,Chile,
-1959-09-30,CN,China,
-1959-09-30,CO,Colombia,
-1959-09-30,CY,Cyprus,
-1959-09-30,CZ,Czechia,
-1959-09-30,DE,Germany,
-1959-09-30,DK,Denmark,
-1959-09-30,EE,Estonia,
-1959-09-30,ES,Spain,
-1959-09-30,FI,Finland,
-1959-09-30,FR,France,
-1959-09-30,GB,United Kingdom,
-1959-09-30,GR,Greece,
-1959-09-30,HK,Hong Kong SAR,
-1959-09-30,HR,Croatia,
-1959-09-30,HU,Hungary,
-1959-09-30,ID,Indonesia,
-1959-09-30,IE,Ireland,
-1959-09-30,IL,Israel,
-1959-09-30,IN,India,
-1959-09-30,IS,Iceland,
-1959-09-30,IT,Italy,35.0985
+1959-09-30,IT,Italy,34.2856
 1959-09-30,JP,Japan,29.9318
-1959-09-30,KR,Korea,
-1959-09-30,LT,Lithuania,
-1959-09-30,LU,Luxembourg,
-1959-09-30,LV,Latvia,
-1959-09-30,MA,Morocco,
-1959-09-30,MK,North Macedonia,
-1959-09-30,MT,Malta,
-1959-09-30,MX,Mexico,
-1959-09-30,MY,Malaysia,
-1959-09-30,NL,Netherlands,
-1959-09-30,NO,Norway,
-1959-09-30,NZ,New Zealand,
-1959-09-30,PE,Peru,
-1959-09-30,PH,Philippines,
-1959-09-30,PL,Poland,
-1959-09-30,PT,Portugal,
-1959-09-30,RO,Romania,
-1959-09-30,RS,Serbia,
-1959-09-30,RU,Russia,
-1959-09-30,SE,Sweden,
-1959-09-30,SG,Singapore,
-1959-09-30,SI,Slovenia,
-1959-09-30,SK,Slovak Republic,
-1959-09-30,TH,Thailand,
-1959-09-30,TR,Türkiye,
-1959-09-30,US,United States,
-1959-09-30,XM,Euro area,
-1959-09-30,XW,World,
-1959-09-30,ZA,South Africa,
-1959-12-31,4T,Emerging market economies (aggregate),
-1959-12-31,5R,Advanced economies,
-1959-12-31,AE,United Arab Emirates,
-1959-12-31,AT,Austria,
-1959-12-31,AU,Australia,
-1959-12-31,BE,Belgium,
-1959-12-31,BG,Bulgaria,
-1959-12-31,BR,Brazil,
-1959-12-31,CA,Canada,
-1959-12-31,CH,Switzerland,
-1959-12-31,CL,Chile,
-1959-12-31,CN,China,
-1959-12-31,CO,Colombia,
-1959-12-31,CY,Cyprus,
-1959-12-31,CZ,Czechia,
-1959-12-31,DE,Germany,
-1959-12-31,DK,Denmark,
-1959-12-31,EE,Estonia,
-1959-12-31,ES,Spain,
-1959-12-31,FI,Finland,
-1959-12-31,FR,France,
-1959-12-31,GB,United Kingdom,
-1959-12-31,GR,Greece,
-1959-12-31,HK,Hong Kong SAR,
-1959-12-31,HR,Croatia,
-1959-12-31,HU,Hungary,
-1959-12-31,ID,Indonesia,
-1959-12-31,IE,Ireland,
-1959-12-31,IL,Israel,
-1959-12-31,IN,India,
-1959-12-31,IS,Iceland,
-1959-12-31,IT,Italy,35.4731
+1959-12-31,IT,Italy,34.7784
 1959-12-31,JP,Japan,31.1929
-1959-12-31,KR,Korea,
-1959-12-31,LT,Lithuania,
-1959-12-31,LU,Luxembourg,
-1959-12-31,LV,Latvia,
-1959-12-31,MA,Morocco,
-1959-12-31,MK,North Macedonia,
-1959-12-31,MT,Malta,
-1959-12-31,MX,Mexico,
-1959-12-31,MY,Malaysia,
-1959-12-31,NL,Netherlands,
-1959-12-31,NO,Norway,
-1959-12-31,NZ,New Zealand,
-1959-12-31,PE,Peru,
-1959-12-31,PH,Philippines,
-1959-12-31,PL,Poland,
-1959-12-31,PT,Portugal,
-1959-12-31,RO,Romania,
-1959-12-31,RS,Serbia,
-1959-12-31,RU,Russia,
-1959-12-31,SE,Sweden,
-1959-12-31,SG,Singapore,
-1959-12-31,SI,Slovenia,
-1959-12-31,SK,Slovak Republic,
-1959-12-31,TH,Thailand,
-1959-12-31,TR,Türkiye,
-1959-12-31,US,United States,
-1959-12-31,XM,Euro area,
-1959-12-31,XW,World,
-1959-12-31,ZA,South Africa,
-1960-03-31,4T,Emerging market economies (aggregate),
-1960-03-31,5R,Advanced economies,
-1960-03-31,AE,United Arab Emirates,
-1960-03-31,AT,Austria,
-1960-03-31,AU,Australia,
-1960-03-31,BE,Belgium,
-1960-03-31,BG,Bulgaria,
-1960-03-31,BR,Brazil,
-1960-03-31,CA,Canada,
-1960-03-31,CH,Switzerland,
-1960-03-31,CL,Chile,
-1960-03-31,CN,China,
-1960-03-31,CO,Colombia,
-1960-03-31,CY,Cyprus,
-1960-03-31,CZ,Czechia,
-1960-03-31,DE,Germany,
-1960-03-31,DK,Denmark,
-1960-03-31,EE,Estonia,
-1960-03-31,ES,Spain,
-1960-03-31,FI,Finland,
-1960-03-31,FR,France,
-1960-03-31,GB,United Kingdom,
-1960-03-31,GR,Greece,
-1960-03-31,HK,Hong Kong SAR,
-1960-03-31,HR,Croatia,
-1960-03-31,HU,Hungary,
-1960-03-31,ID,Indonesia,
-1960-03-31,IE,Ireland,
-1960-03-31,IL,Israel,
-1960-03-31,IN,India,
-1960-03-31,IS,Iceland,
-1960-03-31,IT,Italy,35.4713
+1960-03-31,IT,Italy,34.7413
 1960-03-31,JP,Japan,32.2073
-1960-03-31,KR,Korea,
-1960-03-31,LT,Lithuania,
-1960-03-31,LU,Luxembourg,
-1960-03-31,LV,Latvia,
-1960-03-31,MA,Morocco,
-1960-03-31,MK,North Macedonia,
-1960-03-31,MT,Malta,
-1960-03-31,MX,Mexico,
-1960-03-31,MY,Malaysia,
-1960-03-31,NL,Netherlands,
-1960-03-31,NO,Norway,
-1960-03-31,NZ,New Zealand,
-1960-03-31,PE,Peru,
-1960-03-31,PH,Philippines,
-1960-03-31,PL,Poland,
-1960-03-31,PT,Portugal,
-1960-03-31,RO,Romania,
-1960-03-31,RS,Serbia,
-1960-03-31,RU,Russia,
-1960-03-31,SE,Sweden,
-1960-03-31,SG,Singapore,
-1960-03-31,SI,Slovenia,
-1960-03-31,SK,Slovak Republic,
-1960-03-31,TH,Thailand,
-1960-03-31,TR,Türkiye,
-1960-03-31,US,United States,
-1960-03-31,XM,Euro area,
-1960-03-31,XW,World,
-1960-03-31,ZA,South Africa,
-1960-06-30,4T,Emerging market economies (aggregate),
-1960-06-30,5R,Advanced economies,
-1960-06-30,AE,United Arab Emirates,
-1960-06-30,AT,Austria,
-1960-06-30,AU,Australia,
-1960-06-30,BE,Belgium,
-1960-06-30,BG,Bulgaria,
-1960-06-30,BR,Brazil,
-1960-06-30,CA,Canada,
-1960-06-30,CH,Switzerland,
-1960-06-30,CL,Chile,
-1960-06-30,CN,China,
-1960-06-30,CO,Colombia,
-1960-06-30,CY,Cyprus,
-1960-06-30,CZ,Czechia,
-1960-06-30,DE,Germany,
-1960-06-30,DK,Denmark,
-1960-06-30,EE,Estonia,
-1960-06-30,ES,Spain,
-1960-06-30,FI,Finland,
-1960-06-30,FR,France,
-1960-06-30,GB,United Kingdom,
-1960-06-30,GR,Greece,
-1960-06-30,HK,Hong Kong SAR,
-1960-06-30,HR,Croatia,
-1960-06-30,HU,Hungary,
-1960-06-30,ID,Indonesia,
-1960-06-30,IE,Ireland,
-1960-06-30,IL,Israel,
-1960-06-30,IN,India,
-1960-06-30,IS,Iceland,
-1960-06-30,IT,Italy,35.0499
+1960-06-30,IT,Italy,34.1852
 1960-06-30,JP,Japan,34.3203
-1960-06-30,KR,Korea,
-1960-06-30,LT,Lithuania,
-1960-06-30,LU,Luxembourg,
-1960-06-30,LV,Latvia,
-1960-06-30,MA,Morocco,
-1960-06-30,MK,North Macedonia,
-1960-06-30,MT,Malta,
-1960-06-30,MX,Mexico,
-1960-06-30,MY,Malaysia,
-1960-06-30,NL,Netherlands,
-1960-06-30,NO,Norway,
-1960-06-30,NZ,New Zealand,
-1960-06-30,PE,Peru,
-1960-06-30,PH,Philippines,
-1960-06-30,PL,Poland,
-1960-06-30,PT,Portugal,
-1960-06-30,RO,Romania,
-1960-06-30,RS,Serbia,
-1960-06-30,RU,Russia,
-1960-06-30,SE,Sweden,
-1960-06-30,SG,Singapore,
-1960-06-30,SI,Slovenia,
-1960-06-30,SK,Slovak Republic,
-1960-06-30,TH,Thailand,
-1960-06-30,TR,Türkiye,
-1960-06-30,US,United States,
-1960-06-30,XM,Euro area,
-1960-06-30,XW,World,
-1960-06-30,ZA,South Africa,
-1960-09-30,4T,Emerging market economies (aggregate),
-1960-09-30,5R,Advanced economies,
-1960-09-30,AE,United Arab Emirates,
-1960-09-30,AT,Austria,
-1960-09-30,AU,Australia,
-1960-09-30,BE,Belgium,
-1960-09-30,BG,Bulgaria,
-1960-09-30,BR,Brazil,
-1960-09-30,CA,Canada,
-1960-09-30,CH,Switzerland,
-1960-09-30,CL,Chile,
-1960-09-30,CN,China,
-1960-09-30,CO,Colombia,
-1960-09-30,CY,Cyprus,
-1960-09-30,CZ,Czechia,
-1960-09-30,DE,Germany,
-1960-09-30,DK,Denmark,
-1960-09-30,EE,Estonia,
-1960-09-30,ES,Spain,
-1960-09-30,FI,Finland,
-1960-09-30,FR,France,
-1960-09-30,GB,United Kingdom,
-1960-09-30,GR,Greece,
-1960-09-30,HK,Hong Kong SAR,
-1960-09-30,HR,Croatia,
-1960-09-30,HU,Hungary,
-1960-09-30,ID,Indonesia,
-1960-09-30,IE,Ireland,
-1960-09-30,IL,Israel,
-1960-09-30,IN,India,
-1960-09-30,IS,Iceland,
-1960-09-30,IT,Italy,34.985
+1960-09-30,IT,Italy,34.3409
 1960-09-30,JP,Japan,36.5231
-1960-09-30,KR,Korea,
-1960-09-30,LT,Lithuania,
-1960-09-30,LU,Luxembourg,
-1960-09-30,LV,Latvia,
-1960-09-30,MA,Morocco,
-1960-09-30,MK,North Macedonia,
-1960-09-30,MT,Malta,
-1960-09-30,MX,Mexico,
-1960-09-30,MY,Malaysia,
-1960-09-30,NL,Netherlands,
-1960-09-30,NO,Norway,
-1960-09-30,NZ,New Zealand,
-1960-09-30,PE,Peru,
-1960-09-30,PH,Philippines,
-1960-09-30,PL,Poland,
-1960-09-30,PT,Portugal,
-1960-09-30,RO,Romania,
-1960-09-30,RS,Serbia,
-1960-09-30,RU,Russia,
-1960-09-30,SE,Sweden,
-1960-09-30,SG,Singapore,
-1960-09-30,SI,Slovenia,
-1960-09-30,SK,Slovak Republic,
-1960-09-30,TH,Thailand,
-1960-09-30,TR,Türkiye,
-1960-09-30,US,United States,
-1960-09-30,XM,Euro area,
-1960-09-30,XW,World,
-1960-09-30,ZA,South Africa,
-1960-12-31,4T,Emerging market economies (aggregate),
-1960-12-31,5R,Advanced economies,
-1960-12-31,AE,United Arab Emirates,
-1960-12-31,AT,Austria,
-1960-12-31,AU,Australia,
-1960-12-31,BE,Belgium,
-1960-12-31,BG,Bulgaria,
-1960-12-31,BR,Brazil,
-1960-12-31,CA,Canada,
-1960-12-31,CH,Switzerland,
-1960-12-31,CL,Chile,
-1960-12-31,CN,China,
-1960-12-31,CO,Colombia,
-1960-12-31,CY,Cyprus,
-1960-12-31,CZ,Czechia,
-1960-12-31,DE,Germany,
-1960-12-31,DK,Denmark,
-1960-12-31,EE,Estonia,
-1960-12-31,ES,Spain,
-1960-12-31,FI,Finland,
-1960-12-31,FR,France,
-1960-12-31,GB,United Kingdom,
-1960-12-31,GR,Greece,
-1960-12-31,HK,Hong Kong SAR,
-1960-12-31,HR,Croatia,
-1960-12-31,HU,Hungary,
-1960-12-31,ID,Indonesia,
-1960-12-31,IE,Ireland,
-1960-12-31,IL,Israel,
-1960-12-31,IN,India,
-1960-12-31,IS,Iceland,
-1960-12-31,IT,Italy,34.9099
+1960-12-31,IT,Italy,34.5614
 1960-12-31,JP,Japan,39.9262
-1960-12-31,KR,Korea,
-1960-12-31,LT,Lithuania,
-1960-12-31,LU,Luxembourg,
-1960-12-31,LV,Latvia,
-1960-12-31,MA,Morocco,
-1960-12-31,MK,North Macedonia,
-1960-12-31,MT,Malta,
-1960-12-31,MX,Mexico,
-1960-12-31,MY,Malaysia,
-1960-12-31,NL,Netherlands,
-1960-12-31,NO,Norway,
-1960-12-31,NZ,New Zealand,
-1960-12-31,PE,Peru,
-1960-12-31,PH,Philippines,
-1960-12-31,PL,Poland,
-1960-12-31,PT,Portugal,
-1960-12-31,RO,Romania,
-1960-12-31,RS,Serbia,
-1960-12-31,RU,Russia,
-1960-12-31,SE,Sweden,
-1960-12-31,SG,Singapore,
-1960-12-31,SI,Slovenia,
-1960-12-31,SK,Slovak Republic,
-1960-12-31,TH,Thailand,
-1960-12-31,TR,Türkiye,
-1960-12-31,US,United States,
-1960-12-31,XM,Euro area,
-1960-12-31,XW,World,
-1960-12-31,ZA,South Africa,
-1961-03-31,4T,Emerging market economies (aggregate),
-1961-03-31,5R,Advanced economies,
-1961-03-31,AE,United Arab Emirates,
-1961-03-31,AT,Austria,
-1961-03-31,AU,Australia,
-1961-03-31,BE,Belgium,
-1961-03-31,BG,Bulgaria,
-1961-03-31,BR,Brazil,
-1961-03-31,CA,Canada,
-1961-03-31,CH,Switzerland,
-1961-03-31,CL,Chile,
-1961-03-31,CN,China,
-1961-03-31,CO,Colombia,
-1961-03-31,CY,Cyprus,
-1961-03-31,CZ,Czechia,
-1961-03-31,DE,Germany,
-1961-03-31,DK,Denmark,
-1961-03-31,EE,Estonia,
-1961-03-31,ES,Spain,
-1961-03-31,FI,Finland,
-1961-03-31,FR,France,
-1961-03-31,GB,United Kingdom,
-1961-03-31,GR,Greece,
-1961-03-31,HK,Hong Kong SAR,
-1961-03-31,HR,Croatia,
-1961-03-31,HU,Hungary,
-1961-03-31,ID,Indonesia,
-1961-03-31,IE,Ireland,
-1961-03-31,IL,Israel,
-1961-03-31,IN,India,
-1961-03-31,IS,Iceland,
-1961-03-31,IT,Italy,35.465
+1961-03-31,IT,Italy,34.9726
 1961-03-31,JP,Japan,42.6336
-1961-03-31,KR,Korea,
-1961-03-31,LT,Lithuania,
-1961-03-31,LU,Luxembourg,
-1961-03-31,LV,Latvia,
-1961-03-31,MA,Morocco,
-1961-03-31,MK,North Macedonia,
-1961-03-31,MT,Malta,
-1961-03-31,MX,Mexico,
-1961-03-31,MY,Malaysia,
-1961-03-31,NL,Netherlands,
-1961-03-31,NO,Norway,
-1961-03-31,NZ,New Zealand,
-1961-03-31,PE,Peru,
-1961-03-31,PH,Philippines,
-1961-03-31,PL,Poland,
-1961-03-31,PT,Portugal,
-1961-03-31,RO,Romania,
-1961-03-31,RS,Serbia,
-1961-03-31,RU,Russia,
-1961-03-31,SE,Sweden,
-1961-03-31,SG,Singapore,
-1961-03-31,SI,Slovenia,
-1961-03-31,SK,Slovak Republic,
-1961-03-31,TH,Thailand,
-1961-03-31,TR,Türkiye,
-1961-03-31,US,United States,
-1961-03-31,XM,Euro area,
-1961-03-31,XW,World,
-1961-03-31,ZA,South Africa,
-1961-06-30,4T,Emerging market economies (aggregate),
-1961-06-30,5R,Advanced economies,
-1961-06-30,AE,United Arab Emirates,
-1961-06-30,AT,Austria,
-1961-06-30,AU,Australia,
-1961-06-30,BE,Belgium,
-1961-06-30,BG,Bulgaria,
-1961-06-30,BR,Brazil,
-1961-06-30,CA,Canada,
-1961-06-30,CH,Switzerland,
-1961-06-30,CL,Chile,
-1961-06-30,CN,China,
-1961-06-30,CO,Colombia,
-1961-06-30,CY,Cyprus,
-1961-06-30,CZ,Czechia,
-1961-06-30,DE,Germany,
-1961-06-30,DK,Denmark,
-1961-06-30,EE,Estonia,
-1961-06-30,ES,Spain,
-1961-06-30,FI,Finland,
-1961-06-30,FR,France,
-1961-06-30,GB,United Kingdom,
-1961-06-30,GR,Greece,
-1961-06-30,HK,Hong Kong SAR,
-1961-06-30,HR,Croatia,
-1961-06-30,HU,Hungary,
-1961-06-30,ID,Indonesia,
-1961-06-30,IE,Ireland,
-1961-06-30,IL,Israel,
-1961-06-30,IN,India,
-1961-06-30,IS,Iceland,
-1961-06-30,IT,Italy,35.8042
+1961-06-30,IT,Italy,35.3154
 1961-06-30,JP,Japan,45.6751
-1961-06-30,KR,Korea,
-1961-06-30,LT,Lithuania,
-1961-06-30,LU,Luxembourg,
-1961-06-30,LV,Latvia,
-1961-06-30,MA,Morocco,
-1961-06-30,MK,North Macedonia,
-1961-06-30,MT,Malta,
-1961-06-30,MX,Mexico,
-1961-06-30,MY,Malaysia,
-1961-06-30,NL,Netherlands,
-1961-06-30,NO,Norway,
-1961-06-30,NZ,New Zealand,
-1961-06-30,PE,Peru,
-1961-06-30,PH,Philippines,
-1961-06-30,PL,Poland,
-1961-06-30,PT,Portugal,
-1961-06-30,RO,Romania,
-1961-06-30,RS,Serbia,
-1961-06-30,RU,Russia,
-1961-06-30,SE,Sweden,
-1961-06-30,SG,Singapore,
-1961-06-30,SI,Slovenia,
-1961-06-30,SK,Slovak Republic,
-1961-06-30,TH,Thailand,
-1961-06-30,TR,Türkiye,
-1961-06-30,US,United States,
-1961-06-30,XM,Euro area,
-1961-06-30,XW,World,
-1961-06-30,ZA,South Africa,
-1961-09-30,4T,Emerging market economies (aggregate),
-1961-09-30,5R,Advanced economies,
-1961-09-30,AE,United Arab Emirates,
-1961-09-30,AT,Austria,
-1961-09-30,AU,Australia,
-1961-09-30,BE,Belgium,
-1961-09-30,BG,Bulgaria,
-1961-09-30,BR,Brazil,
-1961-09-30,CA,Canada,
-1961-09-30,CH,Switzerland,
-1961-09-30,CL,Chile,
-1961-09-30,CN,China,
-1961-09-30,CO,Colombia,
-1961-09-30,CY,Cyprus,
-1961-09-30,CZ,Czechia,
-1961-09-30,DE,Germany,
-1961-09-30,DK,Denmark,
-1961-09-30,EE,Estonia,
-1961-09-30,ES,Spain,
-1961-09-30,FI,Finland,
-1961-09-30,FR,France,
-1961-09-30,GB,United Kingdom,
-1961-09-30,GR,Greece,
-1961-09-30,HK,Hong Kong SAR,
-1961-09-30,HR,Croatia,
-1961-09-30,HU,Hungary,
-1961-09-30,ID,Indonesia,
-1961-09-30,IE,Ireland,
-1961-09-30,IL,Israel,
-1961-09-30,IN,India,
-1961-09-30,IS,Iceland,
-1961-09-30,IT,Italy,35.6692
+1961-09-30,IT,Italy,35.4529
 1961-09-30,JP,Japan,48.0695
-1961-09-30,KR,Korea,
-1961-09-30,LT,Lithuania,
-1961-09-30,LU,Luxembourg,
-1961-09-30,LV,Latvia,
-1961-09-30,MA,Morocco,
-1961-09-30,MK,North Macedonia,
-1961-09-30,MT,Malta,
-1961-09-30,MX,Mexico,
-1961-09-30,MY,Malaysia,
-1961-09-30,NL,Netherlands,
-1961-09-30,NO,Norway,
-1961-09-30,NZ,New Zealand,
-1961-09-30,PE,Peru,
-1961-09-30,PH,Philippines,
-1961-09-30,PL,Poland,
-1961-09-30,PT,Portugal,
-1961-09-30,RO,Romania,
-1961-09-30,RS,Serbia,
-1961-09-30,RU,Russia,
-1961-09-30,SE,Sweden,
-1961-09-30,SG,Singapore,
-1961-09-30,SI,Slovenia,
-1961-09-30,SK,Slovak Republic,
-1961-09-30,TH,Thailand,
-1961-09-30,TR,Türkiye,
-1961-09-30,US,United States,
-1961-09-30,XM,Euro area,
-1961-09-30,XW,World,
-1961-09-30,ZA,South Africa,
-1961-12-31,4T,Emerging market economies (aggregate),
-1961-12-31,5R,Advanced economies,
-1961-12-31,AE,United Arab Emirates,
-1961-12-31,AT,Austria,
-1961-12-31,AU,Australia,
-1961-12-31,BE,Belgium,
-1961-12-31,BG,Bulgaria,
-1961-12-31,BR,Brazil,
-1961-12-31,CA,Canada,
-1961-12-31,CH,Switzerland,
-1961-12-31,CL,Chile,
-1961-12-31,CN,China,
-1961-12-31,CO,Colombia,
-1961-12-31,CY,Cyprus,
-1961-12-31,CZ,Czechia,
-1961-12-31,DE,Germany,
-1961-12-31,DK,Denmark,
-1961-12-31,EE,Estonia,
-1961-12-31,ES,Spain,
-1961-12-31,FI,Finland,
-1961-12-31,FR,France,
-1961-12-31,GB,United Kingdom,
-1961-12-31,GR,Greece,
-1961-12-31,HK,Hong Kong SAR,
-1961-12-31,HR,Croatia,
-1961-12-31,HU,Hungary,
-1961-12-31,ID,Indonesia,
-1961-12-31,IE,Ireland,
-1961-12-31,IL,Israel,
-1961-12-31,IN,India,
-1961-12-31,IS,Iceland,
-1961-12-31,IT,Italy,35.8198
+1961-12-31,IT,Italy,35.6239
 1961-12-31,JP,Japan,48.597
-1961-12-31,KR,Korea,
-1961-12-31,LT,Lithuania,
-1961-12-31,LU,Luxembourg,
-1961-12-31,LV,Latvia,
-1961-12-31,MA,Morocco,
-1961-12-31,MK,North Macedonia,
-1961-12-31,MT,Malta,
-1961-12-31,MX,Mexico,
-1961-12-31,MY,Malaysia,
-1961-12-31,NL,Netherlands,
-1961-12-31,NO,Norway,
-1961-12-31,NZ,New Zealand,
-1961-12-31,PE,Peru,
-1961-12-31,PH,Philippines,
-1961-12-31,PL,Poland,
-1961-12-31,PT,Portugal,
-1961-12-31,RO,Romania,
-1961-12-31,RS,Serbia,
-1961-12-31,RU,Russia,
-1961-12-31,SE,Sweden,
-1961-12-31,SG,Singapore,
-1961-12-31,SI,Slovenia,
-1961-12-31,SK,Slovak Republic,
-1961-12-31,TH,Thailand,
-1961-12-31,TR,Türkiye,
-1961-12-31,US,United States,
-1961-12-31,XM,Euro area,
-1961-12-31,XW,World,
-1961-12-31,ZA,South Africa,
-1962-03-31,4T,Emerging market economies (aggregate),
-1962-03-31,5R,Advanced economies,
-1962-03-31,AE,United Arab Emirates,
-1962-03-31,AT,Austria,
-1962-03-31,AU,Australia,
-1962-03-31,BE,Belgium,
-1962-03-31,BG,Bulgaria,
-1962-03-31,BR,Brazil,
-1962-03-31,CA,Canada,
-1962-03-31,CH,Switzerland,
-1962-03-31,CL,Chile,
-1962-03-31,CN,China,
-1962-03-31,CO,Colombia,
-1962-03-31,CY,Cyprus,
-1962-03-31,CZ,Czechia,
-1962-03-31,DE,Germany,
-1962-03-31,DK,Denmark,
-1962-03-31,EE,Estonia,
-1962-03-31,ES,Spain,
-1962-03-31,FI,Finland,
-1962-03-31,FR,France,
-1962-03-31,GB,United Kingdom,
-1962-03-31,GR,Greece,
-1962-03-31,HK,Hong Kong SAR,
-1962-03-31,HR,Croatia,
-1962-03-31,HU,Hungary,
-1962-03-31,ID,Indonesia,
-1962-03-31,IE,Ireland,
-1962-03-31,IL,Israel,
-1962-03-31,IN,India,
-1962-03-31,IS,Iceland,
-1962-03-31,IT,Italy,36.4156
+1962-03-31,IT,Italy,36.1009
 1962-03-31,JP,Japan,50.333
-1962-03-31,KR,Korea,
-1962-03-31,LT,Lithuania,
-1962-03-31,LU,Luxembourg,
-1962-03-31,LV,Latvia,
-1962-03-31,MA,Morocco,
-1962-03-31,MK,North Macedonia,
-1962-03-31,MT,Malta,
-1962-03-31,MX,Mexico,
-1962-03-31,MY,Malaysia,
-1962-03-31,NL,Netherlands,
-1962-03-31,NO,Norway,
-1962-03-31,NZ,New Zealand,
-1962-03-31,PE,Peru,
-1962-03-31,PH,Philippines,
-1962-03-31,PL,Poland,
-1962-03-31,PT,Portugal,
-1962-03-31,RO,Romania,
-1962-03-31,RS,Serbia,
-1962-03-31,RU,Russia,
-1962-03-31,SE,Sweden,
-1962-03-31,SG,Singapore,
-1962-03-31,SI,Slovenia,
-1962-03-31,SK,Slovak Republic,
-1962-03-31,TH,Thailand,
-1962-03-31,TR,Türkiye,
-1962-03-31,US,United States,
-1962-03-31,XM,Euro area,
-1962-03-31,XW,World,
-1962-03-31,ZA,South Africa,
-1962-06-30,4T,Emerging market economies (aggregate),
-1962-06-30,5R,Advanced economies,
-1962-06-30,AE,United Arab Emirates,
-1962-06-30,AT,Austria,
-1962-06-30,AU,Australia,
-1962-06-30,BE,Belgium,
-1962-06-30,BG,Bulgaria,
-1962-06-30,BR,Brazil,
-1962-06-30,CA,Canada,
-1962-06-30,CH,Switzerland,
-1962-06-30,CL,Chile,
-1962-06-30,CN,China,
-1962-06-30,CO,Colombia,
-1962-06-30,CY,Cyprus,
-1962-06-30,CZ,Czechia,
-1962-06-30,DE,Germany,
-1962-06-30,DK,Denmark,
-1962-06-30,EE,Estonia,
-1962-06-30,ES,Spain,
-1962-06-30,FI,Finland,
-1962-06-30,FR,France,
-1962-06-30,GB,United Kingdom,
-1962-06-30,GR,Greece,
-1962-06-30,HK,Hong Kong SAR,
-1962-06-30,HR,Croatia,
-1962-06-30,HU,Hungary,
-1962-06-30,ID,Indonesia,
-1962-06-30,IE,Ireland,
-1962-06-30,IL,Israel,
-1962-06-30,IN,India,
-1962-06-30,IS,Iceland,
-1962-06-30,IT,Italy,37.0886
+1962-06-30,IT,Italy,36.6852
 1962-06-30,JP,Japan,51.5219
-1962-06-30,KR,Korea,
-1962-06-30,LT,Lithuania,
-1962-06-30,LU,Luxembourg,
-1962-06-30,LV,Latvia,
-1962-06-30,MA,Morocco,
-1962-06-30,MK,North Macedonia,
-1962-06-30,MT,Malta,
-1962-06-30,MX,Mexico,
-1962-06-30,MY,Malaysia,
-1962-06-30,NL,Netherlands,
-1962-06-30,NO,Norway,
-1962-06-30,NZ,New Zealand,
-1962-06-30,PE,Peru,
-1962-06-30,PH,Philippines,
-1962-06-30,PL,Poland,
-1962-06-30,PT,Portugal,
-1962-06-30,RO,Romania,
-1962-06-30,RS,Serbia,
-1962-06-30,RU,Russia,
-1962-06-30,SE,Sweden,
-1962-06-30,SG,Singapore,
-1962-06-30,SI,Slovenia,
-1962-06-30,SK,Slovak Republic,
-1962-06-30,TH,Thailand,
-1962-06-30,TR,Türkiye,
-1962-06-30,US,United States,
-1962-06-30,XM,Euro area,
-1962-06-30,XW,World,
-1962-06-30,ZA,South Africa,
-1962-09-30,4T,Emerging market economies (aggregate),
-1962-09-30,5R,Advanced economies,
-1962-09-30,AE,United Arab Emirates,
-1962-09-30,AT,Austria,
-1962-09-30,AU,Australia,
-1962-09-30,BE,Belgium,
-1962-09-30,BG,Bulgaria,
-1962-09-30,BR,Brazil,
-1962-09-30,CA,Canada,
-1962-09-30,CH,Switzerland,
-1962-09-30,CL,Chile,
-1962-09-30,CN,China,
-1962-09-30,CO,Colombia,
-1962-09-30,CY,Cyprus,
-1962-09-30,CZ,Czechia,
-1962-09-30,DE,Germany,
-1962-09-30,DK,Denmark,
-1962-09-30,EE,Estonia,
-1962-09-30,ES,Spain,
-1962-09-30,FI,Finland,
-1962-09-30,FR,France,
-1962-09-30,GB,United Kingdom,
-1962-09-30,GR,Greece,
-1962-09-30,HK,Hong Kong SAR,
-1962-09-30,HR,Croatia,
-1962-09-30,HU,Hungary,
-1962-09-30,ID,Indonesia,
-1962-09-30,IE,Ireland,
-1962-09-30,IL,Israel,
-1962-09-30,IN,India,
-1962-09-30,IS,Iceland,
-1962-09-30,IT,Italy,36.6512
+1962-06-30,NZ,New Zealand,34.7416
+1962-09-30,IT,Italy,36.4358
 1962-09-30,JP,Japan,53.0175
-1962-09-30,KR,Korea,
-1962-09-30,LT,Lithuania,
-1962-09-30,LU,Luxembourg,
-1962-09-30,LV,Latvia,
-1962-09-30,MA,Morocco,
-1962-09-30,MK,North Macedonia,
-1962-09-30,MT,Malta,
-1962-09-30,MX,Mexico,
-1962-09-30,MY,Malaysia,
-1962-09-30,NL,Netherlands,
-1962-09-30,NO,Norway,
-1962-09-30,NZ,New Zealand,
-1962-09-30,PE,Peru,
-1962-09-30,PH,Philippines,
-1962-09-30,PL,Poland,
-1962-09-30,PT,Portugal,
-1962-09-30,RO,Romania,
-1962-09-30,RS,Serbia,
-1962-09-30,RU,Russia,
-1962-09-30,SE,Sweden,
-1962-09-30,SG,Singapore,
-1962-09-30,SI,Slovenia,
-1962-09-30,SK,Slovak Republic,
-1962-09-30,TH,Thailand,
-1962-09-30,TR,Türkiye,
-1962-09-30,US,United States,
-1962-09-30,XM,Euro area,
-1962-09-30,XW,World,
-1962-09-30,ZA,South Africa,
-1962-12-31,4T,Emerging market economies (aggregate),
-1962-12-31,5R,Advanced economies,
-1962-12-31,AE,United Arab Emirates,
-1962-12-31,AT,Austria,
-1962-12-31,AU,Australia,
-1962-12-31,BE,Belgium,
-1962-12-31,BG,Bulgaria,
-1962-12-31,BR,Brazil,
-1962-12-31,CA,Canada,
-1962-12-31,CH,Switzerland,
-1962-12-31,CL,Chile,
-1962-12-31,CN,China,
-1962-12-31,CO,Colombia,
-1962-12-31,CY,Cyprus,
-1962-12-31,CZ,Czechia,
-1962-12-31,DE,Germany,
-1962-12-31,DK,Denmark,
-1962-12-31,EE,Estonia,
-1962-12-31,ES,Spain,
-1962-12-31,FI,Finland,
-1962-12-31,FR,France,
-1962-12-31,GB,United Kingdom,
-1962-12-31,GR,Greece,
-1962-12-31,HK,Hong Kong SAR,
-1962-12-31,HR,Croatia,
-1962-12-31,HU,Hungary,
-1962-12-31,ID,Indonesia,
-1962-12-31,IE,Ireland,
-1962-12-31,IL,Israel,
-1962-12-31,IN,India,
-1962-12-31,IS,Iceland,
-1962-12-31,IT,Italy,36.1928
+1962-09-30,NZ,New Zealand,34.755
+1962-12-31,IT,Italy,36.2291
 1962-12-31,JP,Japan,54.4115
-1962-12-31,KR,Korea,
-1962-12-31,LT,Lithuania,
-1962-12-31,LU,Luxembourg,
-1962-12-31,LV,Latvia,
-1962-12-31,MA,Morocco,
-1962-12-31,MK,North Macedonia,
-1962-12-31,MT,Malta,
-1962-12-31,MX,Mexico,
-1962-12-31,MY,Malaysia,
-1962-12-31,NL,Netherlands,
-1962-12-31,NO,Norway,
-1962-12-31,NZ,New Zealand,
-1962-12-31,PE,Peru,
-1962-12-31,PH,Philippines,
-1962-12-31,PL,Poland,
-1962-12-31,PT,Portugal,
-1962-12-31,RO,Romania,
-1962-12-31,RS,Serbia,
-1962-12-31,RU,Russia,
-1962-12-31,SE,Sweden,
-1962-12-31,SG,Singapore,
-1962-12-31,SI,Slovenia,
-1962-12-31,SK,Slovak Republic,
-1962-12-31,TH,Thailand,
-1962-12-31,TR,Türkiye,
-1962-12-31,US,United States,
-1962-12-31,XM,Euro area,
-1962-12-31,XW,World,
-1962-12-31,ZA,South Africa,
-1963-03-31,4T,Emerging market economies (aggregate),
-1963-03-31,5R,Advanced economies,
-1963-03-31,AE,United Arab Emirates,
-1963-03-31,AT,Austria,
-1963-03-31,AU,Australia,
-1963-03-31,BE,Belgium,
-1963-03-31,BG,Bulgaria,
-1963-03-31,BR,Brazil,
-1963-03-31,CA,Canada,
-1963-03-31,CH,Switzerland,
-1963-03-31,CL,Chile,
-1963-03-31,CN,China,
-1963-03-31,CO,Colombia,
-1963-03-31,CY,Cyprus,
-1963-03-31,CZ,Czechia,
-1963-03-31,DE,Germany,
-1963-03-31,DK,Denmark,
-1963-03-31,EE,Estonia,
-1963-03-31,ES,Spain,
-1963-03-31,FI,Finland,
-1963-03-31,FR,France,
-1963-03-31,GB,United Kingdom,
-1963-03-31,GR,Greece,
-1963-03-31,HK,Hong Kong SAR,
-1963-03-31,HR,Croatia,
-1963-03-31,HU,Hungary,
-1963-03-31,ID,Indonesia,
-1963-03-31,IE,Ireland,
-1963-03-31,IL,Israel,
-1963-03-31,IN,India,
-1963-03-31,IS,Iceland,
-1963-03-31,IT,Italy,37.3154
+1962-12-31,NZ,New Zealand,34.796
+1963-03-31,IT,Italy,37.0561
 1963-03-31,JP,Japan,53.827
-1963-03-31,KR,Korea,
-1963-03-31,LT,Lithuania,
-1963-03-31,LU,Luxembourg,
-1963-03-31,LV,Latvia,
-1963-03-31,MA,Morocco,
-1963-03-31,MK,North Macedonia,
-1963-03-31,MT,Malta,
-1963-03-31,MX,Mexico,
-1963-03-31,MY,Malaysia,
-1963-03-31,NL,Netherlands,
-1963-03-31,NO,Norway,
-1963-03-31,NZ,New Zealand,
-1963-03-31,PE,Peru,
-1963-03-31,PH,Philippines,
-1963-03-31,PL,Poland,
-1963-03-31,PT,Portugal,
-1963-03-31,RO,Romania,
-1963-03-31,RS,Serbia,
-1963-03-31,RU,Russia,
-1963-03-31,SE,Sweden,
-1963-03-31,SG,Singapore,
-1963-03-31,SI,Slovenia,
-1963-03-31,SK,Slovak Republic,
-1963-03-31,TH,Thailand,
-1963-03-31,TR,Türkiye,
-1963-03-31,US,United States,
-1963-03-31,XM,Euro area,
-1963-03-31,XW,World,
-1963-03-31,ZA,South Africa,
-1963-06-30,4T,Emerging market economies (aggregate),
-1963-06-30,5R,Advanced economies,
-1963-06-30,AE,United Arab Emirates,
-1963-06-30,AT,Austria,
-1963-06-30,AU,Australia,
-1963-06-30,BE,Belgium,
-1963-06-30,BG,Bulgaria,
-1963-06-30,BR,Brazil,
-1963-06-30,CA,Canada,
-1963-06-30,CH,Switzerland,
-1963-06-30,CL,Chile,
-1963-06-30,CN,China,
-1963-06-30,CO,Colombia,
-1963-06-30,CY,Cyprus,
-1963-06-30,CZ,Czechia,
-1963-06-30,DE,Germany,
-1963-06-30,DK,Denmark,
-1963-06-30,EE,Estonia,
-1963-06-30,ES,Spain,
-1963-06-30,FI,Finland,
-1963-06-30,FR,France,
-1963-06-30,GB,United Kingdom,
-1963-06-30,GR,Greece,
-1963-06-30,HK,Hong Kong SAR,
-1963-06-30,HR,Croatia,
-1963-06-30,HU,Hungary,
-1963-06-30,ID,Indonesia,
-1963-06-30,IE,Ireland,
-1963-06-30,IL,Israel,
-1963-06-30,IN,India,
-1963-06-30,IS,Iceland,
-1963-06-30,IT,Italy,36.9791
+1963-03-31,NZ,New Zealand,34.7676
+1963-06-30,IT,Italy,36.7035
 1963-06-30,JP,Japan,54.8187
-1963-06-30,KR,Korea,
-1963-06-30,LT,Lithuania,
-1963-06-30,LU,Luxembourg,
-1963-06-30,LV,Latvia,
-1963-06-30,MA,Morocco,
-1963-06-30,MK,North Macedonia,
-1963-06-30,MT,Malta,
-1963-06-30,MX,Mexico,
-1963-06-30,MY,Malaysia,
-1963-06-30,NL,Netherlands,
-1963-06-30,NO,Norway,
-1963-06-30,NZ,New Zealand,
-1963-06-30,PE,Peru,
-1963-06-30,PH,Philippines,
-1963-06-30,PL,Poland,
-1963-06-30,PT,Portugal,
-1963-06-30,RO,Romania,
-1963-06-30,RS,Serbia,
-1963-06-30,RU,Russia,
-1963-06-30,SE,Sweden,
-1963-06-30,SG,Singapore,
-1963-06-30,SI,Slovenia,
-1963-06-30,SK,Slovak Republic,
-1963-06-30,TH,Thailand,
-1963-06-30,TR,Türkiye,
-1963-06-30,US,United States,
-1963-06-30,XM,Euro area,
-1963-06-30,XW,World,
-1963-06-30,ZA,South Africa,
-1963-09-30,4T,Emerging market economies (aggregate),
-1963-09-30,5R,Advanced economies,
-1963-09-30,AE,United Arab Emirates,
-1963-09-30,AT,Austria,
-1963-09-30,AU,Australia,
-1963-09-30,BE,Belgium,
-1963-09-30,BG,Bulgaria,
-1963-09-30,BR,Brazil,
-1963-09-30,CA,Canada,
-1963-09-30,CH,Switzerland,
-1963-09-30,CL,Chile,
-1963-09-30,CN,China,
-1963-09-30,CO,Colombia,
-1963-09-30,CY,Cyprus,
-1963-09-30,CZ,Czechia,
-1963-09-30,DE,Germany,
-1963-09-30,DK,Denmark,
-1963-09-30,EE,Estonia,
-1963-09-30,ES,Spain,
-1963-09-30,FI,Finland,
-1963-09-30,FR,France,
-1963-09-30,GB,United Kingdom,
-1963-09-30,GR,Greece,
-1963-09-30,HK,Hong Kong SAR,
-1963-09-30,HR,Croatia,
-1963-09-30,HU,Hungary,
-1963-09-30,ID,Indonesia,
-1963-09-30,IE,Ireland,
-1963-09-30,IL,Israel,
-1963-09-30,IN,India,
-1963-09-30,IS,Iceland,
-1963-09-30,IT,Italy,36.5918
+1963-06-30,NZ,New Zealand,34.8938
+1963-09-30,IT,Italy,36.3791
 1963-09-30,JP,Japan,56.2845
-1963-09-30,KR,Korea,
-1963-09-30,LT,Lithuania,
-1963-09-30,LU,Luxembourg,
-1963-09-30,LV,Latvia,
-1963-09-30,MA,Morocco,
-1963-09-30,MK,North Macedonia,
-1963-09-30,MT,Malta,
-1963-09-30,MX,Mexico,
-1963-09-30,MY,Malaysia,
-1963-09-30,NL,Netherlands,
-1963-09-30,NO,Norway,
-1963-09-30,NZ,New Zealand,
-1963-09-30,PE,Peru,
-1963-09-30,PH,Philippines,
-1963-09-30,PL,Poland,
-1963-09-30,PT,Portugal,
-1963-09-30,RO,Romania,
-1963-09-30,RS,Serbia,
-1963-09-30,RU,Russia,
-1963-09-30,SE,Sweden,
-1963-09-30,SG,Singapore,
-1963-09-30,SI,Slovenia,
-1963-09-30,SK,Slovak Republic,
-1963-09-30,TH,Thailand,
-1963-09-30,TR,Türkiye,
-1963-09-30,US,United States,
-1963-09-30,XM,Euro area,
-1963-09-30,XW,World,
-1963-09-30,ZA,South Africa,
-1963-12-31,4T,Emerging market economies (aggregate),
-1963-12-31,5R,Advanced economies,
-1963-12-31,AE,United Arab Emirates,
-1963-12-31,AT,Austria,
-1963-12-31,AU,Australia,
-1963-12-31,BE,Belgium,
-1963-12-31,BG,Bulgaria,
-1963-12-31,BR,Brazil,
-1963-12-31,CA,Canada,
-1963-12-31,CH,Switzerland,
-1963-12-31,CL,Chile,
-1963-12-31,CN,China,
-1963-12-31,CO,Colombia,
-1963-12-31,CY,Cyprus,
-1963-12-31,CZ,Czechia,
-1963-12-31,DE,Germany,
-1963-12-31,DK,Denmark,
-1963-12-31,EE,Estonia,
-1963-12-31,ES,Spain,
-1963-12-31,FI,Finland,
-1963-12-31,FR,France,
-1963-12-31,GB,United Kingdom,
-1963-12-31,GR,Greece,
-1963-12-31,HK,Hong Kong SAR,
-1963-12-31,HR,Croatia,
-1963-12-31,HU,Hungary,
-1963-12-31,ID,Indonesia,
-1963-12-31,IE,Ireland,
-1963-12-31,IL,Israel,
-1963-12-31,IN,India,
-1963-12-31,IS,Iceland,
-1963-12-31,IT,Italy,37.6316
+1963-09-30,NZ,New Zealand,35.1728
+1963-12-31,IT,Italy,37.6304
 1963-12-31,JP,Japan,57.5276
-1963-12-31,KR,Korea,
-1963-12-31,LT,Lithuania,
-1963-12-31,LU,Luxembourg,
-1963-12-31,LV,Latvia,
-1963-12-31,MA,Morocco,
-1963-12-31,MK,North Macedonia,
-1963-12-31,MT,Malta,
-1963-12-31,MX,Mexico,
-1963-12-31,MY,Malaysia,
-1963-12-31,NL,Netherlands,
-1963-12-31,NO,Norway,
-1963-12-31,NZ,New Zealand,
-1963-12-31,PE,Peru,
-1963-12-31,PH,Philippines,
-1963-12-31,PL,Poland,
-1963-12-31,PT,Portugal,
-1963-12-31,RO,Romania,
-1963-12-31,RS,Serbia,
-1963-12-31,RU,Russia,
-1963-12-31,SE,Sweden,
-1963-12-31,SG,Singapore,
-1963-12-31,SI,Slovenia,
-1963-12-31,SK,Slovak Republic,
-1963-12-31,TH,Thailand,
-1963-12-31,TR,Türkiye,
-1963-12-31,US,United States,
-1963-12-31,XM,Euro area,
-1963-12-31,XW,World,
-1963-12-31,ZA,South Africa,
-1964-03-31,4T,Emerging market economies (aggregate),
-1964-03-31,5R,Advanced economies,
-1964-03-31,AE,United Arab Emirates,
-1964-03-31,AT,Austria,
-1964-03-31,AU,Australia,
-1964-03-31,BE,Belgium,
-1964-03-31,BG,Bulgaria,
-1964-03-31,BR,Brazil,
-1964-03-31,CA,Canada,
-1964-03-31,CH,Switzerland,
-1964-03-31,CL,Chile,
-1964-03-31,CN,China,
-1964-03-31,CO,Colombia,
-1964-03-31,CY,Cyprus,
-1964-03-31,CZ,Czechia,
-1964-03-31,DE,Germany,
-1964-03-31,DK,Denmark,
-1964-03-31,EE,Estonia,
-1964-03-31,ES,Spain,
-1964-03-31,FI,Finland,
-1964-03-31,FR,France,
-1964-03-31,GB,United Kingdom,
-1964-03-31,GR,Greece,
-1964-03-31,HK,Hong Kong SAR,
-1964-03-31,HR,Croatia,
-1964-03-31,HU,Hungary,
-1964-03-31,ID,Indonesia,
-1964-03-31,IE,Ireland,
-1964-03-31,IL,Israel,
-1964-03-31,IN,India,
-1964-03-31,IS,Iceland,
-1964-03-31,IT,Italy,38.5101
+1963-12-31,NZ,New Zealand,35.3608
+1964-03-31,IT,Italy,38.4218
 1964-03-31,JP,Japan,59.3261
-1964-03-31,KR,Korea,
-1964-03-31,LT,Lithuania,
-1964-03-31,LU,Luxembourg,
-1964-03-31,LV,Latvia,
-1964-03-31,MA,Morocco,
-1964-03-31,MK,North Macedonia,
-1964-03-31,MT,Malta,
-1964-03-31,MX,Mexico,
-1964-03-31,MY,Malaysia,
-1964-03-31,NL,Netherlands,
-1964-03-31,NO,Norway,
-1964-03-31,NZ,New Zealand,
-1964-03-31,PE,Peru,
-1964-03-31,PH,Philippines,
-1964-03-31,PL,Poland,
-1964-03-31,PT,Portugal,
-1964-03-31,RO,Romania,
-1964-03-31,RS,Serbia,
-1964-03-31,RU,Russia,
-1964-03-31,SE,Sweden,
-1964-03-31,SG,Singapore,
-1964-03-31,SI,Slovenia,
-1964-03-31,SK,Slovak Republic,
-1964-03-31,TH,Thailand,
-1964-03-31,TR,Türkiye,
-1964-03-31,US,United States,
-1964-03-31,XM,Euro area,
-1964-03-31,XW,World,
-1964-03-31,ZA,South Africa,
-1964-06-30,4T,Emerging market economies (aggregate),
-1964-06-30,5R,Advanced economies,
-1964-06-30,AE,United Arab Emirates,
-1964-06-30,AT,Austria,
-1964-06-30,AU,Australia,
-1964-06-30,BE,Belgium,
-1964-06-30,BG,Bulgaria,
-1964-06-30,BR,Brazil,
-1964-06-30,CA,Canada,
-1964-06-30,CH,Switzerland,
-1964-06-30,CL,Chile,
-1964-06-30,CN,China,
-1964-06-30,CO,Colombia,
-1964-06-30,CY,Cyprus,
-1964-06-30,CZ,Czechia,
-1964-06-30,DE,Germany,
-1964-06-30,DK,Denmark,
-1964-06-30,EE,Estonia,
-1964-06-30,ES,Spain,
-1964-06-30,FI,Finland,
-1964-06-30,FR,France,
-1964-06-30,GB,United Kingdom,
-1964-06-30,GR,Greece,
-1964-06-30,HK,Hong Kong SAR,
-1964-06-30,HR,Croatia,
-1964-06-30,HU,Hungary,
-1964-06-30,ID,Indonesia,
-1964-06-30,IE,Ireland,
-1964-06-30,IL,Israel,
-1964-06-30,IN,India,
-1964-06-30,IS,Iceland,
-1964-06-30,IT,Italy,39.2404
+1964-03-31,NZ,New Zealand,35.4826
+1964-06-30,IT,Italy,39.0912
 1964-06-30,JP,Japan,60.5561
-1964-06-30,KR,Korea,
-1964-06-30,LT,Lithuania,
-1964-06-30,LU,Luxembourg,
-1964-06-30,LV,Latvia,
-1964-06-30,MA,Morocco,
-1964-06-30,MK,North Macedonia,
-1964-06-30,MT,Malta,
-1964-06-30,MX,Mexico,
-1964-06-30,MY,Malaysia,
-1964-06-30,NL,Netherlands,
-1964-06-30,NO,Norway,
-1964-06-30,NZ,New Zealand,
-1964-06-30,PE,Peru,
-1964-06-30,PH,Philippines,
-1964-06-30,PL,Poland,
-1964-06-30,PT,Portugal,
-1964-06-30,RO,Romania,
-1964-06-30,RS,Serbia,
-1964-06-30,RU,Russia,
-1964-06-30,SE,Sweden,
-1964-06-30,SG,Singapore,
-1964-06-30,SI,Slovenia,
-1964-06-30,SK,Slovak Republic,
-1964-06-30,TH,Thailand,
-1964-06-30,TR,Türkiye,
-1964-06-30,US,United States,
-1964-06-30,XM,Euro area,
-1964-06-30,XW,World,
-1964-06-30,ZA,South Africa,
-1964-09-30,4T,Emerging market economies (aggregate),
-1964-09-30,5R,Advanced economies,
-1964-09-30,AE,United Arab Emirates,
-1964-09-30,AT,Austria,
-1964-09-30,AU,Australia,
-1964-09-30,BE,Belgium,
-1964-09-30,BG,Bulgaria,
-1964-09-30,BR,Brazil,
-1964-09-30,CA,Canada,
-1964-09-30,CH,Switzerland,
-1964-09-30,CL,Chile,
-1964-09-30,CN,China,
-1964-09-30,CO,Colombia,
-1964-09-30,CY,Cyprus,
-1964-09-30,CZ,Czechia,
-1964-09-30,DE,Germany,
-1964-09-30,DK,Denmark,
-1964-09-30,EE,Estonia,
-1964-09-30,ES,Spain,
-1964-09-30,FI,Finland,
-1964-09-30,FR,France,
-1964-09-30,GB,United Kingdom,
-1964-09-30,GR,Greece,
-1964-09-30,HK,Hong Kong SAR,
-1964-09-30,HR,Croatia,
-1964-09-30,HU,Hungary,
-1964-09-30,ID,Indonesia,
-1964-09-30,IE,Ireland,
-1964-09-30,IL,Israel,
-1964-09-30,IN,India,
-1964-09-30,IS,Iceland,
-1964-09-30,IT,Italy,39.4693
+1964-06-30,NZ,New Zealand,35.4335
+1964-09-30,IT,Italy,39.261
 1964-09-30,JP,Japan,62.0947
-1964-09-30,KR,Korea,
-1964-09-30,LT,Lithuania,
-1964-09-30,LU,Luxembourg,
-1964-09-30,LV,Latvia,
-1964-09-30,MA,Morocco,
-1964-09-30,MK,North Macedonia,
-1964-09-30,MT,Malta,
-1964-09-30,MX,Mexico,
-1964-09-30,MY,Malaysia,
-1964-09-30,NL,Netherlands,
-1964-09-30,NO,Norway,
-1964-09-30,NZ,New Zealand,
-1964-09-30,PE,Peru,
-1964-09-30,PH,Philippines,
-1964-09-30,PL,Poland,
-1964-09-30,PT,Portugal,
-1964-09-30,RO,Romania,
-1964-09-30,RS,Serbia,
-1964-09-30,RU,Russia,
-1964-09-30,SE,Sweden,
-1964-09-30,SG,Singapore,
-1964-09-30,SI,Slovenia,
-1964-09-30,SK,Slovak Republic,
-1964-09-30,TH,Thailand,
-1964-09-30,TR,Türkiye,
-1964-09-30,US,United States,
-1964-09-30,XM,Euro area,
-1964-09-30,XW,World,
-1964-09-30,ZA,South Africa,
-1964-12-31,4T,Emerging market economies (aggregate),
-1964-12-31,5R,Advanced economies,
-1964-12-31,AE,United Arab Emirates,
-1964-12-31,AT,Austria,
-1964-12-31,AU,Australia,
-1964-12-31,BE,Belgium,
-1964-12-31,BG,Bulgaria,
-1964-12-31,BR,Brazil,
-1964-12-31,CA,Canada,
-1964-12-31,CH,Switzerland,
-1964-12-31,CL,Chile,
-1964-12-31,CN,China,
-1964-12-31,CO,Colombia,
-1964-12-31,CY,Cyprus,
-1964-12-31,CZ,Czechia,
-1964-12-31,DE,Germany,
-1964-12-31,DK,Denmark,
-1964-12-31,EE,Estonia,
-1964-12-31,ES,Spain,
-1964-12-31,FI,Finland,
-1964-12-31,FR,France,
-1964-12-31,GB,United Kingdom,
-1964-12-31,GR,Greece,
-1964-12-31,HK,Hong Kong SAR,
-1964-12-31,HR,Croatia,
-1964-12-31,HU,Hungary,
-1964-12-31,ID,Indonesia,
-1964-12-31,IE,Ireland,
-1964-12-31,IL,Israel,
-1964-12-31,IN,India,
-1964-12-31,IS,Iceland,
-1964-12-31,IT,Italy,38.9168
+1964-09-30,NZ,New Zealand,35.4204
+1964-12-31,IT,Italy,38.6308
 1964-12-31,JP,Japan,62.7744
-1964-12-31,KR,Korea,
-1964-12-31,LT,Lithuania,
-1964-12-31,LU,Luxembourg,
-1964-12-31,LV,Latvia,
-1964-12-31,MA,Morocco,
-1964-12-31,MK,North Macedonia,
-1964-12-31,MT,Malta,
-1964-12-31,MX,Mexico,
-1964-12-31,MY,Malaysia,
-1964-12-31,NL,Netherlands,
-1964-12-31,NO,Norway,
-1964-12-31,NZ,New Zealand,
-1964-12-31,PE,Peru,
-1964-12-31,PH,Philippines,
-1964-12-31,PL,Poland,
-1964-12-31,PT,Portugal,
-1964-12-31,RO,Romania,
-1964-12-31,RS,Serbia,
-1964-12-31,RU,Russia,
-1964-12-31,SE,Sweden,
-1964-12-31,SG,Singapore,
-1964-12-31,SI,Slovenia,
-1964-12-31,SK,Slovak Republic,
-1964-12-31,TH,Thailand,
-1964-12-31,TR,Türkiye,
-1964-12-31,US,United States,
-1964-12-31,XM,Euro area,
-1964-12-31,XW,World,
-1964-12-31,ZA,South Africa,
-1965-03-31,4T,Emerging market economies (aggregate),
-1965-03-31,5R,Advanced economies,
-1965-03-31,AE,United Arab Emirates,
-1965-03-31,AT,Austria,
-1965-03-31,AU,Australia,
-1965-03-31,BE,Belgium,
-1965-03-31,BG,Bulgaria,
-1965-03-31,BR,Brazil,
-1965-03-31,CA,Canada,
-1965-03-31,CH,Switzerland,
-1965-03-31,CL,Chile,
-1965-03-31,CN,China,
-1965-03-31,CO,Colombia,
-1965-03-31,CY,Cyprus,
-1965-03-31,CZ,Czechia,
-1965-03-31,DE,Germany,
-1965-03-31,DK,Denmark,
-1965-03-31,EE,Estonia,
-1965-03-31,ES,Spain,
-1965-03-31,FI,Finland,
-1965-03-31,FR,France,
-1965-03-31,GB,United Kingdom,
-1965-03-31,GR,Greece,
-1965-03-31,HK,Hong Kong SAR,
-1965-03-31,HR,Croatia,
-1965-03-31,HU,Hungary,
-1965-03-31,ID,Indonesia,
-1965-03-31,IE,Ireland,
-1965-03-31,IL,Israel,
-1965-03-31,IN,India,
-1965-03-31,IS,Iceland,
-1965-03-31,IT,Italy,38.1967
+1964-12-31,NZ,New Zealand,35.6064
+1965-03-31,IT,Italy,37.9347
 1965-03-31,JP,Japan,63.7586
-1965-03-31,KR,Korea,
-1965-03-31,LT,Lithuania,
-1965-03-31,LU,Luxembourg,
-1965-03-31,LV,Latvia,
-1965-03-31,MA,Morocco,
-1965-03-31,MK,North Macedonia,
-1965-03-31,MT,Malta,
-1965-03-31,MX,Mexico,
-1965-03-31,MY,Malaysia,
-1965-03-31,NL,Netherlands,
-1965-03-31,NO,Norway,
-1965-03-31,NZ,New Zealand,
-1965-03-31,PE,Peru,
-1965-03-31,PH,Philippines,
-1965-03-31,PL,Poland,
-1965-03-31,PT,Portugal,
-1965-03-31,RO,Romania,
-1965-03-31,RS,Serbia,
-1965-03-31,RU,Russia,
-1965-03-31,SE,Sweden,
-1965-03-31,SG,Singapore,
-1965-03-31,SI,Slovenia,
-1965-03-31,SK,Slovak Republic,
-1965-03-31,TH,Thailand,
-1965-03-31,TR,Türkiye,
-1965-03-31,US,United States,
-1965-03-31,XM,Euro area,
-1965-03-31,XW,World,
-1965-03-31,ZA,South Africa,
-1965-06-30,4T,Emerging market economies (aggregate),
-1965-06-30,5R,Advanced economies,
-1965-06-30,AE,United Arab Emirates,
-1965-06-30,AT,Austria,
-1965-06-30,AU,Australia,
-1965-06-30,BE,Belgium,
-1965-06-30,BG,Bulgaria,
-1965-06-30,BR,Brazil,
-1965-06-30,CA,Canada,
-1965-06-30,CH,Switzerland,
-1965-06-30,CL,Chile,
-1965-06-30,CN,China,
-1965-06-30,CO,Colombia,
-1965-06-30,CY,Cyprus,
-1965-06-30,CZ,Czechia,
-1965-06-30,DE,Germany,
-1965-06-30,DK,Denmark,
-1965-06-30,EE,Estonia,
-1965-06-30,ES,Spain,
-1965-06-30,FI,Finland,
-1965-06-30,FR,France,
-1965-06-30,GB,United Kingdom,
-1965-06-30,GR,Greece,
-1965-06-30,HK,Hong Kong SAR,
-1965-06-30,HR,Croatia,
-1965-06-30,HU,Hungary,
-1965-06-30,ID,Indonesia,
-1965-06-30,IE,Ireland,
-1965-06-30,IL,Israel,
-1965-06-30,IN,India,
-1965-06-30,IS,Iceland,
-1965-06-30,IT,Italy,37.3398
+1965-03-31,NZ,New Zealand,36.2809
+1965-06-30,IT,Italy,36.9174
 1965-06-30,JP,Japan,63.2761
-1965-06-30,KR,Korea,
-1965-06-30,LT,Lithuania,
-1965-06-30,LU,Luxembourg,
-1965-06-30,LV,Latvia,
-1965-06-30,MA,Morocco,
-1965-06-30,MK,North Macedonia,
-1965-06-30,MT,Malta,
-1965-06-30,MX,Mexico,
-1965-06-30,MY,Malaysia,
-1965-06-30,NL,Netherlands,
-1965-06-30,NO,Norway,
-1965-06-30,NZ,New Zealand,
-1965-06-30,PE,Peru,
-1965-06-30,PH,Philippines,
-1965-06-30,PL,Poland,
-1965-06-30,PT,Portugal,
-1965-06-30,RO,Romania,
-1965-06-30,RS,Serbia,
-1965-06-30,RU,Russia,
-1965-06-30,SE,Sweden,
-1965-06-30,SG,Singapore,
-1965-06-30,SI,Slovenia,
-1965-06-30,SK,Slovak Republic,
-1965-06-30,TH,Thailand,
-1965-06-30,TR,Türkiye,
-1965-06-30,US,United States,
-1965-06-30,XM,Euro area,
-1965-06-30,XW,World,
-1965-06-30,ZA,South Africa,
-1965-09-30,4T,Emerging market economies (aggregate),
-1965-09-30,5R,Advanced economies,
-1965-09-30,AE,United Arab Emirates,
-1965-09-30,AT,Austria,
-1965-09-30,AU,Australia,
-1965-09-30,BE,Belgium,
-1965-09-30,BG,Bulgaria,
-1965-09-30,BR,Brazil,
-1965-09-30,CA,Canada,
-1965-09-30,CH,Switzerland,
-1965-09-30,CL,Chile,
-1965-09-30,CN,China,
-1965-09-30,CO,Colombia,
-1965-09-30,CY,Cyprus,
-1965-09-30,CZ,Czechia,
-1965-09-30,DE,Germany,
-1965-09-30,DK,Denmark,
-1965-09-30,EE,Estonia,
-1965-09-30,ES,Spain,
-1965-09-30,FI,Finland,
-1965-09-30,FR,France,
-1965-09-30,GB,United Kingdom,
-1965-09-30,GR,Greece,
-1965-09-30,HK,Hong Kong SAR,
-1965-09-30,HR,Croatia,
-1965-09-30,HU,Hungary,
-1965-09-30,ID,Indonesia,
-1965-09-30,IE,Ireland,
-1965-09-30,IL,Israel,
-1965-09-30,IN,India,
-1965-09-30,IS,Iceland,
-1965-09-30,IT,Italy,36.9567
+1965-06-30,NZ,New Zealand,36.9797
+1965-09-30,IT,Italy,36.6952
 1965-09-30,JP,Japan,64.0474
-1965-09-30,KR,Korea,
-1965-09-30,LT,Lithuania,
-1965-09-30,LU,Luxembourg,
-1965-09-30,LV,Latvia,
-1965-09-30,MA,Morocco,
-1965-09-30,MK,North Macedonia,
-1965-09-30,MT,Malta,
-1965-09-30,MX,Mexico,
-1965-09-30,MY,Malaysia,
-1965-09-30,NL,Netherlands,
-1965-09-30,NO,Norway,
-1965-09-30,NZ,New Zealand,
-1965-09-30,PE,Peru,
-1965-09-30,PH,Philippines,
-1965-09-30,PL,Poland,
-1965-09-30,PT,Portugal,
-1965-09-30,RO,Romania,
-1965-09-30,RS,Serbia,
-1965-09-30,RU,Russia,
-1965-09-30,SE,Sweden,
-1965-09-30,SG,Singapore,
-1965-09-30,SI,Slovenia,
-1965-09-30,SK,Slovak Republic,
-1965-09-30,TH,Thailand,
-1965-09-30,TR,Türkiye,
-1965-09-30,US,United States,
-1965-09-30,XM,Euro area,
-1965-09-30,XW,World,
-1965-09-30,ZA,South Africa,
-1965-12-31,4T,Emerging market economies (aggregate),
-1965-12-31,5R,Advanced economies,
-1965-12-31,AE,United Arab Emirates,
-1965-12-31,AT,Austria,
-1965-12-31,AU,Australia,
-1965-12-31,BE,Belgium,
-1965-12-31,BG,Bulgaria,
-1965-12-31,BR,Brazil,
-1965-12-31,CA,Canada,
-1965-12-31,CH,Switzerland,
-1965-12-31,CL,Chile,
-1965-12-31,CN,China,
-1965-12-31,CO,Colombia,
-1965-12-31,CY,Cyprus,
-1965-12-31,CZ,Czechia,
-1965-12-31,DE,Germany,
-1965-12-31,DK,Denmark,
-1965-12-31,EE,Estonia,
-1965-12-31,ES,Spain,
-1965-12-31,FI,Finland,
-1965-12-31,FR,France,
-1965-12-31,GB,United Kingdom,
-1965-12-31,GR,Greece,
-1965-12-31,HK,Hong Kong SAR,
-1965-12-31,HR,Croatia,
-1965-12-31,HU,Hungary,
-1965-12-31,ID,Indonesia,
-1965-12-31,IE,Ireland,
-1965-12-31,IL,Israel,
-1965-12-31,IN,India,
-1965-12-31,IS,Iceland,
-1965-12-31,IT,Italy,36.9203
+1965-09-30,NZ,New Zealand,36.7529
+1965-12-31,IT,Italy,36.8548
 1965-12-31,JP,Japan,63.949
-1965-12-31,KR,Korea,
-1965-12-31,LT,Lithuania,
-1965-12-31,LU,Luxembourg,
-1965-12-31,LV,Latvia,
-1965-12-31,MA,Morocco,
-1965-12-31,MK,North Macedonia,
-1965-12-31,MT,Malta,
-1965-12-31,MX,Mexico,
-1965-12-31,MY,Malaysia,
-1965-12-31,NL,Netherlands,
-1965-12-31,NO,Norway,
-1965-12-31,NZ,New Zealand,
-1965-12-31,PE,Peru,
-1965-12-31,PH,Philippines,
-1965-12-31,PL,Poland,
-1965-12-31,PT,Portugal,
-1965-12-31,RO,Romania,
-1965-12-31,RS,Serbia,
-1965-12-31,RU,Russia,
-1965-12-31,SE,Sweden,
-1965-12-31,SG,Singapore,
-1965-12-31,SI,Slovenia,
-1965-12-31,SK,Slovak Republic,
-1965-12-31,TH,Thailand,
-1965-12-31,TR,Türkiye,
-1965-12-31,US,United States,
-1965-12-31,XM,Euro area,
-1965-12-31,XW,World,
-1965-12-31,ZA,South Africa,
-1966-03-31,4T,Emerging market economies (aggregate),
-1966-03-31,5R,Advanced economies,
-1966-03-31,AE,United Arab Emirates,
-1966-03-31,AT,Austria,
-1966-03-31,AU,Australia,
-1966-03-31,BE,Belgium,
-1966-03-31,BG,Bulgaria,
-1966-03-31,BR,Brazil,
-1966-03-31,CA,Canada,
-1966-03-31,CH,Switzerland,
-1966-03-31,CL,Chile,
-1966-03-31,CN,China,
-1966-03-31,CO,Colombia,
-1966-03-31,CY,Cyprus,
-1966-03-31,CZ,Czechia,
-1966-03-31,DE,Germany,
-1966-03-31,DK,Denmark,
-1966-03-31,EE,Estonia,
-1966-03-31,ES,Spain,
-1966-03-31,FI,Finland,
-1966-03-31,FR,France,
-1966-03-31,GB,United Kingdom,
-1966-03-31,GR,Greece,
-1966-03-31,HK,Hong Kong SAR,
-1966-03-31,HR,Croatia,
-1966-03-31,HU,Hungary,
-1966-03-31,ID,Indonesia,
-1966-03-31,IE,Ireland,
-1966-03-31,IL,Israel,
-1966-03-31,IN,India,
-1966-03-31,IS,Iceland,
-1966-03-31,IT,Italy,37.0838
+1965-12-31,NZ,New Zealand,36.9974
+1966-03-31,IT,Italy,37.0149
 1966-03-31,JP,Japan,64.0146
-1966-03-31,KR,Korea,
-1966-03-31,LT,Lithuania,
-1966-03-31,LU,Luxembourg,
-1966-03-31,LV,Latvia,
-1966-03-31,MA,Morocco,
-1966-03-31,MK,North Macedonia,
-1966-03-31,MT,Malta,
-1966-03-31,MX,Mexico,
-1966-03-31,MY,Malaysia,
-1966-03-31,NL,Netherlands,
-1966-03-31,NO,Norway,
-1966-03-31,NZ,New Zealand,
-1966-03-31,PE,Peru,
-1966-03-31,PH,Philippines,
-1966-03-31,PL,Poland,
-1966-03-31,PT,Portugal,
-1966-03-31,RO,Romania,
-1966-03-31,RS,Serbia,
-1966-03-31,RU,Russia,
-1966-03-31,SE,Sweden,
-1966-03-31,SG,Singapore,
-1966-03-31,SI,Slovenia,
-1966-03-31,SK,Slovak Republic,
-1966-03-31,TH,Thailand,
-1966-03-31,TR,Türkiye,
-1966-03-31,US,United States,
-1966-03-31,XM,Euro area,
-1966-03-31,XW,World,
-1966-03-31,ZA,South Africa,54.2254
-1966-06-30,4T,Emerging market economies (aggregate),
-1966-06-30,5R,Advanced economies,
-1966-06-30,AE,United Arab Emirates,
-1966-06-30,AT,Austria,
-1966-06-30,AU,Australia,
-1966-06-30,BE,Belgium,
-1966-06-30,BG,Bulgaria,
-1966-06-30,BR,Brazil,
-1966-06-30,CA,Canada,
-1966-06-30,CH,Switzerland,
-1966-06-30,CL,Chile,
-1966-06-30,CN,China,
-1966-06-30,CO,Colombia,
-1966-06-30,CY,Cyprus,
-1966-06-30,CZ,Czechia,
-1966-06-30,DE,Germany,
-1966-06-30,DK,Denmark,
-1966-06-30,EE,Estonia,
-1966-06-30,ES,Spain,
-1966-06-30,FI,Finland,
-1966-06-30,FR,France,
-1966-06-30,GB,United Kingdom,
-1966-06-30,GR,Greece,
-1966-06-30,HK,Hong Kong SAR,
-1966-06-30,HR,Croatia,
-1966-06-30,HU,Hungary,
-1966-06-30,ID,Indonesia,
-1966-06-30,IE,Ireland,
-1966-06-30,IL,Israel,
-1966-06-30,IN,India,
-1966-06-30,IS,Iceland,
-1966-06-30,IT,Italy,37.1685
+1966-03-31,NZ,New Zealand,36.995
+1966-03-31,ZA,South Africa,54.0544
+1966-06-30,IT,Italy,36.9337
 1966-06-30,JP,Japan,64.4924
-1966-06-30,KR,Korea,
-1966-06-30,LT,Lithuania,
-1966-06-30,LU,Luxembourg,
-1966-06-30,LV,Latvia,
-1966-06-30,MA,Morocco,
-1966-06-30,MK,North Macedonia,
-1966-06-30,MT,Malta,
-1966-06-30,MX,Mexico,
-1966-06-30,MY,Malaysia,
-1966-06-30,NL,Netherlands,
-1966-06-30,NO,Norway,
-1966-06-30,NZ,New Zealand,
-1966-06-30,PE,Peru,
-1966-06-30,PH,Philippines,
-1966-06-30,PL,Poland,
-1966-06-30,PT,Portugal,
-1966-06-30,RO,Romania,
-1966-06-30,RS,Serbia,
-1966-06-30,RU,Russia,
-1966-06-30,SE,Sweden,
-1966-06-30,SG,Singapore,
-1966-06-30,SI,Slovenia,
-1966-06-30,SK,Slovak Republic,
-1966-06-30,TH,Thailand,
-1966-06-30,TR,Türkiye,
-1966-06-30,US,United States,
-1966-06-30,XM,Euro area,
-1966-06-30,XW,World,
-1966-06-30,ZA,South Africa,54.9466
-1966-09-30,4T,Emerging market economies (aggregate),
-1966-09-30,5R,Advanced economies,
-1966-09-30,AE,United Arab Emirates,
-1966-09-30,AT,Austria,
-1966-09-30,AU,Australia,
-1966-09-30,BE,Belgium,
-1966-09-30,BG,Bulgaria,
-1966-09-30,BR,Brazil,
-1966-09-30,CA,Canada,
-1966-09-30,CH,Switzerland,
-1966-09-30,CL,Chile,
-1966-09-30,CN,China,
-1966-09-30,CO,Colombia,
-1966-09-30,CY,Cyprus,
-1966-09-30,CZ,Czechia,
-1966-09-30,DE,Germany,
-1966-09-30,DK,Denmark,
-1966-09-30,EE,Estonia,
-1966-09-30,ES,Spain,
-1966-09-30,FI,Finland,
-1966-09-30,FR,France,
-1966-09-30,GB,United Kingdom,
-1966-09-30,GR,Greece,
-1966-09-30,HK,Hong Kong SAR,
-1966-09-30,HR,Croatia,
-1966-09-30,HU,Hungary,
-1966-09-30,ID,Indonesia,
-1966-09-30,IE,Ireland,
-1966-09-30,IL,Israel,
-1966-09-30,IN,India,
-1966-09-30,IS,Iceland,
-1966-09-30,IT,Italy,36.83
+1966-06-30,NZ,New Zealand,37.2649
+1966-06-30,ZA,South Africa,54.8087
+1966-09-30,IT,Italy,36.4301
 1966-09-30,JP,Japan,65.697
-1966-09-30,KR,Korea,
-1966-09-30,LT,Lithuania,
-1966-09-30,LU,Luxembourg,
-1966-09-30,LV,Latvia,
-1966-09-30,MA,Morocco,
-1966-09-30,MK,North Macedonia,
-1966-09-30,MT,Malta,
-1966-09-30,MX,Mexico,
-1966-09-30,MY,Malaysia,
-1966-09-30,NL,Netherlands,
-1966-09-30,NO,Norway,
-1966-09-30,NZ,New Zealand,
-1966-09-30,PE,Peru,
-1966-09-30,PH,Philippines,
-1966-09-30,PL,Poland,
-1966-09-30,PT,Portugal,
-1966-09-30,RO,Romania,
-1966-09-30,RS,Serbia,
-1966-09-30,RU,Russia,
-1966-09-30,SE,Sweden,
-1966-09-30,SG,Singapore,
-1966-09-30,SI,Slovenia,
-1966-09-30,SK,Slovak Republic,
-1966-09-30,TH,Thailand,
-1966-09-30,TR,Türkiye,
-1966-09-30,US,United States,
-1966-09-30,XM,Euro area,
-1966-09-30,XW,World,
-1966-09-30,ZA,South Africa,53.936
-1966-12-31,4T,Emerging market economies (aggregate),
-1966-12-31,5R,Advanced economies,
-1966-12-31,AE,United Arab Emirates,
-1966-12-31,AT,Austria,
-1966-12-31,AU,Australia,
-1966-12-31,BE,Belgium,
-1966-12-31,BG,Bulgaria,
-1966-12-31,BR,Brazil,
-1966-12-31,CA,Canada,
-1966-12-31,CH,Switzerland,
-1966-12-31,CL,Chile,
-1966-12-31,CN,China,
-1966-12-31,CO,Colombia,
-1966-12-31,CY,Cyprus,
-1966-12-31,CZ,Czechia,
-1966-12-31,DE,Germany,
-1966-12-31,DK,Denmark,
-1966-12-31,EE,Estonia,
-1966-12-31,ES,Spain,
-1966-12-31,FI,Finland,
-1966-12-31,FR,France,
-1966-12-31,GB,United Kingdom,
-1966-12-31,GR,Greece,
-1966-12-31,HK,Hong Kong SAR,
-1966-12-31,HR,Croatia,
-1966-12-31,HU,Hungary,
-1966-12-31,ID,Indonesia,
-1966-12-31,IE,Ireland,
-1966-12-31,IL,Israel,
-1966-12-31,IN,India,
-1966-12-31,IS,Iceland,
-1966-12-31,IT,Italy,36.6091
+1966-09-30,NZ,New Zealand,37.7749
+1966-09-30,ZA,South Africa,53.8077
+1966-12-31,IT,Italy,35.8719
 1966-12-31,JP,Japan,66.7772
-1966-12-31,KR,Korea,
-1966-12-31,LT,Lithuania,
-1966-12-31,LU,Luxembourg,
-1966-12-31,LV,Latvia,
-1966-12-31,MA,Morocco,
-1966-12-31,MK,North Macedonia,
-1966-12-31,MT,Malta,
-1966-12-31,MX,Mexico,
-1966-12-31,MY,Malaysia,
-1966-12-31,NL,Netherlands,
-1966-12-31,NO,Norway,
-1966-12-31,NZ,New Zealand,
-1966-12-31,PE,Peru,
-1966-12-31,PH,Philippines,
-1966-12-31,PL,Poland,
-1966-12-31,PT,Portugal,
-1966-12-31,RO,Romania,
-1966-12-31,RS,Serbia,
-1966-12-31,RU,Russia,
-1966-12-31,SE,Sweden,
-1966-12-31,SG,Singapore,
-1966-12-31,SI,Slovenia,
-1966-12-31,SK,Slovak Republic,
-1966-12-31,TH,Thailand,
-1966-12-31,TR,Türkiye,
-1966-12-31,US,United States,
-1966-12-31,XM,Euro area,
-1966-12-31,XW,World,
-1966-12-31,ZA,South Africa,55.1863
-1967-03-31,4T,Emerging market economies (aggregate),
-1967-03-31,5R,Advanced economies,
-1967-03-31,AE,United Arab Emirates,
-1967-03-31,AT,Austria,
-1967-03-31,AU,Australia,
-1967-03-31,BE,Belgium,
-1967-03-31,BG,Bulgaria,
-1967-03-31,BR,Brazil,
-1967-03-31,CA,Canada,
-1967-03-31,CH,Switzerland,
-1967-03-31,CL,Chile,
-1967-03-31,CN,China,
-1967-03-31,CO,Colombia,
-1967-03-31,CY,Cyprus,
-1967-03-31,CZ,Czechia,
-1967-03-31,DE,Germany,
-1967-03-31,DK,Denmark,
-1967-03-31,EE,Estonia,
-1967-03-31,ES,Spain,
-1967-03-31,FI,Finland,
-1967-03-31,FR,France,
-1967-03-31,GB,United Kingdom,
-1967-03-31,GR,Greece,
-1967-03-31,HK,Hong Kong SAR,
-1967-03-31,HR,Croatia,
-1967-03-31,HU,Hungary,
-1967-03-31,ID,Indonesia,
-1967-03-31,IE,Ireland,
-1967-03-31,IL,Israel,
-1967-03-31,IN,India,
-1967-03-31,IS,Iceland,
-1967-03-31,IT,Italy,36.4114
+1966-12-31,NZ,New Zealand,38.3156
+1966-12-31,ZA,South Africa,55.0679
+1967-03-31,IT,Italy,35.9129
 1967-03-31,JP,Japan,67.344
-1967-03-31,KR,Korea,
-1967-03-31,LT,Lithuania,
-1967-03-31,LU,Luxembourg,
-1967-03-31,LV,Latvia,
-1967-03-31,MA,Morocco,
-1967-03-31,MK,North Macedonia,
-1967-03-31,MT,Malta,
-1967-03-31,MX,Mexico,
-1967-03-31,MY,Malaysia,
-1967-03-31,NL,Netherlands,
-1967-03-31,NO,Norway,
-1967-03-31,NZ,New Zealand,
-1967-03-31,PE,Peru,
-1967-03-31,PH,Philippines,
-1967-03-31,PL,Poland,
-1967-03-31,PT,Portugal,
-1967-03-31,RO,Romania,
-1967-03-31,RS,Serbia,
-1967-03-31,RU,Russia,
-1967-03-31,SE,Sweden,
-1967-03-31,SG,Singapore,
-1967-03-31,SI,Slovenia,
-1967-03-31,SK,Slovak Republic,
-1967-03-31,TH,Thailand,
-1967-03-31,TR,Türkiye,
-1967-03-31,US,United States,
-1967-03-31,XM,Euro area,
-1967-03-31,XW,World,
-1967-03-31,ZA,South Africa,60.961
-1967-06-30,4T,Emerging market economies (aggregate),
-1967-06-30,5R,Advanced economies,
-1967-06-30,AE,United Arab Emirates,
-1967-06-30,AT,Austria,
-1967-06-30,AU,Australia,
-1967-06-30,BE,Belgium,
-1967-06-30,BG,Bulgaria,
-1967-06-30,BR,Brazil,
-1967-06-30,CA,Canada,
-1967-06-30,CH,Switzerland,
-1967-06-30,CL,Chile,
-1967-06-30,CN,China,
-1967-06-30,CO,Colombia,
-1967-06-30,CY,Cyprus,
-1967-06-30,CZ,Czechia,
-1967-06-30,DE,Germany,
-1967-06-30,DK,Denmark,
-1967-06-30,EE,Estonia,
-1967-06-30,ES,Spain,
-1967-06-30,FI,Finland,
-1967-06-30,FR,France,
-1967-06-30,GB,United Kingdom,
-1967-06-30,GR,Greece,
-1967-06-30,HK,Hong Kong SAR,
-1967-06-30,HR,Croatia,
-1967-06-30,HU,Hungary,
-1967-06-30,ID,Indonesia,
-1967-06-30,IE,Ireland,
-1967-06-30,IL,Israel,
-1967-06-30,IN,India,
-1967-06-30,IS,Iceland,
-1967-06-30,IT,Italy,36.2851
+1967-03-31,NZ,New Zealand,37.6125
+1967-03-31,ZA,South Africa,60.8335
+1967-06-30,IT,Italy,35.2479
 1967-06-30,JP,Japan,70.072
-1967-06-30,KR,Korea,
-1967-06-30,LT,Lithuania,
-1967-06-30,LU,Luxembourg,
-1967-06-30,LV,Latvia,
-1967-06-30,MA,Morocco,
-1967-06-30,MK,North Macedonia,
-1967-06-30,MT,Malta,
-1967-06-30,MX,Mexico,
-1967-06-30,MY,Malaysia,
-1967-06-30,NL,Netherlands,
-1967-06-30,NO,Norway,
-1967-06-30,NZ,New Zealand,
-1967-06-30,PE,Peru,
-1967-06-30,PH,Philippines,
-1967-06-30,PL,Poland,
-1967-06-30,PT,Portugal,
-1967-06-30,RO,Romania,
-1967-06-30,RS,Serbia,
-1967-06-30,RU,Russia,
-1967-06-30,SE,Sweden,
-1967-06-30,SG,Singapore,
-1967-06-30,SI,Slovenia,
-1967-06-30,SK,Slovak Republic,
-1967-06-30,TH,Thailand,
-1967-06-30,TR,Türkiye,
-1967-06-30,US,United States,
-1967-06-30,XM,Euro area,
-1967-06-30,XW,World,
-1967-06-30,ZA,South Africa,62.2635
-1967-09-30,4T,Emerging market economies (aggregate),
-1967-09-30,5R,Advanced economies,
-1967-09-30,AE,United Arab Emirates,
-1967-09-30,AT,Austria,
-1967-09-30,AU,Australia,
-1967-09-30,BE,Belgium,
-1967-09-30,BG,Bulgaria,
-1967-09-30,BR,Brazil,
-1967-09-30,CA,Canada,
-1967-09-30,CH,Switzerland,
-1967-09-30,CL,Chile,
-1967-09-30,CN,China,
-1967-09-30,CO,Colombia,
-1967-09-30,CY,Cyprus,
-1967-09-30,CZ,Czechia,
-1967-09-30,DE,Germany,
-1967-09-30,DK,Denmark,
-1967-09-30,EE,Estonia,
-1967-09-30,ES,Spain,
-1967-09-30,FI,Finland,
-1967-09-30,FR,France,
-1967-09-30,GB,United Kingdom,
-1967-09-30,GR,Greece,
-1967-09-30,HK,Hong Kong SAR,
-1967-09-30,HR,Croatia,
-1967-09-30,HU,Hungary,
-1967-09-30,ID,Indonesia,
-1967-09-30,IE,Ireland,
-1967-09-30,IL,Israel,
-1967-09-30,IN,India,
-1967-09-30,IS,Iceland,
-1967-09-30,IT,Italy,36.8368
+1967-06-30,NZ,New Zealand,36.8413
+1967-06-30,ZA,South Africa,62.2096
+1967-09-30,IT,Italy,35.6901
 1967-09-30,JP,Japan,72.3993
-1967-09-30,KR,Korea,
-1967-09-30,LT,Lithuania,
-1967-09-30,LU,Luxembourg,
-1967-09-30,LV,Latvia,
-1967-09-30,MA,Morocco,
-1967-09-30,MK,North Macedonia,
-1967-09-30,MT,Malta,
-1967-09-30,MX,Mexico,
-1967-09-30,MY,Malaysia,
-1967-09-30,NL,Netherlands,
-1967-09-30,NO,Norway,
-1967-09-30,NZ,New Zealand,
-1967-09-30,PE,Peru,
-1967-09-30,PH,Philippines,
-1967-09-30,PL,Poland,
-1967-09-30,PT,Portugal,
-1967-09-30,RO,Romania,
-1967-09-30,RS,Serbia,
-1967-09-30,RU,Russia,
-1967-09-30,SE,Sweden,
-1967-09-30,SG,Singapore,
-1967-09-30,SI,Slovenia,
-1967-09-30,SK,Slovak Republic,
-1967-09-30,TH,Thailand,
-1967-09-30,TR,Türkiye,
-1967-09-30,US,United States,
-1967-09-30,XM,Euro area,
-1967-09-30,XW,World,
-1967-09-30,ZA,South Africa,63.902
-1967-12-31,4T,Emerging market economies (aggregate),
-1967-12-31,5R,Advanced economies,
-1967-12-31,AE,United Arab Emirates,
-1967-12-31,AT,Austria,
-1967-12-31,AU,Australia,
-1967-12-31,BE,Belgium,
-1967-12-31,BG,Bulgaria,
-1967-12-31,BR,Brazil,
-1967-12-31,CA,Canada,
-1967-12-31,CH,Switzerland,
-1967-12-31,CL,Chile,
-1967-12-31,CN,China,
-1967-12-31,CO,Colombia,
-1967-12-31,CY,Cyprus,
-1967-12-31,CZ,Czechia,
-1967-12-31,DE,Germany,
-1967-12-31,DK,Denmark,
-1967-12-31,EE,Estonia,
-1967-12-31,ES,Spain,
-1967-12-31,FI,Finland,
-1967-12-31,FR,France,
-1967-12-31,GB,United Kingdom,
-1967-12-31,GR,Greece,
-1967-12-31,HK,Hong Kong SAR,
-1967-12-31,HR,Croatia,
-1967-12-31,HU,Hungary,
-1967-12-31,ID,Indonesia,
-1967-12-31,IE,Ireland,
-1967-12-31,IL,Israel,
-1967-12-31,IN,India,
-1967-12-31,IS,Iceland,
-1967-12-31,IT,Italy,37.9508
+1967-09-30,NZ,New Zealand,36.4404
+1967-09-30,ZA,South Africa,63.6716
+1967-12-31,IT,Italy,36.8199
 1967-12-31,JP,Japan,73.2067
-1967-12-31,KR,Korea,
-1967-12-31,LT,Lithuania,
-1967-12-31,LU,Luxembourg,
-1967-12-31,LV,Latvia,
-1967-12-31,MA,Morocco,
-1967-12-31,MK,North Macedonia,
-1967-12-31,MT,Malta,
-1967-12-31,MX,Mexico,
-1967-12-31,MY,Malaysia,
-1967-12-31,NL,Netherlands,
-1967-12-31,NO,Norway,
-1967-12-31,NZ,New Zealand,
-1967-12-31,PE,Peru,
-1967-12-31,PH,Philippines,
-1967-12-31,PL,Poland,
-1967-12-31,PT,Portugal,
-1967-12-31,RO,Romania,
-1967-12-31,RS,Serbia,
-1967-12-31,RU,Russia,
-1967-12-31,SE,Sweden,
-1967-12-31,SG,Singapore,
-1967-12-31,SI,Slovenia,
-1967-12-31,SK,Slovak Republic,
-1967-12-31,TH,Thailand,
-1967-12-31,TR,Türkiye,
-1967-12-31,US,United States,
-1967-12-31,XM,Euro area,
-1967-12-31,XW,World,
-1967-12-31,ZA,South Africa,63.902
-1968-03-31,4T,Emerging market economies (aggregate),
-1968-03-31,5R,Advanced economies,
-1968-03-31,AE,United Arab Emirates,
-1968-03-31,AT,Austria,
-1968-03-31,AU,Australia,
-1968-03-31,BE,Belgium,
-1968-03-31,BG,Bulgaria,
-1968-03-31,BR,Brazil,
-1968-03-31,CA,Canada,
-1968-03-31,CH,Switzerland,
-1968-03-31,CL,Chile,
-1968-03-31,CN,China,
-1968-03-31,CO,Colombia,
-1968-03-31,CY,Cyprus,
-1968-03-31,CZ,Czechia,
-1968-03-31,DE,Germany,
-1968-03-31,DK,Denmark,
-1968-03-31,EE,Estonia,
-1968-03-31,ES,Spain,
-1968-03-31,FI,Finland,
-1968-03-31,FR,France,
-1968-03-31,GB,United Kingdom,
-1968-03-31,GR,Greece,
-1968-03-31,HK,Hong Kong SAR,
-1968-03-31,HR,Croatia,
-1968-03-31,HU,Hungary,
-1968-03-31,ID,Indonesia,
-1968-03-31,IE,Ireland,
-1968-03-31,IL,Israel,
-1968-03-31,IN,India,
-1968-03-31,IS,Iceland,
-1968-03-31,IT,Italy,38.9777
+1967-12-31,NZ,New Zealand,36.4071
+1967-12-31,ZA,South Africa,63.7444
+1968-03-31,IT,Italy,37.8475
 1968-03-31,JP,Japan,74.7294
-1968-03-31,KR,Korea,
-1968-03-31,LT,Lithuania,
-1968-03-31,LU,Luxembourg,
-1968-03-31,LV,Latvia,
-1968-03-31,MA,Morocco,
-1968-03-31,MK,North Macedonia,
-1968-03-31,MT,Malta,
-1968-03-31,MX,Mexico,
-1968-03-31,MY,Malaysia,
-1968-03-31,NL,Netherlands,
-1968-03-31,NO,Norway,
-1968-03-31,NZ,New Zealand,
-1968-03-31,PE,Peru,
-1968-03-31,PH,Philippines,
-1968-03-31,PL,Poland,
-1968-03-31,PT,Portugal,
-1968-03-31,RO,Romania,
-1968-03-31,RS,Serbia,
-1968-03-31,RU,Russia,
-1968-03-31,SE,Sweden,
-1968-03-31,SG,Singapore,
-1968-03-31,SI,Slovenia,
-1968-03-31,SK,Slovak Republic,
-1968-03-31,TH,Thailand,
-1968-03-31,TR,Türkiye,
-1968-03-31,US,United States,
-1968-03-31,XM,Euro area,
-1968-03-31,XW,World,
-1968-03-31,ZA,South Africa,62.5455
-1968-06-30,4T,Emerging market economies (aggregate),
-1968-06-30,5R,Advanced economies,
-1968-06-30,AE,United Arab Emirates,
-1968-06-30,AT,Austria,
-1968-06-30,AU,Australia,
-1968-06-30,BE,Belgium,
-1968-06-30,BG,Bulgaria,
-1968-06-30,BR,Brazil,
-1968-06-30,CA,Canada,
-1968-06-30,CH,Switzerland,
-1968-06-30,CL,Chile,
-1968-06-30,CN,China,
-1968-06-30,CO,Colombia,
-1968-06-30,CY,Cyprus,
-1968-06-30,CZ,Czechia,
-1968-06-30,DE,Germany,
-1968-06-30,DK,Denmark,
-1968-06-30,EE,Estonia,
-1968-06-30,ES,Spain,
-1968-06-30,FI,Finland,
-1968-06-30,FR,France,
-1968-06-30,GB,United Kingdom,22.4927
-1968-06-30,GR,Greece,
-1968-06-30,HK,Hong Kong SAR,
-1968-06-30,HR,Croatia,
-1968-06-30,HU,Hungary,
-1968-06-30,ID,Indonesia,
-1968-06-30,IE,Ireland,
-1968-06-30,IL,Israel,
-1968-06-30,IN,India,
-1968-06-30,IS,Iceland,
-1968-06-30,IT,Italy,39.9944
+1968-03-31,NZ,New Zealand,36.2725
+1968-03-31,ZA,South Africa,62.5349
+1968-06-30,GB,United Kingdom,22.4852
+1968-06-30,IT,Italy,38.9996
 1968-06-30,JP,Japan,77.7495
-1968-06-30,KR,Korea,
-1968-06-30,LT,Lithuania,
-1968-06-30,LU,Luxembourg,
-1968-06-30,LV,Latvia,
-1968-06-30,MA,Morocco,
-1968-06-30,MK,North Macedonia,
-1968-06-30,MT,Malta,
-1968-06-30,MX,Mexico,
-1968-06-30,MY,Malaysia,
-1968-06-30,NL,Netherlands,
-1968-06-30,NO,Norway,
-1968-06-30,NZ,New Zealand,
-1968-06-30,PE,Peru,
-1968-06-30,PH,Philippines,
-1968-06-30,PL,Poland,
-1968-06-30,PT,Portugal,
-1968-06-30,RO,Romania,
-1968-06-30,RS,Serbia,
-1968-06-30,RU,Russia,
-1968-06-30,SE,Sweden,
-1968-06-30,SG,Singapore,
-1968-06-30,SI,Slovenia,
-1968-06-30,SK,Slovak Republic,
-1968-06-30,TH,Thailand,
-1968-06-30,TR,Türkiye,
-1968-06-30,US,United States,
-1968-06-30,XM,Euro area,
-1968-06-30,XW,World,
-1968-06-30,ZA,South Africa,62.863
-1968-09-30,4T,Emerging market economies (aggregate),
-1968-09-30,5R,Advanced economies,
-1968-09-30,AE,United Arab Emirates,
-1968-09-30,AT,Austria,
-1968-09-30,AU,Australia,
-1968-09-30,BE,Belgium,
-1968-09-30,BG,Bulgaria,
-1968-09-30,BR,Brazil,
-1968-09-30,CA,Canada,
-1968-09-30,CH,Switzerland,
-1968-09-30,CL,Chile,
-1968-09-30,CN,China,
-1968-09-30,CO,Colombia,
-1968-09-30,CY,Cyprus,
-1968-09-30,CZ,Czechia,
-1968-09-30,DE,Germany,
-1968-09-30,DK,Denmark,
-1968-09-30,EE,Estonia,
-1968-09-30,ES,Spain,
-1968-09-30,FI,Finland,
-1968-09-30,FR,France,
-1968-09-30,GB,United Kingdom,23.048
-1968-09-30,GR,Greece,
-1968-09-30,HK,Hong Kong SAR,
-1968-09-30,HR,Croatia,
-1968-09-30,HU,Hungary,
-1968-09-30,ID,Indonesia,
-1968-09-30,IE,Ireland,
-1968-09-30,IL,Israel,
-1968-09-30,IN,India,
-1968-09-30,IS,Iceland,
-1968-09-30,IT,Italy,40.1323
+1968-06-30,NZ,New Zealand,36.0116
+1968-06-30,ZA,South Africa,62.7126
+1968-09-30,GB,United Kingdom,23.0404
+1968-09-30,IT,Italy,39.1333
 1968-09-30,JP,Japan,80.2992
-1968-09-30,KR,Korea,
-1968-09-30,LT,Lithuania,
-1968-09-30,LU,Luxembourg,
-1968-09-30,LV,Latvia,
-1968-09-30,MA,Morocco,
-1968-09-30,MK,North Macedonia,
-1968-09-30,MT,Malta,
-1968-09-30,MX,Mexico,
-1968-09-30,MY,Malaysia,
-1968-09-30,NL,Netherlands,
-1968-09-30,NO,Norway,
-1968-09-30,NZ,New Zealand,
-1968-09-30,PE,Peru,
-1968-09-30,PH,Philippines,
-1968-09-30,PL,Poland,
-1968-09-30,PT,Portugal,
-1968-09-30,RO,Romania,
-1968-09-30,RS,Serbia,
-1968-09-30,RU,Russia,
-1968-09-30,SE,Sweden,
-1968-09-30,SG,Singapore,
-1968-09-30,SI,Slovenia,
-1968-09-30,SK,Slovak Republic,
-1968-09-30,TH,Thailand,
-1968-09-30,TR,Türkiye,
-1968-09-30,US,United States,
-1968-09-30,XM,Euro area,
-1968-09-30,XW,World,
-1968-09-30,ZA,South Africa,64.6004
-1968-12-31,4T,Emerging market economies (aggregate),
-1968-12-31,5R,Advanced economies,
-1968-12-31,AE,United Arab Emirates,
-1968-12-31,AT,Austria,
-1968-12-31,AU,Australia,
-1968-12-31,BE,Belgium,
-1968-12-31,BG,Bulgaria,
-1968-12-31,BR,Brazil,
-1968-12-31,CA,Canada,
-1968-12-31,CH,Switzerland,
-1968-12-31,CL,Chile,
-1968-12-31,CN,China,
-1968-12-31,CO,Colombia,
-1968-12-31,CY,Cyprus,
-1968-12-31,CZ,Czechia,
-1968-12-31,DE,Germany,
-1968-12-31,DK,Denmark,
-1968-12-31,EE,Estonia,
-1968-12-31,ES,Spain,
-1968-12-31,FI,Finland,
-1968-12-31,FR,France,
-1968-12-31,GB,United Kingdom,22.7745
-1968-12-31,GR,Greece,
-1968-12-31,HK,Hong Kong SAR,
-1968-12-31,HR,Croatia,
-1968-12-31,HU,Hungary,
-1968-12-31,ID,Indonesia,
-1968-12-31,IE,Ireland,
-1968-12-31,IL,Israel,
-1968-12-31,IN,India,
-1968-12-31,IS,Iceland,
-1968-12-31,IT,Italy,39.9452
+1968-09-30,NZ,New Zealand,35.8206
+1968-09-30,ZA,South Africa,64.5295
+1968-12-31,GB,United Kingdom,22.7669
+1968-12-31,IT,Italy,38.9297
 1968-12-31,JP,Japan,82.7989
-1968-12-31,KR,Korea,
-1968-12-31,LT,Lithuania,
-1968-12-31,LU,Luxembourg,
-1968-12-31,LV,Latvia,
-1968-12-31,MA,Morocco,
-1968-12-31,MK,North Macedonia,
-1968-12-31,MT,Malta,
-1968-12-31,MX,Mexico,
-1968-12-31,MY,Malaysia,
-1968-12-31,NL,Netherlands,
-1968-12-31,NO,Norway,
-1968-12-31,NZ,New Zealand,
-1968-12-31,PE,Peru,
-1968-12-31,PH,Philippines,
-1968-12-31,PL,Poland,
-1968-12-31,PT,Portugal,
-1968-12-31,RO,Romania,
-1968-12-31,RS,Serbia,
-1968-12-31,RU,Russia,
-1968-12-31,SE,Sweden,
-1968-12-31,SG,Singapore,
-1968-12-31,SI,Slovenia,
-1968-12-31,SK,Slovak Republic,
-1968-12-31,TH,Thailand,
-1968-12-31,TR,Türkiye,
-1968-12-31,US,United States,
-1968-12-31,XM,Euro area,
-1968-12-31,XW,World,
-1968-12-31,ZA,South Africa,66.6711
-1969-03-31,4T,Emerging market economies (aggregate),
-1969-03-31,5R,Advanced economies,
-1969-03-31,AE,United Arab Emirates,
-1969-03-31,AT,Austria,
-1969-03-31,AU,Australia,
-1969-03-31,BE,Belgium,
-1969-03-31,BG,Bulgaria,
-1969-03-31,BR,Brazil,
-1969-03-31,CA,Canada,
-1969-03-31,CH,Switzerland,
-1969-03-31,CL,Chile,
-1969-03-31,CN,China,
-1969-03-31,CO,Colombia,
-1969-03-31,CY,Cyprus,
-1969-03-31,CZ,Czechia,
-1969-03-31,DE,Germany,
-1969-03-31,DK,Denmark,
-1969-03-31,EE,Estonia,
-1969-03-31,ES,Spain,
-1969-03-31,FI,Finland,
-1969-03-31,FR,France,
-1969-03-31,GB,United Kingdom,22.3761
-1969-03-31,GR,Greece,
-1969-03-31,HK,Hong Kong SAR,
-1969-03-31,HR,Croatia,
-1969-03-31,HU,Hungary,
-1969-03-31,ID,Indonesia,
-1969-03-31,IE,Ireland,
-1969-03-31,IL,Israel,
-1969-03-31,IN,India,
-1969-03-31,IS,Iceland,
-1969-03-31,IT,Italy,39.98
+1968-12-31,NZ,New Zealand,35.5106
+1968-12-31,ZA,South Africa,66.53
+1969-03-31,GB,United Kingdom,22.3686
+1969-03-31,IT,Italy,38.9521
 1969-03-31,JP,Japan,86.1517
-1969-03-31,KR,Korea,
-1969-03-31,LT,Lithuania,
-1969-03-31,LU,Luxembourg,
-1969-03-31,LV,Latvia,
-1969-03-31,MA,Morocco,
-1969-03-31,MK,North Macedonia,
-1969-03-31,MT,Malta,
-1969-03-31,MX,Mexico,
-1969-03-31,MY,Malaysia,
-1969-03-31,NL,Netherlands,
-1969-03-31,NO,Norway,
-1969-03-31,NZ,New Zealand,
-1969-03-31,PE,Peru,
-1969-03-31,PH,Philippines,
-1969-03-31,PL,Poland,
-1969-03-31,PT,Portugal,
-1969-03-31,RO,Romania,
-1969-03-31,RS,Serbia,
-1969-03-31,RU,Russia,
-1969-03-31,SE,Sweden,
-1969-03-31,SG,Singapore,
-1969-03-31,SI,Slovenia,
-1969-03-31,SK,Slovak Republic,
-1969-03-31,TH,Thailand,
-1969-03-31,TR,Türkiye,
-1969-03-31,US,United States,
-1969-03-31,XM,Euro area,
-1969-03-31,XW,World,
-1969-03-31,ZA,South Africa,66.8968
-1969-06-30,4T,Emerging market economies (aggregate),
-1969-06-30,5R,Advanced economies,
-1969-06-30,AE,United Arab Emirates,
-1969-06-30,AT,Austria,
-1969-06-30,AU,Australia,
-1969-06-30,BE,Belgium,
-1969-06-30,BG,Bulgaria,
-1969-06-30,BR,Brazil,
-1969-06-30,CA,Canada,
-1969-06-30,CH,Switzerland,
-1969-06-30,CL,Chile,
-1969-06-30,CN,China,
-1969-06-30,CO,Colombia,
-1969-06-30,CY,Cyprus,
-1969-06-30,CZ,Czechia,
-1969-06-30,DE,Germany,
-1969-06-30,DK,Denmark,
-1969-06-30,EE,Estonia,
-1969-06-30,ES,Spain,
-1969-06-30,FI,Finland,
-1969-06-30,FR,France,
-1969-06-30,GB,United Kingdom,22.5858
-1969-06-30,GR,Greece,
-1969-06-30,HK,Hong Kong SAR,
-1969-06-30,HR,Croatia,
-1969-06-30,HU,Hungary,
-1969-06-30,ID,Indonesia,
-1969-06-30,IE,Ireland,
-1969-06-30,IL,Israel,
-1969-06-30,IN,India,
-1969-06-30,IS,Iceland,
-1969-06-30,IT,Italy,40.1937
+1969-03-31,NZ,New Zealand,35.6646
+1969-03-31,ZA,South Africa,66.9837
+1969-06-30,GB,United Kingdom,22.5782
+1969-06-30,IT,Italy,39.1066
 1969-06-30,JP,Japan,89.6165
-1969-06-30,KR,Korea,
-1969-06-30,LT,Lithuania,
-1969-06-30,LU,Luxembourg,
-1969-06-30,LV,Latvia,
-1969-06-30,MA,Morocco,
-1969-06-30,MK,North Macedonia,
-1969-06-30,MT,Malta,
-1969-06-30,MX,Mexico,
-1969-06-30,MY,Malaysia,
-1969-06-30,NL,Netherlands,
-1969-06-30,NO,Norway,
-1969-06-30,NZ,New Zealand,
-1969-06-30,PE,Peru,
-1969-06-30,PH,Philippines,
-1969-06-30,PL,Poland,
-1969-06-30,PT,Portugal,
-1969-06-30,RO,Romania,
-1969-06-30,RS,Serbia,
-1969-06-30,RU,Russia,
-1969-06-30,SE,Sweden,
-1969-06-30,SG,Singapore,
-1969-06-30,SI,Slovenia,
-1969-06-30,SK,Slovak Republic,
-1969-06-30,TH,Thailand,
-1969-06-30,TR,Türkiye,
-1969-06-30,US,United States,
-1969-06-30,XM,Euro area,
-1969-06-30,XW,World,
-1969-06-30,ZA,South Africa,68.4421
-1969-09-30,4T,Emerging market economies (aggregate),
-1969-09-30,5R,Advanced economies,
-1969-09-30,AE,United Arab Emirates,
-1969-09-30,AT,Austria,
-1969-09-30,AU,Australia,
-1969-09-30,BE,Belgium,
-1969-09-30,BG,Bulgaria,
-1969-09-30,BR,Brazil,
-1969-09-30,CA,Canada,
-1969-09-30,CH,Switzerland,
-1969-09-30,CL,Chile,
-1969-09-30,CN,China,
-1969-09-30,CO,Colombia,
-1969-09-30,CY,Cyprus,
-1969-09-30,CZ,Czechia,
-1969-09-30,DE,Germany,
-1969-09-30,DK,Denmark,
-1969-09-30,EE,Estonia,
-1969-09-30,ES,Spain,
-1969-09-30,FI,Finland,
-1969-09-30,FR,France,
-1969-09-30,GB,United Kingdom,22.5858
-1969-09-30,GR,Greece,
-1969-09-30,HK,Hong Kong SAR,
-1969-09-30,HR,Croatia,
-1969-09-30,HU,Hungary,
-1969-09-30,ID,Indonesia,
-1969-09-30,IE,Ireland,
-1969-09-30,IL,Israel,
-1969-09-30,IN,India,
-1969-09-30,IS,Iceland,
-1969-09-30,IT,Italy,40.3496
+1969-06-30,NZ,New Zealand,35.6945
+1969-06-30,ZA,South Africa,68.2372
+1969-09-30,GB,United Kingdom,22.5782
+1969-09-30,IT,Italy,39.2906
 1969-09-30,JP,Japan,92.2396
-1969-09-30,KR,Korea,
-1969-09-30,LT,Lithuania,
-1969-09-30,LU,Luxembourg,
-1969-09-30,LV,Latvia,
-1969-09-30,MA,Morocco,
-1969-09-30,MK,North Macedonia,
-1969-09-30,MT,Malta,
-1969-09-30,MX,Mexico,
-1969-09-30,MY,Malaysia,
-1969-09-30,NL,Netherlands,
-1969-09-30,NO,Norway,
-1969-09-30,NZ,New Zealand,
-1969-09-30,PE,Peru,
-1969-09-30,PH,Philippines,
-1969-09-30,PL,Poland,
-1969-09-30,PT,Portugal,
-1969-09-30,RO,Romania,
-1969-09-30,RS,Serbia,
-1969-09-30,RU,Russia,
-1969-09-30,SE,Sweden,
-1969-09-30,SG,Singapore,
-1969-09-30,SI,Slovenia,
-1969-09-30,SK,Slovak Republic,
-1969-09-30,TH,Thailand,
-1969-09-30,TR,Türkiye,
-1969-09-30,US,United States,
-1969-09-30,XM,Euro area,
-1969-09-30,XW,World,
-1969-09-30,ZA,South Africa,69.7788
-1969-12-31,4T,Emerging market economies (aggregate),
-1969-12-31,5R,Advanced economies,
-1969-12-31,AE,United Arab Emirates,
-1969-12-31,AT,Austria,
-1969-12-31,AU,Australia,
-1969-12-31,BE,Belgium,
-1969-12-31,BG,Bulgaria,
-1969-12-31,BR,Brazil,
-1969-12-31,CA,Canada,
-1969-12-31,CH,Switzerland,
-1969-12-31,CL,Chile,
-1969-12-31,CN,China,
-1969-12-31,CO,Colombia,
-1969-12-31,CY,Cyprus,
-1969-12-31,CZ,Czechia,
-1969-12-31,DE,Germany,
-1969-12-31,DK,Denmark,
-1969-12-31,EE,Estonia,
-1969-12-31,ES,Spain,
-1969-12-31,FI,Finland,
-1969-12-31,FR,France,
-1969-12-31,GB,United Kingdom,22.7883
-1969-12-31,GR,Greece,
-1969-12-31,HK,Hong Kong SAR,
-1969-12-31,HR,Croatia,
-1969-12-31,HU,Hungary,
-1969-12-31,ID,Indonesia,
-1969-12-31,IE,Ireland,
-1969-12-31,IL,Israel,
-1969-12-31,IN,India,
-1969-12-31,IS,Iceland,
-1969-12-31,IT,Italy,40.3792
+1969-09-30,NZ,New Zealand,35.7534
+1969-09-30,ZA,South Africa,69.8061
+1969-12-31,GB,United Kingdom,22.7808
+1969-12-31,IT,Italy,39.3753
 1969-12-31,JP,Japan,95.7105
-1969-12-31,KR,Korea,
-1969-12-31,LT,Lithuania,
-1969-12-31,LU,Luxembourg,
-1969-12-31,LV,Latvia,
-1969-12-31,MA,Morocco,
-1969-12-31,MK,North Macedonia,
-1969-12-31,MT,Malta,
-1969-12-31,MX,Mexico,
-1969-12-31,MY,Malaysia,
-1969-12-31,NL,Netherlands,
-1969-12-31,NO,Norway,
-1969-12-31,NZ,New Zealand,
-1969-12-31,PE,Peru,
-1969-12-31,PH,Philippines,
-1969-12-31,PL,Poland,
-1969-12-31,PT,Portugal,
-1969-12-31,RO,Romania,
-1969-12-31,RS,Serbia,
-1969-12-31,RU,Russia,
-1969-12-31,SE,Sweden,
-1969-12-31,SG,Singapore,
-1969-12-31,SI,Slovenia,
-1969-12-31,SK,Slovak Republic,
-1969-12-31,TH,Thailand,
-1969-12-31,TR,Türkiye,
-1969-12-31,US,United States,
-1969-12-31,XM,Euro area,
-1969-12-31,XW,World,
-1969-12-31,ZA,South Africa,70.9024
-1970-03-31,4T,Emerging market economies (aggregate),
-1970-03-31,5R,Advanced economies,
-1970-03-31,AE,United Arab Emirates,
-1970-03-31,AT,Austria,
-1970-03-31,AU,Australia,31.3066
-1970-03-31,BE,Belgium,41.1046
-1970-03-31,BG,Bulgaria,
-1970-03-31,BR,Brazil,
-1970-03-31,CA,Canada,37.858
-1970-03-31,CH,Switzerland,75.5267
-1970-03-31,CL,Chile,
-1970-03-31,CN,China,
-1970-03-31,CO,Colombia,
-1970-03-31,CY,Cyprus,
-1970-03-31,CZ,Czechia,
+1969-12-31,NZ,New Zealand,36.0193
+1969-12-31,ZA,South Africa,70.8602
+1970-03-31,AU,Australia,31.1923
+1970-03-31,BE,Belgium,41.4544
+1970-03-31,CA,Canada,38.1516
+1970-03-31,CH,Switzerland,75.5239
 1970-03-31,DE,Germany,118.9989
-1970-03-31,DK,Denmark,54.4725
-1970-03-31,EE,Estonia,
-1970-03-31,ES,Spain,
+1970-03-31,DK,Denmark,54.4759
 1970-03-31,FI,Finland,52.7554
-1970-03-31,FR,France,40.5273
-1970-03-31,GB,United Kingdom,22.4096
-1970-03-31,GR,Greece,
-1970-03-31,HK,Hong Kong SAR,
-1970-03-31,HR,Croatia,
-1970-03-31,HU,Hungary,
-1970-03-31,ID,Indonesia,
-1970-03-31,IE,Ireland,34.4003
-1970-03-31,IL,Israel,
-1970-03-31,IN,India,
-1970-03-31,IS,Iceland,
-1970-03-31,IT,Italy,40.7872
+1970-03-31,FR,France,40.5276
+1970-03-31,GB,United Kingdom,22.4021
+1970-03-31,IE,Ireland,34.417
+1970-03-31,IT,Italy,39.7124
 1970-03-31,JP,Japan,97.4678
-1970-03-31,KR,Korea,
-1970-03-31,LT,Lithuania,
-1970-03-31,LU,Luxembourg,
-1970-03-31,LV,Latvia,
-1970-03-31,MA,Morocco,
-1970-03-31,MK,North Macedonia,
-1970-03-31,MT,Malta,
-1970-03-31,MX,Mexico,
-1970-03-31,MY,Malaysia,
-1970-03-31,NL,Netherlands,30.646
-1970-03-31,NO,Norway,34.2802
-1970-03-31,NZ,New Zealand,35.8618
-1970-03-31,PE,Peru,
-1970-03-31,PH,Philippines,
-1970-03-31,PL,Poland,
-1970-03-31,PT,Portugal,
-1970-03-31,RO,Romania,
-1970-03-31,RS,Serbia,
-1970-03-31,RU,Russia,
-1970-03-31,SE,Sweden,49.2119
-1970-03-31,SG,Singapore,
-1970-03-31,SI,Slovenia,
-1970-03-31,SK,Slovak Republic,
-1970-03-31,TH,Thailand,
-1970-03-31,TR,Türkiye,
-1970-03-31,US,United States,60.8572
-1970-03-31,XM,Euro area,
-1970-03-31,XW,World,
-1970-03-31,ZA,South Africa,74.0596
-1970-06-30,4T,Emerging market economies (aggregate),
-1970-06-30,5R,Advanced economies,
-1970-06-30,AE,United Arab Emirates,
-1970-06-30,AT,Austria,
-1970-06-30,AU,Australia,31.5506
-1970-06-30,BE,Belgium,40.9572
-1970-06-30,BG,Bulgaria,
-1970-06-30,BR,Brazil,
-1970-06-30,CA,Canada,37.6715
-1970-06-30,CH,Switzerland,74.4819
-1970-06-30,CL,Chile,
-1970-06-30,CN,China,
-1970-06-30,CO,Colombia,
-1970-06-30,CY,Cyprus,
-1970-06-30,CZ,Czechia,
+1970-03-31,NL,Netherlands,31.3897
+1970-03-31,NO,Norway,34.3074
+1970-03-31,NZ,New Zealand,35.8672
+1970-03-31,SE,Sweden,49.1956
+1970-03-31,US,United States,60.6714
+1970-03-31,ZA,South Africa,73.8989
+1970-06-30,AU,Australia,31.3875
+1970-06-30,BE,Belgium,41.3058
+1970-06-30,CA,Canada,37.9636
+1970-06-30,CH,Switzerland,74.4792
 1970-06-30,DE,Germany,123.27
-1970-06-30,DK,Denmark,53.6675
-1970-06-30,EE,Estonia,
-1970-06-30,ES,Spain,
+1970-06-30,DK,Denmark,53.6708
 1970-06-30,FI,Finland,53.3642
-1970-06-30,FR,France,40.6816
-1970-06-30,GB,United Kingdom,21.8645
-1970-06-30,GR,Greece,
-1970-06-30,HK,Hong Kong SAR,
-1970-06-30,HR,Croatia,
-1970-06-30,HU,Hungary,
-1970-06-30,ID,Indonesia,
-1970-06-30,IE,Ireland,33.0455
-1970-06-30,IL,Israel,
-1970-06-30,IN,India,
-1970-06-30,IS,Iceland,
-1970-06-30,IT,Italy,41.0527
+1970-06-30,FR,France,40.6819
+1970-06-30,GB,United Kingdom,21.8572
+1970-06-30,IE,Ireland,33.0615
+1970-06-30,IT,Italy,39.9614
 1970-06-30,JP,Japan,100.5088
-1970-06-30,KR,Korea,
-1970-06-30,LT,Lithuania,
-1970-06-30,LU,Luxembourg,
-1970-06-30,LV,Latvia,
-1970-06-30,MA,Morocco,
-1970-06-30,MK,North Macedonia,
-1970-06-30,MT,Malta,
-1970-06-30,MX,Mexico,
-1970-06-30,MY,Malaysia,
-1970-06-30,NL,Netherlands,31.6676
-1970-06-30,NO,Norway,33.8292
-1970-06-30,NZ,New Zealand,36.1133
-1970-06-30,PE,Peru,
-1970-06-30,PH,Philippines,
-1970-06-30,PL,Poland,
-1970-06-30,PT,Portugal,
-1970-06-30,RO,Romania,
-1970-06-30,RS,Serbia,
-1970-06-30,RU,Russia,
-1970-06-30,SE,Sweden,49.7083
-1970-06-30,SG,Singapore,
-1970-06-30,SI,Slovenia,
-1970-06-30,SK,Slovak Republic,
-1970-06-30,TH,Thailand,
-1970-06-30,TR,Türkiye,
-1970-06-30,US,United States,60.2999
-1970-06-30,XM,Euro area,
-1970-06-30,XW,World,
-1970-06-30,ZA,South Africa,76.2956
-1970-09-30,4T,Emerging market economies (aggregate),
-1970-09-30,5R,Advanced economies,
-1970-09-30,AE,United Arab Emirates,
-1970-09-30,AT,Austria,
-1970-09-30,AU,Australia,32.1013
-1970-09-30,BE,Belgium,40.2077
-1970-09-30,BG,Bulgaria,
-1970-09-30,BR,Brazil,
-1970-09-30,CA,Canada,37.6729
-1970-09-30,CH,Switzerland,75.875
-1970-09-30,CL,Chile,
-1970-09-30,CN,China,
-1970-09-30,CO,Colombia,
-1970-09-30,CY,Cyprus,
-1970-09-30,CZ,Czechia,
+1970-06-30,NL,Netherlands,32.4361
+1970-06-30,NO,Norway,33.8102
+1970-06-30,NZ,New Zealand,36.1207
+1970-06-30,SE,Sweden,49.6918
+1970-06-30,US,United States,60.1158
+1970-06-30,ZA,South Africa,76.2261
+1970-09-30,AU,Australia,32.1223
+1970-09-30,BE,Belgium,40.5499
+1970-09-30,CA,Canada,37.965
+1970-09-30,CH,Switzerland,75.8722
 1970-09-30,DE,Germany,124.339
-1970-09-30,DK,Denmark,52.1662
-1970-09-30,EE,Estonia,
-1970-09-30,ES,Spain,
+1970-09-30,DK,Denmark,52.1694
 1970-09-30,FI,Finland,53.382
-1970-09-30,FR,France,41.1835
-1970-09-30,GB,United Kingdom,22.7399
-1970-09-30,GR,Greece,
-1970-09-30,HK,Hong Kong SAR,
-1970-09-30,HR,Croatia,
-1970-09-30,HU,Hungary,
-1970-09-30,ID,Indonesia,
-1970-09-30,IE,Ireland,34.2084
-1970-09-30,IL,Israel,
-1970-09-30,IN,India,
-1970-09-30,IS,Iceland,
-1970-09-30,IT,Italy,40.6774
+1970-09-30,FR,France,41.1838
+1970-09-30,GB,United Kingdom,22.7323
+1970-09-30,IE,Ireland,34.225
+1970-09-30,IT,Italy,39.6384
 1970-09-30,JP,Japan,104.7421
-1970-09-30,KR,Korea,
-1970-09-30,LT,Lithuania,
-1970-09-30,LU,Luxembourg,
-1970-09-30,LV,Latvia,
-1970-09-30,MA,Morocco,
-1970-09-30,MK,North Macedonia,
-1970-09-30,MT,Malta,
-1970-09-30,MX,Mexico,
-1970-09-30,MY,Malaysia,
-1970-09-30,NL,Netherlands,32.1718
-1970-09-30,NO,Norway,33.1317
-1970-09-30,NZ,New Zealand,36.2433
-1970-09-30,PE,Peru,
-1970-09-30,PH,Philippines,
-1970-09-30,PL,Poland,
-1970-09-30,PT,Portugal,
-1970-09-30,RO,Romania,
-1970-09-30,RS,Serbia,
-1970-09-30,RU,Russia,
-1970-09-30,SE,Sweden,48.9539
-1970-09-30,SG,Singapore,
-1970-09-30,SI,Slovenia,
-1970-09-30,SK,Slovak Republic,
-1970-09-30,TH,Thailand,
-1970-09-30,TR,Türkiye,
-1970-09-30,US,United States,60.5691
-1970-09-30,XM,Euro area,
-1970-09-30,XW,World,
-1970-09-30,ZA,South Africa,77.318
-1970-12-31,4T,Emerging market economies (aggregate),
-1970-12-31,5R,Advanced economies,
-1970-12-31,AE,United Arab Emirates,
-1970-12-31,AT,Austria,
-1970-12-31,AU,Australia,32.4367
-1970-12-31,BE,Belgium,38.4508
-1970-12-31,BG,Bulgaria,
-1970-12-31,BR,Brazil,
-1970-12-31,CA,Canada,38.9418
-1970-12-31,CH,Switzerland,74.4664
-1970-12-31,CL,Chile,
-1970-12-31,CN,China,
-1970-12-31,CO,Colombia,
-1970-12-31,CY,Cyprus,
-1970-12-31,CZ,Czechia,
+1970-09-30,NL,Netherlands,32.9525
+1970-09-30,NO,Norway,32.9739
+1970-09-30,NZ,New Zealand,36.2525
+1970-09-30,SE,Sweden,48.9377
+1970-09-30,US,United States,60.3841
+1970-09-30,ZA,South Africa,77.2565
+1970-12-31,AU,Australia,32.5459
+1970-12-31,BE,Belgium,38.7781
+1970-12-31,CA,Canada,39.2437
+1970-12-31,CH,Switzerland,74.4637
 1970-12-31,DE,Germany,124.7133
-1970-12-31,DK,Denmark,51.3891
-1970-12-31,EE,Estonia,
-1970-12-31,ES,Spain,
+1970-12-31,DK,Denmark,51.3923
 1970-12-31,FI,Finland,54.1536
-1970-12-31,FR,France,40.6347
-1970-12-31,GB,United Kingdom,22.2637
-1970-12-31,GR,Greece,
-1970-12-31,HK,Hong Kong SAR,
-1970-12-31,HR,Croatia,
-1970-12-31,HU,Hungary,
-1970-12-31,ID,Indonesia,
-1970-12-31,IE,Ireland,35.3817
-1970-12-31,IL,Israel,
-1970-12-31,IN,India,
-1970-12-31,IS,Iceland,
-1970-12-31,IT,Italy,40.4478
+1970-12-31,FR,France,40.635
+1970-12-31,GB,United Kingdom,22.2563
+1970-12-31,IE,Ireland,35.3989
+1970-12-31,IT,Italy,39.4643
 1970-12-31,JP,Japan,105.9025
-1970-12-31,KR,Korea,
-1970-12-31,LT,Lithuania,
-1970-12-31,LU,Luxembourg,
-1970-12-31,LV,Latvia,
-1970-12-31,MA,Morocco,
-1970-12-31,MK,North Macedonia,
-1970-12-31,MT,Malta,
-1970-12-31,MX,Mexico,
-1970-12-31,MY,Malaysia,
-1970-12-31,NL,Netherlands,32.3006
-1970-12-31,NO,Norway,32.4624
-1970-12-31,NZ,New Zealand,35.7879
-1970-12-31,PE,Peru,
-1970-12-31,PH,Philippines,
-1970-12-31,PL,Poland,
-1970-12-31,PT,Portugal,
-1970-12-31,RO,Romania,
-1970-12-31,RS,Serbia,
-1970-12-31,RU,Russia,
-1970-12-31,SE,Sweden,49.2804
-1970-12-31,SG,Singapore,
-1970-12-31,SI,Slovenia,
-1970-12-31,SK,Slovak Republic,
-1970-12-31,TH,Thailand,
-1970-12-31,TR,Türkiye,
-1970-12-31,US,United States,60.5135
-1970-12-31,XM,Euro area,
-1970-12-31,XW,World,
-1970-12-31,ZA,South Africa,77.617
-1971-03-31,4T,Emerging market economies (aggregate),
-1971-03-31,5R,Advanced economies,
-1971-03-31,AE,United Arab Emirates,
-1971-03-31,AT,Austria,
-1971-03-31,AU,Australia,33.0228
-1971-03-31,BE,Belgium,38.4577
-1971-03-31,BG,Bulgaria,
-1971-03-31,BR,Brazil,
-1971-03-31,CA,Canada,39.0597
-1971-03-31,CH,Switzerland,78.2025
-1971-03-31,CL,Chile,
-1971-03-31,CN,China,
-1971-03-31,CO,Colombia,
-1971-03-31,CY,Cyprus,
-1971-03-31,CZ,Czechia,
+1970-12-31,NL,Netherlands,33.0844
+1970-12-31,NO,Norway,32.4014
+1970-12-31,NZ,New Zealand,35.7722
+1970-12-31,SE,Sweden,49.264
+1970-12-31,US,United States,60.3287
+1970-12-31,ZA,South Africa,77.405
+1971-03-31,AU,Australia,33.0828
+1971-03-31,BE,Belgium,38.785
+1971-03-31,CA,Canada,39.3625
+1971-03-31,CH,Switzerland,78.1996
 1971-03-31,DE,Germany,125.7255
-1971-03-31,DK,Denmark,55.9749
-1971-03-31,EE,Estonia,
+1971-03-31,DK,Denmark,55.9784
 1971-03-31,ES,Spain,28.7667
 1971-03-31,FI,Finland,53.8171
-1971-03-31,FR,France,40.0722
-1971-03-31,GB,United Kingdom,22.2249
-1971-03-31,GR,Greece,
-1971-03-31,HK,Hong Kong SAR,
-1971-03-31,HR,Croatia,
-1971-03-31,HU,Hungary,
-1971-03-31,ID,Indonesia,
-1971-03-31,IE,Ireland,34.3263
-1971-03-31,IL,Israel,
-1971-03-31,IN,India,
-1971-03-31,IS,Iceland,
-1971-03-31,IT,Italy,39.4169
+1971-03-31,FR,France,40.0725
+1971-03-31,GB,United Kingdom,22.2175
+1971-03-31,IE,Ireland,34.343
+1971-03-31,IT,Italy,38.4544
 1971-03-31,JP,Japan,108.3291
-1971-03-31,KR,Korea,
-1971-03-31,LT,Lithuania,
-1971-03-31,LU,Luxembourg,
-1971-03-31,LV,Latvia,
-1971-03-31,MA,Morocco,
-1971-03-31,MK,North Macedonia,
-1971-03-31,MT,Malta,
-1971-03-31,MX,Mexico,
-1971-03-31,MY,Malaysia,
-1971-03-31,NL,Netherlands,32.4789
-1971-03-31,NO,Norway,33.6328
-1971-03-31,NZ,New Zealand,36.0183
-1971-03-31,PE,Peru,
-1971-03-31,PH,Philippines,
-1971-03-31,PL,Poland,
-1971-03-31,PT,Portugal,
-1971-03-31,RO,Romania,
-1971-03-31,RS,Serbia,
-1971-03-31,RU,Russia,
-1971-03-31,SE,Sweden,47.7058
-1971-03-31,SG,Singapore,
-1971-03-31,SI,Slovenia,
-1971-03-31,SK,Slovak Republic,
-1971-03-31,TH,Thailand,
-1971-03-31,TR,Türkiye,
-1971-03-31,US,United States,61.6985
-1971-03-31,XM,Euro area,
-1971-03-31,XW,World,
-1971-03-31,ZA,South Africa,77.9125
-1971-06-30,4T,Emerging market economies (aggregate),
-1971-06-30,5R,Advanced economies,
-1971-06-30,AE,United Arab Emirates,
-1971-06-30,AT,Austria,
-1971-06-30,AU,Australia,33.4476
-1971-06-30,BE,Belgium,38.5287
-1971-06-30,BG,Bulgaria,
-1971-06-30,BR,Brazil,
-1971-06-30,CA,Canada,39.0136
-1971-06-30,CH,Switzerland,76.9336
-1971-06-30,CL,Chile,
-1971-06-30,CN,China,
-1971-06-30,CO,Colombia,
-1971-06-30,CY,Cyprus,
-1971-06-30,CZ,Czechia,
+1971-03-31,NL,Netherlands,33.2671
+1971-03-31,NO,Norway,33.695
+1971-03-31,NZ,New Zealand,36.006
+1971-03-31,SE,Sweden,47.6899
+1971-03-31,US,United States,61.5101
+1971-03-31,ZA,South Africa,77.6688
+1971-06-30,AU,Australia,33.3166
+1971-06-30,BE,Belgium,38.8566
+1971-06-30,CA,Canada,39.3161
+1971-06-30,CH,Switzerland,76.9307
 1971-06-30,DE,Germany,129.8376
-1971-06-30,DK,Denmark,55.244
-1971-06-30,EE,Estonia,
-1971-06-30,ES,Spain,29.0748
+1971-06-30,DK,Denmark,55.2474
+1971-06-30,ES,Spain,29.0749
 1971-06-30,FI,Finland,52.0226
-1971-06-30,FR,France,40.5359
-1971-06-30,GB,United Kingdom,22.0237
-1971-06-30,GR,Greece,
-1971-06-30,HK,Hong Kong SAR,
-1971-06-30,HR,Croatia,
-1971-06-30,HU,Hungary,
-1971-06-30,ID,Indonesia,
-1971-06-30,IE,Ireland,33.1702
-1971-06-30,IL,Israel,
-1971-06-30,IN,India,
-1971-06-30,IS,Iceland,
-1971-06-30,IT,Italy,39.8933
+1971-06-30,FR,France,40.5362
+1971-06-30,GB,United Kingdom,22.0164
+1971-06-30,IE,Ireland,33.1863
+1971-06-30,IT,Italy,38.8935
 1971-06-30,JP,Japan,110.3274
-1971-06-30,KR,Korea,
-1971-06-30,LT,Lithuania,
-1971-06-30,LU,Luxembourg,
-1971-06-30,LV,Latvia,
-1971-06-30,MA,Morocco,
-1971-06-30,MK,North Macedonia,
-1971-06-30,MT,Malta,
-1971-06-30,MX,Mexico,
-1971-06-30,MY,Malaysia,
-1971-06-30,NL,Netherlands,32.8292
-1971-06-30,NO,Norway,33.3843
-1971-06-30,NZ,New Zealand,36.3157
-1971-06-30,PE,Peru,
-1971-06-30,PH,Philippines,
-1971-06-30,PL,Poland,
-1971-06-30,PT,Portugal,
-1971-06-30,RO,Romania,
-1971-06-30,RS,Serbia,
-1971-06-30,RU,Russia,
-1971-06-30,SE,Sweden,48.9146
-1971-06-30,SG,Singapore,
-1971-06-30,SI,Slovenia,
-1971-06-30,SK,Slovak Republic,
-1971-06-30,TH,Thailand,
-1971-06-30,TR,Türkiye,
-1971-06-30,US,United States,62.6905
-1971-06-30,XM,Euro area,
-1971-06-30,XW,World,
-1971-06-30,ZA,South Africa,77.507
-1971-09-30,4T,Emerging market economies (aggregate),
-1971-09-30,5R,Advanced economies,
-1971-09-30,AE,United Arab Emirates,
-1971-09-30,AT,Austria,
-1971-09-30,AU,Australia,33.481
-1971-09-30,BE,Belgium,38.4235
-1971-09-30,BG,Bulgaria,
-1971-09-30,BR,Brazil,
-1971-09-30,CA,Canada,38.1862
-1971-09-30,CH,Switzerland,79.4163
-1971-09-30,CL,Chile,
-1971-09-30,CN,China,
-1971-09-30,CO,Colombia,
-1971-09-30,CY,Cyprus,
-1971-09-30,CZ,Czechia,
-1971-09-30,DE,Germany,130.5305
-1971-09-30,DK,Denmark,56.0443
-1971-09-30,EE,Estonia,
-1971-09-30,ES,Spain,29.1017
+1971-06-30,NL,Netherlands,33.626
+1971-06-30,NO,Norway,33.3524
+1971-06-30,NZ,New Zealand,36.3061
+1971-06-30,SE,Sweden,48.8984
+1971-06-30,US,United States,62.4991
+1971-06-30,ZA,South Africa,77.3655
+1971-09-30,AU,Australia,33.5751
+1971-09-30,BE,Belgium,38.7505
+1971-09-30,CA,Canada,38.4822
+1971-09-30,CH,Switzerland,79.4134
+1971-09-30,DE,Germany,130.5306
+1971-09-30,DK,Denmark,56.0478
+1971-09-30,ES,Spain,29.1018
 1971-09-30,FI,Finland,52.399
-1971-09-30,FR,France,41.5984
-1971-09-30,GB,United Kingdom,23.1038
-1971-09-30,GR,Greece,
-1971-09-30,HK,Hong Kong SAR,
-1971-09-30,HR,Croatia,
-1971-09-30,HU,Hungary,
-1971-09-30,ID,Indonesia,
-1971-09-30,IE,Ireland,35.917
-1971-09-30,IL,Israel,
-1971-09-30,IN,India,
-1971-09-30,IS,Iceland,
-1971-09-30,IT,Italy,40.4939
+1971-09-30,FR,France,41.5987
+1971-09-30,GB,United Kingdom,23.0962
+1971-09-30,IE,Ireland,35.9344
+1971-09-30,IT,Italy,39.4894
 1971-09-30,JP,Japan,112.9774
-1971-09-30,KR,Korea,
-1971-09-30,LT,Lithuania,
-1971-09-30,LU,Luxembourg,
-1971-09-30,LV,Latvia,
-1971-09-30,MA,Morocco,
-1971-09-30,MK,North Macedonia,
-1971-09-30,MT,Malta,
-1971-09-30,MX,Mexico,
-1971-09-30,MY,Malaysia,
-1971-09-30,NL,Netherlands,32.7269
-1971-09-30,NO,Norway,32.9781
-1971-09-30,NZ,New Zealand,36.327
-1971-09-30,PE,Peru,
-1971-09-30,PH,Philippines,
-1971-09-30,PL,Poland,
-1971-09-30,PT,Portugal,
-1971-09-30,RO,Romania,
-1971-09-30,RS,Serbia,
-1971-09-30,RU,Russia,
-1971-09-30,SE,Sweden,48.1835
-1971-09-30,SG,Singapore,
-1971-09-30,SI,Slovenia,
-1971-09-30,SK,Slovak Republic,
-1971-09-30,TH,Thailand,
-1971-09-30,TR,Türkiye,
-1971-09-30,US,United States,62.6983
-1971-09-30,XM,Euro area,
-1971-09-30,XW,World,
-1971-09-30,ZA,South Africa,77.0252
-1971-12-31,4T,Emerging market economies (aggregate),
-1971-12-31,5R,Advanced economies,
-1971-12-31,AE,United Arab Emirates,
-1971-12-31,AT,Austria,
-1971-12-31,AU,Australia,34.1111
-1971-12-31,BE,Belgium,37.4126
-1971-12-31,BG,Bulgaria,
-1971-12-31,BR,Brazil,
-1971-12-31,CA,Canada,39.8771
-1971-12-31,CH,Switzerland,79.3149
-1971-12-31,CL,Chile,
-1971-12-31,CN,China,
-1971-12-31,CO,Colombia,
-1971-12-31,CY,Cyprus,
-1971-12-31,CZ,Czechia,
+1971-09-30,NL,Netherlands,33.5211
+1971-09-30,NO,Norway,33.0166
+1971-09-30,NZ,New Zealand,36.3194
+1971-09-30,SE,Sweden,48.1675
+1971-09-30,US,United States,62.5069
+1971-09-30,ZA,South Africa,77.0171
+1971-12-31,AU,Australia,34.1541
+1971-12-31,BE,Belgium,37.731
+1971-12-31,CA,Canada,40.1863
+1971-12-31,CH,Switzerland,79.312
 1971-12-31,DE,Germany,129.7476
-1971-12-31,DK,Denmark,57.9383
-1971-12-31,EE,Estonia,
+1971-12-31,DK,Denmark,57.9419
 1971-12-31,ES,Spain,28.468
 1971-12-31,FI,Finland,52.3003
-1971-12-31,FR,France,41.3924
-1971-12-31,GB,United Kingdom,23.8771
-1971-12-31,GR,Greece,
-1971-12-31,HK,Hong Kong SAR,
-1971-12-31,HR,Croatia,
-1971-12-31,HU,Hungary,
-1971-12-31,ID,Indonesia,
-1971-12-31,IE,Ireland,37.8815
-1971-12-31,IL,Israel,
-1971-12-31,IN,India,
-1971-12-31,IS,Iceland,
-1971-12-31,IT,Italy,40.4419
+1971-12-31,FR,France,41.3927
+1971-12-31,GB,United Kingdom,23.8692
+1971-12-31,IE,Ireland,37.8999
+1971-12-31,IT,Italy,39.4362
 1971-12-31,JP,Japan,115.1834
-1971-12-31,KR,Korea,
-1971-12-31,LT,Lithuania,
-1971-12-31,LU,Luxembourg,
-1971-12-31,LV,Latvia,
-1971-12-31,MA,Morocco,
-1971-12-31,MK,North Macedonia,
-1971-12-31,MT,Malta,
-1971-12-31,MX,Mexico,
-1971-12-31,MY,Malaysia,
-1971-12-31,NL,Netherlands,32.9703
-1971-12-31,NO,Norway,32.4259
-1971-12-31,NZ,New Zealand,36.3845
-1971-12-31,PE,Peru,
-1971-12-31,PH,Philippines,
-1971-12-31,PL,Poland,
-1971-12-31,PT,Portugal,
-1971-12-31,RO,Romania,
-1971-12-31,RS,Serbia,
-1971-12-31,RU,Russia,
-1971-12-31,SE,Sweden,48.3986
-1971-12-31,SG,Singapore,
-1971-12-31,SI,Slovenia,
-1971-12-31,SK,Slovak Republic,
-1971-12-31,TH,Thailand,
-1971-12-31,TR,Türkiye,
-1971-12-31,US,United States,63.8937
-1971-12-31,XM,Euro area,
-1971-12-31,XW,World,
-1971-12-31,ZA,South Africa,76.7481
-1972-03-31,4T,Emerging market economies (aggregate),
-1972-03-31,5R,Advanced economies,
-1972-03-31,AE,United Arab Emirates,
-1972-03-31,AT,Austria,
-1972-03-31,AU,Australia,34.5306
-1972-03-31,BE,Belgium,38.4345
-1972-03-31,BG,Bulgaria,
-1972-03-31,BR,Brazil,
-1972-03-31,CA,Canada,40.2381
-1972-03-31,CH,Switzerland,81.0918
-1972-03-31,CL,Chile,
-1972-03-31,CN,China,
-1972-03-31,CO,Colombia,
-1972-03-31,CY,Cyprus,
-1972-03-31,CZ,Czechia,
-1972-03-31,DE,Germany,129.7109
-1972-03-31,DK,Denmark,60.7281
-1972-03-31,EE,Estonia,
-1972-03-31,ES,Spain,27.6398
+1971-12-31,NL,Netherlands,33.7705
+1971-12-31,NO,Norway,32.365
+1971-12-31,NZ,New Zealand,36.4042
+1971-12-31,SE,Sweden,48.3826
+1971-12-31,US,United States,63.6987
+1971-12-31,ZA,South Africa,76.7887
+1972-03-31,AU,Australia,34.525
+1972-03-31,BE,Belgium,38.7616
+1972-03-31,CA,Canada,40.5501
+1972-03-31,CH,Switzerland,81.0888
+1972-03-31,DE,Germany,129.711
+1972-03-31,DK,Denmark,60.7319
+1972-03-31,ES,Spain,27.6399
 1972-03-31,FI,Finland,54.3681
-1972-03-31,FR,France,41.1382
-1972-03-31,GB,United Kingdom,25.0096
-1972-03-31,GR,Greece,
-1972-03-31,HK,Hong Kong SAR,
-1972-03-31,HR,Croatia,
-1972-03-31,HU,Hungary,
-1972-03-31,ID,Indonesia,
-1972-03-31,IE,Ireland,35.768
-1972-03-31,IL,Israel,
-1972-03-31,IN,India,
-1972-03-31,IS,Iceland,
-1972-03-31,IT,Italy,40.5444
+1972-03-31,FR,France,41.1385
+1972-03-31,GB,United Kingdom,25.0013
+1972-03-31,IE,Ireland,35.7853
+1972-03-31,IT,Italy,39.5466
 1972-03-31,JP,Japan,118.3767
-1972-03-31,KR,Korea,
-1972-03-31,LT,Lithuania,
-1972-03-31,LU,Luxembourg,
-1972-03-31,LV,Latvia,
-1972-03-31,MA,Morocco,
-1972-03-31,MK,North Macedonia,
-1972-03-31,MT,Malta,
-1972-03-31,MX,Mexico,
-1972-03-31,MY,Malaysia,
-1972-03-31,NL,Netherlands,33.4824
-1972-03-31,NO,Norway,34.1781
-1972-03-31,NZ,New Zealand,37.0694
-1972-03-31,PE,Peru,
-1972-03-31,PH,Philippines,
-1972-03-31,PL,Poland,
-1972-03-31,PT,Portugal,
-1972-03-31,RO,Romania,
-1972-03-31,RS,Serbia,
-1972-03-31,RU,Russia,
-1972-03-31,SE,Sweden,48.7733
-1972-03-31,SG,Singapore,
-1972-03-31,SI,Slovenia,
-1972-03-31,SK,Slovak Republic,
-1972-03-31,TH,Thailand,
-1972-03-31,TR,Türkiye,
-1972-03-31,US,United States,63.6195
-1972-03-31,XM,Euro area,
-1972-03-31,XW,World,
-1972-03-31,ZA,South Africa,76.611
-1972-06-30,4T,Emerging market economies (aggregate),
-1972-06-30,5R,Advanced economies,
-1972-06-30,AE,United Arab Emirates,
-1972-06-30,AT,Austria,
-1972-06-30,AU,Australia,34.8022
-1972-06-30,BE,Belgium,39.5311
-1972-06-30,BG,Bulgaria,
-1972-06-30,BR,Brazil,
-1972-06-30,CA,Canada,39.8673
-1972-06-30,CH,Switzerland,85.0843
-1972-06-30,CL,Chile,
-1972-06-30,CN,China,
-1972-06-30,CO,Colombia,
-1972-06-30,CY,Cyprus,
-1972-06-30,CZ,Czechia,
-1972-06-30,DE,Germany,131.4522
-1972-06-30,DK,Denmark,62.2344
-1972-06-30,EE,Estonia,
-1972-06-30,ES,Spain,28.3079
+1972-03-31,NL,Netherlands,34.2949
+1972-03-31,NO,Norway,34.174
+1972-03-31,NZ,New Zealand,37.0921
+1972-03-31,SE,Sweden,48.7572
+1972-03-31,US,United States,63.4253
+1972-03-31,ZA,South Africa,76.5128
+1972-06-30,AU,Australia,34.7481
+1972-06-30,BE,Belgium,39.8675
+1972-06-30,CA,Canada,40.1764
+1972-06-30,CH,Switzerland,85.0812
+1972-06-30,DE,Germany,131.4523
+1972-06-30,DK,Denmark,62.2382
+1972-06-30,ES,Spain,28.308
 1972-06-30,FI,Finland,53.5681
-1972-06-30,FR,France,41.8191
-1972-06-30,GB,United Kingdom,26.8894
-1972-06-30,GR,Greece,
-1972-06-30,HK,Hong Kong SAR,
-1972-06-30,HR,Croatia,
-1972-06-30,HU,Hungary,
-1972-06-30,ID,Indonesia,
-1972-06-30,IE,Ireland,34.5642
-1972-06-30,IL,Israel,
-1972-06-30,IN,India,
-1972-06-30,IS,Iceland,
-1972-06-30,IT,Italy,41.275
+1972-06-30,FR,France,41.8194
+1972-06-30,GB,United Kingdom,26.8804
+1972-06-30,IE,Ireland,34.581
+1972-06-30,IT,Italy,40.2345
 1972-06-30,JP,Japan,121.0162
-1972-06-30,KR,Korea,
-1972-06-30,LT,Lithuania,
-1972-06-30,LU,Luxembourg,
-1972-06-30,LV,Latvia,
-1972-06-30,MA,Morocco,
-1972-06-30,MK,North Macedonia,
-1972-06-30,MT,Malta,
-1972-06-30,MX,Mexico,
-1972-06-30,MY,Malaysia,
-1972-06-30,NL,Netherlands,34.091
-1972-06-30,NO,Norway,36.1192
-1972-06-30,NZ,New Zealand,38.1483
-1972-06-30,PE,Peru,
-1972-06-30,PH,Philippines,
-1972-06-30,PL,Poland,
-1972-06-30,PT,Portugal,
-1972-06-30,RO,Romania,
-1972-06-30,RS,Serbia,
-1972-06-30,RU,Russia,
-1972-06-30,SE,Sweden,49.3585
-1972-06-30,SG,Singapore,
-1972-06-30,SI,Slovenia,
-1972-06-30,SK,Slovak Republic,
-1972-06-30,TH,Thailand,
-1972-06-30,TR,Türkiye,
-1972-06-30,US,United States,64.903
-1972-06-30,XM,Euro area,
-1972-06-30,XW,World,
-1972-06-30,ZA,South Africa,75.3411
-1972-09-30,4T,Emerging market economies (aggregate),
-1972-09-30,5R,Advanced economies,
-1972-09-30,AE,United Arab Emirates,
-1972-09-30,AT,Austria,
-1972-09-30,AU,Australia,35.1382
-1972-09-30,BE,Belgium,40.1921
-1972-09-30,BG,Bulgaria,
-1972-09-30,BR,Brazil,
-1972-09-30,CA,Canada,39.597
-1972-09-30,CH,Switzerland,87.8644
-1972-09-30,CL,Chile,
-1972-09-30,CN,China,
-1972-09-30,CO,Colombia,
-1972-09-30,CY,Cyprus,
-1972-09-30,CZ,Czechia,
+1972-06-30,NL,Netherlands,34.9183
+1972-06-30,NO,Norway,36.0099
+1972-06-30,NZ,New Zealand,38.1506
+1972-06-30,SE,Sweden,49.3421
+1972-06-30,US,United States,64.7048
+1972-06-30,ZA,South Africa,75.4002
+1972-09-30,AU,Australia,35.2162
+1972-09-30,BE,Belgium,40.5341
+1972-09-30,CA,Canada,39.904
+1972-09-30,CH,Switzerland,87.8613
 1972-09-30,DE,Germany,131.0397
-1972-09-30,DK,Denmark,61.7038
-1972-09-30,EE,Estonia,
-1972-09-30,ES,Spain,28.3252
+1972-09-30,DK,Denmark,61.7076
+1972-09-30,ES,Spain,28.3253
 1972-09-30,FI,Finland,52.824
-1972-09-30,FR,France,42.8198
-1972-09-30,GB,United Kingdom,30.2407
-1972-09-30,GR,Greece,
-1972-09-30,HK,Hong Kong SAR,
-1972-09-30,HR,Croatia,
-1972-09-30,HU,Hungary,
-1972-09-30,ID,Indonesia,
-1972-09-30,IE,Ireland,35.5068
-1972-09-30,IL,Israel,
-1972-09-30,IN,India,
-1972-09-30,IS,Iceland,
-1972-09-30,IT,Italy,41.5336
+1972-09-30,FR,France,42.8201
+1972-09-30,GB,United Kingdom,30.2307
+1972-09-30,IE,Ireland,35.524
+1972-09-30,IT,Italy,40.5024
 1972-09-30,JP,Japan,125.0855
-1972-09-30,KR,Korea,
-1972-09-30,LT,Lithuania,
-1972-09-30,LU,Luxembourg,
-1972-09-30,LV,Latvia,
-1972-09-30,MA,Morocco,
-1972-09-30,MK,North Macedonia,
-1972-09-30,MT,Malta,
-1972-09-30,MX,Mexico,
-1972-09-30,MY,Malaysia,
-1972-09-30,NL,Netherlands,34.1355
-1972-09-30,NO,Norway,35.212
-1972-09-30,NZ,New Zealand,38.9231
-1972-09-30,PE,Peru,
-1972-09-30,PH,Philippines,
-1972-09-30,PL,Poland,
-1972-09-30,PT,Portugal,
-1972-09-30,RO,Romania,
-1972-09-30,RS,Serbia,
-1972-09-30,RU,Russia,
-1972-09-30,SE,Sweden,48.6311
-1972-09-30,SG,Singapore,
-1972-09-30,SI,Slovenia,
-1972-09-30,SK,Slovak Republic,
-1972-09-30,TH,Thailand,
-1972-09-30,TR,Türkiye,
-1972-09-30,US,United States,65.5625
-1972-09-30,XM,Euro area,
-1972-09-30,XW,World,
-1972-09-30,ZA,South Africa,76.0091
-1972-12-31,4T,Emerging market economies (aggregate),
-1972-12-31,5R,Advanced economies,
-1972-12-31,AE,United Arab Emirates,
-1972-12-31,AT,Austria,
-1972-12-31,AU,Australia,36.7062
-1972-12-31,BE,Belgium,39.4411
-1972-12-31,BG,Bulgaria,
-1972-12-31,BR,Brazil,
-1972-12-31,CA,Canada,41.1372
-1972-12-31,CH,Switzerland,90.1535
-1972-12-31,CL,Chile,
-1972-12-31,CN,China,
-1972-12-31,CO,Colombia,
-1972-12-31,CY,Cyprus,
-1972-12-31,CZ,Czechia,
-1972-12-31,DE,Germany,129.8337
-1972-12-31,DK,Denmark,63.0675
-1972-12-31,EE,Estonia,
-1972-12-31,ES,Spain,28.4091
+1972-09-30,NL,Netherlands,34.9639
+1972-09-30,NO,Norway,35.2451
+1972-09-30,NZ,New Zealand,38.9049
+1972-09-30,SE,Sweden,48.615
+1972-09-30,US,United States,65.3623
+1972-09-30,ZA,South Africa,75.9448
+1972-12-31,AU,Australia,36.7368
+1972-12-31,BE,Belgium,39.7768
+1972-12-31,CA,Canada,41.4561
+1972-12-31,CH,Switzerland,90.1502
+1972-12-31,DE,Germany,129.8338
+1972-12-31,DK,Denmark,63.0714
+1972-12-31,ES,Spain,28.4092
 1972-12-31,FI,Finland,54.6682
-1972-12-31,FR,France,42.4634
-1972-12-31,GB,United Kingdom,31.8063
-1972-12-31,GR,Greece,
-1972-12-31,HK,Hong Kong SAR,
-1972-12-31,HR,Croatia,
-1972-12-31,HU,Hungary,
-1972-12-31,ID,Indonesia,
-1972-12-31,IE,Ireland,36.8431
-1972-12-31,IL,Israel,
-1972-12-31,IN,India,
-1972-12-31,IS,Iceland,
-1972-12-31,IT,Italy,40.7042
+1972-12-31,FR,France,42.4637
+1972-12-31,GB,United Kingdom,31.7957
+1972-12-31,IE,Ireland,36.861
+1972-12-31,IT,Italy,39.6929
 1972-12-31,JP,Japan,134.8142
-1972-12-31,KR,Korea,
-1972-12-31,LT,Lithuania,
-1972-12-31,LU,Luxembourg,
-1972-12-31,LV,Latvia,
-1972-12-31,MA,Morocco,
-1972-12-31,MK,North Macedonia,
-1972-12-31,MT,Malta,
-1972-12-31,MX,Mexico,
-1972-12-31,MY,Malaysia,
-1972-12-31,NL,Netherlands,34.9964
-1972-12-31,NO,Norway,33.986
-1972-12-31,NZ,New Zealand,40.0955
-1972-12-31,PE,Peru,
-1972-12-31,PH,Philippines,
-1972-12-31,PL,Poland,
-1972-12-31,PT,Portugal,
-1972-12-31,RO,Romania,
-1972-12-31,RS,Serbia,
-1972-12-31,RU,Russia,
-1972-12-31,SE,Sweden,49.2579
-1972-12-31,SG,Singapore,
-1972-12-31,SI,Slovenia,
-1972-12-31,SK,Slovak Republic,
-1972-12-31,TH,Thailand,
-1972-12-31,TR,Türkiye,
-1972-12-31,US,United States,66.3638
-1972-12-31,XM,Euro area,
-1972-12-31,XW,World,
-1972-12-31,ZA,South Africa,76.6488
-1973-03-31,4T,Emerging market economies (aggregate),
-1973-03-31,5R,Advanced economies,
-1973-03-31,AE,United Arab Emirates,
-1973-03-31,AT,Austria,
-1973-03-31,AU,Australia,37.0803
-1973-03-31,BE,Belgium,40.3298
-1973-03-31,BG,Bulgaria,
-1973-03-31,BR,Brazil,
-1973-03-31,CA,Canada,42.4941
-1973-03-31,CH,Switzerland,94.5134
-1973-03-31,CL,Chile,
-1973-03-31,CN,China,
-1973-03-31,CO,Colombia,
-1973-03-31,CY,Cyprus,
-1973-03-31,CZ,Czechia,
+1972-12-31,NL,Netherlands,35.8458
+1972-12-31,NO,Norway,33.9789
+1972-12-31,NZ,New Zealand,40.0818
+1972-12-31,SE,Sweden,49.2416
+1972-12-31,US,United States,66.1612
+1972-12-31,ZA,South Africa,76.7435
+1973-03-31,AU,Australia,37.0118
+1973-03-31,BE,Belgium,40.6731
+1973-03-31,CA,Canada,42.8236
+1973-03-31,CH,Switzerland,94.5099
 1973-03-31,DE,Germany,128.8482
-1973-03-31,DK,Denmark,65.0423
-1973-03-31,EE,Estonia,
-1973-03-31,ES,Spain,30.704
+1973-03-31,DK,Denmark,65.0464
+1973-03-31,ES,Spain,30.7041
 1973-03-31,FI,Finland,57.4522
-1973-03-31,FR,France,42.3678
-1973-03-31,GB,United Kingdom,35.0269
-1973-03-31,GR,Greece,
-1973-03-31,HK,Hong Kong SAR,
-1973-03-31,HR,Croatia,
-1973-03-31,HU,Hungary,
-1973-03-31,ID,Indonesia,
-1973-03-31,IE,Ireland,35.4079
-1973-03-31,IL,Israel,
-1973-03-31,IN,India,
-1973-03-31,IS,Iceland,
-1973-03-31,IT,Italy,40.4054
+1973-03-31,FR,France,42.3681
+1973-03-31,GB,United Kingdom,35.0153
+1973-03-31,IE,Ireland,35.4251
+1973-03-31,IT,Italy,39.3891
 1973-03-31,JP,Japan,142.2956
-1973-03-31,KR,Korea,
-1973-03-31,LT,Lithuania,
-1973-03-31,LU,Luxembourg,
-1973-03-31,LV,Latvia,
-1973-03-31,MA,Morocco,
-1973-03-31,MK,North Macedonia,
-1973-03-31,MT,Malta,
-1973-03-31,MX,Mexico,
-1973-03-31,MY,Malaysia,
-1973-03-31,NL,Netherlands,35.6104
-1973-03-31,NO,Norway,34.6806
-1973-03-31,NZ,New Zealand,41.5398
-1973-03-31,PE,Peru,
-1973-03-31,PH,Philippines,
-1973-03-31,PL,Poland,
-1973-03-31,PT,Portugal,
-1973-03-31,RO,Romania,
-1973-03-31,RS,Serbia,
-1973-03-31,RU,Russia,
-1973-03-31,SE,Sweden,49.3755
-1973-03-31,SG,Singapore,
-1973-03-31,SI,Slovenia,
-1973-03-31,SK,Slovak Republic,
-1973-03-31,TH,Thailand,
-1973-03-31,TR,Türkiye,
-1973-03-31,US,United States,68.4354
-1973-03-31,XM,Euro area,
-1973-03-31,XW,World,
-1973-03-31,ZA,South Africa,78.2389
-1973-06-30,4T,Emerging market economies (aggregate),
-1973-06-30,5R,Advanced economies,
-1973-06-30,AE,United Arab Emirates,
-1973-06-30,AT,Austria,
-1973-06-30,AU,Australia,37.9458
-1973-06-30,BE,Belgium,41.5323
-1973-06-30,BG,Bulgaria,
-1973-06-30,BR,Brazil,
-1973-06-30,CA,Canada,43.7513
-1973-06-30,CH,Switzerland,92.1621
-1973-06-30,CL,Chile,
-1973-06-30,CN,China,
-1973-06-30,CO,Colombia,
-1973-06-30,CY,Cyprus,
-1973-06-30,CZ,Czechia,
+1973-03-31,NL,Netherlands,36.4746
+1973-03-31,NO,Norway,34.625
+1973-03-31,NZ,New Zealand,41.555
+1973-03-31,SE,Sweden,49.3591
+1973-03-31,US,United States,68.2264
+1973-03-31,ZA,South Africa,78.1449
+1973-06-30,AU,Australia,37.9137
+1973-06-30,BE,Belgium,41.8858
+1973-06-30,CA,Canada,44.0906
+1973-06-30,CH,Switzerland,92.1588
 1973-06-30,DE,Germany,132.1882
-1973-06-30,DK,Denmark,64.8007
-1973-06-30,EE,Estonia,
-1973-06-30,ES,Spain,29.437
+1973-06-30,DK,Denmark,64.8048
+1973-06-30,ES,Spain,29.4371
 1973-06-30,FI,Finland,61.7737
-1973-06-30,FR,France,43.0217
-1973-06-30,GB,United Kingdom,35.5975
-1973-06-30,GR,Greece,
-1973-06-30,HK,Hong Kong SAR,
-1973-06-30,HR,Croatia,
-1973-06-30,HU,Hungary,
-1973-06-30,ID,Indonesia,
-1973-06-30,IE,Ireland,35.0944
-1973-06-30,IL,Israel,
-1973-06-30,IN,India,
-1973-06-30,IS,Iceland,
-1973-06-30,IT,Italy,41.8759
+1973-06-30,FR,France,43.022
+1973-06-30,GB,United Kingdom,35.5857
+1973-06-30,IE,Ireland,35.1114
+1973-06-30,IT,Italy,40.8237
 1973-06-30,JP,Japan,146.5214
-1973-06-30,KR,Korea,
-1973-06-30,LT,Lithuania,
-1973-06-30,LU,Luxembourg,
-1973-06-30,LV,Latvia,
-1973-06-30,MA,Morocco,
-1973-06-30,MK,North Macedonia,
-1973-06-30,MT,Malta,
-1973-06-30,MX,Mexico,
-1973-06-30,MY,Malaysia,
-1973-06-30,NL,Netherlands,36.7432
-1973-06-30,NO,Norway,35.4508
-1973-06-30,NZ,New Zealand,43.3974
-1973-06-30,PE,Peru,
-1973-06-30,PH,Philippines,
-1973-06-30,PL,Poland,
-1973-06-30,PT,Portugal,
-1973-06-30,RO,Romania,
-1973-06-30,RS,Serbia,
-1973-06-30,RU,Russia,
-1973-06-30,SE,Sweden,49.6742
-1973-06-30,SG,Singapore,
-1973-06-30,SI,Slovenia,
-1973-06-30,SK,Slovak Republic,
-1973-06-30,TH,Thailand,
-1973-06-30,TR,Türkiye,
-1973-06-30,US,United States,68.5383
-1973-06-30,XM,Euro area,
-1973-06-30,XW,World,
-1973-06-30,ZA,South Africa,78.6304
-1973-09-30,4T,Emerging market economies (aggregate),
-1973-09-30,5R,Advanced economies,
-1973-09-30,AE,United Arab Emirates,
-1973-09-30,AT,Austria,
-1973-09-30,AU,Australia,39.6809
-1973-09-30,BE,Belgium,42.4638
-1973-09-30,BG,Bulgaria,
-1973-09-30,BR,Brazil,
-1973-09-30,CA,Canada,45.634
-1973-09-30,CH,Switzerland,92.7876
-1973-09-30,CL,Chile,
-1973-09-30,CN,China,
-1973-09-30,CO,Colombia,
-1973-09-30,CY,Cyprus,
-1973-09-30,CZ,Czechia,
-1973-09-30,DE,Germany,132.1987
-1973-09-30,DK,Denmark,66.3391
-1973-09-30,EE,Estonia,
-1973-09-30,ES,Spain,30.6334
+1973-06-30,NL,Netherlands,37.6349
+1973-06-30,NO,Norway,35.4221
+1973-06-30,NZ,New Zealand,43.3975
+1973-06-30,SE,Sweden,49.6577
+1973-06-30,US,United States,68.329
+1973-06-30,ZA,South Africa,78.6275
+1973-09-30,AU,Australia,39.6848
+1973-09-30,BE,Belgium,42.8251
+1973-09-30,CA,Canada,45.9878
+1973-09-30,CH,Switzerland,92.7842
+1973-09-30,DE,Germany,132.1988
+1973-09-30,DK,Denmark,66.3433
+1973-09-30,ES,Spain,30.6335
 1973-09-30,FI,Finland,62.3609
-1973-09-30,FR,France,44.0652
-1973-09-30,GB,United Kingdom,37.165
-1973-09-30,GR,Greece,
-1973-09-30,HK,Hong Kong SAR,
-1973-09-30,HR,Croatia,
-1973-09-30,HU,Hungary,
-1973-09-30,ID,Indonesia,
-1973-09-30,IE,Ireland,34.5166
-1973-09-30,IL,Israel,
-1973-09-30,IN,India,
-1973-09-30,IS,Iceland,
-1973-09-30,IT,Italy,45.5495
+1973-09-30,FR,France,44.0655
+1973-09-30,GB,United Kingdom,37.1526
+1973-09-30,IE,Ireland,34.5333
+1973-09-30,IT,Italy,44.3916
 1973-09-30,JP,Japan,153.1654
-1973-09-30,KR,Korea,
-1973-09-30,LT,Lithuania,
-1973-09-30,LU,Luxembourg,
-1973-09-30,LV,Latvia,
-1973-09-30,MA,Morocco,
-1973-09-30,MK,North Macedonia,
-1973-09-30,MT,Malta,
-1973-09-30,MX,Mexico,
-1973-09-30,MY,Malaysia,
-1973-09-30,NL,Netherlands,37.1543
-1973-09-30,NO,Norway,33.8611
-1973-09-30,NZ,New Zealand,45.6255
-1973-09-30,PE,Peru,
-1973-09-30,PH,Philippines,
-1973-09-30,PL,Poland,
-1973-09-30,PT,Portugal,
-1973-09-30,RO,Romania,
-1973-09-30,RS,Serbia,
-1973-09-30,RU,Russia,
-1973-09-30,SE,Sweden,48.9866
-1973-09-30,SG,Singapore,
-1973-09-30,SI,Slovenia,
-1973-09-30,SK,Slovak Republic,
-1973-09-30,TH,Thailand,
-1973-09-30,TR,Türkiye,
-1973-09-30,US,United States,68.7826
-1973-09-30,XM,Euro area,
-1973-09-30,XW,World,
-1973-09-30,ZA,South Africa,81.7152
-1973-12-31,4T,Emerging market economies (aggregate),
-1973-12-31,5R,Advanced economies,
-1973-12-31,AE,United Arab Emirates,
-1973-12-31,AT,Austria,
-1973-12-31,AU,Australia,41.0876
-1973-12-31,BE,Belgium,42.1305
-1973-12-31,BG,Bulgaria,
-1973-12-31,BR,Brazil,
-1973-12-31,CA,Canada,49.0718
-1973-12-31,CH,Switzerland,87.3266
-1973-12-31,CL,Chile,
-1973-12-31,CN,China,
-1973-12-31,CO,Colombia,
-1973-12-31,CY,Cyprus,
-1973-12-31,CZ,Czechia,
-1973-12-31,DE,Germany,129.7299
-1973-12-31,DK,Denmark,65.5321
-1973-12-31,EE,Estonia,
+1973-09-30,NL,Netherlands,38.056
+1973-09-30,NO,Norway,33.8689
+1973-09-30,NZ,New Zealand,45.6123
+1973-09-30,SE,Sweden,48.9703
+1973-09-30,US,United States,68.5726
+1973-09-30,ZA,South Africa,81.6238
+1973-12-31,AU,Australia,40.9404
+1973-12-31,BE,Belgium,42.4891
+1973-12-31,CA,Canada,49.4522
+1973-12-31,CH,Switzerland,87.3234
+1973-12-31,DE,Germany,129.73
+1973-12-31,DK,Denmark,65.5362
 1973-12-31,ES,Spain,31.3535
 1973-12-31,FI,Finland,63.693
-1973-12-31,FR,France,43.8132
-1973-12-31,GB,United Kingdom,36.1656
-1973-12-31,GR,Greece,
-1973-12-31,HK,Hong Kong SAR,
-1973-12-31,HR,Croatia,
-1973-12-31,HU,Hungary,
-1973-12-31,ID,Indonesia,
-1973-12-31,IE,Ireland,34.158
-1973-12-31,IL,Israel,
-1973-12-31,IN,India,
-1973-12-31,IS,Iceland,
-1973-12-31,IT,Italy,49.8444
+1973-12-31,FR,France,43.8135
+1973-12-31,GB,United Kingdom,36.1535
+1973-12-31,IE,Ireland,34.1746
+1973-12-31,IT,Italy,48.5734
 1973-12-31,JP,Japan,153.0538
-1973-12-31,KR,Korea,
-1973-12-31,LT,Lithuania,
-1973-12-31,LU,Luxembourg,
-1973-12-31,LV,Latvia,
-1973-12-31,MA,Morocco,
-1973-12-31,MK,North Macedonia,
-1973-12-31,MT,Malta,
-1973-12-31,MX,Mexico,
-1973-12-31,MY,Malaysia,
-1973-12-31,NL,Netherlands,38.2767
-1973-12-31,NO,Norway,31.9037
-1973-12-31,NZ,New Zealand,48.715
-1973-12-31,PE,Peru,
-1973-12-31,PH,Philippines,
-1973-12-31,PL,Poland,
-1973-12-31,PT,Portugal,
-1973-12-31,RO,Romania,
-1973-12-31,RS,Serbia,
-1973-12-31,RU,Russia,
-1973-12-31,SE,Sweden,48.9139
-1973-12-31,SG,Singapore,
-1973-12-31,SI,Slovenia,
-1973-12-31,SK,Slovak Republic,
-1973-12-31,TH,Thailand,
-1973-12-31,TR,Türkiye,
-1973-12-31,US,United States,68.6598
-1973-12-31,XM,Euro area,
-1973-12-31,XW,World,
-1973-12-31,ZA,South Africa,82.9192
-1974-03-31,4T,Emerging market economies (aggregate),
-1974-03-31,5R,Advanced economies,
-1974-03-31,AE,United Arab Emirates,
-1974-03-31,AT,Austria,
-1974-03-31,AU,Australia,42.4078
-1974-03-31,BE,Belgium,41.749
-1974-03-31,BG,Bulgaria,
-1974-03-31,BR,Brazil,
-1974-03-31,CA,Canada,53.0157
-1974-03-31,CH,Switzerland,85.0823
-1974-03-31,CL,Chile,
-1974-03-31,CN,China,
-1974-03-31,CO,Colombia,
-1974-03-31,CY,Cyprus,
-1974-03-31,CZ,Czechia,
+1973-12-31,NL,Netherlands,39.2056
+1973-12-31,NO,Norway,31.8685
+1973-12-31,NZ,New Zealand,48.7127
+1973-12-31,SE,Sweden,48.8977
+1973-12-31,US,United States,68.4502
+1973-12-31,ZA,South Africa,82.7824
+1974-03-31,AU,Australia,42.4843
+1974-03-31,BE,Belgium,42.1043
+1974-03-31,CA,Canada,53.4267
+1974-03-31,CH,Switzerland,85.0793
 1974-03-31,DE,Germany,129.4368
-1974-03-31,DK,Denmark,63.1738
-1974-03-31,EE,Estonia,
-1974-03-31,ES,Spain,33.8307
+1974-03-31,DK,Denmark,63.1778
+1974-03-31,ES,Spain,33.8308
 1974-03-31,FI,Finland,64.5438
-1974-03-31,FR,France,43.3315
-1974-03-31,GB,United Kingdom,35.3076
-1974-03-31,GR,Greece,
-1974-03-31,HK,Hong Kong SAR,
-1974-03-31,HR,Croatia,
-1974-03-31,HU,Hungary,
-1974-03-31,ID,Indonesia,
-1974-03-31,IE,Ireland,34.8779
-1974-03-31,IL,Israel,
-1974-03-31,IN,India,
-1974-03-31,IS,Iceland,
-1974-03-31,IT,Italy,53.1363
+1974-03-31,FR,France,43.3319
+1974-03-31,GB,United Kingdom,35.2959
+1974-03-31,IE,Ireland,34.8948
+1974-03-31,IT,Italy,51.7922
 1974-03-31,JP,Japan,145.6404
-1974-03-31,KR,Korea,
-1974-03-31,LT,Lithuania,
-1974-03-31,LU,Luxembourg,
-1974-03-31,LV,Latvia,
-1974-03-31,MA,Morocco,
-1974-03-31,MK,North Macedonia,
-1974-03-31,MT,Malta,
-1974-03-31,MX,Mexico,
-1974-03-31,MY,Malaysia,
-1974-03-31,NL,Netherlands,39.4534
-1974-03-31,NO,Norway,30.814
-1974-03-31,NZ,New Zealand,52.8951
-1974-03-31,PE,Peru,
-1974-03-31,PH,Philippines,
-1974-03-31,PL,Poland,
-1974-03-31,PT,Portugal,
-1974-03-31,RO,Romania,
-1974-03-31,RS,Serbia,
-1974-03-31,RU,Russia,
-1974-03-31,SE,Sweden,48.0772
-1974-03-31,SG,Singapore,
-1974-03-31,SI,Slovenia,
-1974-03-31,SK,Slovak Republic,
-1974-03-31,TH,Thailand,
-1974-03-31,TR,Türkiye,
-1974-03-31,US,United States,68.4047
-1974-03-31,XM,Euro area,
-1974-03-31,XW,World,
-1974-03-31,ZA,South Africa,80.9134
-1974-06-30,4T,Emerging market economies (aggregate),
-1974-06-30,5R,Advanced economies,
-1974-06-30,AE,United Arab Emirates,
-1974-06-30,AT,Austria,
-1974-06-30,AU,Australia,42.2173
-1974-06-30,BE,Belgium,43.3841
-1974-06-30,BG,Bulgaria,
-1974-06-30,BR,Brazil,
-1974-06-30,CA,Canada,53.5368
-1974-06-30,CH,Switzerland,84.5995
-1974-06-30,CL,Chile,
-1974-06-30,CN,China,
-1974-06-30,CO,Colombia,
-1974-06-30,CY,Cyprus,
-1974-06-30,CZ,Czechia,
+1974-03-31,NL,Netherlands,40.4109
+1974-03-31,NO,Norway,30.7484
+1974-03-31,NZ,New Zealand,52.886
+1974-03-31,SE,Sweden,48.0612
+1974-03-31,US,United States,68.1959
+1974-03-31,ZA,South Africa,80.9656
+1974-06-30,AU,Australia,42.1429
+1974-06-30,BE,Belgium,43.7533
+1974-06-30,CA,Canada,53.9518
+1974-06-30,CH,Switzerland,84.5964
 1974-06-30,DE,Germany,132.5986
-1974-06-30,DK,Denmark,58.7862
-1974-06-30,EE,Estonia,
-1974-06-30,ES,Spain,36.0627
+1974-06-30,DK,Denmark,58.7898
+1974-06-30,ES,Spain,36.0628
 1974-06-30,FI,Finland,64.7901
-1974-06-30,FR,France,43.5157
-1974-06-30,GB,United Kingdom,33.4323
-1974-06-30,GR,Greece,
-1974-06-30,HK,Hong Kong SAR,
-1974-06-30,HR,Croatia,
-1974-06-30,HU,Hungary,
-1974-06-30,ID,Indonesia,
-1974-06-30,IE,Ireland,35.188
-1974-06-30,IL,Israel,
-1974-06-30,IN,India,
-1974-06-30,IS,Iceland,
-1974-06-30,IT,Italy,56.411
+1974-06-30,FR,France,43.5161
+1974-06-30,GB,United Kingdom,33.4212
+1974-06-30,IE,Ireland,35.2051
+1974-06-30,IT,Italy,54.99
 1974-06-30,JP,Japan,140.5607
-1974-06-30,KR,Korea,
-1974-06-30,LT,Lithuania,
-1974-06-30,LU,Luxembourg,
-1974-06-30,LV,Latvia,
-1974-06-30,MA,Morocco,
-1974-06-30,MK,North Macedonia,
-1974-06-30,MT,Malta,
-1974-06-30,MX,Mexico,
-1974-06-30,MY,Malaysia,
-1974-06-30,NL,Netherlands,40.5623
-1974-06-30,NO,Norway,32.4972
-1974-06-30,NZ,New Zealand,56.7156
-1974-06-30,PE,Peru,
-1974-06-30,PH,Philippines,
-1974-06-30,PL,Poland,
-1974-06-30,PT,Portugal,
-1974-06-30,RO,Romania,
-1974-06-30,RS,Serbia,
-1974-06-30,RU,Russia,
-1974-06-30,SE,Sweden,48.6773
-1974-06-30,SG,Singapore,
-1974-06-30,SI,Slovenia,
-1974-06-30,SK,Slovak Republic,
-1974-06-30,TH,Thailand,
-1974-06-30,TR,Türkiye,
-1974-06-30,US,United States,67.8198
-1974-06-30,XM,Euro area,
-1974-06-30,XW,World,
-1974-06-30,ZA,South Africa,79.7423
-1974-09-30,4T,Emerging market economies (aggregate),
-1974-09-30,5R,Advanced economies,
-1974-09-30,AE,United Arab Emirates,
-1974-09-30,AT,Austria,
-1974-09-30,AU,Australia,40.6093
-1974-09-30,BE,Belgium,43.3435
-1974-09-30,BG,Bulgaria,
-1974-09-30,BR,Brazil,
-1974-09-30,CA,Canada,51.517
-1974-09-30,CH,Switzerland,83.1446
-1974-09-30,CL,Chile,
-1974-09-30,CN,China,
-1974-09-30,CO,Colombia,
-1974-09-30,CY,Cyprus,
-1974-09-30,CZ,Czechia,
+1974-06-30,NL,Netherlands,41.5468
+1974-06-30,NO,Norway,32.4521
+1974-06-30,NZ,New Zealand,56.7199
+1974-06-30,SE,Sweden,48.6612
+1974-06-30,US,United States,67.6128
+1974-06-30,ZA,South Africa,79.8487
+1974-09-30,AU,Australia,40.607
+1974-09-30,BE,Belgium,43.7123
+1974-09-30,CA,Canada,51.9164
+1974-09-30,CH,Switzerland,83.1415
 1974-09-30,DE,Germany,132.6047
-1974-09-30,DK,Denmark,57.2741
-1974-09-30,EE,Estonia,
+1974-09-30,DK,Denmark,57.2777
 1974-09-30,ES,Spain,36.2914
 1974-09-30,FI,Finland,62.8692
-1974-09-30,FR,France,44.3318
-1974-09-30,GB,United Kingdom,33.0259
-1974-09-30,GR,Greece,
-1974-09-30,HK,Hong Kong SAR,
-1974-09-30,HR,Croatia,
-1974-09-30,HU,Hungary,
-1974-09-30,ID,Indonesia,
-1974-09-30,IE,Ireland,36.0144
-1974-09-30,IL,Israel,
-1974-09-30,IN,India,
-1974-09-30,IS,Iceland,
-1974-09-30,IT,Italy,58.2057
+1974-09-30,FR,France,44.3321
+1974-09-30,GB,United Kingdom,33.0149
+1974-09-30,IE,Ireland,36.0319
+1974-09-30,IT,Italy,56.7654
 1974-09-30,JP,Japan,136.6606
-1974-09-30,KR,Korea,
-1974-09-30,LT,Lithuania,
-1974-09-30,LU,Luxembourg,
-1974-09-30,LV,Latvia,
-1974-09-30,MA,Morocco,
-1974-09-30,MK,North Macedonia,
-1974-09-30,MT,Malta,
-1974-09-30,MX,Mexico,
-1974-09-30,MY,Malaysia,
-1974-09-30,NL,Netherlands,40.9248
-1974-09-30,NO,Norway,32.9458
-1974-09-30,NZ,New Zealand,58.0907
-1974-09-30,PE,Peru,
-1974-09-30,PH,Philippines,
-1974-09-30,PL,Poland,
-1974-09-30,PT,Portugal,
-1974-09-30,RO,Romania,
-1974-09-30,RS,Serbia,
-1974-09-30,RU,Russia,
-1974-09-30,SE,Sweden,48.9912
-1974-09-30,SG,Singapore,
-1974-09-30,SI,Slovenia,
-1974-09-30,SK,Slovak Republic,
-1974-09-30,TH,Thailand,
-1974-09-30,TR,Türkiye,
-1974-09-30,US,United States,67.5842
-1974-09-30,XM,Euro area,
-1974-09-30,XW,World,
-1974-09-30,ZA,South Africa,76.9261
-1974-12-31,4T,Emerging market economies (aggregate),
-1974-12-31,5R,Advanced economies,
-1974-12-31,AE,United Arab Emirates,
-1974-12-31,AT,Austria,
-1974-12-31,AU,Australia,40.163
-1974-12-31,BE,Belgium,41.4876
-1974-12-31,BG,Bulgaria,
-1974-12-31,BR,Brazil,
-1974-12-31,CA,Canada,50.1874
-1974-12-31,CH,Switzerland,80.099
-1974-12-31,CL,Chile,
-1974-12-31,CN,China,
-1974-12-31,CO,Colombia,
-1974-12-31,CY,Cyprus,
-1974-12-31,CZ,Czechia,
+1974-09-30,NL,Netherlands,41.918
+1974-09-30,NO,Norway,32.8997
+1974-09-30,NZ,New Zealand,58.084
+1974-09-30,SE,Sweden,48.975
+1974-09-30,US,United States,67.3778
+1974-09-30,ZA,South Africa,76.7719
+1974-12-31,AU,Australia,40.1499
+1974-12-31,BE,Belgium,41.8407
+1974-12-31,CA,Canada,50.5765
+1974-12-31,CH,Switzerland,80.0961
 1974-12-31,DE,Germany,130.0796
-1974-12-31,DK,Denmark,59.0927
-1974-12-31,EE,Estonia,
-1974-12-31,ES,Spain,34.6341
+1974-12-31,DK,Denmark,59.0964
+1974-12-31,ES,Spain,34.6342
 1974-12-31,FI,Finland,61.8045
-1974-12-31,FR,France,43.8655
-1974-12-31,GB,United Kingdom,31.9127
-1974-12-31,GR,Greece,
-1974-12-31,HK,Hong Kong SAR,
-1974-12-31,HR,Croatia,
-1974-12-31,HU,Hungary,
-1974-12-31,ID,Indonesia,
-1974-12-31,IE,Ireland,37.6831
-1974-12-31,IL,Israel,
-1974-12-31,IN,India,
-1974-12-31,IS,Iceland,
-1974-12-31,IT,Italy,57.9117
+1974-12-31,FR,France,43.8659
+1974-12-31,GB,United Kingdom,31.9021
+1974-12-31,IE,Ireland,37.7014
+1974-12-31,IT,Italy,56.4259
 1974-12-31,JP,Japan,127.3484
-1974-12-31,KR,Korea,
-1974-12-31,LT,Lithuania,
-1974-12-31,LU,Luxembourg,
-1974-12-31,LV,Latvia,
-1974-12-31,MA,Morocco,
-1974-12-31,MK,North Macedonia,
-1974-12-31,MT,Malta,
-1974-12-31,MX,Mexico,
-1974-12-31,MY,Malaysia,
-1974-12-31,NL,Netherlands,41.5744
-1974-12-31,NO,Norway,33.2036
-1974-12-31,NZ,New Zealand,57.7974
-1974-12-31,PE,Peru,
-1974-12-31,PH,Philippines,
-1974-12-31,PL,Poland,
-1974-12-31,PT,Portugal,
-1974-12-31,RO,Romania,
-1974-12-31,RS,Serbia,
-1974-12-31,RU,Russia,
-1974-12-31,SE,Sweden,49.6038
-1974-12-31,SG,Singapore,
-1974-12-31,SI,Slovenia,
-1974-12-31,SK,Slovak Republic,
-1974-12-31,TH,Thailand,
-1974-12-31,TR,Türkiye,
-1974-12-31,US,United States,66.0223
-1974-12-31,XM,Euro area,
-1974-12-31,XW,World,
-1974-12-31,ZA,South Africa,74.7281
-1975-03-31,4T,Emerging market economies (aggregate),
-1975-03-31,5R,Advanced economies,
-1975-03-31,AE,United Arab Emirates,
-1975-03-31,AT,Austria,
-1975-03-31,AU,Australia,39.3666
-1975-03-31,BE,Belgium,43.05
-1975-03-31,BG,Bulgaria,
-1975-03-31,BR,Brazil,
-1975-03-31,CA,Canada,51.8917
-1975-03-31,CH,Switzerland,75.9953
-1975-03-31,CL,Chile,
-1975-03-31,CN,China,
-1975-03-31,CO,Colombia,
-1975-03-31,CY,Cyprus,
-1975-03-31,CZ,Czechia,
-1975-03-31,DE,Germany,128.1796
-1975-03-31,DK,Denmark,62.3054
-1975-03-31,EE,Estonia,
-1975-03-31,ES,Spain,33.2608
+1974-12-31,NL,Netherlands,42.5834
+1974-12-31,NO,Norway,33.1335
+1974-12-31,NZ,New Zealand,57.7949
+1974-12-31,SE,Sweden,49.5873
+1974-12-31,US,United States,65.8207
+1974-12-31,ZA,South Africa,74.6626
+1975-03-31,AU,Australia,39.4901
+1975-03-31,BE,Belgium,43.4163
+1975-03-31,CA,Canada,52.294
+1975-03-31,CH,Switzerland,75.9925
+1975-03-31,DE,Germany,128.0665
+1975-03-31,DK,Denmark,62.3093
+1975-03-31,ES,Spain,33.2609
 1975-03-31,FI,Finland,58.6386
-1975-03-31,FR,France,42.8254
-1975-03-31,GB,United Kingdom,30.6434
-1975-03-31,GR,Greece,
-1975-03-31,HK,Hong Kong SAR,
-1975-03-31,HR,Croatia,
-1975-03-31,HU,Hungary,
-1975-03-31,ID,Indonesia,
-1975-03-31,IE,Ireland,37.0755
-1975-03-31,IL,Israel,
-1975-03-31,IN,India,
-1975-03-31,IS,Iceland,
-1975-03-31,IT,Italy,57.6249
+1975-03-31,FR,France,42.8257
+1975-03-31,GB,United Kingdom,30.6332
+1975-03-31,IE,Ireland,37.0935
+1975-03-31,IT,Italy,56.1914
 1975-03-31,JP,Japan,121.146
-1975-03-31,KR,Korea,63.2476
-1975-03-31,LT,Lithuania,
-1975-03-31,LU,Luxembourg,
-1975-03-31,LV,Latvia,
-1975-03-31,MA,Morocco,
-1975-03-31,MK,North Macedonia,
-1975-03-31,MT,Malta,
-1975-03-31,MX,Mexico,
-1975-03-31,MY,Malaysia,
-1975-03-31,NL,Netherlands,41.5887
-1975-03-31,NO,Norway,32.788
-1975-03-31,NZ,New Zealand,56.3144
-1975-03-31,PE,Peru,
-1975-03-31,PH,Philippines,
-1975-03-31,PL,Poland,
-1975-03-31,PT,Portugal,
-1975-03-31,RO,Romania,
-1975-03-31,RS,Serbia,
-1975-03-31,RU,Russia,
-1975-03-31,SE,Sweden,50.9072
-1975-03-31,SG,Singapore,
-1975-03-31,SI,Slovenia,
-1975-03-31,SK,Slovak Republic,
-1975-03-31,TH,Thailand,
-1975-03-31,TR,Türkiye,
-1975-03-31,US,United States,66.5694
-1975-03-31,XM,Euro area,59.2178
-1975-03-31,XW,World,
-1975-03-31,ZA,South Africa,77.3198
-1975-06-30,4T,Emerging market economies (aggregate),
-1975-06-30,5R,Advanced economies,
-1975-06-30,AE,United Arab Emirates,
-1975-06-30,AT,Austria,
-1975-06-30,AU,Australia,39.7059
-1975-06-30,BE,Belgium,43.363
-1975-06-30,BG,Bulgaria,
-1975-06-30,BR,Brazil,
-1975-06-30,CA,Canada,52.3376
-1975-06-30,CH,Switzerland,74.1322
-1975-06-30,CL,Chile,
-1975-06-30,CN,China,
-1975-06-30,CO,Colombia,
-1975-06-30,CY,Cyprus,
-1975-06-30,CZ,Czechia,
-1975-06-30,DE,Germany,127.2637
-1975-06-30,DK,Denmark,63.0415
-1975-06-30,EE,Estonia,
-1975-06-30,ES,Spain,33.2899
+1975-03-31,KR,Korea,63.2453
+1975-03-31,NL,Netherlands,42.5981
+1975-03-31,NO,Norway,32.7558
+1975-03-31,NZ,New Zealand,56.3127
+1975-03-31,SE,Sweden,50.8904
+1975-03-31,US,United States,66.3661
+1975-03-31,XM,Euro area,59.0344
+1975-03-31,ZA,South Africa,77.3303
+1975-06-30,AU,Australia,39.6713
+1975-06-30,BE,Belgium,43.7321
+1975-06-30,CA,Canada,52.7434
+1975-06-30,CH,Switzerland,74.1295
+1975-06-30,DE,Germany,127.4224
+1975-06-30,DK,Denmark,63.0454
+1975-06-30,ES,Spain,33.29
 1975-06-30,FI,Finland,56.5738
-1975-06-30,FR,France,43.3515
-1975-06-30,GB,United Kingdom,28.7928
-1975-06-30,GR,Greece,
-1975-06-30,HK,Hong Kong SAR,
-1975-06-30,HR,Croatia,
-1975-06-30,HU,Hungary,
-1975-06-30,ID,Indonesia,
-1975-06-30,IE,Ireland,36.8687
-1975-06-30,IL,Israel,
-1975-06-30,IN,India,
-1975-06-30,IS,Iceland,
-1975-06-30,IT,Italy,56.9947
+1975-06-30,FR,France,43.3518
+1975-06-30,GB,United Kingdom,28.7833
+1975-06-30,IE,Ireland,36.8866
+1975-06-30,IT,Italy,55.59
 1975-06-30,JP,Japan,118.2772
-1975-06-30,KR,Korea,65.3178
-1975-06-30,LT,Lithuania,
-1975-06-30,LU,Luxembourg,
-1975-06-30,LV,Latvia,
-1975-06-30,MA,Morocco,
-1975-06-30,MK,North Macedonia,
-1975-06-30,MT,Malta,
-1975-06-30,MX,Mexico,
-1975-06-30,MY,Malaysia,
-1975-06-30,NL,Netherlands,42.209
-1975-06-30,NO,Norway,33.4722
-1975-06-30,NZ,New Zealand,54.1606
-1975-06-30,PE,Peru,
-1975-06-30,PH,Philippines,
-1975-06-30,PL,Poland,
-1975-06-30,PT,Portugal,
-1975-06-30,RO,Romania,
-1975-06-30,RS,Serbia,
-1975-06-30,RU,Russia,
-1975-06-30,SE,Sweden,52.6083
-1975-06-30,SG,Singapore,
-1975-06-30,SI,Slovenia,
-1975-06-30,SK,Slovak Republic,
-1975-06-30,TH,Thailand,
-1975-06-30,TR,Türkiye,
-1975-06-30,US,United States,67.4374
-1975-06-30,XM,Euro area,59.0118
-1975-06-30,XW,World,
-1975-06-30,ZA,South Africa,76.515
-1975-09-30,4T,Emerging market economies (aggregate),
-1975-09-30,5R,Advanced economies,
-1975-09-30,AE,United Arab Emirates,
-1975-09-30,AT,Austria,
-1975-09-30,AU,Australia,40.5704
-1975-09-30,BE,Belgium,43.6028
-1975-09-30,BG,Bulgaria,
-1975-09-30,BR,Brazil,
-1975-09-30,CA,Canada,52.2851
-1975-09-30,CH,Switzerland,72.9357
-1975-09-30,CL,Chile,
-1975-09-30,CN,China,
-1975-09-30,CO,Colombia,
-1975-09-30,CY,Cyprus,
-1975-09-30,CZ,Czechia,
-1975-09-30,DE,Germany,126.3972
-1975-09-30,DK,Denmark,65.1211
-1975-09-30,EE,Estonia,
-1975-09-30,ES,Spain,32.4868
+1975-06-30,KR,Korea,65.3154
+1975-06-30,NL,Netherlands,43.2334
+1975-06-30,NO,Norway,33.4978
+1975-06-30,NZ,New Zealand,54.159
+1975-06-30,SE,Sweden,52.5908
+1975-06-30,US,United States,67.2315
+1975-06-30,XM,Euro area,58.8306
+1975-06-30,ZA,South Africa,76.3911
+1975-09-30,AU,Australia,40.4964
+1975-09-30,BE,Belgium,43.9738
+1975-09-30,CA,Canada,52.6905
+1975-09-30,CH,Switzerland,72.9331
+1975-09-30,DE,Germany,126.4602
+1975-09-30,DK,Denmark,65.1251
+1975-09-30,ES,Spain,32.4869
 1975-09-30,FI,Finland,55.0896
-1975-09-30,FR,France,44.5404
-1975-09-30,GB,United Kingdom,28.4886
-1975-09-30,GR,Greece,
-1975-09-30,HK,Hong Kong SAR,
-1975-09-30,HR,Croatia,
-1975-09-30,HU,Hungary,
-1975-09-30,ID,Indonesia,
-1975-09-30,IE,Ireland,39.7722
-1975-09-30,IL,Israel,
-1975-09-30,IN,India,
-1975-09-30,IS,Iceland,
-1975-09-30,IT,Italy,57.5998
+1975-09-30,FR,France,44.5407
+1975-09-30,GB,United Kingdom,28.4791
+1975-09-30,IE,Ireland,39.7915
+1975-09-30,IT,Italy,56.164
 1975-09-30,JP,Japan,117.3649
-1975-09-30,KR,Korea,67.5589
-1975-09-30,LT,Lithuania,
-1975-09-30,LU,Luxembourg,
-1975-09-30,LV,Latvia,
-1975-09-30,MA,Morocco,
-1975-09-30,MK,North Macedonia,
-1975-09-30,MT,Malta,
-1975-09-30,MX,Mexico,
-1975-09-30,MY,Malaysia,
-1975-09-30,NL,Netherlands,42.9191
-1975-09-30,NO,Norway,31.8761
-1975-09-30,NZ,New Zealand,52.9701
-1975-09-30,PE,Peru,
-1975-09-30,PH,Philippines,
-1975-09-30,PL,Poland,
-1975-09-30,PT,Portugal,
-1975-09-30,RO,Romania,
-1975-09-30,RS,Serbia,
-1975-09-30,RU,Russia,
-1975-09-30,SE,Sweden,52.8457
-1975-09-30,SG,Singapore,
-1975-09-30,SI,Slovenia,
-1975-09-30,SK,Slovak Republic,
-1975-09-30,TH,Thailand,
-1975-09-30,TR,Türkiye,
-1975-09-30,US,United States,67.2112
-1975-09-30,XM,Euro area,58.8968
-1975-09-30,XW,World,
-1975-09-30,ZA,South Africa,74.3753
-1975-12-31,4T,Emerging market economies (aggregate),
-1975-12-31,5R,Advanced economies,
-1975-12-31,AE,United Arab Emirates,
-1975-12-31,AT,Austria,
-1975-12-31,AU,Australia,39.5241
-1975-12-31,BE,Belgium,43.9825
-1975-12-31,BG,Bulgaria,
-1975-12-31,BR,Brazil,
-1975-12-31,CA,Canada,53.3406
-1975-12-31,CH,Switzerland,72.1504
-1975-12-31,CL,Chile,
-1975-12-31,CN,China,
-1975-12-31,CO,Colombia,
-1975-12-31,CY,Cyprus,
-1975-12-31,CZ,Czechia,
-1975-12-31,DE,Germany,125.2817
-1975-12-31,DK,Denmark,65.4711
-1975-12-31,EE,Estonia,
-1975-12-31,ES,Spain,32.266
+1975-09-30,KR,Korea,67.5565
+1975-09-30,NL,Netherlands,43.9607
+1975-09-30,NO,Norway,31.9047
+1975-09-30,NZ,New Zealand,52.9702
+1975-09-30,SE,Sweden,52.8282
+1975-09-30,US,United States,67.006
+1975-09-30,XM,Euro area,58.7036
+1975-09-30,ZA,South Africa,74.2297
+1975-12-31,AU,Australia,39.4723
+1975-12-31,BE,Belgium,44.3568
+1975-12-31,CA,Canada,53.7542
+1975-12-31,CH,Switzerland,72.1478
+1975-12-31,DE,Germany,125.1714
+1975-12-31,DK,Denmark,65.4752
+1975-12-31,ES,Spain,32.2661
 1975-12-31,FI,Finland,55.1051
-1975-12-31,FR,France,44.634
-1975-12-31,GB,United Kingdom,27.8298
-1975-12-31,GR,Greece,
-1975-12-31,HK,Hong Kong SAR,
-1975-12-31,HR,Croatia,
-1975-12-31,HU,Hungary,
-1975-12-31,ID,Indonesia,
-1975-12-31,IE,Ireland,40.529
-1975-12-31,IL,Israel,
-1975-12-31,IN,India,
-1975-12-31,IS,Iceland,
-1975-12-31,IT,Italy,58.0394
+1975-12-31,FR,France,44.6343
+1975-12-31,GB,United Kingdom,27.8205
+1975-12-31,IE,Ireland,40.5487
+1975-12-31,IT,Italy,56.5984
 1975-12-31,JP,Japan,114.8641
-1975-12-31,KR,Korea,69.3324
-1975-12-31,LT,Lithuania,
-1975-12-31,LU,Luxembourg,
-1975-12-31,LV,Latvia,
-1975-12-31,MA,Morocco,
-1975-12-31,MK,North Macedonia,
-1975-12-31,MT,Malta,
-1975-12-31,MX,Mexico,
-1975-12-31,MY,Malaysia,
-1975-12-31,NL,Netherlands,44.0831
-1975-12-31,NO,Norway,30.6624
-1975-12-31,NZ,New Zealand,52.0016
-1975-12-31,PE,Peru,
-1975-12-31,PH,Philippines,
-1975-12-31,PL,Poland,
-1975-12-31,PT,Portugal,
-1975-12-31,RO,Romania,
-1975-12-31,RS,Serbia,
-1975-12-31,RU,Russia,
-1975-12-31,SE,Sweden,53.4468
-1975-12-31,SG,Singapore,
-1975-12-31,SI,Slovenia,
-1975-12-31,SK,Slovak Republic,
-1975-12-31,TH,Thailand,
-1975-12-31,TR,Türkiye,
-1975-12-31,US,United States,67.3887
-1975-12-31,XM,Euro area,58.4488
-1975-12-31,XW,World,
-1975-12-31,ZA,South Africa,74.377
-1976-03-31,4T,Emerging market economies (aggregate),
-1976-03-31,5R,Advanced economies,
-1976-03-31,AE,United Arab Emirates,
-1976-03-31,AT,Austria,
-1976-03-31,AU,Australia,39.8648
-1976-03-31,BE,Belgium,47.4474
-1976-03-31,BG,Bulgaria,
-1976-03-31,BR,Brazil,
-1976-03-31,CA,Canada,54.8418
-1976-03-31,CH,Switzerland,70.204
-1976-03-31,CL,Chile,
-1976-03-31,CN,China,
-1976-03-31,CO,Colombia,
-1976-03-31,CY,Cyprus,
-1976-03-31,CZ,Czechia,
-1976-03-31,DE,Germany,123.4513
-1976-03-31,DK,Denmark,65.5795
-1976-03-31,EE,Estonia,
-1976-03-31,ES,Spain,31.7177
+1975-12-31,KR,Korea,69.3299
+1975-12-31,NL,Netherlands,45.1529
+1975-12-31,NO,Norway,30.6758
+1975-12-31,NZ,New Zealand,52.0048
+1975-12-31,SE,Sweden,53.4291
+1975-12-31,US,United States,67.183
+1975-12-31,XM,Euro area,58.2551
+1975-12-31,ZA,South Africa,74.3792
+1976-03-31,AU,Australia,39.971
+1976-03-31,BE,Belgium,47.8512
+1976-03-31,CA,Canada,55.267
+1976-03-31,CH,Switzerland,70.2015
+1976-03-31,DE,Germany,123.3625
+1976-03-31,DK,Denmark,65.5836
+1976-03-31,ES,Spain,31.7178
 1976-03-31,FI,Finland,53.7841
-1976-03-31,FR,France,44.5969
-1976-03-31,GB,United Kingdom,27.5648
-1976-03-31,GR,Greece,
-1976-03-31,HK,Hong Kong SAR,
-1976-03-31,HR,Croatia,
-1976-03-31,HU,Hungary,
-1976-03-31,ID,Indonesia,
-1976-03-31,IE,Ireland,39.6147
-1976-03-31,IL,Israel,
-1976-03-31,IN,India,
-1976-03-31,IS,Iceland,
-1976-03-31,IT,Italy,57.8811
+1976-03-31,FR,France,44.5973
+1976-03-31,GB,United Kingdom,27.5557
+1976-03-31,IE,Ireland,39.634
+1976-03-31,IT,Italy,56.4225
 1976-03-31,JP,Japan,112.7556
-1976-03-31,KR,Korea,69.9437
-1976-03-31,LT,Lithuania,
-1976-03-31,LU,Luxembourg,
-1976-03-31,LV,Latvia,
-1976-03-31,MA,Morocco,
-1976-03-31,MK,North Macedonia,
-1976-03-31,MT,Malta,
-1976-03-31,MX,Mexico,
-1976-03-31,MY,Malaysia,
-1976-03-31,NL,Netherlands,45.4335
-1976-03-31,NO,Norway,28.7521
-1976-03-31,NZ,New Zealand,50.8961
-1976-03-31,PE,Peru,
-1976-03-31,PH,Philippines,
-1976-03-31,PL,Poland,
-1976-03-31,PT,Portugal,
-1976-03-31,RO,Romania,
-1976-03-31,RS,Serbia,
-1976-03-31,RU,Russia,
-1976-03-31,SE,Sweden,53.7035
-1976-03-31,SG,Singapore,
-1976-03-31,SI,Slovenia,
-1976-03-31,SK,Slovak Republic,
-1976-03-31,TH,Thailand,
-1976-03-31,TR,Türkiye,
-1976-03-31,US,United States,65.0036
-1976-03-31,XM,Euro area,58.2154
-1976-03-31,XW,World,
-1976-03-31,ZA,South Africa,74.3384
-1976-06-30,4T,Emerging market economies (aggregate),
-1976-06-30,5R,Advanced economies,
-1976-06-30,AE,United Arab Emirates,
-1976-06-30,AT,Austria,
-1976-06-30,AU,Australia,39.8785
-1976-06-30,BE,Belgium,47.5271
-1976-06-30,BG,Bulgaria,
-1976-06-30,BR,Brazil,
-1976-06-30,CA,Canada,54.6851
-1976-06-30,CH,Switzerland,70.7213
-1976-06-30,CL,Chile,
-1976-06-30,CN,China,
-1976-06-30,CO,Colombia,
-1976-06-30,CY,Cyprus,
-1976-06-30,CZ,Czechia,
-1976-06-30,DE,Germany,123.8931
-1976-06-30,DK,Denmark,63.7689
-1976-06-30,EE,Estonia,
-1976-06-30,ES,Spain,32.7191
+1976-03-31,KR,Korea,69.9412
+1976-03-31,NL,Netherlands,46.5362
+1976-03-31,NO,Norway,28.7099
+1976-03-31,NZ,New Zealand,50.902
+1976-03-31,SE,Sweden,53.6857
+1976-03-31,US,United States,64.7459
+1976-03-31,XM,Euro area,58.0139
+1976-03-31,ZA,South Africa,74.2431
+1976-06-30,AU,Australia,39.8772
+1976-06-30,BE,Belgium,47.9316
+1976-06-30,CA,Canada,55.1091
+1976-06-30,CH,Switzerland,70.7187
+1976-06-30,DE,Germany,124.0076
+1976-06-30,DK,Denmark,63.7729
+1976-06-30,ES,Spain,32.7192
 1976-06-30,FI,Finland,52.2779
-1976-06-30,FR,France,45.8811
-1976-06-30,GB,United Kingdom,27.4069
-1976-06-30,GR,Greece,
-1976-06-30,HK,Hong Kong SAR,
-1976-06-30,HR,Croatia,
-1976-06-30,HU,Hungary,
-1976-06-30,ID,Indonesia,
-1976-06-30,IE,Ireland,37.7005
-1976-06-30,IL,Israel,
-1976-06-30,IN,India,
-1976-06-30,IS,Iceland,
-1976-06-30,IT,Italy,56.7436
+1976-06-30,FR,France,45.8814
+1976-06-30,GB,United Kingdom,27.3978
+1976-06-30,IE,Ireland,37.7188
+1976-06-30,IT,Italy,55.3195
 1976-06-30,JP,Japan,110.3193
-1976-06-30,KR,Korea,71.2605
-1976-06-30,LT,Lithuania,
-1976-06-30,LU,Luxembourg,
-1976-06-30,LV,Latvia,
-1976-06-30,MA,Morocco,
-1976-06-30,MK,North Macedonia,
-1976-06-30,MT,Malta,
-1976-06-30,MX,Mexico,
-1976-06-30,MY,Malaysia,
-1976-06-30,NL,Netherlands,48.8543
-1976-06-30,NO,Norway,31.4077
-1976-06-30,NZ,New Zealand,49.6717
-1976-06-30,PE,Peru,
-1976-06-30,PH,Philippines,
-1976-06-30,PL,Poland,
-1976-06-30,PT,Portugal,
-1976-06-30,RO,Romania,
-1976-06-30,RS,Serbia,
-1976-06-30,RU,Russia,
-1976-06-30,SE,Sweden,55.22
-1976-06-30,SG,Singapore,
-1976-06-30,SI,Slovenia,
-1976-06-30,SK,Slovak Republic,
-1976-06-30,TH,Thailand,
-1976-06-30,TR,Türkiye,
-1976-06-30,US,United States,66.1857
-1976-06-30,XM,Euro area,59.5405
-1976-06-30,XW,World,
-1976-06-30,ZA,South Africa,73.4206
-1976-09-30,4T,Emerging market economies (aggregate),
-1976-09-30,5R,Advanced economies,
-1976-09-30,AE,United Arab Emirates,
-1976-09-30,AT,Austria,
-1976-09-30,AU,Australia,38.9466
-1976-09-30,BE,Belgium,48.6839
-1976-09-30,BG,Bulgaria,
-1976-09-30,BR,Brazil,
-1976-09-30,CA,Canada,53.972
-1976-09-30,CH,Switzerland,69.6739
-1976-09-30,CL,Chile,
-1976-09-30,CN,China,
-1976-09-30,CO,Colombia,
-1976-09-30,CY,Cyprus,
-1976-09-30,CZ,Czechia,
-1976-09-30,DE,Germany,124.4358
-1976-09-30,DK,Denmark,64.0584
-1976-09-30,EE,Estonia,
-1976-09-30,ES,Spain,33.4078
+1976-06-30,KR,Korea,71.258
+1976-06-30,NL,Netherlands,50.0399
+1976-06-30,NO,Norway,31.4366
+1976-06-30,NZ,New Zealand,49.6648
+1976-06-30,SE,Sweden,55.2017
+1976-06-30,US,United States,66.0186
+1976-06-30,XM,Euro area,59.3546
+1976-06-30,ZA,South Africa,73.2815
+1976-09-30,AU,Australia,38.8458
+1976-09-30,BE,Belgium,49.0982
+1976-09-30,CA,Canada,54.3905
+1976-09-30,CH,Switzerland,69.6713
+1976-09-30,DE,Germany,124.3268
+1976-09-30,DK,Denmark,64.0624
+1976-09-30,ES,Spain,33.4079
 1976-09-30,FI,Finland,51.8481
-1976-09-30,FR,France,47.4708
-1976-09-30,GB,United Kingdom,27.3075
-1976-09-30,GR,Greece,
-1976-09-30,HK,Hong Kong SAR,
-1976-09-30,HR,Croatia,
-1976-09-30,HU,Hungary,
-1976-09-30,ID,Indonesia,
-1976-09-30,IE,Ireland,39.1888
-1976-09-30,IL,Israel,
-1976-09-30,IN,India,
-1976-09-30,IS,Iceland,
-1976-09-30,IT,Italy,57.7297
+1976-09-30,FR,France,47.4711
+1976-09-30,GB,United Kingdom,27.2985
+1976-09-30,IE,Ireland,39.2078
+1976-09-30,IT,Italy,56.2967
 1976-09-30,JP,Japan,109.8089
-1976-09-30,KR,Korea,74.1905
-1976-09-30,LT,Lithuania,
-1976-09-30,LU,Luxembourg,
-1976-09-30,LV,Latvia,
-1976-09-30,MA,Morocco,
-1976-09-30,MK,North Macedonia,
-1976-09-30,MT,Malta,
-1976-09-30,MX,Mexico,
-1976-09-30,MY,Malaysia,
-1976-09-30,NL,Netherlands,51.6514
-1976-09-30,NO,Norway,30.925
-1976-09-30,NZ,New Zealand,48.6364
-1976-09-30,PE,Peru,
-1976-09-30,PH,Philippines,
-1976-09-30,PL,Poland,
-1976-09-30,PT,Portugal,
-1976-09-30,RO,Romania,
-1976-09-30,RS,Serbia,
-1976-09-30,RU,Russia,
-1976-09-30,SE,Sweden,57.5091
-1976-09-30,SG,Singapore,
-1976-09-30,SI,Slovenia,
-1976-09-30,SK,Slovak Republic,
-1976-09-30,TH,Thailand,
-1976-09-30,TR,Türkiye,
-1976-09-30,US,United States,66.8197
-1976-09-30,XM,Euro area,60.6492
-1976-09-30,XW,World,
-1976-09-30,ZA,South Africa,71.2157
-1976-12-31,4T,Emerging market economies (aggregate),
-1976-12-31,5R,Advanced economies,
-1976-12-31,AE,United Arab Emirates,
-1976-12-31,AT,Austria,
-1976-12-31,AU,Australia,37.9084
-1976-12-31,BE,Belgium,49.4473
-1976-12-31,BG,Bulgaria,
-1976-12-31,BR,Brazil,
-1976-12-31,CA,Canada,55.2199
-1976-12-31,CH,Switzerland,71.5161
-1976-12-31,CL,Chile,
-1976-12-31,CN,China,
-1976-12-31,CO,Colombia,
-1976-12-31,CY,Cyprus,
-1976-12-31,CZ,Czechia,
-1976-12-31,DE,Germany,125.3169
-1976-12-31,DK,Denmark,64.2513
-1976-12-31,EE,Estonia,
-1976-12-31,ES,Spain,33.0873
+1976-09-30,KR,Korea,74.1879
+1976-09-30,NL,Netherlands,52.9049
+1976-09-30,NO,Norway,30.9821
+1976-09-30,NZ,New Zealand,48.6454
+1976-09-30,SE,Sweden,57.4901
+1976-09-30,US,United States,66.6259
+1976-09-30,XM,Euro area,60.4599
+1976-09-30,ZA,South Africa,71.1685
+1976-12-31,AU,Australia,37.883
+1976-12-31,BE,Belgium,49.8681
+1976-12-31,CA,Canada,55.6481
+1976-12-31,CH,Switzerland,71.5135
+1976-12-31,DE,Germany,125.399
+1976-12-31,DK,Denmark,64.2553
+1976-12-31,ES,Spain,33.0874
 1976-12-31,FI,Finland,51.1231
-1976-12-31,FR,France,47.4095
-1976-12-31,GB,United Kingdom,26.6519
-1976-12-31,GR,Greece,
-1976-12-31,HK,Hong Kong SAR,
-1976-12-31,HR,Croatia,
-1976-12-31,HU,Hungary,
-1976-12-31,ID,Indonesia,
-1976-12-31,IE,Ireland,41.4384
-1976-12-31,IL,Israel,
-1976-12-31,IN,India,
-1976-12-31,IS,Iceland,
-1976-12-31,IT,Italy,56.375
+1976-12-31,FR,France,47.4099
+1976-12-31,GB,United Kingdom,26.6431
+1976-12-31,IE,Ireland,41.4585
+1976-12-31,IT,Italy,54.9746
 1976-12-31,JP,Japan,108.3847
-1976-12-31,KR,Korea,76.5843
-1976-12-31,LT,Lithuania,
-1976-12-31,LU,Luxembourg,
-1976-12-31,LV,Latvia,
-1976-12-31,MA,Morocco,
-1976-12-31,MK,North Macedonia,
-1976-12-31,MT,Malta,
-1976-12-31,MX,Mexico,
-1976-12-31,MY,Malaysia,
-1976-12-31,NL,Netherlands,54.1913
-1976-12-31,NO,Norway,30.4435
-1976-12-31,NZ,New Zealand,48.1148
-1976-12-31,PE,Peru,
-1976-12-31,PH,Philippines,
-1976-12-31,PL,Poland,
-1976-12-31,PT,Portugal,
-1976-12-31,RO,Romania,
-1976-12-31,RS,Serbia,
-1976-12-31,RU,Russia,
-1976-12-31,SE,Sweden,56.2223
-1976-12-31,SG,Singapore,
-1976-12-31,SI,Slovenia,
-1976-12-31,SK,Slovak Republic,
-1976-12-31,TH,Thailand,
-1976-12-31,TR,Türkiye,
-1976-12-31,US,United States,68.7366
-1976-12-31,XM,Euro area,60.3173
-1976-12-31,XW,World,
-1976-12-31,ZA,South Africa,70.009
-1977-03-31,4T,Emerging market economies (aggregate),
-1977-03-31,5R,Advanced economies,
-1977-03-31,AE,United Arab Emirates,
-1977-03-31,AT,Austria,
-1977-03-31,AU,Australia,38.1009
-1977-03-31,BE,Belgium,50.7495
-1977-03-31,BG,Bulgaria,
-1977-03-31,BR,Brazil,
-1977-03-31,CA,Canada,54.5717
-1977-03-31,CH,Switzerland,71.2066
-1977-03-31,CL,Chile,
-1977-03-31,CN,China,
-1977-03-31,CO,Colombia,
-1977-03-31,CY,Cyprus,
-1977-03-31,CZ,Czechia,
-1977-03-31,DE,Germany,124.4579
-1977-03-31,DK,Denmark,63.7934
-1977-03-31,EE,Estonia,
+1976-12-31,KR,Korea,76.5815
+1976-12-31,NL,Netherlands,55.5065
+1976-12-31,NO,Norway,30.4456
+1976-12-31,NZ,New Zealand,48.1255
+1976-12-31,SE,Sweden,56.2036
+1976-12-31,US,United States,68.5393
+1976-12-31,XM,Euro area,60.116
+1976-12-31,ZA,South Africa,69.9001
+1977-03-31,AU,Australia,37.9861
+1977-03-31,BE,Belgium,51.1814
+1977-03-31,CA,Canada,54.9948
+1977-03-31,CH,Switzerland,71.2041
+1977-03-31,DE,Germany,124.2698
+1977-03-31,DK,Denmark,63.7974
 1977-03-31,ES,Spain,34.3157
 1977-03-31,FI,Finland,49.1418
-1977-03-31,FR,France,47.5637
-1977-03-31,GB,United Kingdom,25.5079
-1977-03-31,GR,Greece,
-1977-03-31,HK,Hong Kong SAR,
-1977-03-31,HR,Croatia,
-1977-03-31,HU,Hungary,
-1977-03-31,ID,Indonesia,
-1977-03-31,IE,Ireland,39.5033
-1977-03-31,IL,Israel,
-1977-03-31,IN,India,
-1977-03-31,IS,Iceland,
-1977-03-31,IT,Italy,55.035
+1977-03-31,FR,France,47.5641
+1977-03-31,GB,United Kingdom,25.4994
+1977-03-31,IE,Ireland,39.5224
+1977-03-31,IT,Italy,54.293
 1977-03-31,JP,Japan,107.142
-1977-03-31,KR,Korea,80.4608
-1977-03-31,LT,Lithuania,
-1977-03-31,LU,Luxembourg,
-1977-03-31,LV,Latvia,
-1977-03-31,MA,Morocco,
-1977-03-31,MK,North Macedonia,
-1977-03-31,MT,Malta,
-1977-03-31,MX,Mexico,
-1977-03-31,MY,Malaysia,
-1977-03-31,NL,Netherlands,59.8305
-1977-03-31,NO,Norway,33.3571
-1977-03-31,NZ,New Zealand,47.9566
-1977-03-31,PE,Peru,
-1977-03-31,PH,Philippines,
-1977-03-31,PL,Poland,
-1977-03-31,PT,Portugal,
-1977-03-31,RO,Romania,
-1977-03-31,RS,Serbia,
-1977-03-31,RU,Russia,
-1977-03-31,SE,Sweden,56.9409
-1977-03-31,SG,Singapore,
-1977-03-31,SI,Slovenia,
-1977-03-31,SK,Slovak Republic,
-1977-03-31,TH,Thailand,
-1977-03-31,TR,Türkiye,
-1977-03-31,US,United States,70.3613
-1977-03-31,XM,Euro area,60.0263
-1977-03-31,XW,World,
-1977-03-31,ZA,South Africa,68.3428
-1977-06-30,4T,Emerging market economies (aggregate),
-1977-06-30,5R,Advanced economies,
-1977-06-30,AE,United Arab Emirates,
-1977-06-30,AT,Austria,
-1977-06-30,AU,Australia,38.0344
-1977-06-30,BE,Belgium,51.4572
-1977-06-30,BG,Bulgaria,
-1977-06-30,BR,Brazil,
-1977-06-30,CA,Canada,53.3954
-1977-06-30,CH,Switzerland,71.7372
-1977-06-30,CL,Chile,
-1977-06-30,CN,China,
-1977-06-30,CO,Colombia,
-1977-06-30,CY,Cyprus,
-1977-06-30,CZ,Czechia,
-1977-06-30,DE,Germany,125.7061
-1977-06-30,DK,Denmark,65.7213
-1977-06-30,EE,Estonia,
-1977-06-30,ES,Spain,35.9545
+1977-03-31,KR,Korea,80.458
+1977-03-31,NL,Netherlands,61.2825
+1977-03-31,NO,Norway,33.3763
+1977-03-31,NZ,New Zealand,47.9561
+1977-03-31,SE,Sweden,56.922
+1977-03-31,US,United States,70.1885
+1977-03-31,XM,Euro area,59.8436
+1977-03-31,ZA,South Africa,68.2158
+1977-06-30,AU,Australia,38.0235
+1977-06-30,BE,Belgium,51.8951
+1977-06-30,CA,Canada,53.8094
+1977-06-30,CH,Switzerland,71.7346
+1977-06-30,DE,Germany,125.884
+1977-06-30,DK,Denmark,65.7253
+1977-06-30,ES,Spain,35.9546
 1977-06-30,FI,Finland,48.6213
-1977-06-30,FR,France,48.217
-1977-06-30,GB,United Kingdom,24.9473
-1977-06-30,GR,Greece,
-1977-06-30,HK,Hong Kong SAR,
-1977-06-30,HR,Croatia,
-1977-06-30,HU,Hungary,
-1977-06-30,ID,Indonesia,
-1977-06-30,IE,Ireland,39.4061
-1977-06-30,IL,Israel,
-1977-06-30,IN,India,
-1977-06-30,IS,Iceland,
-1977-06-30,IT,Italy,53.9297
+1977-06-30,FR,France,48.2174
+1977-06-30,GB,United Kingdom,24.939
+1977-06-30,IE,Ireland,39.4252
+1977-06-30,IT,Italy,53.1922
 1977-06-30,JP,Japan,105.4571
-1977-06-30,KR,Korea,83.9824
-1977-06-30,LT,Lithuania,
-1977-06-30,LU,Luxembourg,
-1977-06-30,LV,Latvia,
-1977-06-30,MA,Morocco,
-1977-06-30,MK,North Macedonia,
-1977-06-30,MT,Malta,
-1977-06-30,MX,Mexico,
-1977-06-30,MY,Malaysia,
-1977-06-30,NL,Netherlands,66.6797
-1977-06-30,NO,Norway,33.9904
-1977-06-30,NZ,New Zealand,46.7761
-1977-06-30,PE,Peru,
-1977-06-30,PH,Philippines,
-1977-06-30,PL,Poland,
-1977-06-30,PT,Portugal,
-1977-06-30,RO,Romania,
-1977-06-30,RS,Serbia,
-1977-06-30,RU,Russia,
-1977-06-30,SE,Sweden,58.0654
-1977-06-30,SG,Singapore,
-1977-06-30,SI,Slovenia,
-1977-06-30,SK,Slovak Republic,
-1977-06-30,TH,Thailand,
-1977-06-30,TR,Türkiye,
-1977-06-30,US,United States,72.0414
-1977-06-30,XM,Euro area,60.797
-1977-06-30,XW,World,
-1977-06-30,ZA,South Africa,66.8401
-1977-09-30,4T,Emerging market economies (aggregate),
-1977-09-30,5R,Advanced economies,
-1977-09-30,AE,United Arab Emirates,
-1977-09-30,AT,Austria,
-1977-09-30,AU,Australia,37.4115
-1977-09-30,BE,Belgium,52.85
-1977-09-30,BG,Bulgaria,
-1977-09-30,BR,Brazil,
-1977-09-30,CA,Canada,52.1106
-1977-09-30,CH,Switzerland,72.9068
-1977-09-30,CL,Chile,
-1977-09-30,CN,China,
-1977-09-30,CO,Colombia,
-1977-09-30,CY,Cyprus,
-1977-09-30,CZ,Czechia,
-1977-09-30,DE,Germany,127.2199
-1977-09-30,DK,Denmark,66.5369
-1977-09-30,EE,Estonia,
-1977-09-30,ES,Spain,35.8957
+1977-06-30,KR,Korea,83.9794
+1977-06-30,NL,Netherlands,68.2979
+1977-06-30,NO,Norway,33.9453
+1977-06-30,NZ,New Zealand,46.7652
+1977-06-30,SE,Sweden,58.0461
+1977-06-30,US,United States,71.8871
+1977-06-30,XM,Euro area,60.6227
+1977-06-30,ZA,South Africa,66.7565
+1977-09-30,AU,Australia,37.4213
+1977-09-30,BE,Belgium,53.2998
+1977-09-30,CA,Canada,52.5147
+1977-09-30,CH,Switzerland,72.9041
+1977-09-30,DE,Germany,127.3566
+1977-09-30,DK,Denmark,66.541
+1977-09-30,ES,Spain,35.8958
 1977-09-30,FI,Finland,46.8637
-1977-09-30,FR,France,49.5936
-1977-09-30,GB,United Kingdom,25.1914
-1977-09-30,GR,Greece,
-1977-09-30,HK,Hong Kong SAR,
-1977-09-30,HR,Croatia,
-1977-09-30,HU,Hungary,
-1977-09-30,ID,Indonesia,
-1977-09-30,IE,Ireland,43.1648
-1977-09-30,IL,Israel,
-1977-09-30,IN,India,
-1977-09-30,IS,Iceland,
-1977-09-30,IT,Italy,53.4492
+1977-09-30,FR,France,49.594
+1977-09-30,GB,United Kingdom,25.1831
+1977-09-30,IE,Ireland,43.1858
+1977-09-30,IT,Italy,52.7026
 1977-09-30,JP,Japan,106.1726
-1977-09-30,KR,Korea,90.4049
-1977-09-30,LT,Lithuania,
-1977-09-30,LU,Luxembourg,
-1977-09-30,LV,Latvia,
-1977-09-30,MA,Morocco,
-1977-09-30,MK,North Macedonia,
-1977-09-30,MT,Malta,
-1977-09-30,MX,Mexico,
-1977-09-30,MY,Malaysia,
-1977-09-30,NL,Netherlands,66.8153
-1977-09-30,NO,Norway,33.5086
-1977-09-30,NZ,New Zealand,45.4274
-1977-09-30,PE,Peru,
-1977-09-30,PH,Philippines,
-1977-09-30,PL,Poland,
-1977-09-30,PT,Portugal,
-1977-09-30,RO,Romania,
-1977-09-30,RS,Serbia,
-1977-09-30,RU,Russia,
-1977-09-30,SE,Sweden,57.7231
-1977-09-30,SG,Singapore,
-1977-09-30,SI,Slovenia,
-1977-09-30,SK,Slovak Republic,
-1977-09-30,TH,Thailand,
-1977-09-30,TR,Türkiye,
-1977-09-30,US,United States,73.5357
-1977-09-30,XM,Euro area,61.6584
-1977-09-30,XW,World,
-1977-09-30,ZA,South Africa,65.4762
-1977-12-31,4T,Emerging market economies (aggregate),
-1977-12-31,5R,Advanced economies,
-1977-12-31,AE,United Arab Emirates,
-1977-12-31,AT,Austria,
-1977-12-31,AU,Australia,37.1898
-1977-12-31,BE,Belgium,54.8405
-1977-12-31,BG,Bulgaria,
-1977-12-31,BR,Brazil,
-1977-12-31,CA,Canada,52.5135
-1977-12-31,CH,Switzerland,72.4989
-1977-12-31,CL,Chile,
-1977-12-31,CN,China,
-1977-12-31,CO,Colombia,
-1977-12-31,CY,Cyprus,
-1977-12-31,CZ,Czechia,
-1977-12-31,DE,Germany,128.4225
-1977-12-31,DK,Denmark,66.5465
-1977-12-31,EE,Estonia,
+1977-09-30,KR,Korea,90.4017
+1977-09-30,NL,Netherlands,68.4368
+1977-09-30,NO,Norway,33.5721
+1977-09-30,NZ,New Zealand,45.4302
+1977-09-30,SE,Sweden,57.704
+1977-09-30,US,United States,73.4093
+1977-09-30,XM,Euro area,61.4729
+1977-09-30,ZA,South Africa,65.3033
+1977-12-31,AU,Australia,37.2177
+1977-12-31,BE,Belgium,55.3072
+1977-12-31,CA,Canada,52.9206
+1977-12-31,CH,Switzerland,72.4963
+1977-12-31,DE,Germany,128.2921
+1977-12-31,DK,Denmark,66.5506
 1977-12-31,ES,Spain,37.4663
 1977-12-31,FI,Finland,46.1509
-1977-12-31,FR,France,49.6723
-1977-12-31,GB,United Kingdom,25.761
-1977-12-31,GR,Greece,
-1977-12-31,HK,Hong Kong SAR,
-1977-12-31,HR,Croatia,
-1977-12-31,HU,Hungary,
-1977-12-31,ID,Indonesia,
-1977-12-31,IE,Ireland,43.7519
-1977-12-31,IL,Israel,
-1977-12-31,IN,India,
-1977-12-31,IS,Iceland,
-1977-12-31,IT,Italy,52.5778
+1977-12-31,FR,France,49.6726
+1977-12-31,GB,United Kingdom,25.7525
+1977-12-31,IE,Ireland,43.7731
+1977-12-31,IT,Italy,51.8586
 1977-12-31,JP,Japan,106.4602
-1977-12-31,KR,Korea,98.8078
-1977-12-31,LT,Lithuania,
-1977-12-31,LU,Luxembourg,
-1977-12-31,LV,Latvia,
-1977-12-31,MA,Morocco,
-1977-12-31,MK,North Macedonia,
-1977-12-31,MT,Malta,
-1977-12-31,MX,Mexico,
-1977-12-31,MY,Malaysia,
-1977-12-31,NL,Netherlands,67.3089
-1977-12-31,NO,Norway,32.9499
-1977-12-31,NZ,New Zealand,43.7939
-1977-12-31,PE,Peru,
-1977-12-31,PH,Philippines,
-1977-12-31,PL,Poland,
-1977-12-31,PT,Portugal,
-1977-12-31,RO,Romania,
-1977-12-31,RS,Serbia,
-1977-12-31,RU,Russia,
-1977-12-31,SE,Sweden,57.939
-1977-12-31,SG,Singapore,
-1977-12-31,SI,Slovenia,
-1977-12-31,SK,Slovak Republic,
-1977-12-31,TH,Thailand,
-1977-12-31,TR,Türkiye,
-1977-12-31,US,United States,74.7931
-1977-12-31,XM,Euro area,62.0939
-1977-12-31,XW,World,
-1977-12-31,ZA,South Africa,64.3723
-1978-03-31,4T,Emerging market economies (aggregate),
-1978-03-31,5R,Advanced economies,
-1978-03-31,AE,United Arab Emirates,
-1978-03-31,AT,Austria,
-1978-03-31,AU,Australia,37.6411
-1978-03-31,BE,Belgium,54.8736
-1978-03-31,BG,Bulgaria,
-1978-03-31,BR,Brazil,
-1978-03-31,CA,Canada,51.2969
-1978-03-31,CH,Switzerland,71.5673
-1978-03-31,CL,Chile,
-1978-03-31,CN,China,
-1978-03-31,CO,Colombia,
-1978-03-31,CY,Cyprus,
-1978-03-31,CZ,Czechia,
-1978-03-31,DE,Germany,129.0396
-1978-03-31,DK,Denmark,67.9667
-1978-03-31,EE,Estonia,
-1978-03-31,ES,Spain,39.3396
+1977-12-31,KR,Korea,98.8042
+1977-12-31,NL,Netherlands,68.9423
+1977-12-31,NO,Norway,32.9232
+1977-12-31,NZ,New Zealand,43.7843
+1977-12-31,SE,Sweden,57.9198
+1977-12-31,US,United States,74.6658
+1977-12-31,XM,Euro area,61.9146
+1977-12-31,ZA,South Africa,64.3765
+1978-03-31,AU,Australia,37.69
+1978-03-31,BE,Belgium,55.3406
+1978-03-31,CA,Canada,51.6946
+1978-03-31,CH,Switzerland,71.5646
+1978-03-31,DE,Germany,129.0026
+1978-03-31,DK,Denmark,67.971
+1978-03-31,ES,Spain,39.3397
 1978-03-31,FI,Finland,46.6659
-1978-03-31,FR,France,49.3925
-1978-03-31,GB,United Kingdom,25.8738
-1978-03-31,GR,Greece,
-1978-03-31,HK,Hong Kong SAR,
-1978-03-31,HR,Croatia,
-1978-03-31,HU,Hungary,
-1978-03-31,ID,Indonesia,
-1978-03-31,IE,Ireland,47.6532
-1978-03-31,IL,Israel,
-1978-03-31,IN,India,
-1978-03-31,IS,Iceland,
-1978-03-31,IT,Italy,52.6496
+1978-03-31,FR,France,49.3929
+1978-03-31,GB,United Kingdom,25.8652
+1978-03-31,IE,Ireland,47.6764
+1978-03-31,IT,Italy,51.9486
 1978-03-31,JP,Japan,107.1862
-1978-03-31,KR,Korea,107.811
-1978-03-31,LT,Lithuania,
-1978-03-31,LU,Luxembourg,
-1978-03-31,LV,Latvia,
-1978-03-31,MA,Morocco,
-1978-03-31,MK,North Macedonia,
-1978-03-31,MT,Malta,
-1978-03-31,MX,Mexico,
-1978-03-31,MY,Malaysia,
-1978-03-31,NL,Netherlands,68.7813
-1978-03-31,NO,Norway,34.3305
-1978-03-31,NZ,New Zealand,43.0071
-1978-03-31,PE,Peru,
-1978-03-31,PH,Philippines,
-1978-03-31,PL,Poland,
-1978-03-31,PT,Portugal,
-1978-03-31,RO,Romania,
-1978-03-31,RS,Serbia,
-1978-03-31,RU,Russia,
-1978-03-31,SE,Sweden,56.4288
-1978-03-31,SG,Singapore,
-1978-03-31,SI,Slovenia,
-1978-03-31,SK,Slovak Republic,
-1978-03-31,TH,Thailand,
-1978-03-31,TR,Türkiye,
-1978-03-31,US,United States,76.6825
-1978-03-31,XM,Euro area,62.6494
-1978-03-31,XW,World,
-1978-03-31,ZA,South Africa,63.7938
-1978-06-30,4T,Emerging market economies (aggregate),
-1978-06-30,5R,Advanced economies,
-1978-06-30,AE,United Arab Emirates,
-1978-06-30,AT,Austria,
-1978-06-30,AU,Australia,36.8346
-1978-06-30,BE,Belgium,55.3548
-1978-06-30,BG,Bulgaria,
-1978-06-30,BR,Brazil,
-1978-06-30,CA,Canada,51.5822
-1978-06-30,CH,Switzerland,73.0355
-1978-06-30,CL,Chile,
-1978-06-30,CN,China,
-1978-06-30,CO,Colombia,
-1978-06-30,CY,Cyprus,
-1978-06-30,CZ,Czechia,
-1978-06-30,DE,Germany,130.7871
-1978-06-30,DK,Denmark,69.5277
-1978-06-30,EE,Estonia,
-1978-06-30,ES,Spain,40.5793
+1978-03-31,KR,Korea,107.8071
+1978-03-31,NL,Netherlands,70.4504
+1978-03-31,NO,Norway,34.272
+1978-03-31,NZ,New Zealand,43.0097
+1978-03-31,SE,Sweden,56.41
+1978-03-31,US,United States,76.554
+1978-03-31,XM,Euro area,62.4647
+1978-03-31,ZA,South Africa,63.7113
+1978-06-30,AU,Australia,36.8026
+1978-06-30,BE,Belgium,55.8259
+1978-06-30,CA,Canada,51.9821
+1978-06-30,CH,Switzerland,73.0328
+1978-06-30,DE,Germany,130.9272
+1978-06-30,DK,Denmark,69.532
+1978-06-30,ES,Spain,40.5794
 1978-06-30,FI,Finland,46.5376
-1978-06-30,FR,France,49.5785
-1978-06-30,GB,United Kingdom,26.522
-1978-06-30,GR,Greece,
-1978-06-30,HK,Hong Kong SAR,
-1978-06-30,HR,Croatia,
-1978-06-30,HU,Hungary,
-1978-06-30,ID,Indonesia,
-1978-06-30,IE,Ireland,49.5811
-1978-06-30,IL,Israel,
-1978-06-30,IN,India,
-1978-06-30,IS,Iceland,
-1978-06-30,IT,Italy,53.9679
+1978-06-30,FR,France,49.5789
+1978-06-30,GB,United Kingdom,26.5132
+1978-06-30,IE,Ireland,49.6052
+1978-06-30,IT,Italy,53.2558
 1978-06-30,JP,Japan,106.7344
-1978-06-30,KR,Korea,115.6597
-1978-06-30,LT,Lithuania,
-1978-06-30,LU,Luxembourg,
-1978-06-30,LV,Latvia,
-1978-06-30,MA,Morocco,
-1978-06-30,MK,North Macedonia,
-1978-06-30,MT,Malta,
-1978-06-30,MX,Mexico,
-1978-06-30,MY,Malaysia,
-1978-06-30,NL,Netherlands,71.7671
-1978-06-30,NO,Norway,34.5741
-1978-06-30,NZ,New Zealand,42.1539
-1978-06-30,PE,Peru,
-1978-06-30,PH,Philippines,
-1978-06-30,PL,Poland,
-1978-06-30,PT,Portugal,
-1978-06-30,RO,Romania,
-1978-06-30,RS,Serbia,
-1978-06-30,RU,Russia,
-1978-06-30,SE,Sweden,59.2043
-1978-06-30,SG,Singapore,
-1978-06-30,SI,Slovenia,
-1978-06-30,SK,Slovak Republic,
-1978-06-30,TH,Thailand,
-1978-06-30,TR,Türkiye,
-1978-06-30,US,United States,77.3156
-1978-06-30,XM,Euro area,63.2082
-1978-06-30,XW,World,
-1978-06-30,ZA,South Africa,62.5542
-1978-09-30,4T,Emerging market economies (aggregate),
-1978-09-30,5R,Advanced economies,
-1978-09-30,AE,United Arab Emirates,
-1978-09-30,AT,Austria,
-1978-09-30,AU,Australia,36.3476
-1978-09-30,BE,Belgium,57.1256
-1978-09-30,BG,Bulgaria,
-1978-09-30,BR,Brazil,
-1978-09-30,CA,Canada,50.2471
-1978-09-30,CH,Switzerland,74.2036
-1978-09-30,CL,Chile,
-1978-09-30,CN,China,
-1978-09-30,CO,Colombia,
-1978-09-30,CY,Cyprus,
-1978-09-30,CZ,Czechia,
-1978-09-30,DE,Germany,133.4952
-1978-09-30,DK,Denmark,70.429
-1978-09-30,EE,Estonia,
-1978-09-30,ES,Spain,40.097
+1978-06-30,KR,Korea,115.6555
+1978-06-30,NL,Netherlands,73.5088
+1978-06-30,NO,Norway,34.6271
+1978-06-30,NZ,New Zealand,42.1455
+1978-06-30,SE,Sweden,59.1847
+1978-06-30,US,United States,77.1973
+1978-06-30,XM,Euro area,63.0233
+1978-06-30,ZA,South Africa,62.3785
+1978-09-30,AU,Australia,36.335
+1978-09-30,BE,Belgium,57.6118
+1978-09-30,CA,Canada,50.6367
+1978-09-30,CH,Switzerland,74.2009
+1978-09-30,DE,Germany,133.4959
+1978-09-30,DK,Denmark,70.4334
+1978-09-30,ES,Spain,40.0971
 1978-09-30,FI,Finland,45.243
-1978-09-30,FR,France,50.3032
-1978-09-30,GB,United Kingdom,27.8133
-1978-09-30,GR,Greece,
-1978-09-30,HK,Hong Kong SAR,
-1978-09-30,HR,Croatia,
-1978-09-30,HU,Hungary,
-1978-09-30,ID,Indonesia,
-1978-09-30,IE,Ireland,51.5007
-1978-09-30,IL,Israel,
-1978-09-30,IN,India,
-1978-09-30,IS,Iceland,
-1978-09-30,IT,Italy,56.0487
+1978-09-30,FR,France,50.3036
+1978-09-30,GB,United Kingdom,27.8041
+1978-09-30,IE,Ireland,51.5257
+1978-09-30,IT,Italy,55.2933
 1978-09-30,JP,Japan,107.6625
-1978-09-30,KR,Korea,119.1321
-1978-09-30,LT,Lithuania,
-1978-09-30,LU,Luxembourg,
-1978-09-30,LV,Latvia,
-1978-09-30,MA,Morocco,
-1978-09-30,MK,North Macedonia,
-1978-09-30,MT,Malta,
-1978-09-30,MX,Mexico,
-1978-09-30,MY,Malaysia,
-1978-09-30,NL,Netherlands,65.7605
-1978-09-30,NO,Norway,34.369
-1978-09-30,NZ,New Zealand,41.5186
-1978-09-30,PE,Peru,
-1978-09-30,PH,Philippines,
-1978-09-30,PL,Poland,
-1978-09-30,PT,Portugal,
-1978-09-30,RO,Romania,
-1978-09-30,RS,Serbia,
-1978-09-30,RU,Russia,
-1978-09-30,SE,Sweden,61.5208
-1978-09-30,SG,Singapore,
-1978-09-30,SI,Slovenia,
-1978-09-30,SK,Slovak Republic,
-1978-09-30,TH,Thailand,
-1978-09-30,TR,Türkiye,
-1978-09-30,US,United States,78.6221
-1978-09-30,XM,Euro area,63.9485
-1978-09-30,XW,World,
-1978-09-30,ZA,South Africa,60.8607
-1978-12-31,4T,Emerging market economies (aggregate),
-1978-12-31,5R,Advanced economies,
-1978-12-31,AE,United Arab Emirates,
-1978-12-31,AT,Austria,
-1978-12-31,AU,Australia,35.9354
-1978-12-31,BE,Belgium,57.0928
-1978-12-31,BG,Bulgaria,
-1978-12-31,BR,Brazil,
-1978-12-31,CA,Canada,51.7425
-1978-12-31,CH,Switzerland,76.6187
-1978-12-31,CL,Chile,
-1978-12-31,CN,China,
-1978-12-31,CO,Colombia,
-1978-12-31,CY,Cyprus,
-1978-12-31,CZ,Czechia,
-1978-12-31,DE,Germany,135.0917
-1978-12-31,DK,Denmark,69.1135
-1978-12-31,EE,Estonia,
-1978-12-31,ES,Spain,39.419
+1978-09-30,KR,Korea,119.1278
+1978-09-30,NL,Netherlands,67.3564
+1978-09-30,NO,Norway,34.3331
+1978-09-30,NZ,New Zealand,41.5227
+1978-09-30,SE,Sweden,61.5004
+1978-09-30,US,United States,78.4984
+1978-09-30,XM,Euro area,63.7664
+1978-09-30,ZA,South Africa,60.7378
+1978-12-31,AU,Australia,35.9167
+1978-12-31,BE,Belgium,57.5787
+1978-12-31,CA,Canada,52.1436
+1978-12-31,CH,Switzerland,76.6159
+1978-12-31,DE,Germany,134.9885
+1978-12-31,DK,Denmark,69.1178
+1978-12-31,ES,Spain,39.4191
 1978-12-31,FI,Finland,45.0554
-1978-12-31,FR,France,50.1273
-1978-12-31,GB,United Kingdom,29.4838
-1978-12-31,GR,Greece,
-1978-12-31,HK,Hong Kong SAR,
-1978-12-31,HR,Croatia,
-1978-12-31,HU,Hungary,
-1978-12-31,ID,Indonesia,
-1978-12-31,IE,Ireland,50.6274
-1978-12-31,IL,Israel,
-1978-12-31,IN,India,
-1978-12-31,IS,Iceland,
-1978-12-31,IT,Italy,57.1867
+1978-12-31,FR,France,50.1276
+1978-12-31,GB,United Kingdom,29.474
+1978-12-31,IE,Ireland,50.6519
+1978-12-31,IT,Italy,56.4125
 1978-12-31,JP,Japan,109.5417
-1978-12-31,KR,Korea,118.0999
-1978-12-31,LT,Lithuania,
-1978-12-31,LU,Luxembourg,
-1978-12-31,LV,Latvia,
-1978-12-31,MA,Morocco,
-1978-12-31,MK,North Macedonia,
-1978-12-31,MT,Malta,
-1978-12-31,MX,Mexico,
-1978-12-31,MY,Malaysia,
-1978-12-31,NL,Netherlands,65.2288
-1978-12-31,NO,Norway,34.8604
-1978-12-31,NZ,New Zealand,40.9276
-1978-12-31,PE,Peru,
-1978-12-31,PH,Philippines,
-1978-12-31,PL,Poland,
-1978-12-31,PT,Portugal,
-1978-12-31,RO,Romania,
-1978-12-31,RS,Serbia,
-1978-12-31,RU,Russia,
-1978-12-31,SE,Sweden,60.54
-1978-12-31,SG,Singapore,
-1978-12-31,SI,Slovenia,
-1978-12-31,SK,Slovak Republic,
-1978-12-31,TH,Thailand,
-1978-12-31,TR,Türkiye,
-1978-12-31,US,United States,79.3053
-1978-12-31,XM,Euro area,64.6825
-1978-12-31,XW,World,
-1978-12-31,ZA,South Africa,61.4034
-1979-03-31,4T,Emerging market economies (aggregate),
-1979-03-31,5R,Advanced economies,
-1979-03-31,AE,United Arab Emirates,
-1979-03-31,AT,Austria,
-1979-03-31,AU,Australia,37.2094
-1979-03-31,BE,Belgium,58.1496
-1979-03-31,BG,Bulgaria,
-1979-03-31,BR,Brazil,
-1979-03-31,CA,Canada,52.3863
-1979-03-31,CH,Switzerland,76.4662
-1979-03-31,CL,Chile,
-1979-03-31,CN,China,
-1979-03-31,CO,Colombia,
-1979-03-31,CY,Cyprus,
-1979-03-31,CZ,Czechia,
-1979-03-31,DE,Germany,135.4543
-1979-03-31,DK,Denmark,70.1219
-1979-03-31,EE,Estonia,
+1978-12-31,KR,Korea,118.0956
+1978-12-31,NL,Netherlands,66.8118
+1978-12-31,NO,Norway,34.8581
+1978-12-31,NZ,New Zealand,40.9328
+1978-12-31,SE,Sweden,60.5199
+1978-12-31,US,United States,79.1487
+1978-12-31,XM,Euro area,64.4943
+1978-12-31,ZA,South Africa,61.4111
+1979-03-31,AU,Australia,37.2083
+1979-03-31,BE,Belgium,58.6445
+1979-03-31,CA,Canada,52.7925
+1979-03-31,CH,Switzerland,76.4634
+1979-03-31,DE,Germany,135.3373
+1979-03-31,DK,Denmark,70.1263
 1979-03-31,ES,Spain,38.1445
 1979-03-31,FI,Finland,44.7534
-1979-03-31,FR,France,49.7524
-1979-03-31,GB,United Kingdom,30.2761
-1979-03-31,GR,Greece,
-1979-03-31,HK,Hong Kong SAR,
-1979-03-31,HR,Croatia,
-1979-03-31,HU,Hungary,
-1979-03-31,ID,Indonesia,
-1979-03-31,IE,Ireland,52.1837
-1979-03-31,IL,Israel,
-1979-03-31,IN,India,
-1979-03-31,IS,Iceland,
-1979-03-31,IT,Italy,57.38
+1979-03-31,FR,France,49.7528
+1979-03-31,GB,United Kingdom,30.2661
+1979-03-31,IE,Ireland,52.209
+1979-03-31,IT,Italy,56.5933
 1979-03-31,JP,Japan,111.9154
-1979-03-31,KR,Korea,117.2678
-1979-03-31,LT,Lithuania,
-1979-03-31,LU,Luxembourg,
-1979-03-31,LV,Latvia,
-1979-03-31,MA,Morocco,
-1979-03-31,MK,North Macedonia,
-1979-03-31,MT,Malta,
-1979-03-31,MX,Mexico,
-1979-03-31,MY,Malaysia,
-1979-03-31,NL,Netherlands,63.9105
-1979-03-31,NO,Norway,35.826
-1979-03-31,NZ,New Zealand,40.7763
-1979-03-31,PE,Peru,
-1979-03-31,PH,Philippines,
-1979-03-31,PL,Poland,
-1979-03-31,PT,Portugal,
-1979-03-31,RO,Romania,
-1979-03-31,RS,Serbia,
-1979-03-31,RU,Russia,
-1979-03-31,SE,Sweden,60.0252
-1979-03-31,SG,Singapore,
-1979-03-31,SI,Slovenia,
-1979-03-31,SK,Slovak Republic,
-1979-03-31,TH,Thailand,
-1979-03-31,TR,Türkiye,
-1979-03-31,US,United States,80.8253
-1979-03-31,XM,Euro area,65.9602
-1979-03-31,XW,World,
-1979-03-31,ZA,South Africa,61.532
-1979-06-30,4T,Emerging market economies (aggregate),
-1979-06-30,5R,Advanced economies,
-1979-06-30,AE,United Arab Emirates,
-1979-06-30,AT,Austria,
-1979-06-30,AU,Australia,38.5412
-1979-06-30,BE,Belgium,58.1676
-1979-06-30,BG,Bulgaria,
-1979-06-30,BR,Brazil,
-1979-06-30,CA,Canada,52.0904
-1979-06-30,CH,Switzerland,75.2138
-1979-06-30,CL,Chile,
-1979-06-30,CN,China,
-1979-06-30,CO,Colombia,
-1979-06-30,CY,Cyprus,
-1979-06-30,CZ,Czechia,
-1979-06-30,DE,Germany,138.5403
-1979-06-30,DK,Denmark,71.4868
-1979-06-30,EE,Estonia,
+1979-03-31,KR,Korea,117.2636
+1979-03-31,NL,Netherlands,65.4615
+1979-03-31,NO,Norway,35.8351
+1979-03-31,NZ,New Zealand,40.7832
+1979-03-31,SE,Sweden,60.0053
+1979-03-31,US,United States,80.6986
+1979-03-31,XM,Euro area,65.768
+1979-03-31,ZA,South Africa,61.4528
+1979-06-30,AU,Australia,38.5322
+1979-06-30,BE,Belgium,58.6626
+1979-06-30,CA,Canada,52.4942
+1979-06-30,CH,Switzerland,75.211
+1979-06-30,DE,Germany,138.7429
+1979-06-30,DK,Denmark,71.4912
 1979-06-30,ES,Spain,36.7891
 1979-06-30,FI,Finland,44.3539
-1979-06-30,FR,France,50.3949
-1979-06-30,GB,United Kingdom,31.7296
-1979-06-30,GR,Greece,
-1979-06-30,HK,Hong Kong SAR,
-1979-06-30,HR,Croatia,
-1979-06-30,HU,Hungary,
-1979-06-30,ID,Indonesia,
-1979-06-30,IE,Ireland,55.1088
-1979-06-30,IL,Israel,
-1979-06-30,IN,India,
-1979-06-30,IS,Iceland,
-1979-06-30,IT,Italy,57.2605
+1979-06-30,FR,France,50.3953
+1979-06-30,GB,United Kingdom,31.7191
+1979-06-30,IE,Ireland,55.1355
+1979-06-30,IT,Italy,56.4964
 1979-06-30,JP,Japan,112.4063
-1979-06-30,KR,Korea,116.7957
-1979-06-30,LT,Lithuania,
-1979-06-30,LU,Luxembourg,
-1979-06-30,LV,Latvia,
-1979-06-30,MA,Morocco,
-1979-06-30,MK,North Macedonia,
-1979-06-30,MT,Malta,
-1979-06-30,MX,Mexico,
-1979-06-30,MY,Malaysia,
-1979-06-30,NL,Netherlands,63.438
-1979-06-30,NO,Norway,35.8394
-1979-06-30,NZ,New Zealand,39.5271
-1979-06-30,PE,Peru,
-1979-06-30,PH,Philippines,
-1979-06-30,PL,Poland,
-1979-06-30,PT,Portugal,
-1979-06-30,RO,Romania,
-1979-06-30,RS,Serbia,
-1979-06-30,RU,Russia,
-1979-06-30,SE,Sweden,62.2191
-1979-06-30,SG,Singapore,
-1979-06-30,SI,Slovenia,
-1979-06-30,SK,Slovak Republic,
-1979-06-30,TH,Thailand,
-1979-06-30,TR,Türkiye,
-1979-06-30,US,United States,81.609
-1979-06-30,XM,Euro area,66.7771
-1979-06-30,XW,World,
-1979-06-30,ZA,South Africa,61.9651
-1979-09-30,4T,Emerging market economies (aggregate),
-1979-09-30,5R,Advanced economies,
-1979-09-30,AE,United Arab Emirates,
-1979-09-30,AT,Austria,
-1979-09-30,AU,Australia,38.4186
-1979-09-30,BE,Belgium,58.9647
-1979-09-30,BG,Bulgaria,
-1979-09-30,BR,Brazil,
-1979-09-30,CA,Canada,50.8677
-1979-09-30,CH,Switzerland,77.1927
-1979-09-30,CL,Chile,
-1979-09-30,CN,China,
-1979-09-30,CO,Colombia,
-1979-09-30,CY,Cyprus,
-1979-09-30,CZ,Czechia,
-1979-09-30,DE,Germany,139.5638
-1979-09-30,DK,Denmark,69.1031
-1979-09-30,EE,Estonia,
-1979-09-30,ES,Spain,35.9109
+1979-06-30,KR,Korea,116.7915
+1979-06-30,NL,Netherlands,64.9775
+1979-06-30,NO,Norway,35.7548
+1979-06-30,NZ,New Zealand,39.5248
+1979-06-30,SE,Sweden,62.1985
+1979-06-30,US,United States,81.4828
+1979-06-30,XM,Euro area,66.573
+1979-06-30,ZA,South Africa,61.8577
+1979-09-30,AU,Australia,38.4706
+1979-09-30,BE,Belgium,59.4665
+1979-09-30,CA,Canada,51.2621
+1979-09-30,CH,Switzerland,77.1899
+1979-09-30,DE,Germany,139.6161
+1979-09-30,DK,Denmark,69.1074
+1979-09-30,ES,Spain,35.911
 1979-09-30,FI,Finland,44.4213
-1979-09-30,FR,France,51.653
-1979-09-30,GB,United Kingdom,32.1716
-1979-09-30,GR,Greece,
-1979-09-30,HK,Hong Kong SAR,
-1979-09-30,HR,Croatia,
-1979-09-30,HU,Hungary,
-1979-09-30,ID,Indonesia,
-1979-09-30,IE,Ireland,54.6376
-1979-09-30,IL,Israel,
-1979-09-30,IN,India,
-1979-09-30,IS,Iceland,
-1979-09-30,IT,Italy,57.374
+1979-09-30,FR,France,51.6533
+1979-09-30,GB,United Kingdom,32.161
+1979-09-30,IE,Ireland,54.6641
+1979-09-30,IT,Italy,56.5971
 1979-09-30,JP,Japan,114.3404
-1979-09-30,KR,Korea,113.5121
-1979-09-30,LT,Lithuania,
-1979-09-30,LU,Luxembourg,
-1979-09-30,LV,Latvia,
-1979-09-30,MA,Morocco,
-1979-09-30,MK,North Macedonia,
-1979-09-30,MT,Malta,
-1979-09-30,MX,Mexico,
-1979-09-30,MY,Malaysia,
-1979-09-30,NL,Netherlands,61.1887
-1979-09-30,NO,Norway,35.0396
-1979-09-30,NZ,New Zealand,38.0544
-1979-09-30,PE,Peru,
-1979-09-30,PH,Philippines,
-1979-09-30,PL,Poland,
-1979-09-30,PT,Portugal,
-1979-09-30,RO,Romania,
-1979-09-30,RS,Serbia,
-1979-09-30,RU,Russia,
-1979-09-30,SE,Sweden,63.0919
-1979-09-30,SG,Singapore,
-1979-09-30,SI,Slovenia,
-1979-09-30,SK,Slovak Republic,
-1979-09-30,TH,Thailand,
-1979-09-30,TR,Türkiye,
-1979-09-30,US,United States,81.8986
-1979-09-30,XM,Euro area,66.6023
-1979-09-30,XW,World,
-1979-09-30,ZA,South Africa,60.7432
-1979-12-31,4T,Emerging market economies (aggregate),
-1979-12-31,5R,Advanced economies,
-1979-12-31,AE,United Arab Emirates,
-1979-12-31,AT,Austria,
-1979-12-31,AU,Australia,37.9887
-1979-12-31,BE,Belgium,57.718
-1979-12-31,BG,Bulgaria,
-1979-12-31,BR,Brazil,
-1979-12-31,CA,Canada,51.9189
-1979-12-31,CH,Switzerland,79.1018
-1979-12-31,CL,Chile,
-1979-12-31,CN,China,
-1979-12-31,CO,Colombia,
-1979-12-31,CY,Cyprus,
-1979-12-31,CZ,Czechia,
-1979-12-31,DE,Germany,139.3361
-1979-12-31,DK,Denmark,67.2278
-1979-12-31,EE,Estonia,
-1979-12-31,ES,Spain,34.446
+1979-09-30,KR,Korea,113.5081
+1979-09-30,NL,Netherlands,62.6737
+1979-09-30,NO,Norway,34.9738
+1979-09-30,NZ,New Zealand,38.0533
+1979-09-30,SE,Sweden,63.0709
+1979-09-30,US,United States,81.7625
+1979-09-30,XM,Euro area,66.3932
+1979-09-30,ZA,South Africa,60.6783
+1979-12-31,AU,Australia,38.008
+1979-12-31,BE,Belgium,58.2092
+1979-12-31,CA,Canada,52.3214
+1979-12-31,CH,Switzerland,79.0989
+1979-12-31,DE,Germany,139.1986
+1979-12-31,DK,Denmark,67.232
+1979-12-31,ES,Spain,34.4461
 1979-12-31,FI,Finland,45.293
-1979-12-31,FR,France,52.0474
-1979-12-31,GB,United Kingdom,33.2983
-1979-12-31,GR,Greece,
+1979-12-31,FR,France,52.0478
+1979-12-31,GB,United Kingdom,33.2873
 1979-12-31,HK,Hong Kong SAR,46.7371
-1979-12-31,HR,Croatia,
-1979-12-31,HU,Hungary,
-1979-12-31,ID,Indonesia,
-1979-12-31,IE,Ireland,52.4743
-1979-12-31,IL,Israel,
-1979-12-31,IN,India,
-1979-12-31,IS,Iceland,
-1979-12-31,IT,Italy,56.7775
+1979-12-31,IE,Ireland,52.4997
+1979-12-31,IT,Italy,56.0014
 1979-12-31,JP,Japan,116.2154
-1979-12-31,KR,Korea,107.9682
-1979-12-31,LT,Lithuania,
-1979-12-31,LU,Luxembourg,
-1979-12-31,LV,Latvia,
-1979-12-31,MA,Morocco,
-1979-12-31,MK,North Macedonia,
-1979-12-31,MT,Malta,
-1979-12-31,MX,Mexico,
-1979-12-31,MY,Malaysia,
-1979-12-31,NL,Netherlands,58.6027
-1979-12-31,NO,Norway,34.6983
-1979-12-31,NZ,New Zealand,37.1162
-1979-12-31,PE,Peru,
-1979-12-31,PH,Philippines,
-1979-12-31,PL,Poland,
-1979-12-31,PT,Portugal,
-1979-12-31,RO,Romania,
-1979-12-31,RS,Serbia,
-1979-12-31,RU,Russia,
-1979-12-31,SE,Sweden,60.758
-1979-12-31,SG,Singapore,
-1979-12-31,SI,Slovenia,
-1979-12-31,SK,Slovak Republic,
-1979-12-31,TH,Thailand,
-1979-12-31,TR,Türkiye,
-1979-12-31,US,United States,82.4692
-1979-12-31,XM,Euro area,65.1844
-1979-12-31,XW,World,
-1979-12-31,ZA,South Africa,61.7003
-1980-03-31,4T,Emerging market economies (aggregate),
-1980-03-31,5R,Advanced economies,
-1980-03-31,AE,United Arab Emirates,
-1980-03-31,AT,Austria,
-1980-03-31,AU,Australia,38.0706
-1980-03-31,BE,Belgium,57.958
-1980-03-31,BG,Bulgaria,
-1980-03-31,BR,Brazil,
-1980-03-31,CA,Canada,51.5592
-1980-03-31,CH,Switzerland,81.7267
-1980-03-31,CL,Chile,
-1980-03-31,CN,China,
-1980-03-31,CO,Colombia,
-1980-03-31,CY,Cyprus,
-1980-03-31,CZ,Czechia,
-1980-03-31,DE,Germany,139.2642
-1980-03-31,DK,Denmark,64.4025
-1980-03-31,EE,Estonia,
+1979-12-31,KR,Korea,107.9643
+1979-12-31,NL,Netherlands,60.0249
+1979-12-31,NO,Norway,34.6768
+1979-12-31,NZ,New Zealand,37.1259
+1979-12-31,SE,Sweden,60.7379
+1979-12-31,US,United States,82.3151
+1979-12-31,XM,Euro area,64.9699
+1979-12-31,ZA,South Africa,61.6089
+1980-03-31,AU,Australia,37.9972
+1980-03-31,BE,Belgium,58.4512
+1980-03-31,CA,Canada,51.9589
+1980-03-31,CH,Switzerland,81.7237
+1980-03-31,DE,Germany,139.1851
+1980-03-31,DK,Denmark,64.4065
 1980-03-31,ES,Spain,34.3027
 1980-03-31,FI,Finland,46.2694
-1980-03-31,FR,France,52.1576
-1980-03-31,GB,United Kingdom,33.7475
-1980-03-31,GR,Greece,
+1980-03-31,FR,France,52.158
+1980-03-31,GB,United Kingdom,33.7363
 1980-03-31,HK,Hong Kong SAR,49.4687
-1980-03-31,HR,Croatia,
-1980-03-31,HU,Hungary,
-1980-03-31,ID,Indonesia,
-1980-03-31,IE,Ireland,54.0554
-1980-03-31,IL,Israel,
-1980-03-31,IN,India,
-1980-03-31,IS,Iceland,
-1980-03-31,IT,Italy,57.1191
+1980-03-31,IE,Ireland,54.0816
+1980-03-31,IT,Italy,56.3447
 1980-03-31,JP,Japan,117.6414
-1980-03-31,KR,Korea,104.3997
-1980-03-31,LT,Lithuania,
-1980-03-31,LU,Luxembourg,
-1980-03-31,LV,Latvia,
-1980-03-31,MA,Morocco,
-1980-03-31,MK,North Macedonia,
-1980-03-31,MT,Malta,
-1980-03-31,MX,Mexico,
-1980-03-31,MY,Malaysia,
-1980-03-31,NL,Netherlands,56.9216
-1980-03-31,NO,Norway,32.9068
+1980-03-31,KR,Korea,104.3959
+1980-03-31,NL,Netherlands,58.303
+1980-03-31,NO,Norway,32.85
 1980-03-31,NZ,New Zealand,36.5163
-1980-03-31,PE,Peru,
-1980-03-31,PH,Philippines,
-1980-03-31,PL,Poland,
-1980-03-31,PT,Portugal,
-1980-03-31,RO,Romania,
-1980-03-31,RS,Serbia,
-1980-03-31,RU,Russia,
-1980-03-31,SE,Sweden,56.8917
-1980-03-31,SG,Singapore,
-1980-03-31,SI,Slovenia,
-1980-03-31,SK,Slovak Republic,
-1980-03-31,TH,Thailand,
-1980-03-31,TR,Türkiye,
-1980-03-31,US,United States,81.0758
-1980-03-31,XM,Euro area,64.2326
-1980-03-31,XW,World,
-1980-03-31,ZA,South Africa,62.999
-1980-06-30,4T,Emerging market economies (aggregate),
-1980-06-30,5R,Advanced economies,
-1980-06-30,AE,United Arab Emirates,
-1980-06-30,AT,Austria,
-1980-06-30,AU,Australia,38.7966
-1980-06-30,BE,Belgium,56.0531
-1980-06-30,BG,Bulgaria,
-1980-06-30,BR,Brazil,
-1980-06-30,CA,Canada,52.2077
-1980-06-30,CH,Switzerland,79.4127
-1980-06-30,CL,Chile,
-1980-06-30,CN,China,
-1980-06-30,CO,Colombia,
-1980-06-30,CY,Cyprus,
-1980-06-30,CZ,Czechia,
-1980-06-30,DE,Germany,140.2524
-1980-06-30,DK,Denmark,60.62
-1980-06-30,EE,Estonia,
+1980-03-31,SE,Sweden,56.8713
+1980-03-31,US,United States,80.9777
+1980-03-31,XM,Euro area,64.0118
+1980-03-31,ZA,South Africa,62.9059
+1980-06-30,AU,Australia,38.8424
+1980-06-30,BE,Belgium,56.5301
+1980-06-30,CA,Canada,52.6125
+1980-06-30,CH,Switzerland,79.4097
+1980-06-30,DE,Germany,140.3889
+1980-06-30,DK,Denmark,60.6237
 1980-06-30,ES,Spain,33.9302
 1980-06-30,FI,Finland,45.8293
-1980-06-30,FR,France,53.5377
-1980-06-30,GB,United Kingdom,33.2026
-1980-06-30,GR,Greece,
+1980-06-30,FR,France,53.5381
+1980-06-30,GB,United Kingdom,33.1916
 1980-06-30,HK,Hong Kong SAR,48.7067
-1980-06-30,HR,Croatia,
-1980-06-30,HU,Hungary,
-1980-06-30,ID,Indonesia,
-1980-06-30,IE,Ireland,51.6092
-1980-06-30,IL,Israel,
-1980-06-30,IN,India,
-1980-06-30,IS,Iceland,
-1980-06-30,IT,Italy,60.9514
+1980-06-30,IE,Ireland,51.6343
+1980-06-30,IT,Italy,60.1251
 1980-06-30,JP,Japan,117.7351
-1980-06-30,KR,Korea,100.8987
-1980-06-30,LT,Lithuania,
-1980-06-30,LU,Luxembourg,
-1980-06-30,LV,Latvia,
-1980-06-30,MA,Morocco,
-1980-06-30,MK,North Macedonia,
-1980-06-30,MT,Malta,
-1980-06-30,MX,Mexico,
-1980-06-30,MY,Malaysia,
-1980-06-30,NL,Netherlands,55.2721
-1980-06-30,NO,Norway,34.1921
+1980-06-30,KR,Korea,100.895
+1980-06-30,NL,Netherlands,56.6135
+1980-06-30,NO,Norway,34.2488
 1980-06-30,NZ,New Zealand,36.1813
-1980-06-30,PE,Peru,
-1980-06-30,PH,Philippines,
-1980-06-30,PL,Poland,
-1980-06-30,PT,Portugal,
-1980-06-30,RO,Romania,
-1980-06-30,RS,Serbia,
-1980-06-30,RU,Russia,
-1980-06-30,SE,Sweden,56.7729
-1980-06-30,SG,Singapore,
-1980-06-30,SI,Slovenia,
-1980-06-30,SK,Slovak Republic,
-1980-06-30,TH,Thailand,
-1980-06-30,TR,Türkiye,
-1980-06-30,US,United States,79.2144
-1980-06-30,XM,Euro area,65.2462
-1980-06-30,XW,World,
-1980-06-30,ZA,South Africa,65.1293
-1980-09-30,4T,Emerging market economies (aggregate),
-1980-09-30,5R,Advanced economies,
-1980-09-30,AE,United Arab Emirates,
-1980-09-30,AT,Austria,
-1980-09-30,AU,Australia,39.4304
-1980-09-30,BE,Belgium,54.8067
-1980-09-30,BG,Bulgaria,
-1980-09-30,BR,Brazil,
-1980-09-30,CA,Canada,52.8494
-1980-09-30,CH,Switzerland,80.1841
-1980-09-30,CL,Chile,
-1980-09-30,CN,China,
-1980-09-30,CO,Colombia,
-1980-09-30,CY,Cyprus,
-1980-09-30,CZ,Czechia,
-1980-09-30,DE,Germany,141.2909
-1980-09-30,DK,Denmark,59.9788
-1980-09-30,EE,Estonia,
+1980-06-30,SE,Sweden,56.7559
+1980-06-30,US,United States,79.1014
+1980-06-30,XM,Euro area,65.0272
+1980-06-30,ZA,South Africa,65.0337
+1980-09-30,AU,Australia,39.4072
+1980-09-30,BE,Belgium,55.2732
+1980-09-30,CA,Canada,53.2591
+1980-09-30,CH,Switzerland,80.1811
+1980-09-30,DE,Germany,141.319
+1980-09-30,DK,Denmark,59.9825
 1980-09-30,ES,Spain,32.5876
 1980-09-30,FI,Finland,46.4037
-1980-09-30,FR,France,55.0964
-1980-09-30,GB,United Kingdom,33.8062
-1980-09-30,GR,Greece,
+1980-09-30,FR,France,55.0968
+1980-09-30,GB,United Kingdom,33.795
 1980-09-30,HK,Hong Kong SAR,51.8077
-1980-09-30,HR,Croatia,
-1980-09-30,HU,Hungary,
-1980-09-30,ID,Indonesia,
-1980-09-30,IE,Ireland,54.6197
-1980-09-30,IL,Israel,
-1980-09-30,IN,India,
-1980-09-30,IS,Iceland,
-1980-09-30,IT,Italy,65.1411
+1980-09-30,IE,Ireland,54.6462
+1980-09-30,IT,Italy,64.2576
 1980-09-30,JP,Japan,120.2159
-1980-09-30,KR,Korea,96.9326
-1980-09-30,LT,Lithuania,
-1980-09-30,LU,Luxembourg,
-1980-09-30,LV,Latvia,
-1980-09-30,MA,Morocco,
-1980-09-30,MK,North Macedonia,
-1980-09-30,MT,Malta,
-1980-09-30,MX,Mexico,
-1980-09-30,MY,Malaysia,
-1980-09-30,NL,Netherlands,50.7416
-1980-09-30,NO,Norway,35.4449
+1980-09-30,KR,Korea,96.9291
+1980-09-30,NL,Netherlands,51.973
+1980-09-30,NO,Norway,35.4795
 1980-09-30,NZ,New Zealand,36.0835
-1980-09-30,PE,Peru,
-1980-09-30,PH,Philippines,
-1980-09-30,PL,Poland,
-1980-09-30,PT,Portugal,
-1980-09-30,RO,Romania,
-1980-09-30,RS,Serbia,
-1980-09-30,RU,Russia,
-1980-09-30,SE,Sweden,56.2341
-1980-09-30,SG,Singapore,
-1980-09-30,SI,Slovenia,
-1980-09-30,SK,Slovak Republic,
-1980-09-30,TH,Thailand,
-1980-09-30,TR,Türkiye,
-1980-09-30,US,United States,80.2622
-1980-09-30,XM,Euro area,67.3112
-1980-09-30,XW,World,
-1980-09-30,ZA,South Africa,68.1123
-1980-12-31,4T,Emerging market economies (aggregate),
-1980-12-31,5R,Advanced economies,
-1980-12-31,AE,United Arab Emirates,
-1980-12-31,AT,Austria,
-1980-12-31,AU,Australia,39.8631
-1980-12-31,BE,Belgium,51.5767
-1980-12-31,BG,Bulgaria,
-1980-12-31,BR,Brazil,
-1980-12-31,CA,Canada,54.6827
-1980-12-31,CH,Switzerland,81.0252
-1980-12-31,CL,Chile,
-1980-12-31,CN,China,
-1980-12-31,CO,Colombia,
-1980-12-31,CY,Cyprus,
-1980-12-31,CZ,Czechia,
-1980-12-31,DE,Germany,142.5771
-1980-12-31,DK,Denmark,58.9062
-1980-12-31,EE,Estonia,
-1980-12-31,ES,Spain,31.1893
+1980-09-30,SE,Sweden,56.2159
+1980-09-30,US,United States,80.1598
+1980-09-30,XM,Euro area,67.0826
+1980-09-30,ZA,South Africa,68.0262
+1980-12-31,AU,Australia,39.8965
+1980-12-31,BE,Belgium,52.0156
+1980-12-31,CA,Canada,55.1066
+1980-12-31,CH,Switzerland,81.0222
+1980-12-31,DE,Germany,142.4921
+1980-12-31,DK,Denmark,58.9098
+1980-12-31,ES,Spain,31.1894
 1980-12-31,FI,Finland,45.3724
-1980-12-31,FR,France,54.3833
-1980-12-31,GB,United Kingdom,33.3632
-1980-12-31,GR,Greece,
+1980-12-31,FR,France,54.3837
+1980-12-31,GB,United Kingdom,33.3522
 1980-12-31,HK,Hong Kong SAR,56.1242
-1980-12-31,HR,Croatia,
-1980-12-31,HU,Hungary,
-1980-12-31,ID,Indonesia,
-1980-12-31,IE,Ireland,55.5374
-1980-12-31,IL,Israel,
-1980-12-31,IN,India,
-1980-12-31,IS,Iceland,
-1980-12-31,IT,Italy,67.724
+1980-12-31,IE,Ireland,55.5643
+1980-12-31,IT,Italy,66.8132
 1980-12-31,JP,Japan,121.8849
-1980-12-31,KR,Korea,93.5804
-1980-12-31,LT,Lithuania,
-1980-12-31,LU,Luxembourg,
-1980-12-31,LV,Latvia,
-1980-12-31,MA,Morocco,
-1980-12-31,MK,North Macedonia,
-1980-12-31,MT,Malta,
-1980-12-31,MX,Mexico,
-1980-12-31,MY,Malaysia,
-1980-12-31,NL,Netherlands,49.9236
-1980-12-31,NO,Norway,36.6118
+1980-12-31,KR,Korea,93.5771
+1980-12-31,NL,Netherlands,51.1352
+1980-12-31,NO,Norway,36.5635
 1980-12-31,NZ,New Zealand,35.916
-1980-12-31,PE,Peru,
-1980-12-31,PH,Philippines,
-1980-12-31,PL,Poland,
-1980-12-31,PT,Portugal,
-1980-12-31,RO,Romania,
-1980-12-31,RS,Serbia,
-1980-12-31,RU,Russia,
-1980-12-31,SE,Sweden,52.545
-1980-12-31,SG,Singapore,
-1980-12-31,SI,Slovenia,
-1980-12-31,SK,Slovak Republic,
-1980-12-31,TH,Thailand,
-1980-12-31,TR,Türkiye,
-1980-12-31,US,United States,79.8229
-1980-12-31,XM,Euro area,68.2971
-1980-12-31,XW,World,
-1980-12-31,ZA,South Africa,71.0953
-1981-03-31,4T,Emerging market economies (aggregate),
-1981-03-31,5R,Advanced economies,
-1981-03-31,AE,United Arab Emirates,
-1981-03-31,AT,Austria,
-1981-03-31,AU,Australia,41.4858
-1981-03-31,BE,Belgium,50.249
-1981-03-31,BG,Bulgaria,
-1981-03-31,BR,Brazil,
-1981-03-31,CA,Canada,54.8932
-1981-03-31,CH,Switzerland,82.405
-1981-03-31,CL,Chile,
-1981-03-31,CN,China,
-1981-03-31,CO,Colombia,
-1981-03-31,CY,Cyprus,
-1981-03-31,CZ,Czechia,
-1981-03-31,DE,Germany,141.5936
-1981-03-31,DK,Denmark,57.0681
-1981-03-31,EE,Estonia,
+1980-12-31,SE,Sweden,52.5268
+1980-12-31,US,United States,79.7381
+1980-12-31,XM,Euro area,68.0704
+1980-12-31,ZA,South Africa,70.9909
+1981-03-31,AU,Australia,41.4264
+1981-03-31,BE,Belgium,50.6767
+1981-03-31,CA,Canada,55.3188
+1981-03-31,CH,Switzerland,82.4021
+1981-03-31,DE,Germany,141.4025
+1981-03-31,DK,Denmark,57.0716
 1981-03-31,ES,Spain,30.8497
 1981-03-31,FI,Finland,46.868
-1981-03-31,FR,France,53.3237
-1981-03-31,GB,United Kingdom,32.5538
-1981-03-31,GR,Greece,
+1981-03-31,FR,France,53.3241
+1981-03-31,GB,United Kingdom,32.543
 1981-03-31,HK,Hong Kong SAR,58.4935
-1981-03-31,HR,Croatia,
-1981-03-31,HU,Hungary,
-1981-03-31,ID,Indonesia,
-1981-03-31,IE,Ireland,52.996
-1981-03-31,IL,Israel,
-1981-03-31,IN,India,
-1981-03-31,IS,Iceland,
-1981-03-31,IT,Italy,69.48
+1981-03-31,IE,Ireland,53.0217
+1981-03-31,IS,Iceland,76.1792
+1981-03-31,IT,Italy,69.5419
 1981-03-31,JP,Japan,123.8945
-1981-03-31,KR,Korea,90.4401
-1981-03-31,LT,Lithuania,
-1981-03-31,LU,Luxembourg,
-1981-03-31,LV,Latvia,
-1981-03-31,MA,Morocco,
-1981-03-31,MK,North Macedonia,
-1981-03-31,MT,Malta,
-1981-03-31,MX,Mexico,
-1981-03-31,MY,Malaysia,
-1981-03-31,NL,Netherlands,49.2941
-1981-03-31,NO,Norway,37.1859
+1981-03-31,KR,Korea,90.4368
+1981-03-31,NL,Netherlands,50.4905
+1981-03-31,NO,Norway,37.2297
 1981-03-31,NZ,New Zealand,36.2751
-1981-03-31,PE,Peru,
-1981-03-31,PH,Philippines,
-1981-03-31,PL,Poland,
-1981-03-31,PT,Portugal,
-1981-03-31,RO,Romania,
-1981-03-31,RS,Serbia,
-1981-03-31,RU,Russia,
-1981-03-31,SE,Sweden,50.8979
-1981-03-31,SG,Singapore,
-1981-03-31,SI,Slovenia,
-1981-03-31,SK,Slovak Republic,
-1981-03-31,TH,Thailand,
-1981-03-31,TR,Türkiye,
-1981-03-31,US,United States,79.2372
-1981-03-31,XM,Euro area,68.9357
-1981-03-31,XW,World,
-1981-03-31,ZA,South Africa,75.245
-1981-06-30,4T,Emerging market economies (aggregate),
-1981-06-30,5R,Advanced economies,
-1981-06-30,AE,United Arab Emirates,
-1981-06-30,AT,Austria,
-1981-06-30,AU,Australia,41.9429
-1981-06-30,BE,Belgium,49.2304
-1981-06-30,BG,Bulgaria,
-1981-06-30,BR,Brazil,
-1981-06-30,CA,Canada,53.7285
-1981-06-30,CH,Switzerland,83.6016
-1981-06-30,CL,Chile,
-1981-06-30,CN,China,
-1981-06-30,CO,Colombia,
-1981-06-30,CY,Cyprus,
-1981-06-30,CZ,Czechia,
-1981-06-30,DE,Germany,143.2212
-1981-06-30,DK,Denmark,52.536
-1981-06-30,EE,Estonia,
+1981-03-31,SE,Sweden,50.8857
+1981-03-31,US,United States,79.1133
+1981-03-31,XM,Euro area,68.726
+1981-03-31,ZA,South Africa,75.1478
+1981-06-30,AU,Australia,41.8558
+1981-06-30,BE,Belgium,49.6494
+1981-06-30,CA,Canada,54.1451
+1981-06-30,CH,Switzerland,83.5985
+1981-06-30,DE,Germany,143.302
+1981-06-30,DK,Denmark,52.5392
 1981-06-30,ES,Spain,30.8752
 1981-06-30,FI,Finland,46.4625
-1981-06-30,FR,France,53.1678
-1981-06-30,GB,United Kingdom,31.9242
-1981-06-30,GR,Greece,
+1981-06-30,FR,France,53.1682
+1981-06-30,GB,United Kingdom,31.9136
 1981-06-30,HK,Hong Kong SAR,56.8727
-1981-06-30,HR,Croatia,
-1981-06-30,HU,Hungary,
-1981-06-30,ID,Indonesia,
-1981-06-30,IE,Ireland,51.3951
-1981-06-30,IL,Israel,
-1981-06-30,IN,India,
-1981-06-30,IS,Iceland,
-1981-06-30,IT,Italy,70.8063
+1981-06-30,IE,Ireland,51.42
+1981-06-30,IS,Iceland,77.3903
+1981-06-30,IT,Italy,70.8534
 1981-06-30,JP,Japan,124.8522
-1981-06-30,KR,Korea,87.6172
-1981-06-30,LT,Lithuania,
-1981-06-30,LU,Luxembourg,
-1981-06-30,LV,Latvia,
-1981-06-30,MA,Morocco,
-1981-06-30,MK,North Macedonia,
-1981-06-30,MT,Malta,
-1981-06-30,MX,Mexico,
-1981-06-30,MY,Malaysia,
-1981-06-30,NL,Netherlands,46.441
-1981-06-30,NO,Norway,39.593
+1981-06-30,KR,Korea,87.6141
+1981-06-30,NL,Netherlands,47.5681
+1981-06-30,NO,Norway,39.5595
 1981-06-30,NZ,New Zealand,37.8907
-1981-06-30,PE,Peru,
-1981-06-30,PH,Philippines,
-1981-06-30,PL,Poland,
-1981-06-30,PT,Portugal,
-1981-06-30,RO,Romania,
-1981-06-30,RS,Serbia,
-1981-06-30,RU,Russia,
-1981-06-30,SE,Sweden,50.185
-1981-06-30,SG,Singapore,
-1981-06-30,SI,Slovenia,
-1981-06-30,SK,Slovak Republic,
-1981-06-30,TH,Thailand,
-1981-06-30,TR,Türkiye,
-1981-06-30,US,United States,78.3883
-1981-06-30,XM,Euro area,69.1237
-1981-06-30,XW,World,
-1981-06-30,ZA,South Africa,79.9099
-1981-09-30,4T,Emerging market economies (aggregate),
-1981-09-30,5R,Advanced economies,
-1981-09-30,AE,United Arab Emirates,
-1981-09-30,AT,Austria,
-1981-09-30,AU,Australia,40.3063
-1981-09-30,BE,Belgium,47.9008
-1981-09-30,BG,Bulgaria,
-1981-09-30,BR,Brazil,
-1981-09-30,CA,Canada,53.4889
-1981-09-30,CH,Switzerland,82.2922
-1981-09-30,CL,Chile,
-1981-09-30,CN,China,
-1981-09-30,CO,Colombia,
-1981-09-30,CY,Cyprus,
-1981-09-30,CZ,Czechia,
-1981-09-30,DE,Germany,142.3338
-1981-09-30,DK,Denmark,49.4303
-1981-09-30,EE,Estonia,
-1981-09-30,ES,Spain,29.5541
+1981-06-30,SE,Sweden,50.1777
+1981-06-30,US,United States,78.2944
+1981-06-30,XM,Euro area,68.921
+1981-06-30,ZA,South Africa,79.7653
+1981-09-30,AU,Australia,40.2973
+1981-09-30,BE,Belgium,48.3085
+1981-09-30,CA,Canada,53.9036
+1981-09-30,CH,Switzerland,82.2892
+1981-09-30,DE,Germany,142.5036
+1981-09-30,DK,Denmark,49.4334
+1981-09-30,ES,Spain,29.5542
 1981-09-30,FI,Finland,47.4414
-1981-09-30,FR,France,53.0271
-1981-09-30,GB,United Kingdom,31.7994
-1981-09-30,GR,Greece,
+1981-09-30,FR,France,53.0275
+1981-09-30,GB,United Kingdom,31.7888
 1981-09-30,HK,Hong Kong SAR,55.2378
-1981-09-30,HR,Croatia,
-1981-09-30,HU,Hungary,
-1981-09-30,ID,Indonesia,
-1981-09-30,IE,Ireland,52.1163
-1981-09-30,IL,Israel,
-1981-09-30,IN,India,
-1981-09-30,IS,Iceland,
-1981-09-30,IT,Italy,71.7327
+1981-09-30,IE,Ireland,52.1416
+1981-09-30,IS,Iceland,85.9555
+1981-09-30,IT,Italy,71.8022
 1981-09-30,JP,Japan,127.3378
-1981-09-30,KR,Korea,86.4981
-1981-09-30,LT,Lithuania,
-1981-09-30,LU,Luxembourg,
-1981-09-30,LV,Latvia,
-1981-09-30,MA,Morocco,
-1981-09-30,MK,North Macedonia,
-1981-09-30,MT,Malta,
-1981-09-30,MX,Mexico,
-1981-09-30,MY,Malaysia,
-1981-09-30,NL,Netherlands,43.5085
-1981-09-30,NO,Norway,40.7669
+1981-09-30,KR,Korea,86.495
+1981-09-30,NL,Netherlands,44.5644
+1981-09-30,NO,Norway,40.7671
 1981-09-30,NZ,New Zealand,39.2264
-1981-09-30,PE,Peru,
-1981-09-30,PH,Philippines,
-1981-09-30,PL,Poland,
-1981-09-30,PT,Portugal,
-1981-09-30,RO,Romania,
-1981-09-30,RS,Serbia,
-1981-09-30,RU,Russia,
-1981-09-30,SE,Sweden,48.6035
-1981-09-30,SG,Singapore,
-1981-09-30,SI,Slovenia,
-1981-09-30,SK,Slovak Republic,
-1981-09-30,TH,Thailand,
-1981-09-30,TR,Türkiye,
-1981-09-30,US,United States,76.9737
-1981-09-30,XM,Euro area,67.7139
-1981-09-30,XW,World,
-1981-09-30,ZA,South Africa,81.8924
-1981-12-31,4T,Emerging market economies (aggregate),
-1981-12-31,5R,Advanced economies,
-1981-12-31,AE,United Arab Emirates,
-1981-12-31,AT,Austria,
-1981-12-31,AU,Australia,40.5353
-1981-12-31,BE,Belgium,46.2604
-1981-12-31,BG,Bulgaria,
-1981-12-31,BR,Brazil,
-1981-12-31,CA,Canada,52.9533
-1981-12-31,CH,Switzerland,83.111
-1981-12-31,CL,Chile,
-1981-12-31,CN,China,
-1981-12-31,CO,Colombia,
-1981-12-31,CY,Cyprus,
-1981-12-31,CZ,Czechia,
-1981-12-31,DE,Germany,140.0288
-1981-12-31,DK,Denmark,49.2188
-1981-12-31,EE,Estonia,
-1981-12-31,ES,Spain,27.9152
+1981-09-30,SE,Sweden,48.594
+1981-09-30,US,United States,76.8507
+1981-09-30,XM,Euro area,67.4943
+1981-09-30,ZA,South Africa,81.7603
+1981-12-31,AU,Australia,40.4942
+1981-12-31,BE,Belgium,46.6541
+1981-12-31,CA,Canada,53.3638
+1981-12-31,CH,Switzerland,83.108
+1981-12-31,DE,Germany,139.9622
+1981-12-31,DK,Denmark,49.2219
+1981-12-31,ES,Spain,27.9153
 1981-12-31,FI,Finland,47.4988
-1981-12-31,FR,France,51.4435
-1981-12-31,GB,United Kingdom,30.6237
-1981-12-31,GR,Greece,
+1981-12-31,FR,France,51.4439
+1981-12-31,GB,United Kingdom,30.6135
 1981-12-31,HK,Hong Kong SAR,52.7462
-1981-12-31,HR,Croatia,
-1981-12-31,HU,Hungary,
-1981-12-31,ID,Indonesia,
-1981-12-31,IE,Ireland,50.5905
-1981-12-31,IL,Israel,
-1981-12-31,IN,India,
-1981-12-31,IS,Iceland,
-1981-12-31,IT,Italy,70.0233
+1981-12-31,IE,Ireland,50.615
+1981-12-31,IS,Iceland,85.0832
+1981-12-31,IT,Italy,70.0668
 1981-12-31,JP,Japan,128.4419
-1981-12-31,KR,Korea,85.4219
-1981-12-31,LT,Lithuania,
-1981-12-31,LU,Luxembourg,
-1981-12-31,LV,Latvia,
-1981-12-31,MA,Morocco,
-1981-12-31,MK,North Macedonia,
-1981-12-31,MT,Malta,
-1981-12-31,MX,Mexico,
-1981-12-31,MY,Malaysia,
-1981-12-31,NL,Netherlands,40.1795
-1981-12-31,NO,Norway,41.8086
+1981-12-31,KR,Korea,85.4188
+1981-12-31,NL,Netherlands,41.1546
+1981-12-31,NO,Norway,41.7923
 1981-12-31,NZ,New Zealand,40.8414
-1981-12-31,PE,Peru,
-1981-12-31,PH,Philippines,
-1981-12-31,PL,Poland,
-1981-12-31,PT,Portugal,
-1981-12-31,RO,Romania,
-1981-12-31,RS,Serbia,
-1981-12-31,RU,Russia,
-1981-12-31,SE,Sweden,46.8477
-1981-12-31,SG,Singapore,
-1981-12-31,SI,Slovenia,
-1981-12-31,SK,Slovak Republic,
-1981-12-31,TH,Thailand,
-1981-12-31,TR,Türkiye,
-1981-12-31,US,United States,76.7536
-1981-12-31,XM,Euro area,65.8516
-1981-12-31,XW,World,
-1981-12-31,ZA,South Africa,83.7833
-1982-03-31,4T,Emerging market economies (aggregate),
-1982-03-31,5R,Advanced economies,
-1982-03-31,AE,United Arab Emirates,
-1982-03-31,AT,Austria,
-1982-03-31,AU,Australia,39.3192
-1982-03-31,BE,Belgium,43.9244
-1982-03-31,BG,Bulgaria,
-1982-03-31,BR,Brazil,
-1982-03-31,CA,Canada,49.5513
-1982-03-31,CH,Switzerland,84.4743
-1982-03-31,CL,Chile,
-1982-03-31,CN,China,
-1982-03-31,CO,Colombia,
-1982-03-31,CY,Cyprus,
-1982-03-31,CZ,Czechia,
-1982-03-31,DE,Germany,138.2868
-1982-03-31,DK,Denmark,47.7901
-1982-03-31,EE,Estonia,
-1982-03-31,ES,Spain,27.4447
+1981-12-31,SE,Sweden,46.8321
+1981-12-31,US,United States,76.6736
+1981-12-31,XM,Euro area,65.6302
+1981-12-31,ZA,South Africa,83.6625
+1982-03-31,AU,Australia,39.329
+1982-03-31,BE,Belgium,44.2983
+1982-03-31,CA,Canada,49.9355
+1982-03-31,CH,Switzerland,84.4712
+1982-03-31,DE,Germany,138.428
+1982-03-31,DK,Denmark,47.793
+1982-03-31,ES,Spain,27.4448
 1982-03-31,FI,Finland,50.0684
-1982-03-31,FR,France,49.811
-1982-03-31,GB,United Kingdom,29.5516
-1982-03-31,GR,Greece,
+1982-03-31,FR,France,49.8113
+1982-03-31,GB,United Kingdom,29.5418
 1982-03-31,HK,Hong Kong SAR,48.099
-1982-03-31,HR,Croatia,
-1982-03-31,HU,Hungary,
-1982-03-31,ID,Indonesia,
-1982-03-31,IE,Ireland,49.2943
-1982-03-31,IL,Israel,
-1982-03-31,IN,India,
-1982-03-31,IS,Iceland,
-1982-03-31,IT,Italy,68.4568
+1982-03-31,IE,Ireland,49.3182
+1982-03-31,IS,Iceland,92.8386
+1982-03-31,IT,Italy,68.502
 1982-03-31,JP,Japan,131.0177
-1982-03-31,KR,Korea,84.6323
-1982-03-31,LT,Lithuania,
-1982-03-31,LU,Luxembourg,
-1982-03-31,LV,Latvia,
-1982-03-31,MA,Morocco,
-1982-03-31,MK,North Macedonia,
-1982-03-31,MT,Malta,
-1982-03-31,MX,Mexico,
-1982-03-31,MY,Malaysia,
-1982-03-31,NL,Netherlands,38.5178
-1982-03-31,NO,Norway,42.7074
+1982-03-31,KR,Korea,84.6293
+1982-03-31,NL,Netherlands,39.4526
+1982-03-31,NO,Norway,42.7693
 1982-03-31,NZ,New Zealand,42.9518
-1982-03-31,PE,Peru,
-1982-03-31,PH,Philippines,
-1982-03-31,PL,Poland,
-1982-03-31,PT,Portugal,
-1982-03-31,RO,Romania,
-1982-03-31,RS,Serbia,
-1982-03-31,RU,Russia,
-1982-03-31,SE,Sweden,45.9872
-1982-03-31,SG,Singapore,
-1982-03-31,SI,Slovenia,
-1982-03-31,SK,Slovak Republic,
-1982-03-31,TH,Thailand,
-1982-03-31,TR,Türkiye,
-1982-03-31,US,United States,76.4692
-1982-03-31,XM,Euro area,64.7911
-1982-03-31,XW,World,
-1982-03-31,ZA,South Africa,84.9975
-1982-06-30,4T,Emerging market economies (aggregate),
-1982-06-30,5R,Advanced economies,
-1982-06-30,AE,United Arab Emirates,
-1982-06-30,AT,Austria,
-1982-06-30,AU,Australia,39.6284
-1982-06-30,BE,Belgium,42.613
-1982-06-30,BG,Bulgaria,
-1982-06-30,BR,Brazil,
-1982-06-30,CA,Canada,46.0486
-1982-06-30,CH,Switzerland,82.1588
-1982-06-30,CL,Chile,
-1982-06-30,CN,China,
-1982-06-30,CO,Colombia,
-1982-06-30,CY,Cyprus,
-1982-06-30,CZ,Czechia,
-1982-06-30,DE,Germany,136.7363
-1982-06-30,DK,Denmark,47.0823
-1982-06-30,EE,Estonia,
+1982-03-31,SE,Sweden,45.9726
+1982-03-31,US,United States,76.3493
+1982-03-31,XM,Euro area,64.5797
+1982-03-31,ZA,South Africa,84.9409
+1982-06-30,AU,Australia,39.6127
+1982-06-30,BE,Belgium,42.9756
+1982-06-30,CA,Canada,46.4056
+1982-06-30,CH,Switzerland,82.1558
+1982-06-30,DE,Germany,136.7187
+1982-06-30,DK,Denmark,47.0852
 1982-06-30,ES,Spain,26.9604
 1982-06-30,FI,Finland,50.0447
-1982-06-30,FR,France,49.407
-1982-06-30,GB,United Kingdom,29.8106
-1982-06-30,GR,Greece,
+1982-06-30,FR,France,49.4073
+1982-06-30,GB,United Kingdom,29.8007
 1982-06-30,HK,Hong Kong SAR,45.2061
-1982-06-30,HR,Croatia,
-1982-06-30,HU,Hungary,
-1982-06-30,ID,Indonesia,
-1982-06-30,IE,Ireland,47.2395
-1982-06-30,IL,Israel,
-1982-06-30,IN,India,
-1982-06-30,IS,Iceland,
-1982-06-30,IT,Italy,68.4317
+1982-06-30,IE,Ireland,47.2624
+1982-06-30,IS,Iceland,96.8299
+1982-06-30,IT,Italy,68.4836
 1982-06-30,JP,Japan,131.7041
-1982-06-30,KR,Korea,84.0745
-1982-06-30,LT,Lithuania,
-1982-06-30,LU,Luxembourg,
-1982-06-30,LV,Latvia,
-1982-06-30,MA,Morocco,
-1982-06-30,MK,North Macedonia,
-1982-06-30,MT,Malta,
-1982-06-30,MX,Mexico,
-1982-06-30,MY,Malaysia,
-1982-06-30,NL,Netherlands,37.79
-1982-06-30,NO,Norway,44.6567
+1982-06-30,KR,Korea,84.0714
+1982-06-30,NL,Netherlands,38.7071
+1982-06-30,NO,Norway,44.6039
 1982-06-30,NZ,New Zealand,44.3346
-1982-06-30,PE,Peru,
-1982-06-30,PH,Philippines,
-1982-06-30,PL,Poland,
-1982-06-30,PT,Portugal,
-1982-06-30,RO,Romania,
-1982-06-30,RS,Serbia,
-1982-06-30,RU,Russia,
-1982-06-30,SE,Sweden,46.3621
-1982-06-30,SG,Singapore,
-1982-06-30,SI,Slovenia,
-1982-06-30,SK,Slovak Republic,
-1982-06-30,TH,Thailand,
-1982-06-30,TR,Türkiye,
-1982-06-30,US,United States,75.4534
-1982-06-30,XM,Euro area,64.032
-1982-06-30,XW,World,
-1982-06-30,ZA,South Africa,84.3638
-1982-09-30,4T,Emerging market economies (aggregate),
-1982-09-30,5R,Advanced economies,
-1982-09-30,AE,United Arab Emirates,
-1982-09-30,AT,Austria,
-1982-09-30,AU,Australia,37.6166
-1982-09-30,BE,Belgium,43.2654
-1982-09-30,BG,Bulgaria,
-1982-09-30,BR,Brazil,
-1982-09-30,CA,Canada,44.2326
-1982-09-30,CH,Switzerland,81.0804
-1982-09-30,CL,Chile,
-1982-09-30,CN,China,
-1982-09-30,CO,Colombia,
-1982-09-30,CY,Cyprus,
-1982-09-30,CZ,Czechia,
-1982-09-30,DE,Germany,135.1869
-1982-09-30,DK,Denmark,44.8698
-1982-09-30,EE,Estonia,
-1982-09-30,ES,Spain,26.5023
+1982-06-30,SE,Sweden,46.349
+1982-06-30,US,United States,75.3682
+1982-06-30,XM,Euro area,63.8318
+1982-06-30,ZA,South Africa,84.2189
+1982-09-30,AU,Australia,37.5919
+1982-09-30,BE,Belgium,43.6336
+1982-09-30,CA,Canada,44.5756
+1982-09-30,CH,Switzerland,81.0774
+1982-09-30,DE,Germany,135.2347
+1982-09-30,DK,Denmark,44.8726
+1982-09-30,ES,Spain,26.5024
 1982-09-30,FI,Finland,50.77
-1982-09-30,FR,France,50.307
-1982-09-30,GB,United Kingdom,30.3191
-1982-09-30,GR,Greece,
+1982-09-30,FR,France,50.3074
+1982-09-30,GB,United Kingdom,30.3091
 1982-09-30,HK,Hong Kong SAR,42.0218
-1982-09-30,HR,Croatia,
-1982-09-30,HU,Hungary,
-1982-09-30,ID,Indonesia,
-1982-09-30,IE,Ireland,47.6931
-1982-09-30,IL,Israel,
-1982-09-30,IN,India,
-1982-09-30,IS,Iceland,
-1982-09-30,IT,Italy,67.571
+1982-09-30,IE,Ireland,47.7163
+1982-09-30,IS,Iceland,100.9022
+1982-09-30,IT,Italy,67.6286
 1982-09-30,JP,Japan,133.1242
-1982-09-30,KR,Korea,85.7109
-1982-09-30,LT,Lithuania,
-1982-09-30,LU,Luxembourg,
-1982-09-30,LV,Latvia,
-1982-09-30,MA,Morocco,
-1982-09-30,MK,North Macedonia,
-1982-09-30,MT,Malta,
-1982-09-30,MX,Mexico,
-1982-09-30,MY,Malaysia,
-1982-09-30,NL,Netherlands,37.7589
-1982-09-30,NO,Norway,44.0592
+1982-09-30,KR,Korea,85.7078
+1982-09-30,NL,Netherlands,38.6752
+1982-09-30,NO,Norway,43.9715
 1982-09-30,NZ,New Zealand,43.7685
-1982-09-30,PE,Peru,
-1982-09-30,PH,Philippines,
-1982-09-30,PL,Poland,
-1982-09-30,PT,Portugal,
-1982-09-30,RO,Romania,
-1982-09-30,RS,Serbia,
-1982-09-30,RU,Russia,
-1982-09-30,SE,Sweden,46.1197
-1982-09-30,SG,Singapore,
-1982-09-30,SI,Slovenia,
-1982-09-30,SK,Slovak Republic,
-1982-09-30,TH,Thailand,
-1982-09-30,TR,Türkiye,
-1982-09-30,US,United States,74.1168
-1982-09-30,XM,Euro area,63.8163
-1982-09-30,XW,World,
-1982-09-30,ZA,South Africa,84.2468
-1982-12-31,4T,Emerging market economies (aggregate),
-1982-12-31,5R,Advanced economies,
-1982-12-31,AE,United Arab Emirates,
-1982-12-31,AT,Austria,
-1982-12-31,AU,Australia,36.3426
-1982-12-31,BE,Belgium,41.7111
-1982-12-31,BG,Bulgaria,
-1982-12-31,BR,Brazil,
-1982-12-31,CA,Canada,44.4937
-1982-12-31,CH,Switzerland,81.5869
-1982-12-31,CL,Chile,
-1982-12-31,CN,China,
-1982-12-31,CO,Colombia,
-1982-12-31,CY,Cyprus,
-1982-12-31,CZ,Czechia,
-1982-12-31,DE,Germany,133.6146
-1982-12-31,DK,Denmark,44.8184
-1982-12-31,EE,Estonia,
-1982-12-31,ES,Spain,26.6357
+1982-09-30,SE,Sweden,46.1081
+1982-09-30,US,United States,74.0346
+1982-09-30,XM,Euro area,63.6198
+1982-09-30,ZA,South Africa,84.139
+1982-12-31,AU,Australia,36.3729
+1982-12-31,BE,Belgium,42.0661
+1982-12-31,CA,Canada,44.8387
+1982-12-31,CH,Switzerland,81.5839
+1982-12-31,DE,Germany,133.4506
+1982-12-31,DK,Denmark,44.8212
+1982-12-31,ES,Spain,26.6358
 1982-12-31,FI,Finland,52.7579
-1982-12-31,FR,France,49.3556
-1982-12-31,GB,United Kingdom,30.3692
-1982-12-31,GR,Greece,
+1982-12-31,FR,France,49.356
+1982-12-31,GB,United Kingdom,30.3591
 1982-12-31,HK,Hong Kong SAR,38.9144
-1982-12-31,HR,Croatia,
-1982-12-31,HU,Hungary,
-1982-12-31,ID,Indonesia,
-1982-12-31,IE,Ireland,47.6183
-1982-12-31,IL,Israel,
-1982-12-31,IN,India,
-1982-12-31,IS,Iceland,
-1982-12-31,IT,Italy,66.1406
+1982-12-31,IE,Ireland,47.6414
+1982-12-31,IS,Iceland,90.5201
+1982-12-31,IT,Italy,66.1875
 1982-12-31,JP,Japan,133.613
-1982-12-31,KR,Korea,89.3848
-1982-12-31,LT,Lithuania,
-1982-12-31,LU,Luxembourg,
-1982-12-31,LV,Latvia,
-1982-12-31,MA,Morocco,
-1982-12-31,MK,North Macedonia,
-1982-12-31,MT,Malta,
-1982-12-31,MX,Mexico,
-1982-12-31,MY,Malaysia,
-1982-12-31,NL,Netherlands,36.5197
-1982-12-31,NO,Norway,43.7323
+1982-12-31,KR,Korea,89.3816
+1982-12-31,NL,Netherlands,37.406
+1982-12-31,NO,Norway,43.6599
 1982-12-31,NZ,New Zealand,43.5644
-1982-12-31,PE,Peru,
-1982-12-31,PH,Philippines,
-1982-12-31,PL,Poland,
-1982-12-31,PT,Portugal,
-1982-12-31,RO,Romania,
-1982-12-31,RS,Serbia,
-1982-12-31,RU,Russia,
-1982-12-31,SE,Sweden,44.4661
-1982-12-31,SG,Singapore,
-1982-12-31,SI,Slovenia,
-1982-12-31,SK,Slovak Republic,
-1982-12-31,TH,Thailand,
-1982-12-31,TR,Türkiye,
-1982-12-31,US,United States,74.4429
-1982-12-31,XM,Euro area,62.9169
-1982-12-31,XW,World,
-1982-12-31,ZA,South Africa,83.557
-1983-03-31,4T,Emerging market economies (aggregate),
-1983-03-31,5R,Advanced economies,
-1983-03-31,AE,United Arab Emirates,
-1983-03-31,AT,Austria,
-1983-03-31,AU,Australia,36.5359
-1983-03-31,BE,Belgium,40.2363
-1983-03-31,BG,Bulgaria,
-1983-03-31,BR,Brazil,
-1983-03-31,CA,Canada,47.2014
-1983-03-31,CH,Switzerland,81.9419
-1983-03-31,CL,Chile,
-1983-03-31,CN,China,
-1983-03-31,CO,Colombia,
-1983-03-31,CY,Cyprus,
-1983-03-31,CZ,Czechia,
-1983-03-31,DE,Germany,132.7529
-1983-03-31,DK,Denmark,48.2533
-1983-03-31,EE,Estonia,
+1982-12-31,SE,Sweden,44.456
+1982-12-31,US,United States,74.3588
+1982-12-31,XM,Euro area,62.7245
+1982-12-31,ZA,South Africa,83.4377
+1983-03-31,AU,Australia,36.5442
+1983-03-31,BE,Belgium,40.5788
+1983-03-31,CA,Canada,47.5674
+1983-03-31,CH,Switzerland,81.9388
+1983-03-31,DE,Germany,132.5901
+1983-03-31,DK,Denmark,48.2563
 1983-03-31,ES,Spain,28.4542
 1983-03-31,FI,Finland,56.0513
-1983-03-31,FR,France,47.8578
-1983-03-31,GB,United Kingdom,31.0947
-1983-03-31,GR,Greece,
+1983-03-31,FR,France,47.8582
+1983-03-31,GB,United Kingdom,31.0843
 1983-03-31,HK,Hong Kong SAR,36.1342
-1983-03-31,HR,Croatia,
-1983-03-31,HU,Hungary,
-1983-03-31,ID,Indonesia,
-1983-03-31,IE,Ireland,45.8552
-1983-03-31,IL,Israel,
-1983-03-31,IN,India,
-1983-03-31,IS,Iceland,
-1983-03-31,IT,Italy,64.9951
+1983-03-31,IE,Ireland,45.8775
+1983-03-31,IS,Iceland,85.3419
+1983-03-31,IT,Italy,65.0452
 1983-03-31,JP,Japan,135.7232
-1983-03-31,KR,Korea,93.5758
-1983-03-31,LT,Lithuania,
-1983-03-31,LU,Luxembourg,
-1983-03-31,LV,Latvia,
-1983-03-31,MA,Morocco,
-1983-03-31,MK,North Macedonia,
-1983-03-31,MT,Malta,
-1983-03-31,MX,Mexico,
-1983-03-31,MY,Malaysia,
-1983-03-31,NL,Netherlands,36.9657
-1983-03-31,NO,Norway,42.7816
+1983-03-31,KR,Korea,93.5724
+1983-03-31,NL,Netherlands,37.8628
+1983-03-31,NO,Norway,42.8262
 1983-03-31,NZ,New Zealand,43.8117
-1983-03-31,PE,Peru,
-1983-03-31,PH,Philippines,
-1983-03-31,PL,Poland,
-1983-03-31,PT,Portugal,
-1983-03-31,RO,Romania,
-1983-03-31,RS,Serbia,
-1983-03-31,RU,Russia,
-1983-03-31,SE,Sweden,42.9436
-1983-03-31,SG,Singapore,
-1983-03-31,SI,Slovenia,
-1983-03-31,SK,Slovak Republic,
-1983-03-31,TH,Thailand,
-1983-03-31,TR,Türkiye,
-1983-03-31,US,United States,75.2798
-1983-03-31,XM,Euro area,62.4919
-1983-03-31,XW,World,
-1983-03-31,ZA,South Africa,86.2229
-1983-06-30,4T,Emerging market economies (aggregate),
-1983-06-30,5R,Advanced economies,
-1983-06-30,AE,United Arab Emirates,
-1983-06-30,AT,Austria,
-1983-06-30,AU,Australia,37.0618
-1983-06-30,BE,Belgium,39.4599
-1983-06-30,BG,Bulgaria,
-1983-06-30,BR,Brazil,
-1983-06-30,CA,Canada,46.5465
-1983-06-30,CH,Switzerland,82.6405
-1983-06-30,CL,Chile,
-1983-06-30,CN,China,
-1983-06-30,CO,Colombia,
-1983-06-30,CY,Cyprus,
-1983-06-30,CZ,Czechia,
-1983-06-30,DE,Germany,133.0032
-1983-06-30,DK,Denmark,53.5669
-1983-06-30,EE,Estonia,
+1983-03-31,SE,Sweden,42.9357
+1983-03-31,US,United States,75.2029
+1983-03-31,XM,Euro area,62.3195
+1983-03-31,ZA,South Africa,86.0778
+1983-06-30,AU,Australia,37.0336
+1983-06-30,BE,Belgium,39.7957
+1983-06-30,CA,Canada,46.9074
+1983-06-30,CH,Switzerland,82.6376
+1983-06-30,DE,Germany,133.0482
+1983-06-30,DK,Denmark,53.5703
 1983-06-30,ES,Spain,29.0514
 1983-06-30,FI,Finland,55.7344
-1983-06-30,FR,France,47.6384
-1983-06-30,GB,United Kingdom,31.6377
-1983-06-30,GR,Greece,
+1983-06-30,FR,France,47.6388
+1983-06-30,GB,United Kingdom,31.6272
 1983-06-30,HK,Hong Kong SAR,35.3897
-1983-06-30,HR,Croatia,
-1983-06-30,HU,Hungary,
-1983-06-30,ID,Indonesia,
-1983-06-30,IE,Ireland,43.3329
-1983-06-30,IL,Israel,
-1983-06-30,IN,India,
-1983-06-30,IS,Iceland,
-1983-06-30,IT,Italy,64.1708
+1983-06-30,IE,Ireland,43.3539
+1983-06-30,IS,Iceland,76.4185
+1983-06-30,IT,Italy,64.2187
 1983-06-30,JP,Japan,135.4447
-1983-06-30,KR,Korea,97.1643
-1983-06-30,LT,Lithuania,
-1983-06-30,LU,Luxembourg,
-1983-06-30,LV,Latvia,
-1983-06-30,MA,Morocco,
-1983-06-30,MK,North Macedonia,
-1983-06-30,MT,Malta,
-1983-06-30,MX,Mexico,
-1983-06-30,MY,Malaysia,
-1983-06-30,NL,Netherlands,38.089
-1983-06-30,NO,Norway,42.155
+1983-06-30,KR,Korea,97.1608
+1983-06-30,NL,Netherlands,39.0133
+1983-06-30,NO,Norway,42.1163
 1983-06-30,NZ,New Zealand,44.1963
-1983-06-30,PE,Peru,
-1983-06-30,PH,Philippines,
-1983-06-30,PL,Poland,
-1983-06-30,PT,Portugal,
-1983-06-30,RO,Romania,
-1983-06-30,RS,Serbia,
-1983-06-30,RU,Russia,
-1983-06-30,SE,Sweden,42.7555
-1983-06-30,SG,Singapore,
-1983-06-30,SI,Slovenia,
-1983-06-30,SK,Slovak Republic,
-1983-06-30,TH,Thailand,
-1983-06-30,TR,Türkiye,
-1983-06-30,US,United States,75.3223
-1983-06-30,XM,Euro area,62.2092
-1983-06-30,XW,World,
-1983-06-30,ZA,South Africa,88.9201
-1983-09-30,4T,Emerging market economies (aggregate),
-1983-09-30,5R,Advanced economies,
-1983-09-30,AE,United Arab Emirates,
-1983-09-30,AT,Austria,
-1983-09-30,AU,Australia,36.2055
-1983-09-30,BE,Belgium,38.9224
-1983-09-30,BG,Bulgaria,
-1983-09-30,BR,Brazil,
-1983-09-30,CA,Canada,45.2222
-1983-09-30,CH,Switzerland,84.5671
-1983-09-30,CL,Chile,
-1983-09-30,CN,China,
-1983-09-30,CO,Colombia,
-1983-09-30,CY,Cyprus,
-1983-09-30,CZ,Czechia,
-1983-09-30,DE,Germany,131.9363
-1983-09-30,DK,Denmark,53.655
-1983-09-30,EE,Estonia,
+1983-06-30,SE,Sweden,42.7483
+1983-06-30,US,United States,75.2389
+1983-06-30,XM,Euro area,62.0499
+1983-06-30,ZA,South Africa,88.8528
+1983-09-30,AU,Australia,36.1734
+1983-09-30,BE,Belgium,39.2537
+1983-09-30,CA,Canada,45.5728
+1983-09-30,CH,Switzerland,84.5639
+1983-09-30,DE,Germany,131.968
+1983-09-30,DK,Denmark,53.6583
 1983-09-30,ES,Spain,28.8656
 1983-09-30,FI,Finland,56.978
-1983-09-30,FR,France,48.2151
-1983-09-30,GB,United Kingdom,32.6077
-1983-09-30,GR,Greece,
+1983-09-30,FR,France,48.2154
+1983-09-30,GB,United Kingdom,32.5969
 1983-09-30,HK,Hong Kong SAR,33.4094
-1983-09-30,HR,Croatia,
-1983-09-30,HU,Hungary,
-1983-09-30,ID,Indonesia,
-1983-09-30,IE,Ireland,44.3178
-1983-09-30,IL,Israel,
-1983-09-30,IN,India,
-1983-09-30,IS,Iceland,
-1983-09-30,IT,Italy,63.5042
+1983-09-30,IE,Ireland,44.3393
+1983-09-30,IS,Iceland,72.6737
+1983-09-30,IT,Italy,63.5587
 1983-09-30,JP,Japan,137.0956
-1983-09-30,KR,Korea,100.2899
-1983-09-30,LT,Lithuania,
-1983-09-30,LU,Luxembourg,
-1983-09-30,LV,Latvia,
-1983-09-30,MA,Morocco,
-1983-09-30,MK,North Macedonia,
-1983-09-30,MT,Malta,
-1983-09-30,MX,Mexico,
-1983-09-30,MY,Malaysia,
-1983-09-30,NL,Netherlands,37.7849
-1983-09-30,NO,Norway,42.3993
+1983-09-30,KR,Korea,100.2863
+1983-09-30,NL,Netherlands,38.7019
+1983-09-30,NO,Norway,42.342
 1983-09-30,NZ,New Zealand,44.9249
-1983-09-30,PE,Peru,
-1983-09-30,PH,Philippines,
-1983-09-30,PL,Poland,
-1983-09-30,PT,Portugal,
-1983-09-30,RO,Romania,
-1983-09-30,RS,Serbia,
-1983-09-30,RU,Russia,
-1983-09-30,SE,Sweden,42.016
-1983-09-30,SG,Singapore,
-1983-09-30,SI,Slovenia,
-1983-09-30,SK,Slovak Republic,
-1983-09-30,TH,Thailand,
-1983-09-30,TR,Türkiye,
-1983-09-30,US,United States,75.4517
-1983-09-30,XM,Euro area,62.1955
-1983-09-30,XW,World,
-1983-09-30,ZA,South Africa,91.0949
-1983-12-31,4T,Emerging market economies (aggregate),
-1983-12-31,5R,Advanced economies,
-1983-12-31,AE,United Arab Emirates,
-1983-12-31,AT,Austria,
-1983-12-31,AU,Australia,36.9361
-1983-12-31,BE,Belgium,38.0955
-1983-12-31,BG,Bulgaria,
-1983-12-31,BR,Brazil,
-1983-12-31,CA,Canada,44.9743
-1983-12-31,CH,Switzerland,85.0149
-1983-12-31,CL,Chile,
-1983-12-31,CN,China,
-1983-12-31,CO,Colombia,
-1983-12-31,CY,Cyprus,
-1983-12-31,CZ,Czechia,
-1983-12-31,DE,Germany,130.0562
-1983-12-31,DK,Denmark,54.0822
-1983-12-31,EE,Estonia,
+1983-09-30,SE,Sweden,42.0049
+1983-09-30,US,United States,75.3792
+1983-09-30,XM,Euro area,62.03
+1983-09-30,ZA,South Africa,91.0017
+1983-12-31,AU,Australia,36.9697
+1983-12-31,BE,Belgium,38.4197
+1983-12-31,CA,Canada,45.323
+1983-12-31,CH,Switzerland,85.0117
+1983-12-31,DE,Germany,130.1368
+1983-12-31,DK,Denmark,54.0855
 1983-12-31,ES,Spain,28.0197
 1983-12-31,FI,Finland,58.4732
-1983-12-31,FR,France,47.2706
-1983-12-31,GB,United Kingdom,32.5003
-1983-12-31,GR,Greece,
+1983-12-31,FR,France,47.2709
+1983-12-31,GB,United Kingdom,32.4895
 1983-12-31,HK,Hong Kong SAR,30.4542
-1983-12-31,HR,Croatia,
-1983-12-31,HU,Hungary,
-1983-12-31,ID,Indonesia,
-1983-12-31,IE,Ireland,42.2847
-1983-12-31,IL,Israel,
-1983-12-31,IN,India,
-1983-12-31,IS,Iceland,
-1983-12-31,IT,Italy,61.8727
+1983-12-31,IE,Ireland,42.3052
+1983-12-31,IS,Iceland,73.3264
+1983-12-31,IT,Italy,61.9232
 1983-12-31,JP,Japan,136.7549
-1983-12-31,KR,Korea,102.9381
-1983-12-31,LT,Lithuania,
-1983-12-31,LU,Luxembourg,
-1983-12-31,LV,Latvia,
-1983-12-31,MA,Morocco,
-1983-12-31,MK,North Macedonia,
-1983-12-31,MT,Malta,
-1983-12-31,MX,Mexico,
-1983-12-31,MY,Malaysia,
-1983-12-31,NL,Netherlands,36.2844
-1983-12-31,NO,Norway,42.7879
+1983-12-31,KR,Korea,102.9344
+1983-12-31,NL,Netherlands,37.165
+1983-12-31,NO,Norway,42.7962
 1983-12-31,NZ,New Zealand,45.9607
-1983-12-31,PE,Peru,
-1983-12-31,PH,Philippines,
-1983-12-31,PL,Poland,
-1983-12-31,PT,Portugal,
-1983-12-31,RO,Romania,
-1983-12-31,RS,Serbia,
-1983-12-31,RU,Russia,
-1983-12-31,SE,Sweden,41.4475
-1983-12-31,SG,Singapore,
-1983-12-31,SI,Slovenia,
-1983-12-31,SK,Slovak Republic,
-1983-12-31,TH,Thailand,
-1983-12-31,TR,Türkiye,
-1983-12-31,US,United States,75.7225
-1983-12-31,XM,Euro area,60.6937
-1983-12-31,XW,World,
-1983-12-31,ZA,South Africa,94.2708
-1984-03-31,4T,Emerging market economies (aggregate),
-1984-03-31,5R,Advanced economies,
-1984-03-31,AE,United Arab Emirates,
-1984-03-31,AT,Austria,
-1984-03-31,AU,Australia,38.3597
-1984-03-31,BE,Belgium,37.8706
-1984-03-31,BG,Bulgaria,
-1984-03-31,BR,Brazil,
-1984-03-31,CA,Canada,44.4042
-1984-03-31,CH,Switzerland,85.3761
-1984-03-31,CL,Chile,
-1984-03-31,CN,China,
-1984-03-31,CO,Colombia,
-1984-03-31,CY,Cyprus,
-1984-03-31,CZ,Czechia,
-1984-03-31,DE,Germany,127.7647
-1984-03-31,DK,Denmark,56.3168
-1984-03-31,EE,Estonia,
-1984-03-31,ES,Spain,28.0554
+1983-12-31,SE,Sweden,41.4371
+1983-12-31,US,United States,75.6543
+1983-12-31,XM,Euro area,60.5385
+1983-12-31,ZA,South Africa,94.1021
+1984-03-31,AU,Australia,38.3508
+1984-03-31,BE,Belgium,38.1929
+1984-03-31,CA,Canada,44.7485
+1984-03-31,CH,Switzerland,85.3729
+1984-03-31,DE,Germany,127.6886
+1984-03-31,DK,Denmark,56.3203
+1984-03-31,ES,Spain,28.0555
 1984-03-31,FI,Finland,60.0529
-1984-03-31,FR,France,46.1062
-1984-03-31,GB,United Kingdom,32.6777
-1984-03-31,GR,Greece,
+1984-03-31,FR,France,46.1065
+1984-03-31,GB,United Kingdom,32.6668
 1984-03-31,HK,Hong Kong SAR,30.8242
-1984-03-31,HR,Croatia,
-1984-03-31,HU,Hungary,
-1984-03-31,ID,Indonesia,
-1984-03-31,IE,Ireland,42.0026
-1984-03-31,IL,Israel,
-1984-03-31,IN,India,
-1984-03-31,IS,Iceland,
-1984-03-31,IT,Italy,60.4538
+1984-03-31,IE,Ireland,42.023
+1984-03-31,IS,Iceland,76.81
+1984-03-31,IT,Italy,60.4947
 1984-03-31,JP,Japan,137.3144
-1984-03-31,KR,Korea,105.8605
-1984-03-31,LT,Lithuania,
-1984-03-31,LU,Luxembourg,
-1984-03-31,LV,Latvia,
-1984-03-31,MA,Morocco,
-1984-03-31,MK,North Macedonia,
-1984-03-31,MT,Malta,
-1984-03-31,MX,Mexico,
-1984-03-31,MY,Malaysia,
-1984-03-31,NL,Netherlands,36.1958
-1984-03-31,NO,Norway,43.131
+1984-03-31,KR,Korea,105.8567
+1984-03-31,NL,Netherlands,37.0742
+1984-03-31,NO,Norway,43.0763
 1984-03-31,NZ,New Zealand,47.2505
-1984-03-31,PE,Peru,
-1984-03-31,PH,Philippines,
-1984-03-31,PL,Poland,
-1984-03-31,PT,Portugal,
-1984-03-31,RO,Romania,
-1984-03-31,RS,Serbia,
-1984-03-31,RU,Russia,
-1984-03-31,SE,Sweden,40.4617
-1984-03-31,SG,Singapore,
-1984-03-31,SI,Slovenia,
-1984-03-31,SK,Slovak Republic,
-1984-03-31,TH,Thailand,
-1984-03-31,TR,Türkiye,
-1984-03-31,US,United States,75.7859
-1984-03-31,XM,Euro area,59.5433
-1984-03-31,XW,World,
-1984-03-31,ZA,South Africa,94.3201
-1984-06-30,4T,Emerging market economies (aggregate),
-1984-06-30,5R,Advanced economies,
-1984-06-30,AE,United Arab Emirates,
-1984-06-30,AT,Austria,
-1984-06-30,AU,Australia,39.1521
-1984-06-30,BE,Belgium,37.5645
-1984-06-30,BG,Bulgaria,
-1984-06-30,BR,Brazil,
-1984-06-30,CA,Canada,44.2889
-1984-06-30,CH,Switzerland,86.6797
-1984-06-30,CL,Chile,
-1984-06-30,CN,China,
-1984-06-30,CO,Colombia,
-1984-06-30,CY,Cyprus,
-1984-06-30,CZ,Czechia,
-1984-06-30,DE,Germany,126.4926
-1984-06-30,DK,Denmark,56.4956
-1984-06-30,EE,Estonia,
-1984-06-30,ES,Spain,28.0246
+1984-03-31,SE,Sweden,40.4511
+1984-03-31,US,United States,75.6943
+1984-03-31,XM,Euro area,59.3946
+1984-03-31,ZA,South Africa,94.1988
+1984-06-30,AU,Australia,39.1422
+1984-06-30,BE,Belgium,37.8842
+1984-06-30,CA,Canada,44.6323
+1984-06-30,CH,Switzerland,86.6766
+1984-06-30,DE,Germany,126.532
+1984-06-30,DK,Denmark,56.4991
+1984-06-30,ES,Spain,28.0247
 1984-06-30,FI,Finland,59.0698
-1984-06-30,FR,France,46.0349
-1984-06-30,GB,United Kingdom,32.992
-1984-06-30,GR,Greece,
+1984-06-30,FR,France,46.0352
+1984-06-30,GB,United Kingdom,32.981
 1984-06-30,HK,Hong Kong SAR,30.4892
-1984-06-30,HR,Croatia,
-1984-06-30,HU,Hungary,
-1984-06-30,ID,Indonesia,
-1984-06-30,IE,Ireland,40.5376
-1984-06-30,IL,Israel,
-1984-06-30,IN,India,
-1984-06-30,IS,Iceland,
-1984-06-30,IT,Italy,59.3091
+1984-06-30,IE,Ireland,40.5572
+1984-06-30,IS,Iceland,79.3028
+1984-06-30,IT,Italy,59.3612
 1984-06-30,JP,Japan,137.1991
-1984-06-30,KR,Korea,108.5403
-1984-06-30,LT,Lithuania,
-1984-06-30,LU,Luxembourg,
-1984-06-30,LV,Latvia,
-1984-06-30,MA,Morocco,
-1984-06-30,MK,North Macedonia,
-1984-06-30,MT,Malta,
-1984-06-30,MX,Mexico,
-1984-06-30,MY,Malaysia,
-1984-06-30,NL,Netherlands,35.9542
-1984-06-30,NO,Norway,43.7656
+1984-06-30,KR,Korea,108.5364
+1984-06-30,NL,Netherlands,36.8267
+1984-06-30,NO,Norway,43.7359
 1984-06-30,NZ,New Zealand,47.7757
-1984-06-30,PE,Peru,
-1984-06-30,PH,Philippines,
-1984-06-30,PL,Poland,
-1984-06-30,PT,Portugal,
-1984-06-30,RO,Romania,
-1984-06-30,RS,Serbia,
-1984-06-30,RU,Russia,
-1984-06-30,SE,Sweden,40.9664
-1984-06-30,SG,Singapore,
-1984-06-30,SI,Slovenia,
-1984-06-30,SK,Slovak Republic,
-1984-06-30,TH,Thailand,
-1984-06-30,TR,Türkiye,
-1984-06-30,US,United States,75.9611
-1984-06-30,XM,Euro area,58.9691
-1984-06-30,XW,World,
-1984-06-30,ZA,South Africa,90.5561
-1984-09-30,4T,Emerging market economies (aggregate),
-1984-09-30,5R,Advanced economies,
-1984-09-30,AE,United Arab Emirates,
-1984-09-30,AT,Austria,
-1984-09-30,AU,Australia,40.2274
-1984-09-30,BE,Belgium,37.8281
-1984-09-30,BG,Bulgaria,
-1984-09-30,BR,Brazil,
-1984-09-30,CA,Canada,43.1127
-1984-09-30,CH,Switzerland,86.5299
-1984-09-30,CL,Chile,
-1984-09-30,CN,China,
-1984-09-30,CO,Colombia,
-1984-09-30,CY,Cyprus,
-1984-09-30,CZ,Czechia,
-1984-09-30,DE,Germany,125.6981
-1984-09-30,DK,Denmark,56.5551
-1984-09-30,EE,Estonia,
-1984-09-30,ES,Spain,27.3668
+1984-06-30,SE,Sweden,40.9584
+1984-06-30,US,United States,75.8725
+1984-06-30,XM,Euro area,58.8313
+1984-06-30,ZA,South Africa,90.4399
+1984-09-30,AU,Australia,40.2757
+1984-09-30,BE,Belgium,38.15
+1984-09-30,CA,Canada,43.447
+1984-09-30,CH,Switzerland,86.5267
+1984-09-30,DE,Germany,125.7555
+1984-09-30,DK,Denmark,56.5586
+1984-09-30,ES,Spain,27.3669
 1984-09-30,FI,Finland,59.5255
-1984-09-30,FR,France,46.4429
-1984-09-30,GB,United Kingdom,34.0898
-1984-09-30,GR,Greece,
+1984-09-30,FR,France,46.4432
+1984-09-30,GB,United Kingdom,34.0785
 1984-09-30,HK,Hong Kong SAR,28.66
-1984-09-30,HR,Croatia,
-1984-09-30,HU,Hungary,
-1984-09-30,ID,Indonesia,
-1984-09-30,IE,Ireland,41.7735
-1984-09-30,IL,Israel,
-1984-09-30,IN,India,
-1984-09-30,IS,Iceland,
-1984-09-30,IT,Italy,58.6682
+1984-09-30,IE,Ireland,41.7938
+1984-09-30,IS,Iceland,79.5199
+1984-09-30,IT,Italy,58.7096
 1984-09-30,JP,Japan,138.1991
-1984-09-30,KR,Korea,110.3602
-1984-09-30,LT,Lithuania,
-1984-09-30,LU,Luxembourg,
-1984-09-30,LV,Latvia,
-1984-09-30,MA,Morocco,
-1984-09-30,MK,North Macedonia,
-1984-09-30,MT,Malta,
-1984-09-30,MX,Mexico,
-1984-09-30,MY,Malaysia,
-1984-09-30,NL,Netherlands,36.0703
-1984-09-30,NO,Norway,43.7104
+1984-09-30,KR,Korea,110.3562
+1984-09-30,NL,Netherlands,36.9456
+1984-09-30,NO,Norway,43.7018
 1984-09-30,NZ,New Zealand,47.6779
-1984-09-30,PE,Peru,
-1984-09-30,PH,Philippines,
-1984-09-30,PL,Poland,
-1984-09-30,PT,Portugal,
-1984-09-30,RO,Romania,
-1984-09-30,RS,Serbia,
-1984-09-30,RU,Russia,
-1984-09-30,SE,Sweden,40.9643
-1984-09-30,SG,Singapore,
-1984-09-30,SI,Slovenia,
-1984-09-30,SK,Slovak Republic,
-1984-09-30,TH,Thailand,
-1984-09-30,TR,Türkiye,
-1984-09-30,US,United States,76.2447
-1984-09-30,XM,Euro area,58.8173
-1984-09-30,XW,World,
-1984-09-30,ZA,South Africa,86.9674
-1984-12-31,4T,Emerging market economies (aggregate),
-1984-12-31,5R,Advanced economies,
-1984-12-31,AE,United Arab Emirates,
-1984-12-31,AT,Austria,
-1984-12-31,AU,Australia,39.6406
-1984-12-31,BE,Belgium,37.0416
-1984-12-31,BG,Bulgaria,
-1984-12-31,BR,Brazil,
-1984-12-31,CA,Canada,43.3161
-1984-12-31,CH,Switzerland,86.2222
-1984-12-31,CL,Chile,
-1984-12-31,CN,China,
-1984-12-31,CO,Colombia,
-1984-12-31,CY,Cyprus,
-1984-12-31,CZ,Czechia,
-1984-12-31,DE,Germany,124.4394
-1984-12-31,DK,Denmark,58.1826
-1984-12-31,EE,Estonia,
-1984-12-31,ES,Spain,27.1558
+1984-09-30,SE,Sweden,40.953
+1984-09-30,US,United States,76.1709
+1984-09-30,XM,Euro area,58.6671
+1984-09-30,ZA,South Africa,86.8565
+1984-12-31,AU,Australia,39.6222
+1984-12-31,BE,Belgium,37.3569
+1984-12-31,CA,Canada,43.6519
+1984-12-31,CH,Switzerland,86.219
+1984-12-31,DE,Germany,124.4181
+1984-12-31,DK,Denmark,58.1863
+1984-12-31,ES,Spain,27.1559
 1984-12-31,FI,Finland,59.1963
-1984-12-31,FR,France,45.6924
-1984-12-31,GB,United Kingdom,34.24
-1984-12-31,GR,Greece,
+1984-12-31,FR,France,45.6928
+1984-12-31,GB,United Kingdom,34.2286
 1984-12-31,HK,Hong Kong SAR,28.8352
-1984-12-31,HR,Croatia,
-1984-12-31,HU,Hungary,
-1984-12-31,ID,Indonesia,
-1984-12-31,IE,Ireland,41.1411
-1984-12-31,IL,Israel,
-1984-12-31,IN,India,
-1984-12-31,IS,Iceland,
-1984-12-31,IT,Italy,57.487
+1984-12-31,IE,Ireland,41.161
+1984-12-31,IS,Iceland,75.8301
+1984-12-31,IT,Italy,57.5347
 1984-12-31,JP,Japan,137.5787
-1984-12-31,KR,Korea,111.33
-1984-12-31,LT,Lithuania,
-1984-12-31,LU,Luxembourg,
-1984-12-31,LV,Latvia,
-1984-12-31,MA,Morocco,
-1984-12-31,MK,North Macedonia,
-1984-12-31,MT,Malta,
-1984-12-31,MX,Mexico,
-1984-12-31,MY,Malaysia,
-1984-12-31,NL,Netherlands,35.1993
-1984-12-31,NO,Norway,42.8513
+1984-12-31,KR,Korea,111.326
+1984-12-31,NL,Netherlands,36.0535
+1984-12-31,NO,Norway,42.8714
 1984-12-31,NZ,New Zealand,47.4922
-1984-12-31,PE,Peru,
-1984-12-31,PH,Philippines,
-1984-12-31,PL,Poland,
-1984-12-31,PT,Portugal,
-1984-12-31,RO,Romania,
-1984-12-31,RS,Serbia,
-1984-12-31,RU,Russia,
-1984-12-31,SE,Sweden,40.1437
-1984-12-31,SG,Singapore,
-1984-12-31,SI,Slovenia,
-1984-12-31,SK,Slovak Republic,
-1984-12-31,TH,Thailand,
-1984-12-31,TR,Türkiye,
-1984-12-31,US,United States,76.2383
-1984-12-31,XM,Euro area,57.8413
-1984-12-31,XW,World,
-1984-12-31,ZA,South Africa,81.7581
-1985-03-31,4T,Emerging market economies (aggregate),
-1985-03-31,5R,Advanced economies,
-1985-03-31,AE,United Arab Emirates,
-1985-03-31,AT,Austria,
-1985-03-31,AU,Australia,41.1082
-1985-03-31,BE,Belgium,36.4536
-1985-03-31,BG,Bulgaria,
-1985-03-31,BR,Brazil,
-1985-03-31,CA,Canada,43.7256
-1985-03-31,CH,Switzerland,89.1461
-1985-03-31,CL,Chile,
-1985-03-31,CN,China,
-1985-03-31,CO,Colombia,
-1985-03-31,CY,Cyprus,
-1985-03-31,CZ,Czechia,
-1985-03-31,DE,Germany,122.8323
-1985-03-31,DK,Denmark,59.7671
-1985-03-31,EE,Estonia,
-1985-03-31,ES,Spain,27.8875
+1984-12-31,SE,Sweden,40.1387
+1984-12-31,US,United States,76.1405
+1984-12-31,XM,Euro area,57.6957
+1984-12-31,ZA,South Africa,81.6722
+1985-03-31,AU,Australia,41.0848
+1985-03-31,BE,Belgium,36.7639
+1985-03-31,CA,Canada,44.0646
+1985-03-31,CH,Switzerland,89.223
+1985-03-31,DE,Germany,122.8
+1985-03-31,DK,Denmark,59.7708
+1985-03-31,ES,Spain,27.8876
 1985-03-31,FI,Finland,59.9044
-1985-03-31,FR,France,44.6791
-1985-03-31,GB,United Kingdom,33.8942
-1985-03-31,GR,Greece,
+1985-03-31,FR,France,44.6795
+1985-03-31,GB,United Kingdom,33.8829
 1985-03-31,HK,Hong Kong SAR,29.7875
-1985-03-31,HR,Croatia,
-1985-03-31,HU,Hungary,
-1985-03-31,ID,Indonesia,
-1985-03-31,IE,Ireland,40.1253
-1985-03-31,IL,Israel,
-1985-03-31,IN,India,
-1985-03-31,IS,Iceland,
-1985-03-31,IT,Italy,56.1925
+1985-03-31,IE,Ireland,40.1448
+1985-03-31,IS,Iceland,71.5466
+1985-03-31,IT,Italy,56.2374
 1985-03-31,JP,Japan,138.3457
-1985-03-31,KR,Korea,112.3398
-1985-03-31,LT,Lithuania,
-1985-03-31,LU,Luxembourg,
-1985-03-31,LV,Latvia,
-1985-03-31,MA,Morocco,
-1985-03-31,MK,North Macedonia,
-1985-03-31,MT,Malta,
-1985-03-31,MX,Mexico,
-1985-03-31,MY,Malaysia,
-1985-03-31,NL,Netherlands,35.1117
-1985-03-31,NO,Norway,42.0247
+1985-03-31,KR,Korea,112.3357
+1985-03-31,NL,Netherlands,35.9638
+1985-03-31,NO,Norway,42.0104
 1985-03-31,NZ,New Zealand,47.0924
-1985-03-31,PE,Peru,
-1985-03-31,PH,Philippines,
-1985-03-31,PL,Poland,
-1985-03-31,PT,Portugal,
-1985-03-31,RO,Romania,
-1985-03-31,RS,Serbia,
-1985-03-31,RU,Russia,
-1985-03-31,SE,Sweden,39.4492
-1985-03-31,SG,Singapore,
-1985-03-31,SI,Slovenia,
-1985-03-31,SK,Slovak Republic,
-1985-03-31,TH,Thailand,
-1985-03-31,TR,Türkiye,
-1985-03-31,US,United States,76.6551
-1985-03-31,XM,Euro area,56.9784
-1985-03-31,XW,World,
-1985-03-31,ZA,South Africa,76.0963
-1985-06-30,4T,Emerging market economies (aggregate),
-1985-06-30,5R,Advanced economies,
-1985-06-30,AE,United Arab Emirates,
-1985-06-30,AT,Austria,
-1985-06-30,AU,Australia,40.5561
-1985-06-30,BE,Belgium,35.6473
-1985-06-30,BG,Bulgaria,
-1985-06-30,BR,Brazil,
-1985-06-30,CA,Canada,44.2199
-1985-06-30,CH,Switzerland,86.8918
-1985-06-30,CL,Chile,
-1985-06-30,CN,China,
-1985-06-30,CO,Colombia,
-1985-06-30,CY,Cyprus,
-1985-06-30,CZ,Czechia,
-1985-06-30,DE,Germany,121.8434
-1985-06-30,DK,Denmark,61.5643
-1985-06-30,EE,Estonia,
-1985-06-30,ES,Spain,28.0522
+1985-03-31,SE,Sweden,39.4409
+1985-03-31,US,United States,76.5674
+1985-03-31,XM,Euro area,56.8508
+1985-03-31,ZA,South Africa,76.0232
+1985-06-30,AU,Australia,40.541
+1985-06-30,BE,Belgium,35.9506
+1985-06-30,CA,Canada,44.5627
+1985-06-30,CH,Switzerland,86.8529
+1985-06-30,DE,Germany,121.7343
+1985-06-30,DK,Denmark,61.5682
+1985-06-30,ES,Spain,28.0523
 1985-06-30,FI,Finland,58.9534
-1985-06-30,FR,France,44.634
-1985-06-30,GB,United Kingdom,34.2516
-1985-06-30,GR,Greece,
+1985-06-30,FR,France,44.6343
+1985-06-30,GB,United Kingdom,34.2402
 1985-06-30,HK,Hong Kong SAR,30.9546
-1985-06-30,HR,Croatia,
-1985-06-30,HU,Hungary,
-1985-06-30,ID,Indonesia,
-1985-06-30,IE,Ireland,39.3062
-1985-06-30,IL,Israel,
-1985-06-30,IN,India,
-1985-06-30,IS,Iceland,
-1985-06-30,IT,Italy,55.1617
+1985-06-30,IE,Ireland,39.3252
+1985-06-30,IS,Iceland,71.4286
+1985-06-30,IT,Italy,55.2026
 1985-06-30,JP,Japan,137.7837
-1985-06-30,KR,Korea,113.3582
-1985-06-30,LT,Lithuania,
-1985-06-30,LU,Luxembourg,
-1985-06-30,LV,Latvia,
-1985-06-30,MA,Morocco,
-1985-06-30,MK,North Macedonia,
-1985-06-30,MT,Malta,
-1985-06-30,MX,Mexico,
-1985-06-30,MY,Malaysia,
-1985-06-30,NL,Netherlands,35.4464
-1985-06-30,NO,Norway,42.1813
+1985-06-30,KR,Korea,113.3541
+1985-06-30,NL,Netherlands,36.3066
+1985-06-30,NO,Norway,42.2098
 1985-06-30,NZ,New Zealand,46.538
-1985-06-30,PE,Peru,
-1985-06-30,PH,Philippines,
-1985-06-30,PL,Poland,
-1985-06-30,PT,Portugal,
-1985-06-30,RO,Romania,
-1985-06-30,RS,Serbia,
-1985-06-30,RU,Russia,
-1985-06-30,SE,Sweden,39.7034
-1985-06-30,SG,Singapore,
-1985-06-30,SI,Slovenia,
-1985-06-30,SK,Slovak Republic,
-1985-06-30,TH,Thailand,
-1985-06-30,TR,Türkiye,
-1985-06-30,US,United States,77.3983
-1985-06-30,XM,Euro area,56.4852
-1985-06-30,XW,World,
-1985-06-30,ZA,South Africa,71.1862
-1985-09-30,4T,Emerging market economies (aggregate),
-1985-09-30,5R,Advanced economies,
-1985-09-30,AE,United Arab Emirates,
-1985-09-30,AT,Austria,
-1985-09-30,AU,Australia,40.5445
-1985-09-30,BE,Belgium,36.8212
-1985-09-30,BG,Bulgaria,
-1985-09-30,BR,Brazil,
-1985-09-30,CA,Canada,44.0167
-1985-09-30,CH,Switzerland,87.7774
-1985-09-30,CL,Chile,
-1985-09-30,CN,China,
-1985-09-30,CO,Colombia,
-1985-09-30,CY,Cyprus,
-1985-09-30,CZ,Czechia,
-1985-09-30,DE,Germany,122.3284
-1985-09-30,DK,Denmark,66.0102
-1985-09-30,EE,Estonia,
+1985-06-30,SE,Sweden,39.6942
+1985-06-30,US,United States,77.3158
+1985-06-30,XM,Euro area,56.3589
+1985-06-30,ZA,South Africa,71.1241
+1985-09-30,AU,Australia,40.5517
+1985-09-30,BE,Belgium,37.1346
+1985-09-30,CA,Canada,44.358
+1985-09-30,CH,Switzerland,87.7643
+1985-09-30,DE,Germany,122.405
+1985-09-30,DK,Denmark,66.0143
 1985-09-30,ES,Spain,28.0618
 1985-09-30,FI,Finland,58.3819
-1985-09-30,FR,France,45.4199
-1985-09-30,GB,United Kingdom,34.8716
-1985-09-30,GR,Greece,
+1985-09-30,FR,France,45.4202
+1985-09-30,GB,United Kingdom,34.86
 1985-09-30,HK,Hong Kong SAR,32.5727
-1985-09-30,HR,Croatia,
-1985-09-30,HU,Hungary,
-1985-09-30,ID,Indonesia,
-1985-09-30,IE,Ireland,40.2913
-1985-09-30,IL,Israel,
-1985-09-30,IN,India,
-1985-09-30,IS,Iceland,
-1985-09-30,IT,Italy,54.8957
+1985-09-30,IE,Ireland,40.3109
+1985-09-30,IS,Iceland,66.5223
+1985-09-30,IT,Italy,54.939
 1985-09-30,JP,Japan,138.2744
-1985-09-30,KR,Korea,114.361
-1985-09-30,LT,Lithuania,
-1985-09-30,LU,Luxembourg,
-1985-09-30,LV,Latvia,
-1985-09-30,MA,Morocco,
-1985-09-30,MK,North Macedonia,
-1985-09-30,MT,Malta,
-1985-09-30,MX,Mexico,
-1985-09-30,MY,Malaysia,
-1985-09-30,NL,Netherlands,34.9885
-1985-09-30,NO,Norway,43.4083
+1985-09-30,KR,Korea,114.3569
+1985-09-30,NL,Netherlands,35.8377
+1985-09-30,NO,Norway,43.3999
 1985-09-30,NZ,New Zealand,47.0503
-1985-09-30,PE,Peru,
-1985-09-30,PH,Philippines,
-1985-09-30,PL,Poland,
-1985-09-30,PT,Portugal,
-1985-09-30,RO,Romania,
-1985-09-30,RS,Serbia,
-1985-09-30,RU,Russia,
-1985-09-30,SE,Sweden,39.6928
-1985-09-30,SG,Singapore,
-1985-09-30,SI,Slovenia,
-1985-09-30,SK,Slovak Republic,
-1985-09-30,TH,Thailand,
-1985-09-30,TR,Türkiye,
-1985-09-30,US,United States,77.5085
-1985-09-30,XM,Euro area,57.0327
-1985-09-30,XW,World,
-1985-09-30,ZA,South Africa,68.1589
-1985-12-31,4T,Emerging market economies (aggregate),
-1985-12-31,5R,Advanced economies,
-1985-12-31,AE,United Arab Emirates,
-1985-12-31,AT,Austria,
-1985-12-31,AU,Australia,40.3243
-1985-12-31,BE,Belgium,36.5186
-1985-12-31,BG,Bulgaria,
-1985-12-31,BR,Brazil,
-1985-12-31,CA,Canada,45.5245
-1985-12-31,CH,Switzerland,86.8077
-1985-12-31,CL,Chile,
-1985-12-31,CN,China,
-1985-12-31,CO,Colombia,
-1985-12-31,CY,Cyprus,
-1985-12-31,CZ,Czechia,
-1985-12-31,DE,Germany,122.0951
-1985-12-31,DK,Denmark,67.0476
-1985-12-31,EE,Estonia,
-1985-12-31,ES,Spain,27.821
+1985-09-30,SE,Sweden,39.6862
+1985-09-30,US,United States,77.4229
+1985-09-30,XM,Euro area,56.899
+1985-09-30,ZA,South Africa,68.0786
+1985-12-31,AU,Australia,40.3391
+1985-12-31,BE,Belgium,36.8293
+1985-12-31,CA,Canada,45.8775
+1985-12-31,CH,Switzerland,86.7725
+1985-12-31,DE,Germany,122.1579
+1985-12-31,DK,Denmark,67.0518
+1985-12-31,ES,Spain,27.8211
 1985-12-31,FI,Finland,58.6048
-1985-12-31,FR,France,45.112
-1985-12-31,GB,United Kingdom,35.7806
-1985-12-31,GR,Greece,
+1985-12-31,FR,France,45.1123
+1985-12-31,GB,United Kingdom,35.7687
 1985-12-31,HK,Hong Kong SAR,33.509
-1985-12-31,HR,Croatia,
-1985-12-31,HU,Hungary,
-1985-12-31,ID,Indonesia,
-1985-12-31,IE,Ireland,41.1374
-1985-12-31,IL,Israel,
-1985-12-31,IN,India,
-1985-12-31,IS,Iceland,
-1985-12-31,IT,Italy,53.9568
+1985-12-31,IE,Ireland,41.1574
+1985-12-31,IS,Iceland,65.151
+1985-12-31,IT,Italy,53.9975
 1985-12-31,JP,Japan,138.4299
-1985-12-31,KR,Korea,115.3269
-1985-12-31,LT,Lithuania,
-1985-12-31,LU,Luxembourg,
-1985-12-31,LV,Latvia,
-1985-12-31,MA,Morocco,
-1985-12-31,MK,North Macedonia,
-1985-12-31,MT,Malta,
-1985-12-31,MX,Mexico,
-1985-12-31,MY,Malaysia,
-1985-12-31,NL,Netherlands,34.9431
-1985-12-31,NO,Norway,45.4699
+1985-12-31,KR,Korea,115.3227
+1985-12-31,NL,Netherlands,35.7912
+1985-12-31,NO,Norway,45.456
 1985-12-31,NZ,New Zealand,47.4513
-1985-12-31,PE,Peru,
-1985-12-31,PH,Philippines,
-1985-12-31,PL,Poland,
-1985-12-31,PT,Portugal,
-1985-12-31,RO,Romania,
-1985-12-31,RS,Serbia,
-1985-12-31,RU,Russia,
-1985-12-31,SE,Sweden,38.8154
-1985-12-31,SG,Singapore,
-1985-12-31,SI,Slovenia,
-1985-12-31,SK,Slovak Republic,
-1985-12-31,TH,Thailand,
-1985-12-31,TR,Türkiye,
-1985-12-31,US,United States,78.3303
-1985-12-31,XM,Euro area,56.7076
-1985-12-31,XW,World,
-1985-12-31,ZA,South Africa,65.2228
-1986-03-31,4T,Emerging market economies (aggregate),
-1986-03-31,5R,Advanced economies,
-1986-03-31,AE,United Arab Emirates,
-1986-03-31,AT,Austria,
-1986-03-31,AU,Australia,40.3183
-1986-03-31,BE,Belgium,36.4789
-1986-03-31,BG,Bulgaria,
-1986-03-31,BR,Brazil,
-1986-03-31,CA,Canada,47.555
-1986-03-31,CH,Switzerland,89.6759
-1986-03-31,CL,Chile,
-1986-03-31,CN,China,
-1986-03-31,CO,Colombia,
-1986-03-31,CY,Cyprus,
-1986-03-31,CZ,Czechia,
-1986-03-31,DE,Germany,121.9063
-1986-03-31,DK,Denmark,70.8711
-1986-03-31,EE,Estonia,
+1985-12-31,SE,Sweden,38.8112
+1985-12-31,US,United States,78.2191
+1985-12-31,XM,Euro area,56.5739
+1985-12-31,ZA,South Africa,65.1333
+1986-03-31,AU,Australia,40.2975
+1986-03-31,BE,Belgium,36.7893
+1986-03-31,CA,Canada,47.9237
+1986-03-31,CH,Switzerland,89.7965
+1986-03-31,DE,Germany,121.8222
+1986-03-31,DK,Denmark,70.8755
 1986-03-31,ES,Spain,27.7051
 1986-03-31,FI,Finland,59.8983
-1986-03-31,FR,France,44.9415
-1986-03-31,GB,United Kingdom,36.3688
-1986-03-31,GR,Greece,
+1986-03-31,FR,France,44.9418
+1986-03-31,GB,United Kingdom,36.3567
 1986-03-31,HK,Hong Kong SAR,33.4486
-1986-03-31,HR,Croatia,
-1986-03-31,HU,Hungary,
-1986-03-31,ID,Indonesia,
-1986-03-31,IE,Ireland,39.6496
-1986-03-31,IL,Israel,
-1986-03-31,IN,India,
-1986-03-31,IS,Iceland,
-1986-03-31,IT,Italy,53.5196
+1986-03-31,IE,Ireland,39.6688
+1986-03-31,IS,Iceland,60.2917
+1986-03-31,IT,Italy,53.5581
 1986-03-31,JP,Japan,139.1313
-1986-03-31,KR,Korea,120.995
-1986-03-31,LT,Lithuania,
-1986-03-31,LU,Luxembourg,
-1986-03-31,LV,Latvia,
-1986-03-31,MA,Morocco,
-1986-03-31,MK,North Macedonia,
-1986-03-31,MT,Malta,
-1986-03-31,MX,Mexico,
-1986-03-31,MY,Malaysia,
-1986-03-31,NL,Netherlands,35.9735
-1986-03-31,NO,Norway,48.307
+1986-03-31,KR,Korea,120.9881
+1986-03-31,NL,Netherlands,36.8465
+1986-03-31,NO,Norway,48.2646
 1986-03-31,NZ,New Zealand,47.3267
-1986-03-31,PE,Peru,
-1986-03-31,PH,Philippines,
-1986-03-31,PL,Poland,
-1986-03-31,PT,Portugal,
-1986-03-31,RO,Romania,
-1986-03-31,RS,Serbia,
-1986-03-31,RU,Russia,
-1986-03-31,SE,Sweden,38.7987
-1986-03-31,SG,Singapore,
-1986-03-31,SI,Slovenia,
-1986-03-31,SK,Slovak Republic,
-1986-03-31,TH,Thailand,
-1986-03-31,TR,Türkiye,
-1986-03-31,US,United States,79.7413
-1986-03-31,XM,Euro area,56.3263
-1986-03-31,XW,World,
-1986-03-31,ZA,South Africa,60.8852
-1986-06-30,4T,Emerging market economies (aggregate),
-1986-06-30,5R,Advanced economies,
-1986-06-30,AE,United Arab Emirates,
-1986-06-30,AT,Austria,
-1986-06-30,AU,Australia,40.7216
-1986-06-30,BE,Belgium,36.8802
-1986-06-30,BG,Bulgaria,
-1986-06-30,BR,Brazil,
-1986-06-30,CA,Canada,49.544
-1986-06-30,CH,Switzerland,86.9574
-1986-06-30,CL,Chile,
-1986-06-30,CN,China,
-1986-06-30,CO,Colombia,
-1986-06-30,CY,Cyprus,
-1986-06-30,CZ,Czechia,
-1986-06-30,DE,Germany,122.8822
-1986-06-30,DK,Denmark,68.8884
-1986-06-30,EE,Estonia,
-1986-06-30,ES,Spain,28.6835
+1986-03-31,SE,Sweden,38.7904
+1986-03-31,US,United States,79.6301
+1986-03-31,XM,Euro area,56.2028
+1986-03-31,ZA,South Africa,60.8073
+1986-06-30,AU,Australia,40.7234
+1986-06-30,BE,Belgium,37.1941
+1986-06-30,CA,Canada,49.9282
+1986-06-30,CH,Switzerland,86.906
+1986-06-30,DE,Germany,122.9146
+1986-06-30,DK,Denmark,68.8927
+1986-06-30,ES,Spain,28.6836
 1986-06-30,FI,Finland,59.1062
-1986-06-30,FR,France,45.5235
-1986-06-30,GB,United Kingdom,37.4498
-1986-06-30,GR,Greece,
+1986-06-30,FR,France,45.5238
+1986-06-30,GB,United Kingdom,37.4374
 1986-06-30,HK,Hong Kong SAR,33.3308
-1986-06-30,HR,Croatia,
-1986-06-30,HU,Hungary,
-1986-06-30,ID,Indonesia,
-1986-06-30,IE,Ireland,39.2326
-1986-06-30,IL,Israel,
-1986-06-30,IN,India,
-1986-06-30,IS,Iceland,
-1986-06-30,IT,Italy,53.4831
+1986-06-30,IE,Ireland,39.2517
+1986-06-30,IS,Iceland,61.4409
+1986-06-30,IT,Italy,53.5304
 1986-06-30,JP,Japan,139.7669
-1986-06-30,KR,Korea,119.025
-1986-06-30,LT,Lithuania,
-1986-06-30,LU,Luxembourg,
-1986-06-30,LV,Latvia,
-1986-06-30,MA,Morocco,
-1986-06-30,MK,North Macedonia,
-1986-06-30,MT,Malta,
-1986-06-30,MX,Mexico,
-1986-06-30,MY,Malaysia,
-1986-06-30,NL,Netherlands,36.5212
-1986-06-30,NO,Norway,51.7446
+1986-06-30,KR,Korea,119.0011
+1986-06-30,NL,Netherlands,37.4075
+1986-06-30,NO,Norway,51.7814
 1986-06-30,NZ,New Zealand,46.7187
-1986-06-30,PE,Peru,
-1986-06-30,PH,Philippines,
-1986-06-30,PL,Poland,
-1986-06-30,PT,Portugal,
-1986-06-30,RO,Romania,
-1986-06-30,RS,Serbia,
-1986-06-30,RU,Russia,
-1986-06-30,SE,Sweden,39.2949
-1986-06-30,SG,Singapore,
-1986-06-30,SI,Slovenia,
-1986-06-30,SK,Slovak Republic,
-1986-06-30,TH,Thailand,
-1986-06-30,TR,Türkiye,
-1986-06-30,US,United States,81.4458
-1986-06-30,XM,Euro area,56.8937
-1986-06-30,XW,World,
-1986-06-30,ZA,South Africa,57.8871
-1986-09-30,4T,Emerging market economies (aggregate),
-1986-09-30,5R,Advanced economies,
-1986-09-30,AE,United Arab Emirates,
-1986-09-30,AT,Austria,
-1986-09-30,AU,Australia,38.5959
-1986-09-30,BE,Belgium,38.726
-1986-09-30,BG,Bulgaria,
-1986-09-30,BR,Brazil,
-1986-09-30,CA,Canada,49.8048
-1986-09-30,CH,Switzerland,88.5379
-1986-09-30,CL,Chile,
-1986-09-30,CN,China,
-1986-09-30,CO,Colombia,
-1986-09-30,CY,Cyprus,
-1986-09-30,CZ,Czechia,
-1986-09-30,DE,Germany,123.2271
-1986-09-30,DK,Denmark,67.0575
-1986-09-30,EE,Estonia,
+1986-06-30,SE,Sweden,39.2844
+1986-06-30,US,United States,81.3545
+1986-06-30,XM,Euro area,56.7666
+1986-06-30,ZA,South Africa,57.8231
+1986-09-30,AT,Austria,56.8516
+1986-09-30,AU,Australia,38.5895
+1986-09-30,BE,Belgium,39.0556
+1986-09-30,CA,Canada,50.191
+1986-09-30,CH,Switzerland,88.5313
+1986-09-30,DE,Germany,123.2699
+1986-09-30,DK,Denmark,67.0617
 1986-09-30,ES,Spain,29.8961
 1986-09-30,FI,Finland,59.2354
-1986-09-30,FR,France,46.5751
-1986-09-30,GB,United Kingdom,38.9299
-1986-09-30,GR,Greece,
+1986-09-30,FR,France,46.5754
+1986-09-30,GB,United Kingdom,38.9169
 1986-09-30,HK,Hong Kong SAR,34.6061
-1986-09-30,HR,Croatia,
-1986-09-30,HU,Hungary,
-1986-09-30,ID,Indonesia,
-1986-09-30,IE,Ireland,41.0905
-1986-09-30,IL,Israel,
-1986-09-30,IN,India,
-1986-09-30,IS,Iceland,
-1986-09-30,IT,Italy,53.6083
+1986-09-30,IE,Ireland,41.1104
+1986-09-30,IS,Iceland,64.0197
+1986-09-30,IT,Italy,53.6549
 1986-09-30,JP,Japan,141.4108
-1986-09-30,KR,Korea,117.8128
-1986-09-30,LT,Lithuania,
-1986-09-30,LU,Luxembourg,
-1986-09-30,LV,Latvia,
-1986-09-30,MA,Morocco,
-1986-09-30,MK,North Macedonia,
-1986-09-30,MT,Malta,
-1986-09-30,MX,Mexico,
-1986-09-30,MY,Malaysia,
-1986-09-30,NL,Netherlands,37.488
-1986-09-30,NO,Norway,54.0743
+1986-09-30,KR,Korea,117.7577
+1986-09-30,NL,Netherlands,38.3978
+1986-09-30,NO,Norway,54.0476
 1986-09-30,NZ,New Zealand,46.2232
-1986-09-30,PE,Peru,
-1986-09-30,PH,Philippines,
-1986-09-30,PL,Poland,
-1986-09-30,PT,Portugal,
-1986-09-30,RO,Romania,
-1986-09-30,RS,Serbia,
-1986-09-30,RU,Russia,
-1986-09-30,SE,Sweden,40.1554
-1986-09-30,SG,Singapore,
-1986-09-30,SI,Slovenia,
-1986-09-30,SK,Slovak Republic,
-1986-09-30,TH,Thailand,
-1986-09-30,TR,Türkiye,
-1986-09-30,US,United States,82.7615
-1986-09-30,XM,Euro area,57.7852
-1986-09-30,XW,World,
-1986-09-30,ZA,South Africa,55.0836
-1986-12-31,4T,Emerging market economies (aggregate),
-1986-12-31,5R,Advanced economies,
-1986-12-31,AE,United Arab Emirates,
-1986-12-31,AT,Austria,
-1986-12-31,AU,Australia,37.9862
-1986-12-31,BE,Belgium,38.1831
-1986-12-31,BG,Bulgaria,
-1986-12-31,BR,Brazil,
-1986-12-31,CA,Canada,52.7062
-1986-12-31,CH,Switzerland,87.5126
-1986-12-31,CL,Chile,
-1986-12-31,CN,China,
-1986-12-31,CO,Colombia,
-1986-12-31,CY,Cyprus,
-1986-12-31,CZ,Czechia,
-1986-12-31,DE,Germany,122.9874
-1986-12-31,DK,Denmark,67.3232
-1986-12-31,EE,Estonia,
+1986-09-30,SE,Sweden,40.1473
+1986-09-30,US,United States,82.6125
+1986-09-30,XM,Euro area,57.6631
+1986-09-30,ZA,South Africa,55.0132
+1986-12-31,AT,Austria,53.7069
+1986-12-31,AU,Australia,37.9594
+1986-12-31,BE,Belgium,38.508
+1986-12-31,CA,Canada,53.1148
+1986-12-31,CH,Switzerland,87.4396
+1986-12-31,DE,Germany,122.9953
+1986-12-31,DK,Denmark,67.3274
 1986-12-31,ES,Spain,32.1552
 1986-12-31,FI,Finland,60.2855
-1986-12-31,FR,France,46.5016
-1986-12-31,GB,United Kingdom,39.7579
-1986-12-31,GR,Greece,
+1986-12-31,FR,France,46.5019
+1986-12-31,GB,United Kingdom,39.7446
 1986-12-31,HK,Hong Kong SAR,36.0542
-1986-12-31,HR,Croatia,
-1986-12-31,HU,Hungary,
-1986-12-31,ID,Indonesia,
-1986-12-31,IE,Ireland,40.4329
-1986-12-31,IL,Israel,
-1986-12-31,IN,India,
-1986-12-31,IS,Iceland,
-1986-12-31,IT,Italy,53.2769
+1986-12-31,IE,Ireland,40.4525
+1986-12-31,IS,Iceland,66.8747
+1986-12-31,IT,Italy,53.3191
 1986-12-31,JP,Japan,143.6332
-1986-12-31,KR,Korea,117.966
-1986-12-31,LT,Lithuania,
-1986-12-31,LU,Luxembourg,
-1986-12-31,LV,Latvia,
-1986-12-31,MA,Morocco,
-1986-12-31,MK,North Macedonia,
-1986-12-31,MT,Malta,
-1986-12-31,MX,Mexico,
-1986-12-31,MY,Malaysia,
-1986-12-31,NL,Netherlands,37.0735
-1986-12-31,NO,Norway,55.3734
+1986-12-31,KR,Korea,118.0349
+1986-12-31,NL,Netherlands,37.9732
+1986-12-31,NO,Norway,55.4297
 1986-12-31,NZ,New Zealand,43.3105
-1986-12-31,PE,Peru,
-1986-12-31,PH,Philippines,
-1986-12-31,PL,Poland,
-1986-12-31,PT,Portugal,
-1986-12-31,RO,Romania,
-1986-12-31,RS,Serbia,
-1986-12-31,RU,Russia,
-1986-12-31,SE,Sweden,40.7745
-1986-12-31,SG,Singapore,
-1986-12-31,SI,Slovenia,
-1986-12-31,SK,Slovak Republic,
-1986-12-31,TH,Thailand,
-1986-12-31,TR,Türkiye,
-1986-12-31,US,United States,83.5923
-1986-12-31,XM,Euro area,58.0144
-1986-12-31,XW,World,
-1986-12-31,ZA,South Africa,53.2606
-1987-03-31,4T,Emerging market economies (aggregate),
-1987-03-31,5R,Advanced economies,
-1987-03-31,AE,United Arab Emirates,
-1987-03-31,AT,Austria,
-1987-03-31,AU,Australia,37.6495
-1987-03-31,BE,Belgium,38.9502
-1987-03-31,BG,Bulgaria,
-1987-03-31,BR,Brazil,
-1987-03-31,CA,Canada,56.6089
-1987-03-31,CH,Switzerland,88.6891
-1987-03-31,CL,Chile,
-1987-03-31,CN,China,
-1987-03-31,CO,Colombia,
-1987-03-31,CY,Cyprus,
-1987-03-31,CZ,Czechia,
-1987-03-31,DE,Germany,121.5717
-1987-03-31,DK,Denmark,62.5626
-1987-03-31,EE,Estonia,
-1987-03-31,ES,Spain,35.9612
+1986-12-31,SE,Sweden,40.7645
+1986-12-31,US,United States,83.4585
+1986-12-31,XM,Euro area,57.9081
+1986-12-31,ZA,South Africa,53.1884
+1987-03-31,AT,Austria,58.0293
+1987-03-31,AU,Australia,37.6293
+1987-03-31,BE,Belgium,39.2817
+1987-03-31,CA,Canada,57.0478
+1987-03-31,CH,Switzerland,88.7
+1987-03-31,DE,Germany,121.6118
+1987-03-31,DK,Denmark,62.5665
+1987-03-31,ES,Spain,35.9613
 1987-03-31,FI,Finland,61.0184
-1987-03-31,FR,France,46.014
-1987-03-31,GB,United Kingdom,40.6393
-1987-03-31,GR,Greece,
+1987-03-31,FR,France,46.0143
+1987-03-31,GB,United Kingdom,40.6258
 1987-03-31,HK,Hong Kong SAR,38.5722
-1987-03-31,HR,Croatia,
-1987-03-31,HU,Hungary,
-1987-03-31,ID,Indonesia,
-1987-03-31,IE,Ireland,38.9808
-1987-03-31,IL,Israel,
-1987-03-31,IN,India,
-1987-03-31,IS,Iceland,
-1987-03-31,IT,Italy,53.2546
+1987-03-31,IE,Ireland,38.9997
+1987-03-31,IS,Iceland,70.0435
+1987-03-31,IT,Italy,53.2992
 1987-03-31,JP,Japan,146.6125
-1987-03-31,KR,Korea,116.4085
-1987-03-31,LT,Lithuania,
-1987-03-31,LU,Luxembourg,
-1987-03-31,LV,Latvia,
-1987-03-31,MA,Morocco,
-1987-03-31,MK,North Macedonia,
-1987-03-31,MT,Malta,
-1987-03-31,MX,Mexico,
-1987-03-31,MY,Malaysia,
-1987-03-31,NL,Netherlands,38.3617
-1987-03-31,NO,Norway,59.5033
+1987-03-31,KR,Korea,116.361
+1987-03-31,NL,Netherlands,39.2927
+1987-03-31,NO,Norway,59.426
 1987-03-31,NZ,New Zealand,44.733
-1987-03-31,PE,Peru,
-1987-03-31,PH,Philippines,
-1987-03-31,PL,Poland,
-1987-03-31,PT,Portugal,
-1987-03-31,RO,Romania,
-1987-03-31,RS,Serbia,
-1987-03-31,RU,Russia,
-1987-03-31,SE,Sweden,41.9128
-1987-03-31,SG,Singapore,
-1987-03-31,SI,Slovenia,
-1987-03-31,SK,Slovak Republic,
-1987-03-31,TH,Thailand,
-1987-03-31,TR,Türkiye,
-1987-03-31,US,United States,85.3988
-1987-03-31,XM,Euro area,58.6835
-1987-03-31,XW,World,
-1987-03-31,ZA,South Africa,53.099
-1987-06-30,4T,Emerging market economies (aggregate),
-1987-06-30,5R,Advanced economies,
-1987-06-30,AE,United Arab Emirates,
-1987-06-30,AT,Austria,
-1987-06-30,AU,Australia,37.4883
-1987-06-30,BE,Belgium,38.7144
-1987-06-30,BG,Bulgaria,
-1987-06-30,BR,Brazil,
-1987-06-30,CA,Canada,55.1368
-1987-06-30,CH,Switzerland,89.9225
-1987-06-30,CL,Chile,
-1987-06-30,CN,China,
-1987-06-30,CO,Colombia,
-1987-06-30,CY,Cyprus,
-1987-06-30,CZ,Czechia,
-1987-06-30,DE,Germany,121.1573
-1987-06-30,DK,Denmark,61.4882
-1987-06-30,EE,Estonia,
-1987-06-30,ES,Spain,38.0252
+1987-03-31,SE,Sweden,41.907
+1987-03-31,US,United States,85.2536
+1987-03-31,XM,Euro area,58.5998
+1987-03-31,ZA,South Africa,53.0271
+1987-06-30,AT,Austria,63.082
+1987-06-30,AU,Australia,37.499
+1987-06-30,BE,Belgium,39.0439
+1987-06-30,CA,Canada,55.5643
+1987-06-30,CH,Switzerland,89.973
+1987-06-30,DE,Germany,121.0947
+1987-06-30,DK,Denmark,61.492
+1987-06-30,ES,Spain,38.0253
 1987-06-30,FI,Finland,62.3302
-1987-06-30,FR,France,46.9214
-1987-06-30,GB,United Kingdom,41.9386
-1987-06-30,GR,Greece,
+1987-06-30,FR,France,46.9218
+1987-06-30,GB,United Kingdom,41.9247
 1987-06-30,HK,Hong Kong SAR,40.1813
-1987-06-30,HR,Croatia,
-1987-06-30,HU,Hungary,
-1987-06-30,ID,Indonesia,
-1987-06-30,IE,Ireland,37.4456
-1987-06-30,IL,Israel,
-1987-06-30,IN,India,
-1987-06-30,IS,Iceland,
-1987-06-30,IT,Italy,53.7404
+1987-06-30,IE,Ireland,37.4637
+1987-06-30,IS,Iceland,71.1995
+1987-06-30,IT,Italy,53.7774
 1987-06-30,JP,Japan,149.2652
-1987-06-30,KR,Korea,114.0842
-1987-06-30,LT,Lithuania,
-1987-06-30,LU,Luxembourg,
-1987-06-30,LV,Latvia,
-1987-06-30,MA,Morocco,
-1987-06-30,MK,North Macedonia,
-1987-06-30,MT,Malta,
-1987-06-30,MX,Mexico,
-1987-06-30,MY,Malaysia,
-1987-06-30,NL,Netherlands,39.1067
-1987-06-30,NO,Norway,59.6714
+1987-06-30,KR,Korea,113.8964
+1987-06-30,NL,Netherlands,40.0558
+1987-06-30,NO,Norway,59.6417
 1987-06-30,NZ,New Zealand,45.4731
-1987-06-30,PE,Peru,
-1987-06-30,PH,Philippines,
-1987-06-30,PL,Poland,
-1987-06-30,PT,Portugal,
-1987-06-30,RO,Romania,
-1987-06-30,RS,Serbia,
-1987-06-30,RU,Russia,
-1987-06-30,SE,Sweden,42.7162
-1987-06-30,SG,Singapore,
-1987-06-30,SI,Slovenia,
-1987-06-30,SK,Slovak Republic,
-1987-06-30,TH,Thailand,
-1987-06-30,TR,Türkiye,
-1987-06-30,US,United States,86.1853
-1987-06-30,XM,Euro area,59.2913
-1987-06-30,XW,World,
-1987-06-30,ZA,South Africa,53.339
-1987-09-30,4T,Emerging market economies (aggregate),
-1987-09-30,5R,Advanced economies,
-1987-09-30,AE,United Arab Emirates,
-1987-09-30,AT,Austria,
-1987-09-30,AU,Australia,37.4805
-1987-09-30,BE,Belgium,39.8595
-1987-09-30,BG,Bulgaria,
-1987-09-30,BR,Brazil,
-1987-09-30,CA,Canada,54.5505
-1987-09-30,CH,Switzerland,89.8267
-1987-09-30,CL,Chile,
-1987-09-30,CN,China,
-1987-09-30,CO,Colombia,
-1987-09-30,CY,Cyprus,
-1987-09-30,CZ,Czechia,
-1987-09-30,DE,Germany,121.1435
-1987-09-30,DK,Denmark,60.6254
-1987-09-30,EE,Estonia,
+1987-06-30,SE,Sweden,42.7085
+1987-06-30,US,United States,86.0106
+1987-06-30,XM,Euro area,59.222
+1987-06-30,ZA,South Africa,53.2628
+1987-09-30,AT,Austria,55.2984
+1987-09-30,AU,Australia,37.5088
+1987-09-30,BE,Belgium,40.1987
+1987-09-30,CA,Canada,54.9735
+1987-09-30,CH,Switzerland,89.8346
+1987-09-30,DE,Germany,121.142
+1987-09-30,DK,Denmark,60.6291
 1987-09-30,ES,Spain,39.5375
 1987-09-30,FI,Finland,64.0891
-1987-09-30,FR,France,48.5587
-1987-09-30,GB,United Kingdom,43.9255
-1987-09-30,GR,Greece,
+1987-09-30,FR,France,48.559
+1987-09-30,GB,United Kingdom,43.9109
 1987-09-30,HK,Hong Kong SAR,41.0479
-1987-09-30,HR,Croatia,
-1987-09-30,HU,Hungary,
-1987-09-30,ID,Indonesia,
-1987-09-30,IE,Ireland,39.7379
-1987-09-30,IL,Israel,
-1987-09-30,IN,India,
-1987-09-30,IS,Iceland,
-1987-09-30,IT,Italy,54.3662
+1987-09-30,IE,Ireland,39.7572
+1987-09-30,IS,Iceland,73.0881
+1987-09-30,IT,Italy,54.4138
 1987-09-30,JP,Japan,154.0581
-1987-09-30,KR,Korea,114.4032
-1987-09-30,LT,Lithuania,
-1987-09-30,LU,Luxembourg,
-1987-09-30,LV,Latvia,
-1987-09-30,MA,Morocco,
-1987-09-30,MK,North Macedonia,
-1987-09-30,MT,Malta,
-1987-09-30,MX,Mexico,
-1987-09-30,MY,Malaysia,
-1987-09-30,NL,Netherlands,38.8433
-1987-09-30,NO,Norway,59.3707
+1987-09-30,KR,Korea,114.3701
+1987-09-30,NL,Netherlands,39.786
+1987-09-30,NO,Norway,59.3307
 1987-09-30,NZ,New Zealand,46.9391
-1987-09-30,PE,Peru,
-1987-09-30,PH,Philippines,
-1987-09-30,PL,Poland,
-1987-09-30,PT,Portugal,
-1987-09-30,RO,Romania,
-1987-09-30,RS,Serbia,
-1987-09-30,RU,Russia,
-1987-09-30,SE,Sweden,43.2958
-1987-09-30,SG,Singapore,
-1987-09-30,SI,Slovenia,
-1987-09-30,SK,Slovak Republic,
-1987-09-30,TH,Thailand,
-1987-09-30,TR,Türkiye,
-1987-09-30,US,United States,87.0604
-1987-09-30,XM,Euro area,59.8347
-1987-09-30,XW,World,
-1987-09-30,ZA,South Africa,53.505
-1987-12-31,4T,Emerging market economies (aggregate),
-1987-12-31,5R,Advanced economies,
-1987-12-31,AE,United Arab Emirates,
-1987-12-31,AT,Austria,
-1987-12-31,AU,Australia,38.6215
-1987-12-31,BE,Belgium,39.9127
-1987-12-31,BG,Bulgaria,
-1987-12-31,BR,Brazil,
-1987-12-31,CA,Canada,57.1512
-1987-12-31,CH,Switzerland,88.8657
-1987-12-31,CL,Chile,
-1987-12-31,CN,China,
-1987-12-31,CO,Colombia,
-1987-12-31,CY,Cyprus,
-1987-12-31,CZ,Czechia,
-1987-12-31,DE,Germany,121.479
-1987-12-31,DK,Denmark,59.3876
-1987-12-31,EE,Estonia,
-1987-12-31,ES,Spain,41.5586
+1987-09-30,SE,Sweden,43.2904
+1987-09-30,US,United States,86.9022
+1987-09-30,XM,Euro area,59.7576
+1987-09-30,ZA,South Africa,53.4174
+1987-12-31,AT,Austria,60.6207
+1987-12-31,AU,Australia,38.6216
+1987-12-31,BE,Belgium,40.2524
+1987-12-31,CA,Canada,57.5943
+1987-12-31,CH,Switzerland,88.7852
+1987-12-31,DE,Germany,121.5033
+1987-12-31,DK,Denmark,59.3913
+1987-12-31,ES,Spain,41.5587
 1987-12-31,FI,Finland,67.8676
-1987-12-31,FR,France,48.8293
-1987-12-31,GB,United Kingdom,46.1085
-1987-12-31,GR,Greece,
+1987-12-31,FR,France,48.8297
+1987-12-31,GB,United Kingdom,46.0931
 1987-12-31,HK,Hong Kong SAR,40.5984
-1987-12-31,HR,Croatia,
-1987-12-31,HU,Hungary,
-1987-12-31,ID,Indonesia,
-1987-12-31,IE,Ireland,41.7964
-1987-12-31,IL,Israel,
-1987-12-31,IN,India,
-1987-12-31,IS,Iceland,
-1987-12-31,IT,Italy,54.589
+1987-12-31,IE,Ireland,41.8167
+1987-12-31,IS,Iceland,75.6409
+1987-12-31,IT,Italy,54.6317
 1987-12-31,JP,Japan,155.1931
-1987-12-31,KR,Korea,118.7506
-1987-12-31,LT,Lithuania,
-1987-12-31,LU,Luxembourg,
-1987-12-31,LV,Latvia,
-1987-12-31,MA,Morocco,
-1987-12-31,MK,North Macedonia,
-1987-12-31,MT,Malta,
-1987-12-31,MX,Mexico,
-1987-12-31,MY,Malaysia,
-1987-12-31,NL,Netherlands,38.7777
-1987-12-31,NO,Norway,59.0599
+1987-12-31,KR,Korea,118.7791
+1987-12-31,NL,Netherlands,39.7187
+1987-12-31,NO,Norway,59.0191
 1987-12-31,NZ,New Zealand,48.0986
-1987-12-31,PE,Peru,
-1987-12-31,PH,Philippines,
-1987-12-31,PL,Poland,
-1987-12-31,PT,Portugal,
-1987-12-31,RO,Romania,
-1987-12-31,RS,Serbia,
-1987-12-31,RU,Russia,
-1987-12-31,SE,Sweden,44.2988
-1987-12-31,SG,Singapore,
-1987-12-31,SI,Slovenia,
-1987-12-31,SK,Slovak Republic,
-1987-12-31,TH,Thailand,
-1987-12-31,TR,Türkiye,
-1987-12-31,US,United States,88.0847
-1987-12-31,XM,Euro area,61.0164
-1987-12-31,XW,World,
-1987-12-31,ZA,South Africa,54.1125
-1988-03-31,4T,Emerging market economies (aggregate),
-1988-03-31,5R,Advanced economies,
-1988-03-31,AE,United Arab Emirates,
-1988-03-31,AT,Austria,
-1988-03-31,AU,Australia,39.6618
-1988-03-31,BE,Belgium,40.5714
-1988-03-31,BG,Bulgaria,
-1988-03-31,BR,Brazil,
-1988-03-31,CA,Canada,61.9075
-1988-03-31,CH,Switzerland,90.033
-1988-03-31,CL,Chile,
-1988-03-31,CN,China,
-1988-03-31,CO,Colombia,103.3498
-1988-03-31,CY,Cyprus,
-1988-03-31,CZ,Czechia,
-1988-03-31,DE,Germany,121.054
-1988-03-31,DK,Denmark,59.4652
-1988-03-31,EE,Estonia,
-1988-03-31,ES,Spain,43.8546
+1987-12-31,SE,Sweden,44.2933
+1987-12-31,US,United States,87.9082
+1987-12-31,XM,Euro area,60.9433
+1987-12-31,ZA,South Africa,54.0435
+1988-03-31,AT,Austria,57.4645
+1988-03-31,AU,Australia,39.6329
+1988-03-31,BE,Belgium,40.9167
+1988-03-31,CA,Canada,62.3874
+1988-03-31,CH,Switzerland,89.9881
+1988-03-31,CO,Colombia,105.1867
+1988-03-31,DE,Germany,120.9057
+1988-03-31,DK,Denmark,59.4689
+1988-03-31,ES,Spain,43.8547
 1988-03-31,FI,Finland,74.9981
-1988-03-31,FR,France,49.1133
-1988-03-31,GB,United Kingdom,47.8388
-1988-03-31,GR,Greece,
+1988-03-31,FR,France,49.1136
+1988-03-31,GB,United Kingdom,47.8229
 1988-03-31,HK,Hong Kong SAR,41.498
-1988-03-31,HR,Croatia,
-1988-03-31,HU,Hungary,
-1988-03-31,ID,Indonesia,
-1988-03-31,IE,Ireland,40.6549
-1988-03-31,IL,Israel,
-1988-03-31,IN,India,
-1988-03-31,IS,Iceland,
-1988-03-31,IT,Italy,55.4765
+1988-03-31,IE,Ireland,40.6746
+1988-03-31,IS,Iceland,78.2255
+1988-03-31,IT,Italy,55.5198
 1988-03-31,JP,Japan,157.6194
-1988-03-31,KR,Korea,120.6553
-1988-03-31,LT,Lithuania,
-1988-03-31,LU,Luxembourg,
-1988-03-31,LV,Latvia,
-1988-03-31,MA,Morocco,
-1988-03-31,MK,North Macedonia,
-1988-03-31,MT,Malta,
-1988-03-31,MX,Mexico,
+1988-03-31,KR,Korea,120.6676
 1988-03-31,MY,Malaysia,59.4685
-1988-03-31,NL,Netherlands,39.2361
-1988-03-31,NO,Norway,58.3613
+1988-03-31,NL,Netherlands,40.1883
+1988-03-31,NO,Norway,58.3734
 1988-03-31,NZ,New Zealand,48.624
-1988-03-31,PE,Peru,
-1988-03-31,PH,Philippines,
-1988-03-31,PL,Poland,
-1988-03-31,PT,Portugal,
-1988-03-31,RO,Romania,
-1988-03-31,RS,Serbia,
-1988-03-31,RU,Russia,
-1988-03-31,SE,Sweden,45.9793
-1988-03-31,SG,Singapore,
-1988-03-31,SI,Slovenia,
-1988-03-31,SK,Slovak Republic,
-1988-03-31,TH,Thailand,
-1988-03-31,TR,Türkiye,
-1988-03-31,US,United States,88.9216
-1988-03-31,XM,Euro area,61.4838
-1988-03-31,XW,World,
-1988-03-31,ZA,South Africa,54.75
-1988-06-30,4T,Emerging market economies (aggregate),
-1988-06-30,5R,Advanced economies,
-1988-06-30,AE,United Arab Emirates,
-1988-06-30,AT,Austria,
-1988-06-30,AU,Australia,41.0255
-1988-06-30,BE,Belgium,41.5711
-1988-06-30,BG,Bulgaria,
-1988-06-30,BR,Brazil,
-1988-06-30,CA,Canada,62.4261
-1988-06-30,CH,Switzerland,90.4285
-1988-06-30,CL,Chile,
-1988-06-30,CN,China,
-1988-06-30,CO,Colombia,92.1922
-1988-06-30,CY,Cyprus,
-1988-06-30,CZ,Czechia,
-1988-06-30,DE,Germany,121.6456
-1988-06-30,DK,Denmark,58.4592
-1988-06-30,EE,Estonia,
+1988-03-31,PT,Portugal,98.2818
+1988-03-31,SE,Sweden,45.9723
+1988-03-31,US,United States,88.7378
+1988-03-31,XM,Euro area,61.4257
+1988-03-31,ZA,South Africa,54.6909
+1988-06-30,AT,Austria,61.391
+1988-06-30,AU,Australia,41.05
+1988-06-30,BE,Belgium,41.9249
+1988-06-30,CA,Canada,62.9101
+1988-06-30,CH,Switzerland,90.3591
+1988-06-30,CO,Colombia,93.8681
+1988-06-30,DE,Germany,121.718
+1988-06-30,DK,Denmark,58.4628
 1988-06-30,ES,Spain,46.1542
 1988-06-30,FI,Finland,77.7538
-1988-06-30,FR,France,50.484
-1988-06-30,GB,United Kingdom,49.7748
-1988-06-30,GR,Greece,
+1988-06-30,FR,France,50.4844
+1988-06-30,GB,United Kingdom,49.7582
 1988-06-30,HK,Hong Kong SAR,43.9373
-1988-06-30,HR,Croatia,
-1988-06-30,HU,Hungary,
-1988-06-30,ID,Indonesia,
-1988-06-30,IE,Ireland,39.5139
-1988-06-30,IL,Israel,
-1988-06-30,IN,India,
-1988-06-30,IS,Iceland,
-1988-06-30,IT,Italy,57.2886
+1988-06-30,IE,Ireland,39.5331
+1988-06-30,IS,Iceland,78.0144
+1988-06-30,IT,Italy,57.337
 1988-06-30,JP,Japan,158.1782
-1988-06-30,KR,Korea,124.8724
-1988-06-30,LT,Lithuania,
-1988-06-30,LU,Luxembourg,
-1988-06-30,LV,Latvia,
-1988-06-30,MA,Morocco,
-1988-06-30,MK,North Macedonia,
-1988-06-30,MT,Malta,
-1988-06-30,MX,Mexico,
+1988-06-30,KR,Korea,124.8719
 1988-06-30,MY,Malaysia,59.6089
-1988-06-30,NL,Netherlands,40.5273
-1988-06-30,NO,Norway,56.9036
+1988-06-30,NL,Netherlands,41.5108
+1988-06-30,NO,Norway,56.8961
 1988-06-30,NZ,New Zealand,49.6367
-1988-06-30,PE,Peru,
-1988-06-30,PH,Philippines,
-1988-06-30,PL,Poland,
-1988-06-30,PT,Portugal,
-1988-06-30,RO,Romania,
-1988-06-30,RS,Serbia,
-1988-06-30,RU,Russia,
-1988-06-30,SE,Sweden,47.0744
-1988-06-30,SG,Singapore,
-1988-06-30,SI,Slovenia,
-1988-06-30,SK,Slovak Republic,
-1988-06-30,TH,Thailand,
-1988-06-30,TR,Türkiye,
-1988-06-30,US,United States,90.017
-1988-06-30,XM,Euro area,62.7002
-1988-06-30,XW,World,
-1988-06-30,ZA,South Africa,54.2926
-1988-09-30,4T,Emerging market economies (aggregate),
-1988-09-30,5R,Advanced economies,
-1988-09-30,AE,United Arab Emirates,
-1988-09-30,AT,Austria,
-1988-09-30,AU,Australia,44.2326
-1988-09-30,BE,Belgium,42.8288
-1988-09-30,BG,Bulgaria,
-1988-09-30,BR,Brazil,
-1988-09-30,CA,Canada,62.3743
-1988-09-30,CH,Switzerland,93.2156
-1988-09-30,CL,Chile,
-1988-09-30,CN,China,
-1988-09-30,CO,Colombia,105.3652
-1988-09-30,CY,Cyprus,
-1988-09-30,CZ,Czechia,
-1988-09-30,DE,Germany,122.3705
-1988-09-30,DK,Denmark,59.2708
-1988-09-30,EE,Estonia,
-1988-09-30,ES,Spain,46.6871
+1988-06-30,PT,Portugal,100.4219
+1988-06-30,SE,Sweden,47.0713
+1988-06-30,US,United States,89.8224
+1988-06-30,XM,Euro area,62.6539
+1988-06-30,ZA,South Africa,54.223
+1988-09-30,AT,Austria,72.4144
+1988-09-30,AU,Australia,44.214
+1988-09-30,BE,Belgium,43.1933
+1988-09-30,CA,Canada,62.8579
+1988-09-30,CH,Switzerland,93.2114
+1988-09-30,CO,Colombia,107.0487
+1988-09-30,DE,Germany,122.4968
+1988-09-30,DK,Denmark,59.2744
+1988-09-30,ES,Spain,46.6872
 1988-09-30,FI,Finland,83.5736
-1988-09-30,FR,France,52.5789
-1988-09-30,GB,United Kingdom,55.8726
-1988-09-30,GR,Greece,
+1988-09-30,FR,France,52.5793
+1988-09-30,GB,United Kingdom,55.854
 1988-09-30,HK,Hong Kong SAR,46.0922
-1988-09-30,HR,Croatia,
-1988-09-30,HU,Hungary,
-1988-09-30,ID,Indonesia,
-1988-09-30,IE,Ireland,41.862
-1988-09-30,IL,Israel,
-1988-09-30,IN,India,
-1988-09-30,IS,Iceland,
-1988-09-30,IT,Italy,59.0644
+1988-09-30,IE,Ireland,41.8823
+1988-09-30,IS,Iceland,72.554
+1988-09-30,IT,Italy,59.1099
 1988-09-30,JP,Japan,159.4759
-1988-09-30,KR,Korea,127.6811
-1988-09-30,LT,Lithuania,
-1988-09-30,LU,Luxembourg,
-1988-09-30,LV,Latvia,
-1988-09-30,MA,Morocco,
-1988-09-30,MK,North Macedonia,
-1988-09-30,MT,Malta,
-1988-09-30,MX,Mexico,
+1988-09-30,KR,Korea,127.6467
 1988-09-30,MY,Malaysia,60.7906
-1988-09-30,NL,Netherlands,40.7125
-1988-09-30,NO,Norway,54.6593
+1988-09-30,NL,Netherlands,41.7005
+1988-09-30,NO,Norway,54.6596
 1988-09-30,NZ,New Zealand,49.5199
-1988-09-30,PE,Peru,
-1988-09-30,PH,Philippines,
-1988-09-30,PL,Poland,
-1988-09-30,PT,Portugal,
-1988-09-30,RO,Romania,
-1988-09-30,RS,Serbia,
-1988-09-30,RU,Russia,
-1988-09-30,SE,Sweden,49.3479
-1988-09-30,SG,Singapore,
-1988-09-30,SI,Slovenia,
-1988-09-30,SK,Slovak Republic,
-1988-09-30,TH,Thailand,
-1988-09-30,TR,Türkiye,
-1988-09-30,US,United States,91.2961
-1988-09-30,XM,Euro area,64.2917
-1988-09-30,XW,World,
-1988-09-30,ZA,South Africa,54.6753
-1988-12-31,4T,Emerging market economies (aggregate),
-1988-12-31,5R,Advanced economies,
-1988-12-31,AE,United Arab Emirates,
-1988-12-31,AT,Austria,
-1988-12-31,AU,Australia,47.7116
-1988-12-31,BE,Belgium,43.1574
-1988-12-31,BG,Bulgaria,
-1988-12-31,BR,Brazil,
-1988-12-31,CA,Canada,66.9181
-1988-12-31,CH,Switzerland,96.6857
-1988-12-31,CL,Chile,
-1988-12-31,CN,China,
-1988-12-31,CO,Colombia,100.7913
-1988-12-31,CY,Cyprus,
-1988-12-31,CZ,Czechia,
-1988-12-31,DE,Germany,122.2532
-1988-12-31,DK,Denmark,58.9361
-1988-12-31,EE,Estonia,
-1988-12-31,ES,Spain,48.2435
+1988-09-30,PT,Portugal,102.6592
+1988-09-30,SE,Sweden,49.3424
+1988-09-30,US,United States,91.1093
+1988-09-30,XM,Euro area,64.2372
+1988-09-30,ZA,South Africa,54.609
+1988-12-31,AT,Austria,67.8427
+1988-12-31,AU,Australia,47.6842
+1988-12-31,BE,Belgium,43.5247
+1988-12-31,CA,Canada,67.4369
+1988-12-31,CH,Switzerland,96.7893
+1988-12-31,CO,Colombia,102.5018
+1988-12-31,DE,Germany,122.2013
+1988-12-31,DK,Denmark,58.9397
+1988-12-31,ES,Spain,48.2436
 1988-12-31,FI,Finland,90.7907
-1988-12-31,FR,France,53.142
-1988-12-31,GB,United Kingdom,58.6713
-1988-12-31,GR,Greece,
+1988-12-31,FR,France,53.1424
+1988-12-31,GB,United Kingdom,58.6518
 1988-12-31,HK,Hong Kong SAR,48.4309
-1988-12-31,HR,Croatia,
-1988-12-31,HU,Hungary,
-1988-12-31,ID,Indonesia,
-1988-12-31,IE,Ireland,43.0147
-1988-12-31,IL,Israel,
-1988-12-31,IN,India,
-1988-12-31,IS,Iceland,
-1988-12-31,IT,Italy,60.1338
+1988-12-31,IE,Ireland,43.0356
+1988-12-31,IS,Iceland,79.0725
+1988-12-31,IT,Italy,60.1845
 1988-12-31,JP,Japan,160.9037
-1988-12-31,KR,Korea,126.6662
-1988-12-31,LT,Lithuania,
-1988-12-31,LU,Luxembourg,
-1988-12-31,LV,Latvia,
-1988-12-31,MA,Morocco,
-1988-12-31,MK,North Macedonia,
-1988-12-31,MT,Malta,
-1988-12-31,MX,Mexico,
+1988-12-31,KR,Korea,126.6101
 1988-12-31,MY,Malaysia,60.9699
-1988-12-31,NL,Netherlands,40.5539
-1988-12-31,NO,Norway,52.0649
+1988-12-31,NL,Netherlands,41.5381
+1988-12-31,NO,Norway,52.0722
 1988-12-31,NZ,New Zealand,49.237
-1988-12-31,PE,Peru,
-1988-12-31,PH,Philippines,
-1988-12-31,PL,Poland,
-1988-12-31,PT,Portugal,
-1988-12-31,RO,Romania,
-1988-12-31,RS,Serbia,
-1988-12-31,RU,Russia,
-1988-12-31,SE,Sweden,49.832
-1988-12-31,SG,Singapore,
-1988-12-31,SI,Slovenia,
-1988-12-31,SK,Slovak Republic,
-1988-12-31,TH,Thailand,
-1988-12-31,TR,Türkiye,
-1988-12-31,US,United States,92.6549
-1988-12-31,XM,Euro area,64.961
-1988-12-31,XW,World,
-1988-12-31,ZA,South Africa,54.7263
-1989-03-31,4T,Emerging market economies (aggregate),
-1989-03-31,5R,Advanced economies,
-1989-03-31,AE,United Arab Emirates,
-1989-03-31,AT,Austria,
-1989-03-31,AU,Australia,51.0783
-1989-03-31,BE,Belgium,44.8601
-1989-03-31,BG,Bulgaria,
-1989-03-31,BR,Brazil,
-1989-03-31,CA,Canada,72.7325
-1989-03-31,CH,Switzerland,97.1858
-1989-03-31,CL,Chile,
-1989-03-31,CN,China,
-1989-03-31,CO,Colombia,106.6015
-1989-03-31,CY,Cyprus,
-1989-03-31,CZ,Czechia,
-1989-03-31,DE,Germany,121.3874
-1989-03-31,DK,Denmark,57.6508
-1989-03-31,EE,Estonia,
-1989-03-31,ES,Spain,51.0694
+1988-12-31,PT,Portugal,104.4655
+1988-12-31,SE,Sweden,49.826
+1988-12-31,US,United States,92.457
+1988-12-31,XM,Euro area,64.9179
+1988-12-31,ZA,South Africa,54.6495
+1989-03-31,AT,Austria,69.0246
+1989-03-31,AU,Australia,51.0595
+1989-03-31,BE,Belgium,45.2419
+1989-03-31,CA,Canada,73.2964
+1989-03-31,CH,Switzerland,97.2691
+1989-03-31,CO,Colombia,108.3963
+1989-03-31,DE,Germany,121.3541
+1989-03-31,DK,Denmark,57.6544
+1989-03-31,ES,Spain,51.0695
 1989-03-31,FI,Finland,96.2057
-1989-03-31,FR,France,53.5326
-1989-03-31,GB,United Kingdom,59.3291
-1989-03-31,GR,Greece,
+1989-03-31,FR,France,53.533
+1989-03-31,GB,United Kingdom,59.3094
 1989-03-31,HK,Hong Kong SAR,52.5368
-1989-03-31,HR,Croatia,
-1989-03-31,HU,Hungary,
-1989-03-31,ID,Indonesia,
-1989-03-31,IE,Ireland,43.8371
-1989-03-31,IL,Israel,
-1989-03-31,IN,India,
-1989-03-31,IS,Iceland,
-1989-03-31,IT,Italy,61.24
+1989-03-31,IE,Ireland,43.8583
+1989-03-31,IS,Iceland,76.7491
+1989-03-31,IT,Italy,61.2896
 1989-03-31,JP,Japan,164.4053
-1989-03-31,KR,Korea,129.9193
-1989-03-31,LT,Lithuania,
-1989-03-31,LU,Luxembourg,
-1989-03-31,LV,Latvia,
-1989-03-31,MA,Morocco,
-1989-03-31,MK,North Macedonia,
-1989-03-31,MT,Malta,
-1989-03-31,MX,Mexico,
+1989-03-31,KR,Korea,129.9423
 1989-03-31,MY,Malaysia,61.289
-1989-03-31,NL,Netherlands,41.5173
-1989-03-31,NO,Norway,48.5531
+1989-03-31,NL,Netherlands,42.5248
+1989-03-31,NO,Norway,48.53
 1989-03-31,NZ,New Zealand,49.9426
-1989-03-31,PE,Peru,
-1989-03-31,PH,Philippines,
-1989-03-31,PL,Poland,
-1989-03-31,PT,Portugal,
-1989-03-31,RO,Romania,
-1989-03-31,RS,Serbia,
-1989-03-31,RU,Russia,
-1989-03-31,SE,Sweden,51.9347
-1989-03-31,SG,Singapore,
-1989-03-31,SI,Slovenia,
-1989-03-31,SK,Slovak Republic,
-1989-03-31,TH,Thailand,
-1989-03-31,TR,Türkiye,
-1989-03-31,US,United States,93.607
-1989-03-31,XM,Euro area,66.2041
-1989-03-31,XW,World,
-1989-03-31,ZA,South Africa,54.5085
-1989-06-30,4T,Emerging market economies (aggregate),
-1989-06-30,5R,Advanced economies,
-1989-06-30,AE,United Arab Emirates,
-1989-06-30,AT,Austria,
-1989-06-30,AU,Australia,50.7994
-1989-06-30,BE,Belgium,45.5399
-1989-06-30,BG,Bulgaria,
-1989-06-30,BR,Brazil,
-1989-06-30,CA,Canada,65.3303
-1989-06-30,CH,Switzerland,95.3198
-1989-06-30,CL,Chile,
-1989-06-30,CN,China,
-1989-06-30,CO,Colombia,106.926
-1989-06-30,CY,Cyprus,
-1989-06-30,CZ,Czechia,
-1989-06-30,DE,Germany,121.3138
-1989-06-30,DK,Denmark,56.8011
-1989-06-30,EE,Estonia,
-1989-06-30,ES,Spain,53.1743
+1989-03-31,PT,Portugal,103.883
+1989-03-31,SE,Sweden,51.9259
+1989-03-31,US,United States,93.3897
+1989-03-31,XM,Euro area,66.16
+1989-03-31,ZA,South Africa,54.4292
+1989-06-30,AT,Austria,71.5957
+1989-06-30,AU,Australia,50.7986
+1989-06-30,BE,Belgium,45.9275
+1989-06-30,CA,Canada,65.8368
+1989-06-30,CH,Switzerland,95.2428
+1989-06-30,CO,Colombia,108.7639
+1989-06-30,DE,Germany,121.4258
+1989-06-30,DK,Denmark,56.8047
+1989-06-30,ES,Spain,53.1744
 1989-06-30,FI,Finland,95.721
-1989-06-30,FR,France,54.8308
-1989-06-30,GB,United Kingdom,60.1121
-1989-06-30,GR,Greece,
+1989-06-30,FR,France,54.8312
+1989-06-30,GB,United Kingdom,60.0922
 1989-06-30,HK,Hong Kong SAR,52.7303
-1989-06-30,HR,Croatia,
-1989-06-30,HU,Hungary,
-1989-06-30,ID,Indonesia,
-1989-06-30,IE,Ireland,41.7256
-1989-06-30,IL,Israel,
-1989-06-30,IN,India,
-1989-06-30,IS,Iceland,
-1989-06-30,IT,Italy,63.2659
+1989-06-30,IE,Ireland,41.7458
+1989-06-30,IS,Iceland,76.2586
+1989-06-30,IT,Italy,63.3174
 1989-06-30,JP,Japan,164.4297
-1989-06-30,KR,Korea,137.4768
-1989-06-30,LT,Lithuania,
-1989-06-30,LU,Luxembourg,
-1989-06-30,LV,Latvia,
-1989-06-30,MA,Morocco,
-1989-06-30,MK,North Macedonia,
-1989-06-30,MT,Malta,
-1989-06-30,MX,Mexico,
+1989-06-30,KR,Korea,137.4459
 1989-06-30,MY,Malaysia,61.3345
-1989-06-30,NL,Netherlands,42.6225
-1989-06-30,NO,Norway,46.7838
+1989-06-30,NL,Netherlands,43.6569
+1989-06-30,NO,Norway,46.7367
 1989-06-30,NZ,New Zealand,49.808
-1989-06-30,PE,Peru,
-1989-06-30,PH,Philippines,
-1989-06-30,PL,Poland,
-1989-06-30,PT,Portugal,
-1989-06-30,RO,Romania,
-1989-06-30,RS,Serbia,
-1989-06-30,RU,Russia,
-1989-06-30,SE,Sweden,53.3951
-1989-06-30,SG,Singapore,
-1989-06-30,SI,Slovenia,
-1989-06-30,SK,Slovak Republic,
-1989-06-30,TH,Thailand,
-1989-06-30,TR,Türkiye,
-1989-06-30,US,United States,93.4809
-1989-06-30,XM,Euro area,67.1142
-1989-06-30,XW,World,
-1989-06-30,ZA,South Africa,54.7443
-1989-09-30,4T,Emerging market economies (aggregate),
-1989-09-30,5R,Advanced economies,
-1989-09-30,AE,United Arab Emirates,
-1989-09-30,AT,Austria,
-1989-09-30,AU,Australia,49.6747
-1989-09-30,BE,Belgium,46.9012
-1989-09-30,BG,Bulgaria,
-1989-09-30,BR,Brazil,
-1989-09-30,CA,Canada,65.9249
-1989-09-30,CH,Switzerland,96.5371
-1989-09-30,CL,Chile,
-1989-09-30,CN,China,
-1989-09-30,CO,Colombia,105.31
-1989-09-30,CY,Cyprus,
-1989-09-30,CZ,Czechia,
-1989-09-30,DE,Germany,122.9987
-1989-09-30,DK,Denmark,55.4308
-1989-09-30,EE,Estonia,
-1989-09-30,ES,Spain,54.2853
+1989-06-30,PT,Portugal,104.2523
+1989-06-30,SE,Sweden,53.3888
+1989-06-30,US,United States,93.2643
+1989-06-30,XM,Euro area,67.0911
+1989-06-30,ZA,South Africa,54.668
+1989-09-30,AT,Austria,78.3038
+1989-09-30,AU,Australia,49.6517
+1989-09-30,BE,Belgium,47.3004
+1989-09-30,CA,Canada,66.436
+1989-09-30,CH,Switzerland,96.4365
+1989-09-30,CO,Colombia,107.0358
+1989-09-30,DE,Germany,122.9919
+1989-09-30,DK,Denmark,55.4343
+1989-09-30,ES,Spain,54.2854
 1989-09-30,FI,Finland,93.9191
-1989-09-30,FR,France,56.8677
-1989-09-30,GB,United Kingdom,61.7899
-1989-09-30,GR,Greece,
+1989-09-30,FR,France,56.8681
+1989-09-30,GB,United Kingdom,61.7694
 1989-09-30,HK,Hong Kong SAR,49.6587
-1989-09-30,HR,Croatia,
-1989-09-30,HU,Hungary,
-1989-09-30,ID,Indonesia,
-1989-09-30,IE,Ireland,44.5679
-1989-09-30,IL,Israel,
-1989-09-30,IN,India,
-1989-09-30,IS,Iceland,
-1989-09-30,IT,Italy,65.6589
+1989-09-30,IE,Ireland,44.5895
+1989-09-30,IS,Iceland,72.9979
+1989-09-30,IT,Italy,65.7122
 1989-09-30,JP,Japan,167.9446
-1989-09-30,KR,Korea,136.1393
-1989-09-30,LT,Lithuania,
-1989-09-30,LU,Luxembourg,
-1989-09-30,LV,Latvia,
-1989-09-30,MA,Morocco,
-1989-09-30,MK,North Macedonia,
-1989-09-30,MT,Malta,
-1989-09-30,MX,Mexico,
+1989-09-30,KR,Korea,136.0966
 1989-09-30,MY,Malaysia,61.1665
-1989-09-30,NL,Netherlands,42.9951
-1989-09-30,NO,Norway,44.7002
+1989-09-30,NL,Netherlands,44.0385
+1989-09-30,NO,Norway,44.6807
 1989-09-30,NZ,New Zealand,49.0315
-1989-09-30,PE,Peru,
-1989-09-30,PH,Philippines,
-1989-09-30,PL,Poland,
-1989-09-30,PT,Portugal,
-1989-09-30,RO,Romania,
-1989-09-30,RS,Serbia,
-1989-09-30,RU,Russia,
-1989-09-30,SE,Sweden,54.9597
-1989-09-30,SG,Singapore,
-1989-09-30,SI,Slovenia,
-1989-09-30,SK,Slovak Republic,
-1989-09-30,TH,Thailand,
-1989-09-30,TR,Türkiye,
-1989-09-30,US,United States,93.9845
-1989-09-30,XM,Euro area,68.7902
-1989-09-30,XW,World,
-1989-09-30,ZA,South Africa,54.8188
-1989-12-31,4T,Emerging market economies (aggregate),
-1989-12-31,5R,Advanced economies,
-1989-12-31,AE,United Arab Emirates,
-1989-12-31,AT,Austria,
-1989-12-31,AU,Australia,48.9242
-1989-12-31,BE,Belgium,48.3458
-1989-12-31,BG,Bulgaria,
-1989-12-31,BR,Brazil,
-1989-12-31,CA,Canada,69.2091
-1989-12-31,CH,Switzerland,99.8918
-1989-12-31,CL,Chile,
-1989-12-31,CN,China,
-1989-12-31,CO,Colombia,106.1047
-1989-12-31,CY,Cyprus,
-1989-12-31,CZ,Czechia,
-1989-12-31,DE,Germany,124.1484
-1989-12-31,DK,Denmark,53.9045
-1989-12-31,EE,Estonia,
-1989-12-31,ES,Spain,54.9797
+1989-09-30,PT,Portugal,108.5327
+1989-09-30,SE,Sweden,54.949
+1989-09-30,US,United States,93.7683
+1989-09-30,XM,Euro area,68.7577
+1989-09-30,ZA,South Africa,54.7484
+1989-12-31,AT,Austria,79.6978
+1989-12-31,AU,Australia,48.8948
+1989-12-31,BE,Belgium,48.7573
+1989-12-31,CA,Canada,69.7457
+1989-12-31,CH,Switzerland,99.9726
+1989-12-31,CO,Colombia,107.7895
+1989-12-31,DE,Germany,124.0771
+1989-12-31,DK,Denmark,53.9079
+1989-12-31,ES,Spain,54.9798
 1989-12-31,FI,Finland,90.3977
-1989-12-31,FR,France,57.0726
-1989-12-31,GB,United Kingdom,59.6447
-1989-12-31,GR,Greece,
+1989-12-31,FR,France,57.073
+1989-12-31,GB,United Kingdom,59.6248
 1989-12-31,HK,Hong Kong SAR,51.514
-1989-12-31,HR,Croatia,
-1989-12-31,HU,Hungary,
-1989-12-31,ID,Indonesia,
-1989-12-31,IE,Ireland,47.1542
-1989-12-31,IL,Israel,
-1989-12-31,IN,India,
-1989-12-31,IS,Iceland,
-1989-12-31,IT,Italy,67.1374
+1989-12-31,IE,Ireland,47.1771
+1989-12-31,IS,Iceland,72.4149
+1989-12-31,IT,Italy,67.1938
 1989-12-31,JP,Japan,173.3542
-1989-12-31,KR,Korea,136.1291
-1989-12-31,LT,Lithuania,
-1989-12-31,LU,Luxembourg,
-1989-12-31,LV,Latvia,
-1989-12-31,MA,Morocco,
-1989-12-31,MK,North Macedonia,
-1989-12-31,MT,Malta,
-1989-12-31,MX,Mexico,
+1989-12-31,KR,Korea,136.1694
 1989-12-31,MY,Malaysia,60.491
-1989-12-31,NL,Netherlands,42.7499
-1989-12-31,NO,Norway,43.2654
+1989-12-31,NL,Netherlands,43.7873
+1989-12-31,NO,Norway,43.2461
 1989-12-31,NZ,New Zealand,49.2873
-1989-12-31,PE,Peru,
-1989-12-31,PH,Philippines,
-1989-12-31,PL,Poland,
-1989-12-31,PT,Portugal,
-1989-12-31,RO,Romania,
-1989-12-31,RS,Serbia,
-1989-12-31,RU,Russia,
-1989-12-31,SE,Sweden,54.2938
-1989-12-31,SG,Singapore,
-1989-12-31,SI,Slovenia,
-1989-12-31,SK,Slovak Republic,
-1989-12-31,TH,Thailand,
-1989-12-31,TR,Türkiye,
-1989-12-31,US,United States,94.2381
-1989-12-31,XM,Euro area,69.662
-1989-12-31,XW,World,
-1989-12-31,ZA,South Africa,54.339
-1990-03-31,4T,Emerging market economies (aggregate),
-1990-03-31,5R,Advanced economies,
-1990-03-31,AE,United Arab Emirates,
-1990-03-31,AT,Austria,
-1990-03-31,AU,Australia,48.2928
-1990-03-31,BE,Belgium,49.5551
-1990-03-31,BG,Bulgaria,
-1990-03-31,BR,Brazil,
-1990-03-31,CA,Canada,67.0024
-1990-03-31,CH,Switzerland,99.9666
-1990-03-31,CL,Chile,
-1990-03-31,CN,China,
-1990-03-31,CO,Colombia,108.5727
-1990-03-31,CY,Cyprus,
-1990-03-31,CZ,Czechia,
-1990-03-31,DE,Germany,126.0872
-1990-03-31,DK,Denmark,51.5265
-1990-03-31,EE,Estonia,
-1990-03-31,ES,Spain,57.5406
+1989-12-31,PT,Portugal,109.4143
+1989-12-31,SE,Sweden,54.2844
+1989-12-31,US,United States,94.0579
+1989-12-31,XM,Euro area,69.6233
+1989-12-31,ZA,South Africa,54.2694
+1990-03-31,AT,Austria,79.758
+1990-03-31,AU,Australia,48.3067
+1990-03-31,BE,Belgium,49.9768
+1990-03-31,CA,Canada,67.5219
+1990-03-31,CH,Switzerland,100.0506
+1990-03-31,CO,Colombia,110.2661
+1990-03-31,DE,Germany,126.0751
+1990-03-31,DK,Denmark,51.5297
+1990-03-31,ES,Spain,57.5407
 1990-03-31,FI,Finland,86.4705
-1990-03-31,FR,France,56.8682
-1990-03-31,GB,United Kingdom,57.7052
-1990-03-31,GR,Greece,
+1990-03-31,FR,France,56.8686
+1990-03-31,GB,United Kingdom,57.686
 1990-03-31,HK,Hong Kong SAR,51.9807
-1990-03-31,HR,Croatia,
-1990-03-31,HU,Hungary,
-1990-03-31,ID,Indonesia,
-1990-03-31,IE,Ireland,48.3657
-1990-03-31,IL,Israel,
-1990-03-31,IN,India,
-1990-03-31,IS,Iceland,
-1990-03-31,IT,Italy,68.4477
+1990-03-31,IE,Ireland,48.3906
+1990-03-31,IS,Iceland,73.2206
+1990-03-31,IT,Italy,68.5049
 1990-03-31,JP,Japan,179.1034
-1990-03-31,KR,Korea,139.3717
-1990-03-31,LT,Lithuania,
-1990-03-31,LU,Luxembourg,
-1990-03-31,LV,Latvia,
-1990-03-31,MA,Morocco,
-1990-03-31,MK,North Macedonia,
-1990-03-31,MT,Malta,
-1990-03-31,MX,Mexico,
+1990-03-31,KR,Korea,139.3814
 1990-03-31,MY,Malaysia,60.445
-1990-03-31,NL,Netherlands,42.5453
-1990-03-31,NO,Norway,43.2908
+1990-03-31,NL,Netherlands,43.5777
+1990-03-31,NO,Norway,43.2952
 1990-03-31,NZ,New Zealand,49.8821
-1990-03-31,PE,Peru,
-1990-03-31,PH,Philippines,
-1990-03-31,PL,Poland,
-1990-03-31,PT,Portugal,
-1990-03-31,RO,Romania,
-1990-03-31,RS,Serbia,
-1990-03-31,RU,Russia,
-1990-03-31,SE,Sweden,55.0861
-1990-03-31,SG,Singapore,
-1990-03-31,SI,Slovenia,
-1990-03-31,SK,Slovak Republic,
-1990-03-31,TH,Thailand,
-1990-03-31,TR,Türkiye,
-1990-03-31,US,United States,93.9306
-1990-03-31,XM,Euro area,71.234
-1990-03-31,XW,World,
-1990-03-31,ZA,South Africa,54.6873
-1990-06-30,4T,Emerging market economies (aggregate),
-1990-06-30,5R,Advanced economies,
-1990-06-30,AE,United Arab Emirates,
-1990-06-30,AT,Austria,
-1990-06-30,AU,Australia,47.9595
-1990-06-30,BE,Belgium,49.0742
-1990-06-30,BG,Bulgaria,
-1990-06-30,BR,Brazil,
-1990-06-30,CA,Canada,61.93
-1990-06-30,CH,Switzerland,100.4564
-1990-06-30,CL,Chile,
-1990-06-30,CN,China,
-1990-06-30,CO,Colombia,101.0565
-1990-06-30,CY,Cyprus,
-1990-06-30,CZ,Czechia,
-1990-06-30,DE,Germany,128.8115
-1990-06-30,DK,Denmark,51.3742
-1990-06-30,EE,Estonia,
-1990-06-30,ES,Spain,58.0625
+1990-03-31,PT,Portugal,106.9434
+1990-03-31,SE,Sweden,55.0779
+1990-03-31,US,United States,93.7557
+1990-03-31,XM,Euro area,71.2053
+1990-03-31,ZA,South Africa,54.6259
+1990-06-30,AT,Austria,89.1859
+1990-06-30,AU,Australia,47.9791
+1990-06-30,BE,Belgium,49.4919
+1990-06-30,CA,Canada,62.4101
+1990-06-30,CH,Switzerland,100.5212
+1990-06-30,CO,Colombia,102.7554
+1990-06-30,DE,Germany,128.921
+1990-06-30,DK,Denmark,51.3774
+1990-06-30,ES,Spain,58.0626
 1990-06-30,FI,Finland,85.5438
-1990-06-30,FR,France,58.0297
-1990-06-30,GB,United Kingdom,55.4895
-1990-06-30,GR,Greece,
+1990-06-30,FR,France,58.0301
+1990-06-30,GB,United Kingdom,55.4711
 1990-06-30,HK,Hong Kong SAR,51.3767
-1990-06-30,HR,Croatia,
-1990-06-30,HU,Hungary,
-1990-06-30,ID,Indonesia,
-1990-06-30,IE,Ireland,46.6155
-1990-06-30,IL,Israel,
-1990-06-30,IN,India,
-1990-06-30,IS,Iceland,
-1990-06-30,IT,Italy,70.3509
+1990-06-30,IE,Ireland,46.6309
+1990-06-30,IS,Iceland,72.9271
+1990-06-30,IT,Italy,70.4065
 1990-06-30,JP,Japan,182.8323
-1990-06-30,KR,Korea,145.2377
-1990-06-30,LT,Lithuania,
-1990-06-30,LU,Luxembourg,
-1990-06-30,LV,Latvia,
-1990-06-30,MA,Morocco,
-1990-06-30,MK,North Macedonia,
-1990-06-30,MT,Malta,
-1990-06-30,MX,Mexico,
+1990-06-30,KR,Korea,145.2229
 1990-06-30,MY,Malaysia,60.0092
-1990-06-30,NL,Netherlands,43.5796
-1990-06-30,NO,Norway,43.4161
+1990-06-30,NL,Netherlands,44.6372
+1990-06-30,NO,Norway,43.4043
 1990-06-30,NZ,New Zealand,49.5267
-1990-06-30,PE,Peru,
-1990-06-30,PH,Philippines,
-1990-06-30,PL,Poland,
-1990-06-30,PT,Portugal,
-1990-06-30,RO,Romania,
-1990-06-30,RS,Serbia,
-1990-06-30,RU,Russia,
-1990-06-30,SE,Sweden,54.7354
-1990-06-30,SG,Singapore,
-1990-06-30,SI,Slovenia,
-1990-06-30,SK,Slovak Republic,
-1990-06-30,TH,Thailand,
-1990-06-30,TR,Türkiye,
-1990-06-30,US,United States,93.0795
-1990-06-30,XM,Euro area,72.6832
-1990-06-30,XW,World,
-1990-06-30,ZA,South Africa,55.4515
-1990-09-30,4T,Emerging market economies (aggregate),
-1990-09-30,5R,Advanced economies,
-1990-09-30,AE,United Arab Emirates,
-1990-09-30,AT,Austria,
-1990-09-30,AU,Australia,47.2009
-1990-09-30,BE,Belgium,49.9704
-1990-09-30,BG,Bulgaria,
-1990-09-30,BR,Brazil,
-1990-09-30,CA,Canada,61.6537
-1990-09-30,CH,Switzerland,99.1091
-1990-09-30,CL,Chile,
-1990-09-30,CN,China,
-1990-09-30,CO,Colombia,104.6114
-1990-09-30,CY,Cyprus,
-1990-09-30,CZ,Czechia,
-1990-09-30,DE,Germany,129.9628
-1990-09-30,DK,Denmark,49.7445
-1990-09-30,EE,Estonia,
-1990-09-30,ES,Spain,57.9254
+1990-06-30,PT,Portugal,107.0528
+1990-06-30,SE,Sweden,54.7251
+1990-06-30,US,United States,92.9173
+1990-06-30,XM,Euro area,72.6667
+1990-06-30,ZA,South Africa,55.3943
+1990-09-30,AT,Austria,97.4248
+1990-09-30,AU,Australia,47.1819
+1990-09-30,BE,Belgium,50.3957
+1990-09-30,CA,Canada,62.1317
+1990-09-30,CH,Switzerland,99.1017
+1990-09-30,CO,Colombia,106.2362
+1990-09-30,DE,Germany,129.9612
+1990-09-30,DK,Denmark,49.7476
+1990-09-30,ES,Spain,57.9255
 1990-09-30,FI,Finland,83.3744
-1990-09-30,FR,France,59.7255
-1990-09-30,GB,United Kingdom,55.6605
-1990-09-30,GR,Greece,
+1990-09-30,FR,France,59.726
+1990-09-30,GB,United Kingdom,55.642
 1990-09-30,HK,Hong Kong SAR,52.0918
-1990-09-30,HR,Croatia,
-1990-09-30,HU,Hungary,
-1990-09-30,ID,Indonesia,
-1990-09-30,IE,Ireland,49.3941
-1990-09-30,IL,Israel,
-1990-09-30,IN,India,
-1990-09-30,IS,Iceland,
-1990-09-30,IT,Italy,71.4922
+1990-09-30,IE,Ireland,49.3878
+1990-09-30,IS,Iceland,72.675
+1990-09-30,IT,Italy,71.555
 1990-09-30,JP,Japan,188.68
-1990-09-30,KR,Korea,146.2993
-1990-09-30,LT,Lithuania,
-1990-09-30,LU,Luxembourg,
-1990-09-30,LV,Latvia,
-1990-09-30,MA,Morocco,
-1990-09-30,MK,North Macedonia,
-1990-09-30,MT,Malta,
-1990-09-30,MX,Mexico,
+1990-09-30,KR,Korea,146.3522
 1990-09-30,MY,Malaysia,60.6285
-1990-09-30,NL,Netherlands,41.9401
-1990-09-30,NO,Norway,42.092
+1990-09-30,NL,Netherlands,42.958
+1990-09-30,NO,Norway,42.1035
 1990-09-30,NZ,New Zealand,49.1325
-1990-09-30,PE,Peru,
-1990-09-30,PH,Philippines,
-1990-09-30,PL,Poland,
-1990-09-30,PT,Portugal,
-1990-09-30,RO,Romania,
-1990-09-30,RS,Serbia,
-1990-09-30,RU,Russia,
-1990-09-30,SE,Sweden,54.747
-1990-09-30,SG,Singapore,
-1990-09-30,SI,Slovenia,
-1990-09-30,SK,Slovak Republic,
-1990-09-30,TH,Thailand,
-1990-09-30,TR,Türkiye,
-1990-09-30,US,United States,91.2817
-1990-09-30,XM,Euro area,74.2488
-1990-09-30,XW,World,
-1990-09-30,ZA,South Africa,54.9947
-1990-12-31,4T,Emerging market economies (aggregate),
-1990-12-31,5R,Advanced economies,
-1990-12-31,AE,United Arab Emirates,
-1990-12-31,AT,Austria,
-1990-12-31,AU,Australia,46.2753
-1990-12-31,BE,Belgium,49.9355
-1990-12-31,BG,Bulgaria,
-1990-12-31,BR,Brazil,
-1990-12-31,CA,Canada,61.2397
-1990-12-31,CH,Switzerland,95.2025
-1990-12-31,CL,Chile,
-1990-12-31,CN,China,
-1990-12-31,CO,Colombia,102.5049
-1990-12-31,CY,Cyprus,
-1990-12-31,CZ,Czechia,
-1990-12-31,DE,Germany,129.2914
-1990-12-31,DK,Denmark,48.9523
-1990-12-31,EE,Estonia,
-1990-12-31,ES,Spain,57.909
+1990-09-30,PT,Portugal,108.5765
+1990-09-30,SE,Sweden,54.7382
+1990-09-30,US,United States,91.1128
+1990-09-30,XM,Euro area,74.2221
+1990-09-30,ZA,South Africa,54.9376
+1990-12-31,AT,Austria,98.3696
+1990-12-31,AU,Australia,46.2588
+1990-12-31,BE,Belgium,50.3604
+1990-12-31,CA,Canada,61.7145
+1990-12-31,CH,Switzerland,95.0546
+1990-12-31,CO,Colombia,104.1576
+1990-12-31,DE,Germany,129.1977
+1990-12-31,DK,Denmark,48.9553
+1990-12-31,ES,Spain,57.9092
 1990-12-31,FI,Finland,79.8407
-1990-12-31,FR,France,59.3537
-1990-12-31,GB,United Kingdom,53.7811
-1990-12-31,GR,Greece,
+1990-12-31,FR,France,59.3541
+1990-12-31,GB,United Kingdom,53.7632
 1990-12-31,HK,Hong Kong SAR,52.8624
-1990-12-31,HR,Croatia,
-1990-12-31,HU,Hungary,
-1990-12-31,ID,Indonesia,
-1990-12-31,IE,Ireland,48.0969
-1990-12-31,IL,Israel,
-1990-12-31,IN,India,
-1990-12-31,IS,Iceland,
-1990-12-31,IT,Italy,73.1584
+1990-12-31,IE,Ireland,48.155
+1990-12-31,IS,Iceland,74.4541
+1990-12-31,IT,Italy,73.2144
 1990-12-31,JP,Japan,187.9441
-1990-12-31,KR,Korea,150.995
-1990-12-31,LT,Lithuania,
-1990-12-31,LU,Luxembourg,
-1990-12-31,LV,Latvia,
-1990-12-31,MA,Morocco,
-1990-12-31,MK,North Macedonia,
-1990-12-31,MT,Malta,
-1990-12-31,MX,Mexico,
+1990-12-31,KR,Korea,151.088
 1990-12-31,MY,Malaysia,65.3035
-1990-12-31,NL,Netherlands,41.1439
-1990-12-31,NO,Norway,40.2345
+1990-12-31,NL,Netherlands,42.1424
+1990-12-31,NO,Norway,40.2278
 1990-12-31,NZ,New Zealand,48.3236
-1990-12-31,PE,Peru,
-1990-12-31,PH,Philippines,
-1990-12-31,PL,Poland,
-1990-12-31,PT,Portugal,
-1990-12-31,RO,Romania,
-1990-12-31,RS,Serbia,
-1990-12-31,RU,Russia,
-1990-12-31,SE,Sweden,52.9837
-1990-12-31,SG,Singapore,
-1990-12-31,SI,Slovenia,
-1990-12-31,SK,Slovak Republic,
-1990-12-31,TH,Thailand,
-1990-12-31,TR,Türkiye,
-1990-12-31,US,United States,89.387
-1990-12-31,XM,Euro area,74.1651
-1990-12-31,XW,World,
-1990-12-31,ZA,South Africa,53.9587
-1991-03-31,4T,Emerging market economies (aggregate),
-1991-03-31,5R,Advanced economies,
-1991-03-31,AE,United Arab Emirates,
-1991-03-31,AT,Austria,
-1991-03-31,AU,Australia,46.3072
-1991-03-31,BE,Belgium,49.9204
-1991-03-31,BG,Bulgaria,
-1991-03-31,BR,Brazil,
-1991-03-31,CA,Canada,62.3985
-1991-03-31,CH,Switzerland,93.722
-1991-03-31,CL,Chile,
-1991-03-31,CN,China,
-1991-03-31,CO,Colombia,95.9201
-1991-03-31,CY,Cyprus,
-1991-03-31,CZ,Czechia,
-1991-03-31,DE,Germany,129.7609
-1991-03-31,DK,Denmark,49.9489
-1991-03-31,EE,Estonia,
-1991-03-31,ES,Spain,60.3909
+1990-12-31,PT,Portugal,109.0693
+1990-12-31,SE,Sweden,52.9787
+1990-12-31,US,United States,89.2438
+1990-12-31,XM,Euro area,74.1492
+1990-12-31,ZA,South Africa,53.8996
+1991-03-31,AT,Austria,99.9483
+1991-03-31,AU,Australia,46.3026
+1991-03-31,BE,Belgium,50.3452
+1991-03-31,CA,Canada,62.8823
+1991-03-31,CH,Switzerland,93.5611
+1991-03-31,CO,Colombia,97.5115
+1991-03-31,DE,Germany,129.5755
+1991-03-31,DK,Denmark,49.952
+1991-03-31,ES,Spain,60.391
 1991-03-31,FI,Finland,73.1921
-1991-03-31,FR,France,58.9511
-1991-03-31,GB,United Kingdom,52.845
-1991-03-31,GR,Greece,
+1991-03-31,FR,France,58.9515
+1991-03-31,GB,United Kingdom,52.8275
 1991-03-31,HK,Hong Kong SAR,53.8771
-1991-03-31,HR,Croatia,
-1991-03-31,HU,Hungary,
-1991-03-31,ID,Indonesia,
-1991-03-31,IE,Ireland,48.3932
-1991-03-31,IL,Israel,
-1991-03-31,IN,India,
-1991-03-31,IS,Iceland,
-1991-03-31,IT,Italy,75.6889
+1991-03-31,IE,Ireland,48.3524
+1991-03-31,IS,Iceland,76.1539
+1991-03-31,IT,Italy,75.7529
 1991-03-31,JP,Japan,189.2763
-1991-03-31,KR,Korea,149.1904
-1991-03-31,LT,Lithuania,
-1991-03-31,LU,Luxembourg,
-1991-03-31,LV,Latvia,
-1991-03-31,MA,Morocco,
-1991-03-31,MK,North Macedonia,
-1991-03-31,MT,Malta,
-1991-03-31,MX,Mexico,
+1991-03-31,KR,Korea,149.2413
 1991-03-31,MY,Malaysia,69.6306
-1991-03-31,NL,Netherlands,41.5546
-1991-03-31,NO,Norway,39.1532
+1991-03-31,NL,Netherlands,42.5631
+1991-03-31,NO,Norway,39.1596
 1991-03-31,NZ,New Zealand,47.1767
-1991-03-31,PE,Peru,
-1991-03-31,PH,Philippines,
-1991-03-31,PL,Poland,
-1991-03-31,PT,Portugal,
-1991-03-31,RO,Romania,
-1991-03-31,RS,Serbia,
-1991-03-31,RU,Russia,
-1991-03-31,SE,Sweden,54.2184
-1991-03-31,SG,Singapore,
-1991-03-31,SI,Slovenia,
-1991-03-31,SK,Slovak Republic,
-1991-03-31,TH,Thailand,100.7374
-1991-03-31,TR,Türkiye,
-1991-03-31,US,United States,87.9952
-1991-03-31,XM,Euro area,74.9501
-1991-03-31,XW,World,
-1991-03-31,ZA,South Africa,53.8035
-1991-06-30,4T,Emerging market economies (aggregate),
-1991-06-30,5R,Advanced economies,
-1991-06-30,AE,United Arab Emirates,
-1991-06-30,AT,Austria,
-1991-06-30,AU,Australia,46.7826
-1991-06-30,BE,Belgium,49.0371
-1991-06-30,BG,Bulgaria,
-1991-06-30,BR,Brazil,
-1991-06-30,CA,Canada,64.1448
-1991-06-30,CH,Switzerland,94.4286
-1991-06-30,CL,Chile,
-1991-06-30,CN,China,
-1991-06-30,CO,Colombia,98.4124
-1991-06-30,CY,Cyprus,
-1991-06-30,CZ,Czechia,
-1991-06-30,DE,Germany,131.1746
-1991-06-30,DK,Denmark,50.0701
-1991-06-30,EE,Estonia,
-1991-06-30,ES,Spain,62.3812
+1991-03-31,PT,Portugal,111.8242
+1991-03-31,SE,Sweden,54.2101
+1991-03-31,TH,Thailand,100.7297
+1991-03-31,US,United States,87.8691
+1991-03-31,XM,Euro area,74.9471
+1991-03-31,ZA,South Africa,53.7539
+1991-06-30,AT,Austria,105.3308
+1991-06-30,AU,Australia,46.7659
+1991-06-30,BE,Belgium,49.4545
+1991-06-30,CA,Canada,64.6421
+1991-06-30,CH,Switzerland,94.3487
+1991-06-30,CO,Colombia,99.9402
+1991-06-30,DE,Germany,131.3203
+1991-06-30,DK,Denmark,50.0732
+1991-06-30,ES,Spain,62.3813
 1991-06-30,FI,Finland,71.3872
-1991-06-30,FR,France,59.6935
-1991-06-30,GB,United Kingdom,50.3859
-1991-06-30,GR,Greece,
+1991-06-30,FR,France,59.694
+1991-06-30,GB,United Kingdom,50.3691
 1991-06-30,HK,Hong Kong SAR,58.8724
-1991-06-30,HR,Croatia,
-1991-06-30,HU,Hungary,
-1991-06-30,ID,Indonesia,
-1991-06-30,IE,Ireland,45.4082
-1991-06-30,IL,Israel,
-1991-06-30,IN,India,
-1991-06-30,IS,Iceland,
-1991-06-30,IT,Italy,77.37
+1991-06-30,IE,Ireland,45.4217
+1991-06-30,IS,Iceland,77.1713
+1991-06-30,IT,Italy,77.4345
 1991-06-30,JP,Japan,187.1214
-1991-06-30,KR,Korea,151.349
-1991-06-30,LT,Lithuania,
-1991-06-30,LU,Luxembourg,
-1991-06-30,LV,Latvia,
-1991-06-30,MA,Morocco,
-1991-06-30,MK,North Macedonia,
-1991-06-30,MT,Malta,
-1991-06-30,MX,Mexico,
+1991-06-30,KR,Korea,151.2834
 1991-06-30,MY,Malaysia,74.1098
-1991-06-30,NL,Netherlands,42.3796
-1991-06-30,NO,Norway,38.7526
+1991-06-30,NL,Netherlands,43.4081
+1991-06-30,NO,Norway,38.7529
 1991-06-30,NZ,New Zealand,46.6435
-1991-06-30,PE,Peru,
-1991-06-30,PH,Philippines,
-1991-06-30,PL,Poland,
-1991-06-30,PT,Portugal,
-1991-06-30,RO,Romania,
-1991-06-30,RS,Serbia,
-1991-06-30,RU,Russia,
-1991-06-30,SE,Sweden,53.0525
-1991-06-30,SG,Singapore,
-1991-06-30,SI,Slovenia,
-1991-06-30,SK,Slovak Republic,
-1991-06-30,TH,Thailand,110.4827
-1991-06-30,TR,Türkiye,
-1991-06-30,US,United States,88.1112
-1991-06-30,XM,Euro area,75.8812
-1991-06-30,XW,World,
-1991-06-30,ZA,South Africa,54.0639
-1991-09-30,4T,Emerging market economies (aggregate),
-1991-09-30,5R,Advanced economies,
-1991-09-30,AE,United Arab Emirates,
-1991-09-30,AT,Austria,
-1991-09-30,AU,Australia,47.9623
-1991-09-30,BE,Belgium,50.5998
-1991-09-30,BG,Bulgaria,
-1991-09-30,BR,Brazil,
-1991-09-30,CA,Canada,60.1711
-1991-09-30,CH,Switzerland,98.0044
-1991-09-30,CL,Chile,
-1991-09-30,CN,China,
-1991-09-30,CO,Colombia,94.1128
-1991-09-30,CY,Cyprus,
-1991-09-30,CZ,Czechia,
-1991-09-30,DE,Germany,130.2109
-1991-09-30,DK,Denmark,49.707
-1991-09-30,EE,Estonia,
-1991-09-30,ES,Spain,62.5486
+1991-06-30,PT,Portugal,114.5131
+1991-06-30,SE,Sweden,53.0438
+1991-06-30,TH,Thailand,110.4898
+1991-06-30,US,United States,87.9619
+1991-06-30,XM,Euro area,75.8999
+1991-06-30,ZA,South Africa,53.9969
+1991-09-30,AT,Austria,108.2886
+1991-09-30,AU,Australia,47.9201
+1991-09-30,BE,Belgium,51.0304
+1991-09-30,CA,Canada,60.6376
+1991-09-30,CH,Switzerland,98.1682
+1991-09-30,CO,Colombia,95.5772
+1991-09-30,DE,Germany,130.2542
+1991-09-30,DK,Denmark,49.7101
+1991-09-30,ES,Spain,62.5487
 1991-09-30,FI,Finland,68.1091
-1991-09-30,FR,France,60.6153
-1991-09-30,GB,United Kingdom,50.8936
-1991-09-30,GR,Greece,
+1991-09-30,FR,France,60.6157
+1991-09-30,GB,United Kingdom,50.8766
 1991-09-30,HK,Hong Kong SAR,67.7936
-1991-09-30,HR,Croatia,
-1991-09-30,HU,Hungary,
-1991-09-30,ID,Indonesia,
-1991-09-30,IE,Ireland,47.6463
-1991-09-30,IL,Israel,
-1991-09-30,IN,India,
-1991-09-30,IS,Iceland,
-1991-09-30,IT,Italy,77.6109
+1991-09-30,IE,Ireland,47.6269
+1991-09-30,IS,Iceland,75.937
+1991-09-30,IT,Italy,77.6771
 1991-09-30,JP,Japan,186.8737
-1991-09-30,KR,Korea,146.6567
-1991-09-30,LT,Lithuania,
-1991-09-30,LU,Luxembourg,
-1991-09-30,LV,Latvia,
-1991-09-30,MA,Morocco,
-1991-09-30,MK,North Macedonia,
-1991-09-30,MT,Malta,
-1991-09-30,MX,Mexico,
+1991-09-30,KR,Korea,146.7395
 1991-09-30,MY,Malaysia,75.9167
-1991-09-30,NL,Netherlands,41.8944
-1991-09-30,NO,Norway,38.0893
+1991-09-30,NL,Netherlands,42.9111
+1991-09-30,NO,Norway,38.0918
 1991-09-30,NZ,New Zealand,46.8753
-1991-09-30,PE,Peru,
-1991-09-30,PH,Philippines,
-1991-09-30,PL,Poland,
-1991-09-30,PT,Portugal,
-1991-09-30,RO,Romania,
-1991-09-30,RS,Serbia,
-1991-09-30,RU,Russia,
-1991-09-30,SE,Sweden,53.1713
-1991-09-30,SG,Singapore,
-1991-09-30,SI,Slovenia,
-1991-09-30,SK,Slovak Republic,
-1991-09-30,TH,Thailand,111.2034
-1991-09-30,TR,Türkiye,
-1991-09-30,US,United States,87.1223
-1991-09-30,XM,Euro area,76.5319
-1991-09-30,XW,World,
-1991-09-30,ZA,South Africa,54.1743
-1991-12-31,4T,Emerging market economies (aggregate),
-1991-12-31,5R,Advanced economies,
-1991-12-31,AE,United Arab Emirates,
-1991-12-31,AT,Austria,
-1991-12-31,AU,Australia,47.4819
-1991-12-31,BE,Belgium,50.9809
-1991-12-31,BG,Bulgaria,
-1991-12-31,BR,Brazil,
-1991-12-31,CA,Canada,60.9953
-1991-12-31,CH,Switzerland,94.6638
-1991-12-31,CL,Chile,
-1991-12-31,CN,China,
-1991-12-31,CO,Colombia,96.6891
-1991-12-31,CY,Cyprus,
-1991-12-31,CZ,Czechia,
-1991-12-31,DE,Germany,128.9868
-1991-12-31,DK,Denmark,49.6516
-1991-12-31,EE,Estonia,
-1991-12-31,ES,Spain,64.3605
+1991-09-30,PT,Portugal,116.1609
+1991-09-30,SE,Sweden,53.165
+1991-09-30,TH,Thailand,111.2072
+1991-09-30,US,United States,86.9999
+1991-09-30,XM,Euro area,76.5411
+1991-09-30,ZA,South Africa,54.1139
+1991-12-31,AT,Austria,111.9496
+1991-12-31,AU,Australia,47.4709
+1991-12-31,BE,Belgium,51.4148
+1991-12-31,CA,Canada,61.4683
+1991-12-31,CH,Switzerland,94.7186
+1991-12-31,CO,Colombia,98.1693
+1991-12-31,DE,Germany,128.9789
+1991-12-31,DK,Denmark,49.6547
+1991-12-31,ES,Spain,64.3606
 1991-12-31,FI,Finland,64.0109
-1991-12-31,FR,France,59.2436
-1991-12-31,GB,United Kingdom,49.9296
-1991-12-31,GR,Greece,
+1991-12-31,FR,France,59.2441
+1991-12-31,GB,United Kingdom,49.913
 1991-12-31,HK,Hong Kong SAR,74.2993
-1991-12-31,HR,Croatia,
-1991-12-31,HU,Hungary,
-1991-12-31,ID,Indonesia,
-1991-12-31,IE,Ireland,49.043
-1991-12-31,IL,Israel,
-1991-12-31,IN,India,
-1991-12-31,IS,Iceland,
-1991-12-31,IT,Italy,78.3819
+1991-12-31,IE,Ireland,49.0862
+1991-12-31,IS,Iceland,74.7564
+1991-12-31,IT,Italy,78.4468
 1991-12-31,JP,Japan,182.567
-1991-12-31,KR,Korea,140.6574
-1991-12-31,LT,Lithuania,
-1991-12-31,LU,Luxembourg,
-1991-12-31,LV,Latvia,
-1991-12-31,MA,Morocco,
-1991-12-31,MK,North Macedonia,
-1991-12-31,MT,Malta,
-1991-12-31,MX,Mexico,
+1991-12-31,KR,Korea,140.7537
 1991-12-31,MY,Malaysia,76.6738
-1991-12-31,NL,Netherlands,42.3778
-1991-12-31,NO,Norway,37.2064
+1991-12-31,NL,Netherlands,43.4063
+1991-12-31,NO,Norway,37.2037
 1991-12-31,NZ,New Zealand,46.6662
-1991-12-31,PE,Peru,
-1991-12-31,PH,Philippines,
-1991-12-31,PL,Poland,
-1991-12-31,PT,Portugal,
-1991-12-31,RO,Romania,
-1991-12-31,RS,Serbia,
-1991-12-31,RU,Russia,
-1991-12-31,SE,Sweden,52.0014
-1991-12-31,SG,Singapore,
-1991-12-31,SI,Slovenia,
-1991-12-31,SK,Slovak Republic,
-1991-12-31,TH,Thailand,116.2274
-1991-12-31,TR,Türkiye,
-1991-12-31,US,United States,86.2466
-1991-12-31,XM,Euro area,76.8923
-1991-12-31,XW,World,
-1991-12-31,ZA,South Africa,53.3796
-1992-03-31,4T,Emerging market economies (aggregate),
-1992-03-31,5R,Advanced economies,
-1992-03-31,AE,United Arab Emirates,
-1992-03-31,AT,Austria,
-1992-03-31,AU,Australia,47.1658
-1992-03-31,BE,Belgium,51.4823
-1992-03-31,BG,Bulgaria,
-1992-03-31,BR,Brazil,
-1992-03-31,CA,Canada,61.7599
-1992-03-31,CH,Switzerland,93.06
-1992-03-31,CL,Chile,
-1992-03-31,CN,China,
-1992-03-31,CO,Colombia,93.2113
-1992-03-31,CY,Cyprus,
-1992-03-31,CZ,Czechia,
-1992-03-31,DE,Germany,129.215
-1992-03-31,DK,Denmark,49.2121
-1992-03-31,EE,Estonia,
-1992-03-31,ES,Spain,60.1021
+1991-12-31,PT,Portugal,118.3655
+1991-12-31,SE,Sweden,51.9921
+1991-12-31,TH,Thailand,116.229
+1991-12-31,US,United States,86.1231
+1991-12-31,XM,Euro area,76.9044
+1991-12-31,ZA,South Africa,53.3176
+1992-03-31,AT,Austria,117.6424
+1992-03-31,AU,Australia,47.1548
+1992-03-31,BE,Belgium,51.9205
+1992-03-31,CA,Canada,62.2387
+1992-03-31,CH,Switzerland,93.1085
+1992-03-31,CO,Colombia,93.4565
+1992-03-31,DE,Germany,129.2132
+1992-03-31,DK,Denmark,49.2152
+1992-03-31,ES,Spain,60.1022
 1992-03-31,FI,Finland,61.4947
-1992-03-31,FR,France,57.3226
-1992-03-31,GB,United Kingdom,48.9527
-1992-03-31,GR,Greece,
+1992-03-31,FR,France,57.323
+1992-03-31,GB,United Kingdom,48.9364
 1992-03-31,HK,Hong Kong SAR,78.625
-1992-03-31,HR,Croatia,
-1992-03-31,HU,Hungary,
-1992-03-31,ID,Indonesia,
-1992-03-31,IE,Ireland,48.5523
-1992-03-31,IL,Israel,
-1992-03-31,IN,India,
-1992-03-31,IS,Iceland,
-1992-03-31,IT,Italy,82.135
+1992-03-31,HU,Hungary,110.8006
+1992-03-31,IE,Ireland,48.495
+1992-03-31,IS,Iceland,76.2321
+1992-03-31,IT,Italy,82.2036
 1992-03-31,JP,Japan,181.1672
-1992-03-31,KR,Korea,134.909
-1992-03-31,LT,Lithuania,
-1992-03-31,LU,Luxembourg,
-1992-03-31,LV,Latvia,
-1992-03-31,MA,Morocco,
-1992-03-31,MK,North Macedonia,
-1992-03-31,MT,Malta,
-1992-03-31,MX,Mexico,
+1992-03-31,KR,Korea,134.9463
 1992-03-31,MY,Malaysia,77.9957
-1992-03-31,NL,Netherlands,44.0034
-1992-03-31,NO,Norway,36.107
+1992-03-31,NL,Netherlands,45.0713
+1992-03-31,NO,Norway,36.0919
 1992-03-31,NZ,New Zealand,46.2331
-1992-03-31,PE,Peru,
-1992-03-31,PH,Philippines,
-1992-03-31,PL,Poland,
-1992-03-31,PT,Portugal,
-1992-03-31,RO,Romania,
-1992-03-31,RS,Serbia,
-1992-03-31,RU,Russia,
-1992-03-31,SE,Sweden,49.5574
-1992-03-31,SG,Singapore,
-1992-03-31,SI,Slovenia,
-1992-03-31,SK,Slovak Republic,
-1992-03-31,TH,Thailand,119.0758
-1992-03-31,TR,Türkiye,
-1992-03-31,US,United States,85.8418
-1992-03-31,XM,Euro area,76.6593
-1992-03-31,XW,World,
-1992-03-31,ZA,South Africa,51.9654
-1992-06-30,4T,Emerging market economies (aggregate),
-1992-06-30,5R,Advanced economies,
-1992-06-30,AE,United Arab Emirates,
-1992-06-30,AT,Austria,
-1992-06-30,AU,Australia,47.4619
-1992-06-30,BE,Belgium,52.4334
-1992-06-30,BG,Bulgaria,
-1992-06-30,BR,Brazil,
-1992-06-30,CA,Canada,61.9171
-1992-06-30,CH,Switzerland,91.8261
-1992-06-30,CL,Chile,
-1992-06-30,CN,China,
-1992-06-30,CO,Colombia,90.9063
-1992-06-30,CY,Cyprus,
-1992-06-30,CZ,Czechia,
-1992-06-30,DE,Germany,129.9487
-1992-06-30,DK,Denmark,48.7045
-1992-06-30,EE,Estonia,
-1992-06-30,ES,Spain,58.4331
+1992-03-31,PT,Portugal,119.4162
+1992-03-31,SE,Sweden,49.5514
+1992-03-31,TH,Thailand,119.0734
+1992-03-31,US,United States,85.7143
+1992-03-31,XM,Euro area,76.6725
+1992-03-31,ZA,South Africa,51.8948
+1992-06-30,AT,Austria,122.3255
+1992-06-30,AU,Australia,47.4293
+1992-06-30,BE,Belgium,52.8797
+1992-06-30,CA,Canada,62.3972
+1992-06-30,CH,Switzerland,91.8684
+1992-06-30,CO,Colombia,92.0063
+1992-06-30,DE,Germany,130.0107
+1992-06-30,DK,Denmark,48.7075
+1992-06-30,ES,Spain,58.4332
 1992-06-30,FI,Finland,57.7244
-1992-06-30,FR,France,56.7304
-1992-06-30,GB,United Kingdom,46.8658
-1992-06-30,GR,Greece,
+1992-06-30,FR,France,56.7308
+1992-06-30,GB,United Kingdom,46.8502
 1992-06-30,HK,Hong Kong SAR,83.4938
-1992-06-30,HR,Croatia,
-1992-06-30,HU,Hungary,
-1992-06-30,ID,Indonesia,
-1992-06-30,IE,Ireland,46.4462
-1992-06-30,IL,Israel,
-1992-06-30,IN,India,
-1992-06-30,IS,Iceland,
-1992-06-30,IT,Italy,84.4495
+1992-06-30,HU,Hungary,108.2974
+1992-06-30,IE,Ireland,46.4466
+1992-06-30,IS,Iceland,75.6117
+1992-06-30,IT,Italy,84.5173
 1992-06-30,JP,Japan,176.461
-1992-06-30,KR,Korea,129.8106
-1992-06-30,LT,Lithuania,
-1992-06-30,LU,Luxembourg,
-1992-06-30,LV,Latvia,
-1992-06-30,MA,Morocco,
-1992-06-30,MK,North Macedonia,
-1992-06-30,MT,Malta,
-1992-06-30,MX,Mexico,
+1992-06-30,KR,Korea,129.7787
 1992-06-30,MY,Malaysia,79.5328
-1992-06-30,NL,Netherlands,42.746
-1992-06-30,NO,Norway,35.8983
+1992-06-30,NL,Netherlands,43.7834
+1992-06-30,NO,Norway,35.8898
 1992-06-30,NZ,New Zealand,46.785
-1992-06-30,PE,Peru,
-1992-06-30,PH,Philippines,
-1992-06-30,PL,Poland,
-1992-06-30,PT,Portugal,
-1992-06-30,RO,Romania,
-1992-06-30,RS,Serbia,
-1992-06-30,RU,Russia,
-1992-06-30,SE,Sweden,48.3458
-1992-06-30,SG,Singapore,
-1992-06-30,SI,Slovenia,
-1992-06-30,SK,Slovak Republic,
-1992-06-30,TH,Thailand,118.8742
-1992-06-30,TR,Türkiye,
-1992-06-30,US,United States,84.9828
-1992-06-30,XM,Euro area,76.7436
-1992-06-30,XW,World,
-1992-06-30,ZA,South Africa,49.5265
-1992-09-30,4T,Emerging market economies (aggregate),
-1992-09-30,5R,Advanced economies,
-1992-09-30,AE,United Arab Emirates,
-1992-09-30,AT,Austria,
-1992-09-30,AU,Australia,47.4234
-1992-09-30,BE,Belgium,52.561
-1992-09-30,BG,Bulgaria,
-1992-09-30,BR,Brazil,
-1992-09-30,CA,Canada,61.7973
-1992-09-30,CH,Switzerland,89.4648
-1992-09-30,CL,Chile,
-1992-09-30,CN,China,
-1992-09-30,CO,Colombia,89.653
-1992-09-30,CY,Cyprus,
-1992-09-30,CZ,Czechia,
-1992-09-30,DE,Germany,130.6494
-1992-09-30,DK,Denmark,47.7757
-1992-09-30,EE,Estonia,
-1992-09-30,ES,Spain,57.5158
+1992-06-30,PT,Portugal,119.7005
+1992-06-30,SE,Sweden,48.3383
+1992-06-30,TH,Thailand,118.8753
+1992-06-30,US,United States,84.8566
+1992-06-30,XM,Euro area,76.7613
+1992-06-30,ZA,South Africa,49.4724
+1992-09-30,AT,Austria,116.4245
+1992-09-30,AU,Australia,47.4244
+1992-09-30,BE,Belgium,53.0083
+1992-09-30,CA,Canada,62.2764
+1992-09-30,CH,Switzerland,89.4052
+1992-09-30,CO,Colombia,90.9404
+1992-09-30,DE,Germany,130.7235
+1992-09-30,DK,Denmark,47.7787
+1992-09-30,ES,Spain,57.5159
 1992-09-30,FI,Finland,53.5999
-1992-09-30,FR,France,57.2942
-1992-09-30,GB,United Kingdom,47.1128
-1992-09-30,GR,Greece,
+1992-09-30,FR,France,57.2946
+1992-09-30,GB,United Kingdom,47.0971
 1992-09-30,HK,Hong Kong SAR,83.8409
-1992-09-30,HR,Croatia,
-1992-09-30,HU,Hungary,
-1992-09-30,ID,Indonesia,
-1992-09-30,IE,Ireland,48.1367
-1992-09-30,IL,Israel,
-1992-09-30,IN,India,
-1992-09-30,IS,Iceland,
-1992-09-30,IT,Italy,85.4558
+1992-09-30,HU,Hungary,105.6261
+1992-09-30,IE,Ireland,48.1206
+1992-09-30,IS,Iceland,76.3067
+1992-09-30,IT,Italy,85.5299
 1992-09-30,JP,Japan,175.0462
-1992-09-30,KR,Korea,126.5075
-1992-09-30,LT,Lithuania,
-1992-09-30,LU,Luxembourg,
-1992-09-30,LV,Latvia,
-1992-09-30,MA,Morocco,
-1992-09-30,MK,North Macedonia,
-1992-09-30,MT,Malta,
-1992-09-30,MX,Mexico,
+1992-09-30,KR,Korea,126.503
 1992-09-30,MY,Malaysia,79.8925
-1992-09-30,NL,Netherlands,45.0859
-1992-09-30,NO,Norway,35.9936
+1992-09-30,NL,Netherlands,46.1801
+1992-09-30,NO,Norway,36.0015
 1992-09-30,NZ,New Zealand,46.9211
-1992-09-30,PE,Peru,
-1992-09-30,PH,Philippines,
-1992-09-30,PL,Poland,
-1992-09-30,PT,Portugal,
-1992-09-30,RO,Romania,
-1992-09-30,RS,Serbia,
-1992-09-30,RU,Russia,
-1992-09-30,SE,Sweden,46.7922
-1992-09-30,SG,Singapore,
-1992-09-30,SI,Slovenia,
-1992-09-30,SK,Slovak Republic,
-1992-09-30,TH,Thailand,118.1341
-1992-09-30,TR,Türkiye,
-1992-09-30,US,United States,84.1946
-1992-09-30,XM,Euro area,77.2013
-1992-09-30,XW,World,
-1992-09-30,ZA,South Africa,47.803
-1992-12-31,4T,Emerging market economies (aggregate),
-1992-12-31,5R,Advanced economies,
-1992-12-31,AE,United Arab Emirates,
-1992-12-31,AT,Austria,
-1992-12-31,AU,Australia,47.639
-1992-12-31,BE,Belgium,52.3687
-1992-12-31,BG,Bulgaria,
-1992-12-31,BR,Brazil,
-1992-12-31,CA,Canada,62.8594
-1992-12-31,CH,Switzerland,88.7433
-1992-12-31,CL,Chile,
-1992-12-31,CN,China,
-1992-12-31,CO,Colombia,89.4184
-1992-12-31,CY,Cyprus,
-1992-12-31,CZ,Czechia,
-1992-12-31,DE,Germany,130.7798
-1992-12-31,DK,Denmark,46.4233
-1992-12-31,EE,Estonia,
-1992-12-31,ES,Spain,56.6356
+1992-09-30,PT,Portugal,117.7089
+1992-09-30,SE,Sweden,46.7896
+1992-09-30,TH,Thailand,118.145
+1992-09-30,US,United States,84.083
+1992-09-30,XM,Euro area,77.2096
+1992-09-30,ZA,South Africa,47.7558
+1992-12-31,AT,Austria,118.2464
+1992-12-31,AU,Australia,47.6609
+1992-12-31,BE,Belgium,52.8144
+1992-12-31,CA,Canada,63.3468
+1992-12-31,CH,Switzerland,88.7017
+1992-12-31,CO,Colombia,91.203
+1992-12-31,DE,Germany,130.6468
+1992-12-31,DK,Denmark,46.4262
+1992-12-31,ES,Spain,56.6357
 1992-12-31,FI,Finland,50.352
-1992-12-31,FR,France,56.1135
-1992-12-31,GB,United Kingdom,45.017
-1992-12-31,GR,Greece,
+1992-12-31,FR,France,56.1139
+1992-12-31,GB,United Kingdom,45.0021
 1992-12-31,HK,Hong Kong SAR,79.3728
-1992-12-31,HR,Croatia,
-1992-12-31,HU,Hungary,
-1992-12-31,ID,Indonesia,
-1992-12-31,IE,Ireland,48.1388
-1992-12-31,IL,Israel,
-1992-12-31,IN,India,
-1992-12-31,IS,Iceland,
-1992-12-31,IT,Italy,85.3523
+1992-12-31,HU,Hungary,99.4047
+1992-12-31,IE,Ireland,48.1186
+1992-12-31,IS,Iceland,76.2543
+1992-12-31,IT,Italy,85.4237
 1992-12-31,JP,Japan,172.1491
-1992-12-31,KR,Korea,126.1897
-1992-12-31,LT,Lithuania,
-1992-12-31,LU,Luxembourg,
-1992-12-31,LV,Latvia,
-1992-12-31,MA,Morocco,
-1992-12-31,MK,North Macedonia,
-1992-12-31,MT,Malta,
-1992-12-31,MX,Mexico,
+1992-12-31,KR,Korea,126.2521
 1992-12-31,MY,Malaysia,79.8994
-1992-12-31,NL,Netherlands,44.8292
-1992-12-31,NO,Norway,34.9182
+1992-12-31,NL,Netherlands,45.9171
+1992-12-31,NO,Norway,34.9028
 1992-12-31,NZ,New Zealand,46.8502
-1992-12-31,PE,Peru,
-1992-12-31,PH,Philippines,
-1992-12-31,PL,Poland,
-1992-12-31,PT,Portugal,
-1992-12-31,RO,Romania,
-1992-12-31,RS,Serbia,
-1992-12-31,RU,Russia,
-1992-12-31,SE,Sweden,43.267
-1992-12-31,SG,Singapore,
-1992-12-31,SI,Slovenia,
-1992-12-31,SK,Slovak Republic,
-1992-12-31,TH,Thailand,122.785
-1992-12-31,TR,Türkiye,
-1992-12-31,US,United States,83.8501
-1992-12-31,XM,Euro area,76.7299
-1992-12-31,XW,World,
-1992-12-31,ZA,South Africa,48.344
-1993-03-31,4T,Emerging market economies (aggregate),
-1993-03-31,5R,Advanced economies,
-1993-03-31,AE,United Arab Emirates,
-1993-03-31,AT,Austria,
-1993-03-31,AU,Australia,47.6945
-1993-03-31,BE,Belgium,52.1378
-1993-03-31,BG,Bulgaria,
-1993-03-31,BR,Brazil,
-1993-03-31,CA,Canada,62.9535
-1993-03-31,CH,Switzerland,87.3972
-1993-03-31,CL,Chile,
-1993-03-31,CN,China,
-1993-03-31,CO,Colombia,88.694
-1993-03-31,CY,Cyprus,
-1993-03-31,CZ,Czechia,
-1993-03-31,DE,Germany,129.2254
-1993-03-31,DK,Denmark,45.835
-1993-03-31,EE,Estonia,
-1993-03-31,ES,Spain,55.445
+1992-12-31,PT,Portugal,116.3964
+1992-12-31,SE,Sweden,43.2594
+1992-12-31,TH,Thailand,122.7913
+1992-12-31,US,United States,83.7356
+1992-12-31,XM,Euro area,76.7385
+1992-12-31,ZA,South Africa,48.2822
+1993-03-31,AT,Austria,112.8763
+1993-03-31,AU,Australia,47.6677
+1993-03-31,BE,Belgium,52.5815
+1993-03-31,CA,Canada,63.4415
+1993-03-31,CH,Switzerland,87.3602
+1993-03-31,CO,Colombia,90.1984
+1993-03-31,DE,Germany,129.2787
+1993-03-31,DK,Denmark,45.8379
+1993-03-31,ES,Spain,55.4451
 1993-03-31,FI,Finland,49.0632
-1993-03-31,FR,France,54.7767
-1993-03-31,GB,United Kingdom,45.226
-1993-03-31,GR,Greece,
+1993-03-31,FR,France,54.7771
+1993-03-31,GB,United Kingdom,45.211
 1993-03-31,HK,Hong Kong SAR,77.0225
-1993-03-31,HR,Croatia,
-1993-03-31,HU,Hungary,
-1993-03-31,ID,Indonesia,
-1993-03-31,IE,Ireland,46.5053
-1993-03-31,IL,Israel,
-1993-03-31,IN,India,
-1993-03-31,IS,Iceland,
-1993-03-31,IT,Italy,85.1951
+1993-03-31,HU,Hungary,94.718
+1993-03-31,IE,Ireland,46.478
+1993-03-31,IS,Iceland,74.8125
+1993-03-31,IT,Italy,85.2639
 1993-03-31,JP,Japan,169.9309
-1993-03-31,KR,Korea,123.4693
-1993-03-31,LT,Lithuania,
-1993-03-31,LU,Luxembourg,
-1993-03-31,LV,Latvia,
-1993-03-31,MA,Morocco,
-1993-03-31,MK,North Macedonia,
-1993-03-31,MT,Malta,
-1993-03-31,MX,Mexico,
+1993-03-31,KR,Korea,123.4865
 1993-03-31,MY,Malaysia,80.0609
-1993-03-31,NL,Netherlands,45.4595
+1993-03-31,NL,Netherlands,46.5628
 1993-03-31,NO,Norway,33.3185
 1993-03-31,NZ,New Zealand,47.3032
-1993-03-31,PE,Peru,
-1993-03-31,PH,Philippines,
-1993-03-31,PL,Poland,
-1993-03-31,PT,Portugal,
-1993-03-31,RO,Romania,
-1993-03-31,RS,Serbia,
-1993-03-31,RU,Russia,
-1993-03-31,SE,Sweden,40.1134
-1993-03-31,SG,Singapore,
-1993-03-31,SI,Slovenia,
-1993-03-31,SK,Slovak Republic,
-1993-03-31,TH,Thailand,124.618
-1993-03-31,TR,Türkiye,
-1993-03-31,US,United States,83.3903
-1993-03-31,XM,Euro area,75.7227
-1993-03-31,XW,World,
-1993-03-31,ZA,South Africa,48.1966
-1993-06-30,4T,Emerging market economies (aggregate),
-1993-06-30,5R,Advanced economies,
-1993-06-30,AE,United Arab Emirates,
-1993-06-30,AT,Austria,
-1993-06-30,AU,Australia,47.8491
-1993-06-30,BE,Belgium,53.4027
-1993-06-30,BG,Bulgaria,
-1993-06-30,BR,Brazil,
-1993-06-30,CA,Canada,62.8305
-1993-06-30,CH,Switzerland,88.6022
-1993-06-30,CL,Chile,
-1993-06-30,CN,China,
-1993-06-30,CO,Colombia,89.6347
-1993-06-30,CY,Cyprus,
-1993-06-30,CZ,Czechia,
-1993-06-30,DE,Germany,129.5808
-1993-06-30,DK,Denmark,45.1773
-1993-06-30,EE,Estonia,
-1993-06-30,ES,Spain,55.7468
+1993-03-31,PT,Portugal,113.8104
+1993-03-31,SE,Sweden,40.1102
+1993-03-31,TH,Thailand,124.6228
+1993-03-31,US,United States,83.2865
+1993-03-31,XM,Euro area,75.7396
+1993-03-31,ZA,South Africa,48.1469
+1993-06-30,AT,Austria,116.5885
+1993-06-30,AU,Australia,47.8097
+1993-06-30,BE,Belgium,53.8572
+1993-06-30,CA,Canada,63.3176
+1993-06-30,CH,Switzerland,88.6865
+1993-06-30,CO,Colombia,91.1295
+1993-06-30,DE,Germany,129.5972
+1993-06-30,DK,Denmark,45.1801
+1993-06-30,ES,Spain,55.7469
 1993-06-30,FI,Finland,49.1218
-1993-06-30,FR,France,54.6916
-1993-06-30,GB,United Kingdom,44.6958
-1993-06-30,GR,Greece,
+1993-06-30,FR,France,54.692
+1993-06-30,GB,United Kingdom,44.6809
 1993-06-30,HK,Hong Kong SAR,80.5585
-1993-06-30,HR,Croatia,
-1993-06-30,HU,Hungary,
-1993-06-30,ID,Indonesia,
-1993-06-30,IE,Ireland,46.756
-1993-06-30,IL,Israel,
-1993-06-30,IN,India,
-1993-06-30,IS,Iceland,
-1993-06-30,IT,Italy,84.863
+1993-06-30,HU,Hungary,97.5213
+1993-06-30,IE,Ireland,46.8031
+1993-06-30,IS,Iceland,74.477
+1993-06-30,IT,Italy,84.9294
 1993-06-30,JP,Japan,166.9616
-1993-06-30,KR,Korea,119.9606
-1993-06-30,LT,Lithuania,
-1993-06-30,LU,Luxembourg,
-1993-06-30,LV,Latvia,
-1993-06-30,MA,Morocco,
-1993-06-30,MK,North Macedonia,
-1993-06-30,MT,Malta,
-1993-06-30,MX,Mexico,
+1993-06-30,KR,Korea,119.9986
 1993-06-30,MY,Malaysia,80.2231
-1993-06-30,NL,Netherlands,46.225
-1993-06-30,NO,Norway,34.6797
+1993-06-30,NL,Netherlands,47.3468
+1993-06-30,NO,Norway,34.6568
 1993-06-30,NZ,New Zealand,47.4568
-1993-06-30,PE,Peru,
-1993-06-30,PH,Philippines,
-1993-06-30,PL,Poland,
-1993-06-30,PT,Portugal,
-1993-06-30,RO,Romania,
-1993-06-30,RS,Serbia,
-1993-06-30,RU,Russia,
-1993-06-30,SE,Sweden,39.9015
-1993-06-30,SG,Singapore,
-1993-06-30,SI,Slovenia,
-1993-06-30,SK,Slovak Republic,
-1993-06-30,TH,Thailand,129.2613
-1993-06-30,TR,Türkiye,
-1993-06-30,US,United States,83.1582
-1993-06-30,XM,Euro area,76.0147
-1993-06-30,XW,World,
-1993-06-30,ZA,South Africa,46.6657
-1993-09-30,4T,Emerging market economies (aggregate),
-1993-09-30,5R,Advanced economies,
-1993-09-30,AE,United Arab Emirates,
-1993-09-30,AT,Austria,
-1993-09-30,AU,Australia,47.6591
-1993-09-30,BE,Belgium,53.4358
-1993-09-30,BG,Bulgaria,
-1993-09-30,BR,Brazil,
-1993-09-30,CA,Canada,61.2056
-1993-09-30,CH,Switzerland,86.2727
-1993-09-30,CL,Chile,
-1993-09-30,CN,China,
-1993-09-30,CO,Colombia,93.1373
-1993-09-30,CY,Cyprus,
-1993-09-30,CZ,Czechia,
-1993-09-30,DE,Germany,129.9122
-1993-09-30,DK,Denmark,47.2156
-1993-09-30,EE,Estonia,
-1993-09-30,ES,Spain,55.5005
+1993-06-30,PT,Portugal,113.2532
+1993-06-30,SE,Sweden,39.8981
+1993-06-30,TH,Thailand,129.2606
+1993-06-30,US,United States,83.0581
+1993-06-30,XM,Euro area,76.0304
+1993-06-30,ZA,South Africa,46.6123
+1993-09-30,AT,Austria,113.8081
+1993-09-30,AU,Australia,47.6294
+1993-09-30,BE,Belgium,53.8906
+1993-09-30,CA,Canada,61.6801
+1993-09-30,CH,Switzerland,86.2493
+1993-09-30,CO,Colombia,94.4566
+1993-09-30,DE,Germany,129.9068
+1993-09-30,DK,Denmark,47.2186
+1993-09-30,ES,Spain,55.5006
 1993-09-30,FI,Finland,49.6397
-1993-09-30,FR,France,55.511
-1993-09-30,GB,United Kingdom,45.571
-1993-09-30,GR,Greece,
+1993-09-30,FR,France,55.5114
+1993-09-30,GB,United Kingdom,45.5559
 1993-09-30,HK,Hong Kong SAR,85.3006
-1993-09-30,HR,Croatia,
-1993-09-30,HU,Hungary,
-1993-09-30,ID,Indonesia,
-1993-09-30,IE,Ireland,48.6416
-1993-09-30,IL,Israel,
-1993-09-30,IN,India,
-1993-09-30,IS,Iceland,
-1993-09-30,IT,Italy,84.8369
+1993-09-30,HU,Hungary,91.4844
+1993-09-30,IE,Ireland,48.6655
+1993-09-30,IS,Iceland,70.7819
+1993-09-30,IT,Italy,84.906
 1993-09-30,JP,Japan,164.7718
-1993-09-30,KR,Korea,117.4892
-1993-09-30,LT,Lithuania,
-1993-09-30,LU,Luxembourg,
-1993-09-30,LV,Latvia,
-1993-09-30,MA,Morocco,
-1993-09-30,MK,North Macedonia,
-1993-09-30,MT,Malta,
-1993-09-30,MX,Mexico,
+1993-09-30,KR,Korea,117.5277
 1993-09-30,MY,Malaysia,80.3288
-1993-09-30,NL,Netherlands,47.0249
-1993-09-30,NO,Norway,35.9778
+1993-09-30,NL,Netherlands,48.1662
+1993-09-30,NO,Norway,36.005
 1993-09-30,NZ,New Zealand,48.1174
-1993-09-30,PE,Peru,
-1993-09-30,PH,Philippines,
-1993-09-30,PL,Poland,
-1993-09-30,PT,Portugal,
-1993-09-30,RO,Romania,
-1993-09-30,RS,Serbia,
-1993-09-30,RU,Russia,
-1993-09-30,SE,Sweden,39.7224
-1993-09-30,SG,Singapore,
-1993-09-30,SI,Slovenia,
-1993-09-30,SK,Slovak Republic,
-1993-09-30,TH,Thailand,127.7017
-1993-09-30,TR,Türkiye,
-1993-09-30,US,United States,83.4189
-1993-09-30,XM,Euro area,76.4365
-1993-09-30,XW,World,
-1993-09-30,ZA,South Africa,46.9108
-1993-12-31,4T,Emerging market economies (aggregate),
-1993-12-31,5R,Advanced economies,
-1993-12-31,AE,United Arab Emirates,
-1993-12-31,AT,Austria,
-1993-12-31,AU,Australia,48.0254
-1993-12-31,BE,Belgium,55.0574
-1993-12-31,BG,Bulgaria,
-1993-12-31,BR,Brazil,
-1993-12-31,CA,Canada,61.6484
-1993-12-31,CH,Switzerland,85.8293
-1993-12-31,CL,Chile,
-1993-12-31,CN,China,
-1993-12-31,CO,Colombia,95.4941
-1993-12-31,CY,Cyprus,
-1993-12-31,CZ,Czechia,
-1993-12-31,DE,Germany,130.7818
-1993-12-31,DK,Denmark,49.7047
-1993-12-31,EE,Estonia,
-1993-12-31,ES,Spain,54.9091
+1993-09-30,PT,Portugal,111.5547
+1993-09-30,SE,Sweden,39.7213
+1993-09-30,TH,Thailand,127.7047
+1993-09-30,US,United States,83.313
+1993-09-30,XM,Euro area,76.4427
+1993-09-30,ZA,South Africa,46.8555
+1993-12-31,AT,Austria,116.5812
+1993-12-31,AU,Australia,47.9836
+1993-12-31,BE,Belgium,55.526
+1993-12-31,CA,Canada,62.1264
+1993-12-31,CH,Switzerland,85.7931
+1993-12-31,CO,Colombia,96.5207
+1993-12-31,DE,Germany,130.7196
+1993-12-31,DK,Denmark,49.7078
+1993-12-31,ES,Spain,54.9092
 1993-12-31,FI,Finland,51.2361
-1993-12-31,FR,France,54.5882
-1993-12-31,GB,United Kingdom,44.618
-1993-12-31,GR,Greece,
+1993-12-31,FR,France,54.5886
+1993-12-31,GB,United Kingdom,44.6032
 1993-12-31,HK,Hong Kong SAR,83.3913
-1993-12-31,HR,Croatia,
-1993-12-31,HU,Hungary,
-1993-12-31,ID,Indonesia,
-1993-12-31,IE,Ireland,47.6849
-1993-12-31,IL,Israel,
-1993-12-31,IN,India,
-1993-12-31,IS,Iceland,
-1993-12-31,IT,Italy,83.0974
+1993-12-31,HU,Hungary,95.017
+1993-12-31,IE,Ireland,47.7003
+1993-12-31,IS,Iceland,70.6854
+1993-12-31,IT,Italy,83.1667
 1993-12-31,JP,Japan,164.1822
-1993-12-31,KR,Korea,115.7664
-1993-12-31,LT,Lithuania,
-1993-12-31,LU,Luxembourg,
-1993-12-31,LV,Latvia,
-1993-12-31,MA,Morocco,
-1993-12-31,MK,North Macedonia,
-1993-12-31,MT,Malta,
-1993-12-31,MX,Mexico,
+1993-12-31,KR,Korea,115.762
 1993-12-31,MY,Malaysia,80.6792
-1993-12-31,NL,Netherlands,47.7013
-1993-12-31,NO,Norway,37.0145
+1993-12-31,NL,Netherlands,48.8589
+1993-12-31,NO,Norway,37.0138
 1993-12-31,NZ,New Zealand,49.1213
-1993-12-31,PE,Peru,
-1993-12-31,PH,Philippines,
-1993-12-31,PL,Poland,
-1993-12-31,PT,Portugal,
-1993-12-31,RO,Romania,
-1993-12-31,RS,Serbia,
-1993-12-31,RU,Russia,
-1993-12-31,SE,Sweden,39.8497
-1993-12-31,SG,Singapore,
-1993-12-31,SI,Slovenia,
-1993-12-31,SK,Slovak Republic,
-1993-12-31,TH,Thailand,127.533
-1993-12-31,TR,Türkiye,
-1993-12-31,US,United States,83.5993
-1993-12-31,XM,Euro area,76.04
-1993-12-31,XW,World,
-1993-12-31,ZA,South Africa,47.2153
-1994-03-31,4T,Emerging market economies (aggregate),
-1994-03-31,5R,Advanced economies,
-1994-03-31,AE,United Arab Emirates,
-1994-03-31,AT,Austria,
-1994-03-31,AU,Australia,48.3176
-1994-03-31,BE,Belgium,54.719
-1994-03-31,BG,Bulgaria,
-1994-03-31,BR,Brazil,
-1994-03-31,CA,Canada,64.7708
-1994-03-31,CH,Switzerland,86.9136
-1994-03-31,CL,Chile,
-1994-03-31,CN,China,
-1994-03-31,CO,Colombia,96.3735
-1994-03-31,CY,Cyprus,
-1994-03-31,CZ,Czechia,
-1994-03-31,DE,Germany,130.4858
-1994-03-31,DK,Denmark,52.3994
-1994-03-31,EE,Estonia,
-1994-03-31,ES,Spain,53.5884
+1993-12-31,PT,Portugal,110.1554
+1993-12-31,SE,Sweden,39.8477
+1993-12-31,TH,Thailand,127.538
+1993-12-31,US,United States,83.5053
+1993-12-31,XM,Euro area,76.0483
+1993-12-31,ZA,South Africa,47.158
+1994-03-31,AT,Austria,115.2616
+1994-03-31,AU,Australia,48.3416
+1994-03-31,BE,Belgium,55.1847
+1994-03-31,CA,Canada,65.273
+1994-03-31,CH,Switzerland,86.9613
+1994-03-31,CO,Colombia,98.2549
+1994-03-31,DE,Germany,130.4209
+1994-03-31,DK,Denmark,52.4026
+1994-03-31,ES,Spain,53.5885
 1994-03-31,FI,Finland,52.5087
-1994-03-31,FR,France,53.5555
-1994-03-31,GB,United Kingdom,45.0497
-1994-03-31,GR,Greece,
+1994-03-31,FR,France,53.5559
+1994-03-31,GB,United Kingdom,45.0347
 1994-03-31,HK,Hong Kong SAR,94.6147
-1994-03-31,HR,Croatia,
-1994-03-31,HU,Hungary,
-1994-03-31,ID,Indonesia,
-1994-03-31,IE,Ireland,49.0633
-1994-03-31,IL,Israel,89.4356
-1994-03-31,IN,India,
-1994-03-31,IS,Iceland,
-1994-03-31,IT,Italy,81.6033
+1994-03-31,HU,Hungary,92.8171
+1994-03-31,IE,Ireland,49.0626
+1994-03-31,IL,Israel,89.4355
+1994-03-31,IS,Iceland,72.5238
+1994-03-31,IT,Italy,81.6735
 1994-03-31,JP,Japan,162.9622
-1994-03-31,KR,Korea,112.5746
-1994-03-31,LT,Lithuania,
-1994-03-31,LU,Luxembourg,
-1994-03-31,LV,Latvia,
-1994-03-31,MA,Morocco,
-1994-03-31,MK,North Macedonia,
-1994-03-31,MT,Malta,
-1994-03-31,MX,Mexico,
+1994-03-31,KR,Korea,112.5637
 1994-03-31,MY,Malaysia,81.8204
-1994-03-31,NL,Netherlands,49.153
-1994-03-31,NO,Norway,38.0859
+1994-03-31,NL,Netherlands,50.3459
+1994-03-31,NO,Norway,38.0704
 1994-03-31,NZ,New Zealand,51.8931
-1994-03-31,PE,Peru,
-1994-03-31,PH,Philippines,
-1994-03-31,PL,Poland,
-1994-03-31,PT,Portugal,
-1994-03-31,RO,Romania,
-1994-03-31,RS,Serbia,
-1994-03-31,RU,Russia,
-1994-03-31,SE,Sweden,40.3682
-1994-03-31,SG,Singapore,
-1994-03-31,SI,Slovenia,
-1994-03-31,SK,Slovak Republic,
-1994-03-31,TH,Thailand,119.5646
-1994-03-31,TR,Türkiye,
-1994-03-31,US,United States,83.3308
-1994-03-31,XM,Euro area,75.3379
-1994-03-31,XW,World,
-1994-03-31,ZA,South Africa,47.4748
-1994-06-30,4T,Emerging market economies (aggregate),
-1994-06-30,5R,Advanced economies,
-1994-06-30,AE,United Arab Emirates,
-1994-06-30,AT,Austria,
-1994-06-30,AU,Australia,48.5777
-1994-06-30,BE,Belgium,55.252
-1994-06-30,BG,Bulgaria,
-1994-06-30,BR,Brazil,
-1994-06-30,CA,Canada,64.4565
-1994-06-30,CH,Switzerland,86.1224
-1994-06-30,CL,Chile,
-1994-06-30,CN,China,
-1994-06-30,CO,Colombia,94.7412
-1994-06-30,CY,Cyprus,
-1994-06-30,CZ,Czechia,
-1994-06-30,DE,Germany,131.4301
-1994-06-30,DK,Denmark,51.9531
-1994-06-30,EE,Estonia,
-1994-06-30,ES,Spain,53.3351
+1994-03-31,PT,Portugal,109.1782
+1994-03-31,SE,Sweden,40.3666
+1994-03-31,TH,Thailand,119.567
+1994-03-31,US,United States,83.2284
+1994-03-31,XM,Euro area,75.3374
+1994-03-31,ZA,South Africa,47.4171
+1994-06-30,AT,Austria,112.6838
+1994-06-30,AU,Australia,48.5653
+1994-06-30,BE,Belgium,55.7222
+1994-06-30,CA,Canada,64.9563
+1994-06-30,CH,Switzerland,86.1228
+1994-06-30,CO,Colombia,96.1982
+1994-06-30,DE,Germany,131.4139
+1994-06-30,DK,Denmark,51.9563
+1994-06-30,ES,Spain,53.3352
 1994-06-30,FI,Finland,52.9558
-1994-06-30,FR,France,53.7312
-1994-06-30,GB,United Kingdom,44.9854
-1994-06-30,GR,Greece,
+1994-06-30,FR,France,53.7316
+1994-06-30,GB,United Kingdom,44.9705
 1994-06-30,HK,Hong Kong SAR,95.1972
-1994-06-30,HR,Croatia,
-1994-06-30,HU,Hungary,
-1994-06-30,ID,Indonesia,
-1994-06-30,IE,Ireland,46.9016
-1994-06-30,IL,Israel,91.0896
-1994-06-30,IN,India,
-1994-06-30,IS,Iceland,
-1994-06-30,IT,Italy,80.1644
+1994-06-30,HU,Hungary,97.6786
+1994-06-30,IE,Ireland,46.9505
+1994-06-30,IL,Israel,91.0901
+1994-06-30,IS,Iceland,72.254
+1994-06-30,IT,Italy,80.2246
 1994-06-30,JP,Japan,161.511
-1994-06-30,KR,Korea,110.8514
-1994-06-30,LT,Lithuania,
-1994-06-30,LU,Luxembourg,
-1994-06-30,LV,Latvia,
-1994-06-30,MA,Morocco,
-1994-06-30,MK,North Macedonia,
-1994-06-30,MT,Malta,
-1994-06-30,MX,Mexico,
+1994-06-30,KR,Korea,110.8343
 1994-06-30,MY,Malaysia,81.6056
-1994-06-30,NL,Netherlands,49.4413
-1994-06-30,NO,Norway,38.9362
+1994-06-30,NL,Netherlands,50.6412
+1994-06-30,NO,Norway,38.9324
 1994-06-30,NZ,New Zealand,53.4157
-1994-06-30,PE,Peru,
-1994-06-30,PH,Philippines,
-1994-06-30,PL,Poland,
-1994-06-30,PT,Portugal,
-1994-06-30,RO,Romania,
-1994-06-30,RS,Serbia,
-1994-06-30,RU,Russia,
-1994-06-30,SE,Sweden,41.12
-1994-06-30,SG,Singapore,
-1994-06-30,SI,Slovenia,
-1994-06-30,SK,Slovak Republic,
-1994-06-30,TH,Thailand,121.6055
-1994-06-30,TR,Türkiye,
-1994-06-30,US,United States,83.2865
-1994-06-30,XM,Euro area,75.2776
-1994-06-30,XW,World,
-1994-06-30,ZA,South Africa,48.4491
-1994-09-30,4T,Emerging market economies (aggregate),
-1994-09-30,5R,Advanced economies,
-1994-09-30,AE,United Arab Emirates,
-1994-09-30,AT,Austria,
-1994-09-30,AU,Australia,49.0061
-1994-09-30,BE,Belgium,56.2379
-1994-09-30,BG,Bulgaria,
-1994-09-30,BR,Brazil,
-1994-09-30,CA,Canada,63.0952
-1994-09-30,CH,Switzerland,85.6705
-1994-09-30,CL,Chile,
-1994-09-30,CN,China,
-1994-09-30,CO,Colombia,99.9001
-1994-09-30,CY,Cyprus,
-1994-09-30,CZ,Czechia,
-1994-09-30,DE,Germany,131.7095
-1994-09-30,DK,Denmark,51.0278
-1994-09-30,EE,Estonia,
-1994-09-30,ES,Spain,53.4023
+1994-06-30,PT,Portugal,108.1784
+1994-06-30,SE,Sweden,41.1183
+1994-06-30,TH,Thailand,121.6122
+1994-06-30,US,United States,83.1811
+1994-06-30,XM,Euro area,75.2826
+1994-06-30,ZA,South Africa,48.3918
+1994-09-30,AT,Austria,111.5627
+1994-09-30,AU,Australia,49.0024
+1994-09-30,BE,Belgium,56.7165
+1994-09-30,CA,Canada,63.5844
+1994-09-30,CH,Switzerland,85.6582
+1994-09-30,CO,Colombia,101.5065
+1994-09-30,DE,Germany,131.8267
+1994-09-30,DK,Denmark,51.031
+1994-09-30,ES,Spain,53.4024
 1994-09-30,FI,Finland,51.9496
-1994-09-30,FR,France,54.6184
-1994-09-30,GB,United Kingdom,45.8543
-1994-09-30,GR,Greece,
+1994-09-30,FR,France,54.6188
+1994-09-30,GB,United Kingdom,45.8391
 1994-09-30,HK,Hong Kong SAR,92.4175
-1994-09-30,HR,Croatia,
-1994-09-30,HU,Hungary,
-1994-09-30,ID,Indonesia,
-1994-09-30,IE,Ireland,47.4207
-1994-09-30,IL,Israel,91.8227
-1994-09-30,IN,India,
-1994-09-30,IS,Iceland,
-1994-09-30,IT,Italy,80.2314
+1994-09-30,HU,Hungary,99.8134
+1994-09-30,IE,Ireland,47.4503
+1994-09-30,IL,Israel,91.8241
+1994-09-30,IS,Iceland,69.9234
+1994-09-30,IT,Italy,80.2924
 1994-09-30,JP,Japan,161.347
-1994-09-30,KR,Korea,108.8441
-1994-09-30,LT,Lithuania,
-1994-09-30,LU,Luxembourg,
-1994-09-30,LV,Latvia,
-1994-09-30,MA,Morocco,
-1994-09-30,MK,North Macedonia,
-1994-09-30,MT,Malta,
-1994-09-30,MX,Mexico,
+1994-09-30,KR,Korea,108.8422
 1994-09-30,MY,Malaysia,83.6989
-1994-09-30,NL,Netherlands,50.9149
-1994-09-30,NO,Norway,40.3634
+1994-09-30,NL,Netherlands,52.1505
+1994-09-30,NO,Norway,40.3591
 1994-09-30,NZ,New Zealand,54.3737
-1994-09-30,PE,Peru,
-1994-09-30,PH,Philippines,
-1994-09-30,PL,Poland,
-1994-09-30,PT,Portugal,
-1994-09-30,RO,Romania,
-1994-09-30,RS,Serbia,
-1994-09-30,RU,Russia,
-1994-09-30,SE,Sweden,41.3893
-1994-09-30,SG,Singapore,
-1994-09-30,SI,Slovenia,
-1994-09-30,SK,Slovak Republic,
-1994-09-30,TH,Thailand,119.4062
-1994-09-30,TR,Türkiye,
-1994-09-30,US,United States,82.9497
-1994-09-30,XM,Euro area,75.7138
-1994-09-30,XW,World,
-1994-09-30,ZA,South Africa,48.1161
-1994-12-31,4T,Emerging market economies (aggregate),
-1994-12-31,5R,Advanced economies,
-1994-12-31,AE,United Arab Emirates,
-1994-12-31,AT,Austria,
-1994-12-31,AU,Australia,48.3971
-1994-12-31,BE,Belgium,56.2659
-1994-12-31,BG,Bulgaria,
-1994-12-31,BR,Brazil,
-1994-12-31,CA,Canada,63.6509
-1994-12-31,CH,Switzerland,84.8844
-1994-12-31,CL,Chile,
-1994-12-31,CN,China,
-1994-12-31,CO,Colombia,104.721
-1994-12-31,CY,Cyprus,
-1994-12-31,CZ,Czechia,
-1994-12-31,DE,Germany,131.6891
-1994-12-31,DK,Denmark,51.4888
-1994-12-31,EE,Estonia,
-1994-12-31,ES,Spain,52.7791
+1994-09-30,PT,Portugal,108.7752
+1994-09-30,SE,Sweden,41.3862
+1994-09-30,TH,Thailand,119.4043
+1994-09-30,US,United States,82.8521
+1994-09-30,XM,Euro area,75.7162
+1994-09-30,ZA,South Africa,48.0589
+1994-12-31,AT,Austria,108.9967
+1994-12-31,AU,Australia,48.3902
+1994-12-31,BE,Belgium,56.7447
+1994-12-31,CA,Canada,64.1443
+1994-12-31,CH,Switzerland,84.8374
+1994-12-31,CO,Colombia,106.1684
+1994-12-31,DE,Germany,131.6508
+1994-12-31,DK,Denmark,51.492
+1994-12-31,ES,Spain,52.7792
 1994-12-31,FI,Finland,51.2828
-1994-12-31,FR,France,53.6947
-1994-12-31,GB,United Kingdom,45.4097
-1994-12-31,GR,Greece,
+1994-12-31,FR,France,53.6951
+1994-12-31,GB,United Kingdom,45.3946
 1994-12-31,HK,Hong Kong SAR,88.6915
-1994-12-31,HR,Croatia,
-1994-12-31,HU,Hungary,
-1994-12-31,ID,Indonesia,
-1994-12-31,IE,Ireland,50.075
-1994-12-31,IL,Israel,91.6687
-1994-12-31,IN,India,
-1994-12-31,IS,Iceland,
-1994-12-31,IT,Italy,78.8294
+1994-12-31,HU,Hungary,93.9999
+1994-12-31,IE,Ireland,50.102
+1994-12-31,IL,Israel,91.6689
+1994-12-31,IS,Iceland,70.1511
+1994-12-31,IT,Italy,78.8922
 1994-12-31,JP,Japan,159.9417
-1994-12-31,KR,Korea,109.0694
-1994-12-31,LT,Lithuania,
-1994-12-31,LU,Luxembourg,
-1994-12-31,LV,Latvia,
-1994-12-31,MA,Morocco,
-1994-12-31,MK,North Macedonia,
-1994-12-31,MT,Malta,
-1994-12-31,MX,Mexico,
+1994-12-31,KR,Korea,109.0888
 1994-12-31,MY,Malaysia,87.4594
-1994-12-31,NL,Netherlands,50.0276
-1994-12-31,NO,Norway,40.0189
+1994-12-31,NL,Netherlands,51.2416
+1994-12-31,NO,Norway,39.9815
 1994-12-31,NZ,New Zealand,54.7464
-1994-12-31,PE,Peru,
-1994-12-31,PH,Philippines,
-1994-12-31,PL,Poland,
-1994-12-31,PT,Portugal,
-1994-12-31,RO,Romania,
-1994-12-31,RS,Serbia,
-1994-12-31,RU,Russia,
-1994-12-31,SE,Sweden,40.4752
-1994-12-31,SG,Singapore,
-1994-12-31,SI,Slovenia,
-1994-12-31,SK,Slovak Republic,
-1994-12-31,TH,Thailand,122.9784
-1994-12-31,TR,Türkiye,
-1994-12-31,US,United States,82.9235
-1994-12-31,XM,Euro area,75.1962
-1994-12-31,XW,World,
-1994-12-31,ZA,South Africa,47.9516
-1995-03-31,4T,Emerging market economies (aggregate),
-1995-03-31,5R,Advanced economies,
-1995-03-31,AE,United Arab Emirates,
-1995-03-31,AT,Austria,
-1995-03-31,AU,Australia,48.1077
-1995-03-31,BE,Belgium,56.417
-1995-03-31,BG,Bulgaria,
-1995-03-31,BR,Brazil,
-1995-03-31,CA,Canada,61.3174
-1995-03-31,CH,Switzerland,84.2181
-1995-03-31,CL,Chile,
-1995-03-31,CN,China,
-1995-03-31,CO,Colombia,102.1545
-1995-03-31,CY,Cyprus,
-1995-03-31,CZ,Czechia,
-1995-03-31,DE,Germany,130.6659
-1995-03-31,DK,Denmark,52.4153
-1995-03-31,EE,Estonia,
-1995-03-31,ES,Spain,52.6162
+1994-12-31,PT,Portugal,109.1852
+1994-12-31,SE,Sweden,40.4735
+1994-12-31,TH,Thailand,122.9769
+1994-12-31,US,United States,82.8281
+1994-12-31,XM,Euro area,75.1855
+1994-12-31,ZA,South Africa,47.8931
+1995-03-31,AT,Austria,109.8428
+1995-03-31,AU,Australia,48.0623
+1995-03-31,BE,Belgium,56.8971
+1995-03-31,CA,Canada,61.7928
+1995-03-31,CH,Switzerland,84.2009
+1995-03-31,CO,Colombia,103.4396
+1995-03-31,DE,Germany,130.6837
+1995-03-31,DK,Denmark,52.4185
+1995-03-31,ES,Spain,52.6163
 1995-03-31,FI,Finland,50.842
-1995-03-31,FR,France,52.2115
-1995-03-31,GB,United Kingdom,44.6374
-1995-03-31,GR,Greece,
+1995-03-31,FR,France,52.2119
+1995-03-31,GB,United Kingdom,44.6225
 1995-03-31,HK,Hong Kong SAR,85.3621
-1995-03-31,HR,Croatia,
-1995-03-31,HU,Hungary,
-1995-03-31,ID,Indonesia,
-1995-03-31,IE,Ireland,50.95
-1995-03-31,IL,Israel,93.0595
-1995-03-31,IN,India,
-1995-03-31,IS,Iceland,
-1995-03-31,IT,Italy,77.2204
+1995-03-31,HU,Hungary,87.7519
+1995-03-31,IE,Ireland,50.9566
+1995-03-31,IL,Israel,93.0596
+1995-03-31,IS,Iceland,68.1937
+1995-03-31,IT,Italy,77.2666
 1995-03-31,JP,Japan,160.1496
-1995-03-31,KR,Korea,107.2023
-1995-03-31,LT,Lithuania,
-1995-03-31,LU,Luxembourg,
-1995-03-31,LV,Latvia,
-1995-03-31,MA,Morocco,
-1995-03-31,MK,North Macedonia,
-1995-03-31,MT,Malta,
-1995-03-31,MX,Mexico,
+1995-03-31,KR,Korea,107.2005
 1995-03-31,MY,Malaysia,91.2764
-1995-03-31,NL,Netherlands,50.5274
-1995-03-31,NO,Norway,39.8
+1995-03-31,NL,Netherlands,51.7848
+1995-03-31,NO,Norway,39.8047
 1995-03-31,NZ,New Zealand,55.1691
-1995-03-31,PE,Peru,
-1995-03-31,PH,Philippines,
-1995-03-31,PL,Poland,
-1995-03-31,PT,Portugal,
-1995-03-31,RO,Romania,
-1995-03-31,RS,Serbia,
-1995-03-31,RU,Russia,
-1995-03-31,SE,Sweden,40.2337
-1995-03-31,SG,Singapore,
-1995-03-31,SI,Slovenia,
-1995-03-31,SK,Slovak Republic,
-1995-03-31,TH,Thailand,121.6096
-1995-03-31,TR,Türkiye,
-1995-03-31,US,United States,82.5331
-1995-03-31,XM,Euro area,74.545
-1995-03-31,XW,World,
-1995-03-31,ZA,South Africa,47.8575
-1995-06-30,4T,Emerging market economies (aggregate),
-1995-06-30,5R,Advanced economies,
-1995-06-30,AE,United Arab Emirates,
-1995-06-30,AT,Austria,
-1995-06-30,AU,Australia,47.1033
-1995-06-30,BE,Belgium,56.651
-1995-06-30,BG,Bulgaria,
-1995-06-30,BR,Brazil,
-1995-06-30,CA,Canada,59.2802
-1995-06-30,CH,Switzerland,84.3634
-1995-06-30,CL,Chile,
-1995-06-30,CN,China,
-1995-06-30,CO,Colombia,104.5025
-1995-06-30,CY,Cyprus,
-1995-06-30,CZ,Czechia,
-1995-06-30,DE,Germany,130.7288
-1995-06-30,DK,Denmark,53.8532
-1995-06-30,EE,Estonia,
-1995-06-30,ES,Spain,52.6701
+1995-03-31,PT,Portugal,106.9229
+1995-03-31,SE,Sweden,40.2295
+1995-03-31,TH,Thailand,121.6051
+1995-03-31,US,United States,82.4361
+1995-03-31,XM,Euro area,74.5338
+1995-03-31,ZA,South Africa,47.8033
+1995-06-30,AT,Austria,107.4877
+1995-06-30,AU,Australia,47.1066
+1995-06-30,BE,Belgium,57.1331
+1995-06-30,CA,Canada,59.7398
+1995-06-30,CH,Switzerland,84.3759
+1995-06-30,CO,Colombia,106.3299
+1995-06-30,DE,Germany,130.7493
+1995-06-30,DK,Denmark,53.8566
+1995-06-30,ES,Spain,52.6702
 1995-06-30,FI,Finland,50.1617
-1995-06-30,FR,France,52.3376
-1995-06-30,GB,United Kingdom,44.5
-1995-06-30,GR,Greece,
+1995-06-30,FR,France,52.338
+1995-06-30,GB,United Kingdom,44.4852
 1995-06-30,HK,Hong Kong SAR,82.164
-1995-06-30,HR,Croatia,
-1995-06-30,HU,Hungary,
-1995-06-30,ID,Indonesia,
-1995-06-30,IE,Ireland,48.5236
-1995-06-30,IL,Israel,93.6963
-1995-06-30,IN,India,
-1995-06-30,IS,Iceland,
-1995-06-30,IT,Italy,76.625
+1995-06-30,HU,Hungary,83.2679
+1995-06-30,IE,Ireland,48.5718
+1995-06-30,IL,Israel,93.6967
+1995-06-30,IS,Iceland,68.0804
+1995-06-30,IT,Italy,76.6842
 1995-06-30,JP,Japan,159.1476
-1995-06-30,KR,Korea,105.6636
-1995-06-30,LT,Lithuania,
-1995-06-30,LU,Luxembourg,
-1995-06-30,LV,Latvia,
-1995-06-30,MA,Morocco,
-1995-06-30,MK,North Macedonia,
-1995-06-30,MT,Malta,
-1995-06-30,MX,Mexico,
+1995-06-30,KR,Korea,105.6618
 1995-06-30,MY,Malaysia,94.5331
-1995-06-30,NL,Netherlands,50.8672
-1995-06-30,NO,Norway,41.1338
+1995-06-30,NL,Netherlands,52.2239
+1995-06-30,NO,Norway,41.1151
 1995-06-30,NZ,New Zealand,55.601
-1995-06-30,PE,Peru,
-1995-06-30,PH,Philippines,
-1995-06-30,PL,Poland,
-1995-06-30,PT,Portugal,
-1995-06-30,RO,Romania,
-1995-06-30,RS,Serbia,
-1995-06-30,RU,Russia,
-1995-06-30,SE,Sweden,40.456
-1995-06-30,SG,Singapore,
-1995-06-30,SI,Slovenia,
-1995-06-30,SK,Slovak Republic,
-1995-06-30,TH,Thailand,120.9574
-1995-06-30,TR,Türkiye,
-1995-06-30,US,United States,82.3271
-1995-06-30,XM,Euro area,74.4119
-1995-06-30,XW,World,
-1995-06-30,ZA,South Africa,47.585
-1995-09-30,4T,Emerging market economies (aggregate),
-1995-09-30,5R,Advanced economies,
-1995-09-30,AE,United Arab Emirates,
-1995-09-30,AT,Austria,
-1995-09-30,AU,Australia,46.6119
-1995-09-30,BE,Belgium,57.8679
-1995-09-30,BG,Bulgaria,
-1995-09-30,BR,Brazil,
-1995-09-30,CA,Canada,59.7364
-1995-09-30,CH,Switzerland,83.8987
-1995-09-30,CL,Chile,
-1995-09-30,CN,China,
-1995-09-30,CO,Colombia,106.9105
-1995-09-30,CY,Cyprus,
-1995-09-30,CZ,Czechia,
-1995-09-30,DE,Germany,129.8932
-1995-09-30,DK,Denmark,55.2248
-1995-09-30,EE,Estonia,
-1995-09-30,ES,Spain,52.8004
+1995-06-30,PT,Portugal,105.8389
+1995-06-30,SE,Sweden,40.4533
+1995-06-30,TH,Thailand,120.9566
+1995-06-30,US,United States,82.2397
+1995-06-30,XM,Euro area,74.41
+1995-06-30,ZA,South Africa,47.5295
+1995-09-30,AT,Austria,112.5475
+1995-09-30,AU,Australia,46.6309
+1995-09-30,BE,Belgium,58.3604
+1995-09-30,CA,Canada,60.1995
+1995-09-30,CH,Switzerland,83.9156
+1995-09-30,CO,Colombia,108.3191
+1995-09-30,DE,Germany,129.8685
+1995-09-30,DK,Denmark,55.2282
+1995-09-30,ES,Spain,52.8005
 1995-09-30,FI,Finland,49.1442
-1995-09-30,FR,France,53.1391
-1995-09-30,GB,United Kingdom,44.8128
-1995-09-30,GR,Greece,
+1995-09-30,FR,France,53.1395
+1995-09-30,GB,United Kingdom,44.7979
 1995-09-30,HK,Hong Kong SAR,76.343
-1995-09-30,HR,Croatia,
-1995-09-30,HU,Hungary,
-1995-09-30,ID,Indonesia,
-1995-09-30,IE,Ireland,50.3691
-1995-09-30,IL,Israel,96.1211
-1995-09-30,IN,India,
-1995-09-30,IS,Iceland,
-1995-09-30,IT,Italy,76.7402
+1995-09-30,HU,Hungary,80.3028
+1995-09-30,IE,Ireland,50.4068
+1995-09-30,IL,Israel,96.1206
+1995-09-30,IS,Iceland,67.531
+1995-09-30,IT,Italy,76.8021
 1995-09-30,JP,Japan,158.9133
-1995-09-30,KR,Korea,104.5864
-1995-09-30,LT,Lithuania,
-1995-09-30,LU,Luxembourg,
-1995-09-30,LV,Latvia,
-1995-09-30,MA,Morocco,
-1995-09-30,MK,North Macedonia,
-1995-09-30,MT,Malta,
-1995-09-30,MX,Mexico,
+1995-09-30,KR,Korea,104.6483
 1995-09-30,MY,Malaysia,97.2568
-1995-09-30,NL,Netherlands,52.2285
-1995-09-30,NO,Norway,41.7664
+1995-09-30,NL,Netherlands,53.374
+1995-09-30,NO,Norway,41.7447
 1995-09-30,NZ,New Zealand,57.0492
-1995-09-30,PE,Peru,
-1995-09-30,PH,Philippines,
-1995-09-30,PL,Poland,
-1995-09-30,PT,Portugal,
-1995-09-30,RO,Romania,
-1995-09-30,RS,Serbia,
-1995-09-30,RU,Russia,
-1995-09-30,SE,Sweden,40.0195
-1995-09-30,SG,Singapore,
-1995-09-30,SI,Slovenia,
-1995-09-30,SK,Slovak Republic,
-1995-09-30,TH,Thailand,122.4219
-1995-09-30,TR,Türkiye,
-1995-09-30,US,United States,82.7158
-1995-09-30,XM,Euro area,75.1483
-1995-09-30,XW,World,
-1995-09-30,ZA,South Africa,47.3961
-1995-12-31,4T,Emerging market economies (aggregate),
-1995-12-31,5R,Advanced economies,
-1995-12-31,AE,United Arab Emirates,
-1995-12-31,AT,Austria,
-1995-12-31,AU,Australia,46.1755
-1995-12-31,BE,Belgium,58.2286
-1995-12-31,BG,Bulgaria,
-1995-12-31,BR,Brazil,
-1995-12-31,CA,Canada,59.8095
-1995-12-31,CH,Switzerland,82.5297
-1995-12-31,CL,Chile,
-1995-12-31,CN,China,
-1995-12-31,CO,Colombia,109.1523
-1995-12-31,CY,Cyprus,
-1995-12-31,CZ,Czechia,
-1995-12-31,DE,Germany,129.729
-1995-12-31,DK,Denmark,56.5055
-1995-12-31,EE,Estonia,
-1995-12-31,ES,Spain,52.5274
+1995-09-30,PT,Portugal,105.7777
+1995-09-30,SE,Sweden,40.0166
+1995-09-30,TH,Thailand,122.4247
+1995-09-30,US,United States,82.6115
+1995-09-30,XM,Euro area,75.1405
+1995-09-30,ZA,South Africa,47.3368
+1995-12-31,AT,Austria,104.4756
+1995-12-31,AU,Australia,46.1914
+1995-12-31,BE,Belgium,58.7242
+1995-12-31,CA,Canada,60.2732
+1995-12-31,CH,Switzerland,82.5053
+1995-12-31,CO,Colombia,110.8472
+1995-12-31,DE,Germany,129.7161
+1995-12-31,DK,Denmark,56.509
+1995-12-31,ES,Spain,52.5275
 1995-12-31,FI,Finland,49.0249
-1995-12-31,FR,France,52.172
-1995-12-31,GB,United Kingdom,43.9541
-1995-12-31,GR,Greece,
+1995-12-31,FR,France,52.1724
+1995-12-31,GB,United Kingdom,43.9394
 1995-12-31,HK,Hong Kong SAR,73.9584
-1995-12-31,HR,Croatia,
-1995-12-31,HU,Hungary,
-1995-12-31,ID,Indonesia,
-1995-12-31,IE,Ireland,52.3965
+1995-12-31,HU,Hungary,78.4839
+1995-12-31,IE,Ireland,52.357
 1995-12-31,IL,Israel,97.8219
-1995-12-31,IN,India,
-1995-12-31,IS,Iceland,
-1995-12-31,IT,Italy,76.6391
+1995-12-31,IS,Iceland,64.7954
+1995-12-31,IT,Italy,76.6989
 1995-12-31,JP,Japan,158.215
-1995-12-31,KR,Korea,104.1719
-1995-12-31,LT,Lithuania,
-1995-12-31,LU,Luxembourg,
-1995-12-31,LV,Latvia,
-1995-12-31,MA,Morocco,
-1995-12-31,MK,North Macedonia,
-1995-12-31,MT,Malta,
-1995-12-31,MX,Mexico,
-1995-12-31,MY,Malaysia,99.5429
-1995-12-31,NL,Netherlands,52.6371
-1995-12-31,NO,Norway,42.1977
+1995-12-31,KR,Korea,104.2335
+1995-12-31,MY,Malaysia,99.5428
+1995-12-31,NL,Netherlands,53.8837
+1995-12-31,NO,Norway,42.1938
 1995-12-31,NZ,New Zealand,57.9252
-1995-12-31,PE,Peru,
-1995-12-31,PH,Philippines,
-1995-12-31,PL,Poland,
-1995-12-31,PT,Portugal,
-1995-12-31,RO,Romania,
-1995-12-31,RS,Serbia,
-1995-12-31,RU,Russia,
-1995-12-31,SE,Sweden,39.1742
-1995-12-31,SG,Singapore,
-1995-12-31,SI,Slovenia,
-1995-12-31,SK,Slovak Republic,
-1995-12-31,TH,Thailand,121.3155
-1995-12-31,TR,Türkiye,
-1995-12-31,US,United States,82.7332
-1995-12-31,XM,Euro area,74.7386
-1995-12-31,XW,World,
-1995-12-31,ZA,South Africa,47.2128
-1996-03-31,4T,Emerging market economies (aggregate),
-1996-03-31,5R,Advanced economies,
-1996-03-31,AE,United Arab Emirates,
-1996-03-31,AT,Austria,
-1996-03-31,AU,Australia,45.953
-1996-03-31,BE,Belgium,56.4066
-1996-03-31,BG,Bulgaria,
-1996-03-31,BR,Brazil,
-1996-03-31,CA,Canada,58.8398
-1996-03-31,CH,Switzerland,81.2262
-1996-03-31,CL,Chile,
-1996-03-31,CN,China,
-1996-03-31,CO,Colombia,107.1065
-1996-03-31,CY,Cyprus,
-1996-03-31,CZ,Czechia,
-1996-03-31,DE,Germany,128.0322
-1996-03-31,DK,Denmark,57.0994
-1996-03-31,EE,Estonia,
-1996-03-31,ES,Spain,52.0898
+1995-12-31,PT,Portugal,105.566
+1995-12-31,SE,Sweden,39.1717
+1995-12-31,TH,Thailand,121.3197
+1995-12-31,US,United States,82.6474
+1995-12-31,XM,Euro area,74.7251
+1995-12-31,ZA,South Africa,47.1537
+1996-03-31,AT,Austria,109.8245
+1996-03-31,AU,Australia,45.9176
+1996-03-31,BE,Belgium,56.8866
+1996-03-31,CA,Canada,59.296
+1996-03-31,CH,Switzerland,81.1834
+1996-03-31,CO,Colombia,108.4235
+1996-03-31,DE,Germany,128.0838
+1996-03-31,DK,Denmark,57.103
+1996-03-31,ES,Spain,52.0899
 1996-03-31,FI,Finland,49.6906
-1996-03-31,FR,France,51.5647
-1996-03-31,GB,United Kingdom,44.3521
-1996-03-31,GR,Greece,
+1996-03-31,FR,France,51.5646
+1996-03-31,GB,United Kingdom,44.3374
 1996-03-31,HK,Hong Kong SAR,77.7028
-1996-03-31,HR,Croatia,
-1996-03-31,HU,Hungary,
-1996-03-31,ID,Indonesia,
-1996-03-31,IE,Ireland,52.4043
-1996-03-31,IL,Israel,99.5988
-1996-03-31,IN,India,
-1996-03-31,IS,Iceland,
-1996-03-31,IT,Italy,76.5982
+1996-03-31,HU,Hungary,75.7937
+1996-03-31,IE,Ireland,52.3524
+1996-03-31,IL,Israel,99.5987
+1996-03-31,IS,Iceland,65.4869
+1996-03-31,IT,Italy,76.5994
 1996-03-31,JP,Japan,157.8455
-1996-03-31,KR,Korea,102.6619
-1996-03-31,LT,Lithuania,
-1996-03-31,LU,Luxembourg,
-1996-03-31,LV,Latvia,
-1996-03-31,MA,Morocco,
-1996-03-31,MK,North Macedonia,
-1996-03-31,MT,Malta,
-1996-03-31,MX,Mexico,
-1996-03-31,MY,Malaysia,102.0514
-1996-03-31,NL,Netherlands,53.622
-1996-03-31,NO,Norway,42.6589
+1996-03-31,KR,Korea,102.6179
+1996-03-31,MY,Malaysia,102.0515
+1996-03-31,NL,Netherlands,54.8274
+1996-03-31,NO,Norway,42.6657
 1996-03-31,NZ,New Zealand,60.3463
-1996-03-31,PE,Peru,
-1996-03-31,PH,Philippines,
-1996-03-31,PL,Poland,
-1996-03-31,PT,Portugal,
-1996-03-31,RO,Romania,
-1996-03-31,RS,Serbia,
-1996-03-31,RU,Russia,
-1996-03-31,SE,Sweden,39.4454
-1996-03-31,SG,Singapore,
-1996-03-31,SI,Slovenia,
-1996-03-31,SK,Slovak Republic,
-1996-03-31,TH,Thailand,118.9094
-1996-03-31,TR,Türkiye,
-1996-03-31,US,United States,82.6804
-1996-03-31,XM,Euro area,74.4894
-1996-03-31,XW,World,
-1996-03-31,ZA,South Africa,46.7881
-1996-06-30,4T,Emerging market economies (aggregate),
-1996-06-30,5R,Advanced economies,
-1996-06-30,AE,United Arab Emirates,
-1996-06-30,AT,Austria,
-1996-06-30,AU,Australia,46.1763
-1996-06-30,BE,Belgium,57.0636
-1996-06-30,BG,Bulgaria,
-1996-06-30,BR,Brazil,
-1996-06-30,CA,Canada,59.6298
-1996-06-30,CH,Switzerland,81.4764
-1996-06-30,CL,Chile,
-1996-06-30,CN,China,
-1996-06-30,CO,Colombia,105.54
-1996-06-30,CY,Cyprus,
-1996-06-30,CZ,Czechia,
-1996-06-30,DE,Germany,127.114
-1996-06-30,DK,Denmark,57.9594
-1996-06-30,EE,Estonia,
-1996-06-30,ES,Spain,51.8893
+1996-03-31,PT,Portugal,105.0335
+1996-03-31,SE,Sweden,39.4432
+1996-03-31,TH,Thailand,118.9136
+1996-03-31,US,United States,82.5968
+1996-03-31,XM,Euro area,74.4806
+1996-03-31,ZA,South Africa,46.7308
+1996-06-30,AT,Austria,110.5128
+1996-06-30,AU,Australia,46.178
+1996-06-30,BE,Belgium,57.5492
+1996-06-30,CA,Canada,60.0922
+1996-06-30,CH,Switzerland,81.484
+1996-06-30,CO,Colombia,106.7513
+1996-06-30,DE,Germany,127.1258
+1996-06-30,DK,Denmark,57.963
+1996-06-30,ES,Spain,51.8894
 1996-06-30,FI,Finland,51.2084
-1996-06-30,FR,France,51.1691
-1996-06-30,GB,United Kingdom,43.9368
-1996-06-30,GR,Greece,
+1996-06-30,FR,France,51.17
+1996-06-30,GB,United Kingdom,43.9222
 1996-06-30,HK,Hong Kong SAR,79.2879
-1996-06-30,HR,Croatia,
-1996-06-30,HU,Hungary,
-1996-06-30,ID,Indonesia,
-1996-06-30,IE,Ireland,52.8613
-1996-06-30,IL,Israel,100.6016
-1996-06-30,IN,India,
-1996-06-30,IS,Iceland,
-1996-06-30,IT,Italy,76.1241
+1996-06-30,HU,Hungary,74.088
+1996-06-30,IE,Ireland,52.871
+1996-06-30,IL,Israel,100.6018
+1996-06-30,IS,Iceland,66.246
+1996-06-30,IT,Italy,76.1265
 1996-06-30,JP,Japan,155.9868
-1996-06-30,KR,Korea,101.2374
-1996-06-30,LT,Lithuania,
-1996-06-30,LU,Luxembourg,
-1996-06-30,LV,Latvia,
-1996-06-30,MA,Morocco,
-1996-06-30,MK,North Macedonia,
-1996-06-30,MT,Malta,
-1996-06-30,MX,Mexico,
+1996-06-30,KR,Korea,101.2868
 1996-06-30,MY,Malaysia,104.2324
-1996-06-30,NL,Netherlands,55.1288
-1996-06-30,NO,Norway,44.2723
+1996-06-30,NL,Netherlands,55.9943
+1996-06-30,NO,Norway,44.2678
 1996-06-30,NZ,New Zealand,60.8245
-1996-06-30,PE,Peru,
-1996-06-30,PH,Philippines,
-1996-06-30,PL,Poland,
-1996-06-30,PT,Portugal,
-1996-06-30,RO,Romania,
-1996-06-30,RS,Serbia,
-1996-06-30,RU,Russia,
-1996-06-30,SE,Sweden,39.7079
-1996-06-30,SG,Singapore,
-1996-06-30,SI,Slovenia,
-1996-06-30,SK,Slovak Republic,
-1996-06-30,TH,Thailand,121.4599
-1996-06-30,TR,Türkiye,
-1996-06-30,US,United States,82.4521
-1996-06-30,XM,Euro area,74.3542
-1996-06-30,XW,World,
-1996-06-30,ZA,South Africa,46.2684
-1996-09-30,4T,Emerging market economies (aggregate),
-1996-09-30,5R,Advanced economies,
-1996-09-30,AE,United Arab Emirates,
-1996-09-30,AT,Austria,
-1996-09-30,AU,Australia,46.2026
-1996-09-30,BE,Belgium,57.8527
-1996-09-30,BG,Bulgaria,
-1996-09-30,BR,Brazil,
-1996-09-30,CA,Canada,58.72
-1996-09-30,CH,Switzerland,81.9463
-1996-09-30,CL,Chile,
-1996-09-30,CN,China,
-1996-09-30,CO,Colombia,102.7345
-1996-09-30,CY,Cyprus,
-1996-09-30,CZ,Czechia,
-1996-09-30,DE,Germany,126.3502
-1996-09-30,DK,Denmark,59.5403
-1996-09-30,EE,Estonia,
-1996-09-30,ES,Spain,51.6804
+1996-06-30,PT,Portugal,104.3811
+1996-06-30,SE,Sweden,39.7066
+1996-06-30,TH,Thailand,121.4587
+1996-06-30,US,United States,82.3626
+1996-06-30,XM,Euro area,74.3456
+1996-06-30,ZA,South Africa,46.218
+1996-09-30,AT,Austria,105.5307
+1996-09-30,AU,Australia,46.2231
+1996-09-30,BE,Belgium,58.3451
+1996-09-30,CA,Canada,59.1753
+1996-09-30,CH,Switzerland,82.0112
+1996-09-30,CO,Colombia,104.303
+1996-09-30,DE,Germany,126.3816
+1996-09-30,DK,Denmark,59.544
+1996-09-30,ES,Spain,51.6805
 1996-09-30,FI,Finland,52.9012
-1996-09-30,FR,France,52.5333
-1996-09-30,GB,United Kingdom,45.6188
-1996-09-30,GR,Greece,
+1996-09-30,FR,France,52.5365
+1996-09-30,GB,United Kingdom,45.6036
 1996-09-30,HK,Hong Kong SAR,80.7938
-1996-09-30,HR,Croatia,
-1996-09-30,HU,Hungary,
-1996-09-30,ID,Indonesia,
-1996-09-30,IE,Ireland,58.4722
-1996-09-30,IL,Israel,97.7945
-1996-09-30,IN,India,
-1996-09-30,IS,Iceland,
-1996-09-30,IT,Italy,76.8425
+1996-09-30,HU,Hungary,77.8136
+1996-09-30,IE,Ireland,58.4691
+1996-09-30,IL,Israel,97.7943
+1996-09-30,IS,Iceland,65.2191
+1996-09-30,IT,Italy,76.8415
 1996-09-30,JP,Japan,155.5456
-1996-09-30,KR,Korea,100.3455
-1996-09-30,LT,Lithuania,
-1996-09-30,LU,Luxembourg,
-1996-09-30,LV,Latvia,
-1996-09-30,MA,Morocco,
-1996-09-30,MK,North Macedonia,
-1996-09-30,MT,Malta,
-1996-09-30,MX,Mexico,
+1996-09-30,KR,Korea,100.3669
 1996-09-30,MY,Malaysia,105.4416
-1996-09-30,NL,Netherlands,56.9747
-1996-09-30,NO,Norway,44.8937
+1996-09-30,NL,Netherlands,57.6829
+1996-09-30,NO,Norway,44.8804
 1996-09-30,NZ,New Zealand,60.5611
-1996-09-30,PE,Peru,
-1996-09-30,PH,Philippines,
-1996-09-30,PL,Poland,
-1996-09-30,PT,Portugal,
-1996-09-30,RO,Romania,
-1996-09-30,RS,Serbia,
-1996-09-30,RU,Russia,
-1996-09-30,SE,Sweden,40.6062
-1996-09-30,SG,Singapore,
-1996-09-30,SI,Slovenia,
-1996-09-30,SK,Slovak Republic,
-1996-09-30,TH,Thailand,114.6978
-1996-09-30,TR,Türkiye,
-1996-09-30,US,United States,82.4742
-1996-09-30,XM,Euro area,75.2672
-1996-09-30,XW,World,
-1996-09-30,ZA,South Africa,45.4848
-1996-12-31,4T,Emerging market economies (aggregate),
-1996-12-31,5R,Advanced economies,
-1996-12-31,AE,United Arab Emirates,
-1996-12-31,AT,Austria,
-1996-12-31,AU,Australia,46.2522
-1996-12-31,BE,Belgium,58.067
-1996-12-31,BG,Bulgaria,
-1996-12-31,BR,Brazil,
-1996-12-31,CA,Canada,58.7048
-1996-12-31,CH,Switzerland,79.3964
-1996-12-31,CL,Chile,
-1996-12-31,CN,China,
-1996-12-31,CO,Colombia,100.9826
-1996-12-31,CY,Cyprus,
-1996-12-31,CZ,Czechia,
-1996-12-31,DE,Germany,125.5565
-1996-12-31,DK,Denmark,61.59
-1996-12-31,EE,Estonia,
-1996-12-31,ES,Spain,51.5206
+1996-09-30,PT,Portugal,104.1473
+1996-09-30,SE,Sweden,40.6049
+1996-09-30,TH,Thailand,114.6968
+1996-09-30,US,United States,82.3867
+1996-09-30,XM,Euro area,75.2385
+1996-09-30,ZA,South Africa,45.4314
+1996-12-31,AT,Austria,103.0067
+1996-12-31,AU,Australia,46.2622
+1996-12-31,BE,Belgium,58.5612
+1996-12-31,CA,Canada,59.16
+1996-12-31,CH,Switzerland,79.3545
+1996-12-31,CO,Colombia,101.9711
+1996-12-31,DE,Germany,125.4626
+1996-12-31,DK,Denmark,61.5939
+1996-12-31,ES,Spain,51.5207
 1996-12-31,FI,Finland,54.9808
-1996-12-31,FR,France,52.3219
-1996-12-31,GB,United Kingdom,46.1127
-1996-12-31,GR,Greece,
+1996-12-31,FR,France,52.3193
+1996-12-31,GB,United Kingdom,46.0974
 1996-12-31,HK,Hong Kong SAR,87.2769
-1996-12-31,HR,Croatia,
-1996-12-31,HU,Hungary,
-1996-12-31,ID,Indonesia,
-1996-12-31,IE,Ireland,58.8267
-1996-12-31,IL,Israel,98.9585
-1996-12-31,IN,India,
-1996-12-31,IS,Iceland,
-1996-12-31,IT,Italy,77.2544
+1996-12-31,HU,Hungary,78.5747
+1996-12-31,IE,Ireland,58.8918
+1996-12-31,IL,Israel,98.9589
+1996-12-31,IS,Iceland,66.376
+1996-12-31,IT,Italy,77.2558
 1996-12-31,JP,Japan,154.6418
-1996-12-31,KR,Korea,100.5741
-1996-12-31,LT,Lithuania,
-1996-12-31,LU,Luxembourg,
-1996-12-31,LV,Latvia,
-1996-12-31,MA,Morocco,
-1996-12-31,MK,North Macedonia,
-1996-12-31,MT,Malta,
-1996-12-31,MX,Mexico,
+1996-12-31,KR,Korea,100.5524
 1996-12-31,MY,Malaysia,105.7314
-1996-12-31,NL,Netherlands,57.7736
-1996-12-31,NO,Norway,45.6607
+1996-12-31,NL,Netherlands,58.856
+1996-12-31,NO,Norway,45.6302
 1996-12-31,NZ,New Zealand,61.0504
-1996-12-31,PE,Peru,
-1996-12-31,PH,Philippines,
-1996-12-31,PL,Poland,
-1996-12-31,PT,Portugal,
-1996-12-31,RO,Romania,
-1996-12-31,RS,Serbia,
-1996-12-31,RU,Russia,
-1996-12-31,SE,Sweden,40.5724
-1996-12-31,SG,Singapore,
-1996-12-31,SI,Slovenia,
-1996-12-31,SK,Slovak Republic,
-1996-12-31,TH,Thailand,114.1435
-1996-12-31,TR,Türkiye,
-1996-12-31,US,United States,82.3989
-1996-12-31,XM,Euro area,75.1629
-1996-12-31,XW,World,
-1996-12-31,ZA,South Africa,44.9202
-1997-03-31,4T,Emerging market economies (aggregate),
-1997-03-31,5R,Advanced economies,
-1997-03-31,AE,United Arab Emirates,
-1997-03-31,AT,Austria,
-1997-03-31,AU,Australia,46.5884
-1997-03-31,BE,Belgium,55.4747
-1997-03-31,BG,Bulgaria,
-1997-03-31,BR,Brazil,
-1997-03-31,CA,Canada,59.0675
-1997-03-31,CH,Switzerland,79.1723
-1997-03-31,CL,Chile,
-1997-03-31,CN,China,
-1997-03-31,CO,Colombia,97.5537
-1997-03-31,CY,Cyprus,
-1997-03-31,CZ,Czechia,
-1997-03-31,DE,Germany,123.6047
-1997-03-31,DK,Denmark,63.001
-1997-03-31,EE,Estonia,
-1997-03-31,ES,Spain,51.3843
+1996-12-31,PT,Portugal,104.6188
+1996-12-31,SE,Sweden,40.5676
+1996-12-31,TH,Thailand,114.1365
+1996-12-31,US,United States,82.3164
+1996-12-31,XM,Euro area,75.1342
+1996-12-31,ZA,South Africa,44.8673
+1997-03-31,AT,Austria,107.1062
+1997-03-31,AU,Australia,46.5979
+1997-03-31,BE,Belgium,55.9468
+1997-03-31,CA,Canada,59.5255
+1997-03-31,CH,Switzerland,79.1598
+1997-03-31,CO,Colombia,98.7601
+1997-03-31,DE,Germany,123.6417
+1997-03-31,DK,Denmark,63.0049
+1997-03-31,ES,Spain,51.3844
 1997-03-31,FI,Finland,58.8582
-1997-03-31,FR,France,49.5859
-1997-03-31,GB,United Kingdom,46.7359
-1997-03-31,GR,Greece,
+1997-03-31,FR,France,49.5867
+1997-03-31,GB,United Kingdom,46.7203
+1997-03-31,GR,Greece,62.9963
 1997-03-31,HK,Hong Kong SAR,102.9375
-1997-03-31,HR,Croatia,
-1997-03-31,HU,Hungary,
-1997-03-31,ID,Indonesia,
-1997-03-31,IE,Ireland,59.1183
-1997-03-31,IL,Israel,99.6851
-1997-03-31,IN,India,
-1997-03-31,IS,Iceland,
-1997-03-31,IT,Italy,77.9983
+1997-03-31,HR,Croatia,73.7434
+1997-03-31,HU,Hungary,74.2788
+1997-03-31,IE,Ireland,59.116
+1997-03-31,IL,Israel,99.6854
+1997-03-31,IS,Iceland,65.7186
+1997-03-31,IT,Italy,77.9973
 1997-03-31,JP,Japan,154.543
-1997-03-31,KR,Korea,100.9679
-1997-03-31,LT,Lithuania,
-1997-03-31,LU,Luxembourg,
-1997-03-31,LV,Latvia,
-1997-03-31,MA,Morocco,
-1997-03-31,MK,North Macedonia,
-1997-03-31,MT,Malta,
-1997-03-31,MX,Mexico,
+1997-03-31,KR,Korea,100.9494
 1997-03-31,MY,Malaysia,106.3274
-1997-03-31,NL,Netherlands,59.4291
-1997-03-31,NO,Norway,45.8938
+1997-03-31,NL,Netherlands,60.18
+1997-03-31,NO,Norway,45.9011
 1997-03-31,NZ,New Zealand,63.3309
-1997-03-31,PE,Peru,
-1997-03-31,PH,Philippines,
-1997-03-31,PL,Poland,
-1997-03-31,PT,Portugal,
-1997-03-31,RO,Romania,
-1997-03-31,RS,Serbia,
-1997-03-31,RU,Russia,
-1997-03-31,SE,Sweden,41.2555
-1997-03-31,SG,Singapore,
-1997-03-31,SI,Slovenia,
-1997-03-31,SK,Slovak Republic,
-1997-03-31,TH,Thailand,116.7253
-1997-03-31,TR,Türkiye,
-1997-03-31,US,United States,82.5228
-1997-03-31,XM,Euro area,74.1929
-1997-03-31,XW,World,
-1997-03-31,ZA,South Africa,44.2677
-1997-06-30,4T,Emerging market economies (aggregate),
-1997-06-30,5R,Advanced economies,
-1997-06-30,AE,United Arab Emirates,
-1997-06-30,AT,Austria,
-1997-06-30,AU,Australia,47.3349
-1997-06-30,BE,Belgium,57.6442
-1997-06-30,BG,Bulgaria,
-1997-06-30,BR,Brazil,
-1997-06-30,CA,Canada,60.3768
-1997-06-30,CH,Switzerland,78.7937
-1997-06-30,CL,Chile,
-1997-06-30,CN,China,
-1997-06-30,CO,Colombia,96.4167
-1997-06-30,CY,Cyprus,
-1997-06-30,CZ,Czechia,
-1997-06-30,DE,Germany,122.8746
-1997-06-30,DK,Denmark,64.0973
-1997-06-30,EE,Estonia,
-1997-06-30,ES,Spain,51.7118
+1997-03-31,PT,Portugal,104.7205
+1997-03-31,SE,Sweden,41.2527
+1997-03-31,TH,Thailand,116.7252
+1997-03-31,US,United States,82.4332
+1997-03-31,XM,Euro area,74.1783
+1997-03-31,ZA,South Africa,44.211
+1997-06-30,AT,Austria,104.7071
+1997-06-30,AU,Australia,47.3151
+1997-06-30,BE,Belgium,58.1348
+1997-06-30,CA,Canada,60.8449
+1997-06-30,CH,Switzerland,78.7797
+1997-06-30,CO,Colombia,97.8421
+1997-06-30,DE,Germany,122.8379
+1997-06-30,DK,Denmark,64.1013
+1997-06-30,ES,Spain,51.7119
 1997-06-30,FI,Finland,60.3461
-1997-06-30,FR,France,51.9377
-1997-06-30,GB,United Kingdom,47.2393
-1997-06-30,GR,Greece,
+1997-06-30,FR,France,51.9416
+1997-06-30,GB,United Kingdom,47.2236
+1997-06-30,GR,Greece,62.6313
 1997-06-30,HK,Hong Kong SAR,110.4558
-1997-06-30,HR,Croatia,
-1997-06-30,HU,Hungary,
-1997-06-30,ID,Indonesia,
-1997-06-30,IE,Ireland,61.8741
+1997-06-30,HR,Croatia,73.2476
+1997-06-30,HU,Hungary,74.3033
+1997-06-30,IE,Ireland,61.8684
 1997-06-30,IL,Israel,99.9908
-1997-06-30,IN,India,
-1997-06-30,IS,Iceland,
-1997-06-30,IT,Italy,77.7546
+1997-06-30,IS,Iceland,66.487
+1997-06-30,IT,Italy,77.7547
 1997-06-30,JP,Japan,150.9251
-1997-06-30,KR,Korea,100.571
-1997-06-30,LT,Lithuania,
-1997-06-30,LU,Luxembourg,
-1997-06-30,LV,Latvia,
-1997-06-30,MA,Morocco,
-1997-06-30,MK,North Macedonia,
-1997-06-30,MT,Malta,
-1997-06-30,MX,Mexico,
+1997-06-30,KR,Korea,100.5107
 1997-06-30,MY,Malaysia,106.365
-1997-06-30,NL,Netherlands,60.6615
-1997-06-30,NO,Norway,48.973
+1997-06-30,NL,Netherlands,61.4869
+1997-06-30,NO,Norway,48.9657
 1997-06-30,NZ,New Zealand,63.8819
-1997-06-30,PE,Peru,
-1997-06-30,PH,Philippines,
-1997-06-30,PL,Poland,
-1997-06-30,PT,Portugal,
-1997-06-30,RO,Romania,
-1997-06-30,RS,Serbia,
-1997-06-30,RU,Russia,
-1997-06-30,SE,Sweden,42.4325
-1997-06-30,SG,Singapore,
-1997-06-30,SI,Slovenia,
-1997-06-30,SK,Slovak Republic,
+1997-06-30,PT,Portugal,105.1874
+1997-06-30,SE,Sweden,42.4289
 1997-06-30,TH,Thailand,122.4342
-1997-06-30,TR,Türkiye,
-1997-06-30,US,United States,83.0198
-1997-06-30,XM,Euro area,75.1925
-1997-06-30,XW,World,
-1997-06-30,ZA,South Africa,44.781
-1997-09-30,4T,Emerging market economies (aggregate),
-1997-09-30,5R,Advanced economies,
-1997-09-30,AE,United Arab Emirates,
-1997-09-30,AT,Austria,
-1997-09-30,AU,Australia,48.4057
-1997-09-30,BE,Belgium,58.8915
-1997-09-30,BG,Bulgaria,
-1997-09-30,BR,Brazil,
-1997-09-30,CA,Canada,59.1709
-1997-09-30,CH,Switzerland,79.3671
-1997-09-30,CL,Chile,
-1997-09-30,CN,China,
-1997-09-30,CO,Colombia,96.1398
-1997-09-30,CY,Cyprus,
-1997-09-30,CZ,Czechia,
-1997-09-30,DE,Germany,121.3101
-1997-09-30,DK,Denmark,65.1363
-1997-09-30,EE,Estonia,
-1997-09-30,ES,Spain,51.6257
+1997-06-30,US,United States,82.9395
+1997-06-30,XM,Euro area,75.1608
+1997-06-30,ZA,South Africa,44.7302
+1997-09-30,AT,Austria,109.5631
+1997-09-30,AU,Australia,48.3662
+1997-09-30,BE,Belgium,59.3927
+1997-09-30,CA,Canada,59.6296
+1997-09-30,CH,Switzerland,79.4008
+1997-09-30,CO,Colombia,97.3599
+1997-09-30,DE,Germany,121.2985
+1997-09-30,DK,Denmark,65.1403
+1997-09-30,ES,Spain,51.6258
 1997-09-30,FI,Finland,61.002
-1997-09-30,FR,France,51.8687
-1997-09-30,GB,United Kingdom,49.4437
-1997-09-30,GR,Greece,
+1997-09-30,FR,France,51.8688
+1997-09-30,GB,United Kingdom,49.4273
+1997-09-30,GR,Greece,64.4501
 1997-09-30,HK,Hong Kong SAR,110.5733
-1997-09-30,HR,Croatia,
-1997-09-30,HU,Hungary,
-1997-09-30,ID,Indonesia,
-1997-09-30,IE,Ireland,66.1679
-1997-09-30,IL,Israel,99.8034
-1997-09-30,IN,India,
-1997-09-30,IS,Iceland,
-1997-09-30,IT,Italy,77.6458
+1997-09-30,HR,Croatia,76.1526
+1997-09-30,HU,Hungary,73.5646
+1997-09-30,IE,Ireland,66.1736
+1997-09-30,IL,Israel,99.8032
+1997-09-30,IS,Iceland,65.4399
+1997-09-30,IT,Italy,77.6487
 1997-09-30,JP,Japan,150.5558
-1997-09-30,KR,Korea,99.5956
-1997-09-30,LT,Lithuania,
-1997-09-30,LU,Luxembourg,
-1997-09-30,LV,Latvia,
-1997-09-30,MA,Morocco,
-1997-09-30,MK,North Macedonia,
-1997-09-30,MT,Malta,
-1997-09-30,MX,Mexico,
+1997-09-30,KR,Korea,99.5678
 1997-09-30,MY,Malaysia,103.6548
-1997-09-30,NL,Netherlands,62.0636
-1997-09-30,NO,Norway,49.2239
+1997-09-30,NL,Netherlands,62.8475
+1997-09-30,NO,Norway,49.2458
 1997-09-30,NZ,New Zealand,63.7843
-1997-09-30,PE,Peru,
-1997-09-30,PH,Philippines,
-1997-09-30,PL,Poland,
-1997-09-30,PT,Portugal,
-1997-09-30,RO,Romania,
-1997-09-30,RS,Serbia,
-1997-09-30,RU,Russia,
-1997-09-30,SE,Sweden,43.1863
-1997-09-30,SG,Singapore,
-1997-09-30,SI,Slovenia,
-1997-09-30,SK,Slovak Republic,
-1997-09-30,TH,Thailand,119.1943
-1997-09-30,TR,Türkiye,
-1997-09-30,US,United States,83.7127
-1997-09-30,XM,Euro area,75.5514
-1997-09-30,XW,World,
-1997-09-30,ZA,South Africa,46.3565
-1997-12-31,4T,Emerging market economies (aggregate),
-1997-12-31,5R,Advanced economies,
-1997-12-31,AE,United Arab Emirates,
-1997-12-31,AT,Austria,
-1997-12-31,AU,Australia,49.1935
-1997-12-31,BE,Belgium,59.1136
-1997-12-31,BG,Bulgaria,
-1997-12-31,BR,Brazil,
-1997-12-31,CA,Canada,59.139
-1997-12-31,CH,Switzerland,78.2093
-1997-12-31,CL,Chile,
-1997-12-31,CN,China,
-1997-12-31,CO,Colombia,98.0589
-1997-12-31,CY,Cyprus,
-1997-12-31,CZ,Czechia,
-1997-12-31,DE,Germany,120.9
-1997-12-31,DK,Denmark,65.5876
-1997-12-31,EE,Estonia,
-1997-12-31,ES,Spain,51.6719
+1997-09-30,PT,Portugal,106.4417
+1997-09-30,SE,Sweden,43.1797
+1997-09-30,TH,Thailand,119.1955
+1997-09-30,US,United States,83.6316
+1997-09-30,XM,Euro area,75.5118
+1997-09-30,ZA,South Africa,46.2983
+1997-12-31,AT,Austria,105.0299
+1997-12-31,AU,Australia,49.1841
+1997-12-31,BE,Belgium,59.6166
+1997-12-31,CA,Canada,59.5975
+1997-12-31,CH,Switzerland,78.1902
+1997-12-31,CO,Colombia,98.9299
+1997-12-31,DE,Germany,120.9118
+1997-12-31,DK,Denmark,65.5917
+1997-12-31,ES,Spain,51.672
 1997-12-31,FI,Finland,62.1769
-1997-12-31,FR,France,51.7223
-1997-12-31,GB,United Kingdom,48.8811
-1997-12-31,GR,Greece,
+1997-12-31,FR,France,51.7213
+1997-12-31,GB,United Kingdom,48.8649
+1997-12-31,GR,Greece,66.2785
 1997-12-31,HK,Hong Kong SAR,104.9255
-1997-12-31,HR,Croatia,
-1997-12-31,HU,Hungary,
-1997-12-31,ID,Indonesia,
-1997-12-31,IE,Ireland,70.5752
-1997-12-31,IL,Israel,98.1234
-1997-12-31,IN,India,
-1997-12-31,IS,Iceland,
-1997-12-31,IT,Italy,77.5161
+1997-12-31,HR,Croatia,77.2482
+1997-12-31,HU,Hungary,70.6099
+1997-12-31,IE,Ireland,70.583
+1997-12-31,IL,Israel,98.1227
+1997-12-31,IS,Iceland,66.3405
+1997-12-31,IT,Italy,77.5165
 1997-12-31,JP,Japan,149.5916
-1997-12-31,KR,Korea,98.0909
-1997-12-31,LT,Lithuania,
-1997-12-31,LU,Luxembourg,
-1997-12-31,LV,Latvia,
-1997-12-31,MA,Morocco,
-1997-12-31,MK,North Macedonia,
-1997-12-31,MT,Malta,
-1997-12-31,MX,Mexico,
+1997-12-31,KR,Korea,98.0765
 1997-12-31,MY,Malaysia,98.3005
-1997-12-31,NL,Netherlands,62.8942
-1997-12-31,NO,Norway,49.6286
+1997-12-31,NL,Netherlands,63.7584
+1997-12-31,NO,Norway,49.6088
 1997-12-31,NZ,New Zealand,63.4901
-1997-12-31,PE,Peru,
-1997-12-31,PH,Philippines,
-1997-12-31,PL,Poland,
-1997-12-31,PT,Portugal,
-1997-12-31,RO,Romania,
-1997-12-31,RS,Serbia,
-1997-12-31,RU,Russia,
-1997-12-31,SE,Sweden,42.9371
-1997-12-31,SG,Singapore,
-1997-12-31,SI,Slovenia,
-1997-12-31,SK,Slovak Republic,
-1997-12-31,TH,Thailand,114.8781
-1997-12-31,TR,Türkiye,
-1997-12-31,US,United States,84.6354
-1997-12-31,XM,Euro area,75.6891
-1997-12-31,XW,World,
-1997-12-31,ZA,South Africa,48.4532
-1998-03-31,4T,Emerging market economies (aggregate),
-1998-03-31,5R,Advanced economies,
-1998-03-31,AE,United Arab Emirates,
-1998-03-31,AT,Austria,
-1998-03-31,AU,Australia,50.2592
-1998-03-31,BE,Belgium,59.6806
-1998-03-31,BG,Bulgaria,
-1998-03-31,BR,Brazil,
-1998-03-31,CA,Canada,58.2653
-1998-03-31,CH,Switzerland,78.5297
-1998-03-31,CL,Chile,
-1998-03-31,CN,China,
-1998-03-31,CO,Colombia,95.6636
-1998-03-31,CY,Cyprus,
-1998-03-31,CZ,Czechia,
-1998-03-31,DE,Germany,120.1577
-1998-03-31,DK,Denmark,66.7169
-1998-03-31,EE,Estonia,
-1998-03-31,ES,Spain,51.6896
+1997-12-31,PT,Portugal,107.074
+1997-12-31,SE,Sweden,42.9342
+1997-12-31,TH,Thailand,114.8816
+1997-12-31,US,United States,84.5553
+1997-12-31,XM,Euro area,75.6332
+1997-12-31,ZA,South Africa,48.3946
+1998-03-31,AT,Austria,103.1905
+1998-03-31,AU,Australia,50.2701
+1998-03-31,BE,Belgium,60.1885
+1998-03-31,BG,Bulgaria,63.5273
+1998-03-31,CA,Canada,58.7171
+1998-03-31,CH,Switzerland,78.5375
+1998-03-31,CO,Colombia,96.8231
+1998-03-31,DE,Germany,120.0915
+1998-03-31,DK,Denmark,66.721
+1998-03-31,ES,Spain,51.6897
 1998-03-31,FI,Finland,63.9745
-1998-03-31,FR,France,50.4477
-1998-03-31,GB,United Kingdom,50.1998
-1998-03-31,GR,Greece,
+1998-03-31,FR,France,50.4481
+1998-03-31,GB,United Kingdom,50.1831
+1998-03-31,GR,Greece,69.0261
 1998-03-31,HK,Hong Kong SAR,89.506
-1998-03-31,HR,Croatia,
-1998-03-31,HU,Hungary,
-1998-03-31,ID,Indonesia,
-1998-03-31,IE,Ireland,73.2809
-1998-03-31,IL,Israel,98.6732
-1998-03-31,IN,India,
-1998-03-31,IS,Iceland,
-1998-03-31,IT,Italy,75.9364
+1998-03-31,HR,Croatia,77.3557
+1998-03-31,HU,Hungary,65.4945
+1998-03-31,IE,Ireland,73.2591
+1998-03-31,IL,Israel,98.6734
+1998-03-31,IS,Iceland,68.2667
+1998-03-31,IT,Italy,75.9406
 1998-03-31,JP,Japan,149.644
-1998-03-31,KR,Korea,90.5228
-1998-03-31,LT,Lithuania,
-1998-03-31,LU,Luxembourg,
-1998-03-31,LV,Latvia,
-1998-03-31,MA,Morocco,
-1998-03-31,MK,North Macedonia,
-1998-03-31,MT,Malta,
-1998-03-31,MX,Mexico,
-1998-03-31,MY,Malaysia,94.3537
-1998-03-31,NL,Netherlands,64.3132
-1998-03-31,NO,Norway,51.1971
+1998-03-31,KR,Korea,90.4875
+1998-03-31,MY,Malaysia,94.3536
+1998-03-31,NL,Netherlands,65.032
+1998-03-31,NO,Norway,51.1941
 1998-03-31,NZ,New Zealand,62.6609
 1998-03-31,PE,Peru,82.0315
-1998-03-31,PH,Philippines,
-1998-03-31,PL,Poland,
-1998-03-31,PT,Portugal,
-1998-03-31,RO,Romania,
-1998-03-31,RS,Serbia,
-1998-03-31,RU,Russia,
-1998-03-31,SE,Sweden,44.7015
-1998-03-31,SG,Singapore,87.6284
-1998-03-31,SI,Slovenia,
-1998-03-31,SK,Slovak Republic,
-1998-03-31,TH,Thailand,115.8241
-1998-03-31,TR,Türkiye,
-1998-03-31,US,United States,86.1026
-1998-03-31,XM,Euro area,75.1622
-1998-03-31,XW,World,
-1998-03-31,ZA,South Africa,49.3597
-1998-06-30,4T,Emerging market economies (aggregate),
-1998-06-30,5R,Advanced economies,
-1998-06-30,AE,United Arab Emirates,
-1998-06-30,AT,Austria,
-1998-06-30,AU,Australia,51.0486
-1998-06-30,BE,Belgium,59.5289
-1998-06-30,BG,Bulgaria,
-1998-06-30,BR,Brazil,
-1998-06-30,CA,Canada,58.6175
-1998-06-30,CH,Switzerland,78.0168
-1998-06-30,CL,Chile,
-1998-06-30,CN,China,
-1998-06-30,CO,Colombia,92.0353
-1998-06-30,CY,Cyprus,
-1998-06-30,CZ,Czechia,
-1998-06-30,DE,Germany,120.0255
-1998-06-30,DK,Denmark,68.9217
-1998-06-30,EE,Estonia,
-1998-06-30,ES,Spain,52.6645
+1998-03-31,PT,Portugal,106.9811
+1998-03-31,SE,Sweden,44.6972
+1998-03-31,SG,Singapore,87.6438
+1998-03-31,TH,Thailand,115.8309
+1998-03-31,US,United States,86.0159
+1998-03-31,XM,Euro area,75.1011
+1998-03-31,ZA,South Africa,49.3013
+1998-06-30,AT,Austria,98.82
+1998-06-30,AU,Australia,51.068
+1998-06-30,BE,Belgium,60.0356
+1998-06-30,BG,Bulgaria,68.1054
+1998-06-30,CA,Canada,59.072
+1998-06-30,CH,Switzerland,78.001
+1998-06-30,CO,Colombia,92.8542
+1998-06-30,DE,Germany,120.0297
+1998-06-30,DK,Denmark,68.9259
+1998-06-30,ES,Spain,52.6646
 1998-06-30,FI,Finland,65.1458
-1998-06-30,FR,France,51.4298
-1998-06-30,GB,United Kingdom,52.3133
-1998-06-30,GR,Greece,
+1998-06-30,FR,France,51.434
+1998-06-30,GB,United Kingdom,52.296
+1998-06-30,GR,Greece,69.0181
 1998-06-30,HK,Hong Kong SAR,79.0146
-1998-06-30,HR,Croatia,
-1998-06-30,HU,Hungary,
-1998-06-30,ID,Indonesia,
-1998-06-30,IE,Ireland,73.8712
+1998-06-30,HR,Croatia,75.81
+1998-06-30,HU,Hungary,63.8528
+1998-06-30,IE,Ireland,73.8475
 1998-06-30,IL,Israel,97.8239
-1998-06-30,IN,India,
-1998-06-30,IS,Iceland,
-1998-06-30,IT,Italy,76.3598
+1998-06-30,IS,Iceland,68.924
+1998-06-30,IT,Italy,76.3611
 1998-06-30,JP,Japan,148.1475
-1998-06-30,KR,Korea,83.8415
-1998-06-30,LT,Lithuania,
-1998-06-30,LU,Luxembourg,
-1998-06-30,LV,Latvia,
-1998-06-30,MA,Morocco,
-1998-06-30,MK,North Macedonia,
-1998-06-30,MT,Malta,
-1998-06-30,MX,Mexico,
+1998-06-30,KR,Korea,83.8584
 1998-06-30,MY,Malaysia,89.7754
-1998-06-30,NL,Netherlands,65.5234
-1998-06-30,NO,Norway,54.1387
+1998-06-30,NL,Netherlands,66.2003
+1998-06-30,NO,Norway,54.135
 1998-06-30,NZ,New Zealand,61.279
 1998-06-30,PE,Peru,76.8365
-1998-06-30,PH,Philippines,
-1998-06-30,PL,Poland,
-1998-06-30,PT,Portugal,
-1998-06-30,RO,Romania,
-1998-06-30,RS,Serbia,
-1998-06-30,RU,Russia,
-1998-06-30,SE,Sweden,46.0323
-1998-06-30,SG,Singapore,80.7153
-1998-06-30,SI,Slovenia,
-1998-06-30,SK,Slovak Republic,
-1998-06-30,TH,Thailand,101.9475
-1998-06-30,TR,Türkiye,
-1998-06-30,US,United States,86.787
-1998-06-30,XM,Euro area,75.6901
-1998-06-30,XW,World,
-1998-06-30,ZA,South Africa,49.636
-1998-09-30,4T,Emerging market economies (aggregate),
-1998-09-30,5R,Advanced economies,
-1998-09-30,AE,United Arab Emirates,
-1998-09-30,AT,Austria,
-1998-09-30,AU,Australia,50.9729
-1998-09-30,BE,Belgium,62.1352
-1998-09-30,BG,Bulgaria,
-1998-09-30,BR,Brazil,
-1998-09-30,CA,Canada,57.3909
-1998-09-30,CH,Switzerland,78.5681
-1998-09-30,CL,Chile,
-1998-09-30,CN,China,
-1998-09-30,CO,Colombia,89.286
-1998-09-30,CY,Cyprus,
-1998-09-30,CZ,Czechia,
-1998-09-30,DE,Germany,119.529
-1998-09-30,DK,Denmark,69.7891
-1998-09-30,EE,Estonia,
-1998-09-30,ES,Spain,53.3728
+1998-06-30,PT,Portugal,106.943
+1998-06-30,SE,Sweden,46.0303
+1998-06-30,SG,Singapore,80.7296
+1998-06-30,TH,Thailand,101.9462
+1998-06-30,US,United States,86.7006
+1998-06-30,XM,Euro area,75.6319
+1998-06-30,ZA,South Africa,49.5748
+1998-09-30,AT,Austria,102.0087
+1998-09-30,AU,Australia,50.9264
+1998-09-30,BE,Belgium,62.664
+1998-09-30,BG,Bulgaria,66.798
+1998-09-30,CA,Canada,57.8359
+1998-09-30,CH,Switzerland,78.581
+1998-09-30,CO,Colombia,90.7852
+1998-09-30,DE,Germany,119.5016
+1998-09-30,DK,Denmark,69.7934
+1998-09-30,ES,Spain,53.3729
 1998-09-30,FI,Finland,66.8414
-1998-09-30,FR,France,52.7822
-1998-09-30,GB,United Kingdom,54.6134
-1998-09-30,GR,Greece,
+1998-09-30,FR,France,52.7835
+1998-09-30,GB,United Kingdom,54.5952
+1998-09-30,GR,Greece,70.3825
 1998-09-30,HK,Hong Kong SAR,65.7476
-1998-09-30,HR,Croatia,
-1998-09-30,HU,Hungary,
-1998-09-30,ID,Indonesia,
-1998-09-30,IE,Ireland,76.8549
-1998-09-30,IL,Israel,96.8562
-1998-09-30,IN,India,
-1998-09-30,IS,Iceland,
-1998-09-30,IT,Italy,76.3726
+1998-09-30,HR,Croatia,76.0832
+1998-09-30,HU,Hungary,67.0218
+1998-09-30,IE,Ireland,76.8782
+1998-09-30,IL,Israel,96.8564
+1998-09-30,IS,Iceland,71.1912
+1998-09-30,IT,Italy,76.3722
 1998-09-30,JP,Japan,148.2559
-1998-09-30,KR,Korea,81.9701
-1998-09-30,LT,Lithuania,
-1998-09-30,LU,Luxembourg,
-1998-09-30,LV,Latvia,
-1998-09-30,MA,Morocco,
-1998-09-30,MK,North Macedonia,
-1998-09-30,MT,Malta,
-1998-09-30,MX,Mexico,
-1998-09-30,MY,Malaysia,86.6355
-1998-09-30,NL,Netherlands,67.5793
-1998-09-30,NO,Norway,53.5078
+1998-09-30,KR,Korea,81.9914
+1998-09-30,MY,Malaysia,86.6356
+1998-09-30,NL,Netherlands,68.2649
+1998-09-30,NO,Norway,53.4571
 1998-09-30,NZ,New Zealand,61.0478
 1998-09-30,PE,Peru,79.4818
-1998-09-30,PH,Philippines,
-1998-09-30,PL,Poland,
-1998-09-30,PT,Portugal,
-1998-09-30,RO,Romania,
-1998-09-30,RS,Serbia,
-1998-09-30,RU,Russia,
-1998-09-30,SE,Sweden,47.5662
-1998-09-30,SG,Singapore,70.257
-1998-09-30,SI,Slovenia,
-1998-09-30,SK,Slovak Republic,
-1998-09-30,TH,Thailand,106.138
-1998-09-30,TR,Türkiye,
-1998-09-30,US,United States,87.9786
-1998-09-30,XM,Euro area,76.7157
-1998-09-30,XW,World,
-1998-09-30,ZA,South Africa,48.9076
-1998-12-31,4T,Emerging market economies (aggregate),
-1998-12-31,5R,Advanced economies,
-1998-12-31,AE,United Arab Emirates,
-1998-12-31,AT,Austria,
-1998-12-31,AU,Australia,51.5853
-1998-12-31,BE,Belgium,62.1693
-1998-12-31,BG,Bulgaria,
-1998-12-31,BR,Brazil,
-1998-12-31,CA,Canada,58.102
-1998-12-31,CH,Switzerland,78.3778
-1998-12-31,CL,Chile,
-1998-12-31,CN,China,
-1998-12-31,CO,Colombia,87.4014
-1998-12-31,CY,Cyprus,
-1998-12-31,CZ,Czechia,
-1998-12-31,DE,Germany,119.9936
-1998-12-31,DK,Denmark,70.5327
-1998-12-31,EE,Estonia,
-1998-12-31,ES,Spain,54.3534
+1998-09-30,PT,Portugal,108.0622
+1998-09-30,SE,Sweden,47.5622
+1998-09-30,SG,Singapore,70.2694
+1998-09-30,TH,Thailand,106.1408
+1998-09-30,US,United States,87.8889
+1998-09-30,XM,Euro area,76.6477
+1998-09-30,ZA,South Africa,48.8539
+1998-12-31,AT,Austria,97.8907
+1998-12-31,AU,Australia,51.5475
+1998-12-31,BE,Belgium,62.6984
+1998-12-31,BG,Bulgaria,65.8505
+1998-12-31,CA,Canada,58.5525
+1998-12-31,CH,Switzerland,78.3616
+1998-12-31,CO,Colombia,88.5582
+1998-12-31,DE,Germany,120.0815
+1998-12-31,DK,Denmark,70.537
+1998-12-31,ES,Spain,54.3535
 1998-12-31,FI,Finland,67.4812
-1998-12-31,FR,France,52.816
-1998-12-31,GB,United Kingdom,54.0067
-1998-12-31,GR,Greece,
+1998-12-31,FR,France,52.8162
+1998-12-31,GB,United Kingdom,53.9888
+1998-12-31,GR,Greece,71.4137
 1998-12-31,HK,Hong Kong SAR,65.0424
-1998-12-31,HR,Croatia,
-1998-12-31,HU,Hungary,
-1998-12-31,ID,Indonesia,
-1998-12-31,IE,Ireland,83.7411
-1998-12-31,IL,Israel,97.8947
-1998-12-31,IN,India,
-1998-12-31,IS,Iceland,
-1998-12-31,IT,Italy,76.1329
+1998-12-31,HR,Croatia,74.6814
+1998-12-31,HU,Hungary,67.0191
+1998-12-31,IE,Ireland,83.7978
+1998-12-31,IL,Israel,97.8951
+1998-12-31,IS,Iceland,70.7505
+1998-12-31,IT,Italy,76.1598
 1998-12-31,JP,Japan,145.5123
-1998-12-31,KR,Korea,80.7407
+1998-12-31,KR,Korea,80.7011
 1998-12-31,LT,Lithuania,48.3281
-1998-12-31,LU,Luxembourg,
-1998-12-31,LV,Latvia,
-1998-12-31,MA,Morocco,
-1998-12-31,MK,North Macedonia,
-1998-12-31,MT,Malta,
-1998-12-31,MX,Mexico,
 1998-12-31,MY,Malaysia,86.0594
-1998-12-31,NL,Netherlands,69.0458
-1998-12-31,NO,Norway,51.6805
+1998-12-31,NL,Netherlands,69.6305
+1998-12-31,NO,Norway,51.6792
 1998-12-31,NZ,New Zealand,61.8163
 1998-12-31,PE,Peru,83.209
-1998-12-31,PH,Philippines,
-1998-12-31,PL,Poland,
-1998-12-31,PT,Portugal,
-1998-12-31,RO,Romania,
-1998-12-31,RS,Serbia,
-1998-12-31,RU,Russia,
-1998-12-31,SE,Sweden,48.1723
-1998-12-31,SG,Singapore,64.278
-1998-12-31,SI,Slovenia,
-1998-12-31,SK,Slovak Republic,
-1998-12-31,TH,Thailand,105.3534
-1998-12-31,TR,Türkiye,
-1998-12-31,US,United States,89.3363
-1998-12-31,XM,Euro area,77.3095
-1998-12-31,XW,World,
-1998-12-31,ZA,South Africa,48.0251
-1999-03-31,4T,Emerging market economies (aggregate),
-1999-03-31,5R,Advanced economies,
-1999-03-31,AE,United Arab Emirates,
-1999-03-31,AT,Austria,
-1999-03-31,AU,Australia,52.5088
-1999-03-31,BE,Belgium,63.1113
-1999-03-31,BG,Bulgaria,
-1999-03-31,BR,Brazil,
-1999-03-31,CA,Canada,58.2676
-1999-03-31,CH,Switzerland,78.9559
-1999-03-31,CL,Chile,
-1999-03-31,CN,China,
-1999-03-31,CO,Colombia,83.5144
-1999-03-31,CY,Cyprus,
-1999-03-31,CZ,Czechia,
-1999-03-31,DE,Germany,119.8707
-1999-03-31,DK,Denmark,71.2688
-1999-03-31,EE,Estonia,
-1999-03-31,ES,Spain,55.6096
+1998-12-31,PT,Portugal,109.2191
+1998-12-31,SE,Sweden,48.1688
+1998-12-31,SG,Singapore,64.2896
+1998-12-31,TH,Thailand,105.3558
+1998-12-31,US,United States,89.2441
+1998-12-31,XM,Euro area,77.2281
+1998-12-31,ZA,South Africa,47.9733
+1999-03-31,AT,Austria,98.1357
+1999-03-31,AU,Australia,52.5037
+1999-03-31,BE,Belgium,63.6484
+1999-03-31,BG,Bulgaria,65.2397
+1999-03-31,CA,Canada,58.7194
+1999-03-31,CH,Switzerland,78.9741
+1999-03-31,CO,Colombia,84.4698
+1999-03-31,DE,Germany,119.873
+1999-03-31,DK,Denmark,71.2732
+1999-03-31,ES,Spain,55.6097
 1999-03-31,FI,Finland,68.5455
-1999-03-31,FR,France,52.7732
-1999-03-31,GB,United Kingdom,54.4092
-1999-03-31,GR,Greece,
+1999-03-31,FR,France,52.7726
+1999-03-31,GB,United Kingdom,54.3911
+1999-03-31,GR,Greece,72.8594
 1999-03-31,HK,Hong Kong SAR,66.8824
-1999-03-31,HR,Croatia,
-1999-03-31,HU,Hungary,
-1999-03-31,ID,Indonesia,
-1999-03-31,IE,Ireland,87.2599
-1999-03-31,IL,Israel,97.8986
-1999-03-31,IN,India,
-1999-03-31,IS,Iceland,NaN
-1999-03-31,IT,Italy,75.7172
+1999-03-31,HR,Croatia,72.9148
+1999-03-31,HU,Hungary,67.5872
+1999-03-31,IE,Ireland,87.2232
+1999-03-31,IL,Israel,97.8991
+1999-03-31,IS,Iceland,74.7772
+1999-03-31,IT,Italy,75.7162
 1999-03-31,JP,Japan,145.7911
-1999-03-31,KR,Korea,81.8639
+1999-03-31,KR,Korea,81.9548
 1999-03-31,LT,Lithuania,51.139
-1999-03-31,LU,Luxembourg,
-1999-03-31,LV,Latvia,
-1999-03-31,MA,Morocco,
-1999-03-31,MK,North Macedonia,
-1999-03-31,MT,Malta,
-1999-03-31,MX,Mexico,
 1999-03-31,MY,Malaysia,83.6236
-1999-03-31,NL,Netherlands,71.4103
-1999-03-31,NO,Norway,53.2194
+1999-03-31,NL,Netherlands,71.7694
+1999-03-31,NO,Norway,53.211
 1999-03-31,NZ,New Zealand,63.0056
 1999-03-31,PE,Peru,94.6678
-1999-03-31,PH,Philippines,
-1999-03-31,PL,Poland,
-1999-03-31,PT,Portugal,
-1999-03-31,RO,Romania,
-1999-03-31,RS,Serbia,
-1999-03-31,RU,Russia,
-1999-03-31,SE,Sweden,48.8355
-1999-03-31,SG,Singapore,67.7042
-1999-03-31,SI,Slovenia,
-1999-03-31,SK,Slovak Republic,
-1999-03-31,TH,Thailand,104.3971
-1999-03-31,TR,Türkiye,
-1999-03-31,US,United States,90.3324
-1999-03-31,XM,Euro area,77.7367
-1999-03-31,XW,World,
-1999-03-31,ZA,South Africa,47.5604
-1999-06-30,4T,Emerging market economies (aggregate),
-1999-06-30,5R,Advanced economies,
-1999-06-30,AE,United Arab Emirates,
-1999-06-30,AT,Austria,
-1999-06-30,AU,Australia,53.4705
-1999-06-30,BE,Belgium,63.9428
-1999-06-30,BG,Bulgaria,
-1999-06-30,BR,Brazil,
-1999-06-30,CA,Canada,59.8956
-1999-06-30,CH,Switzerland,78.6877
-1999-06-30,CL,Chile,
-1999-06-30,CN,China,
-1999-06-30,CO,Colombia,81.6894
-1999-06-30,CY,Cyprus,
-1999-06-30,CZ,Czechia,
-1999-06-30,DE,Germany,119.2507
-1999-06-30,DK,Denmark,71.5753
-1999-06-30,EE,Estonia,
-1999-06-30,ES,Spain,57.0731
+1999-03-31,PT,Portugal,112.6323
+1999-03-31,SE,Sweden,48.8317
+1999-03-31,SG,Singapore,67.7159
+1999-03-31,TH,Thailand,104.3964
+1999-03-31,US,United States,90.2718
+1999-03-31,XM,Euro area,77.6552
+1999-03-31,ZA,South Africa,47.5026
+1999-06-30,AT,Austria,98.1359
+1999-06-30,AU,Australia,53.4634
+1999-06-30,BE,Belgium,64.4869
+1999-06-30,BG,Bulgaria,68.3358
+1999-06-30,CA,Canada,60.36
+1999-06-30,CH,Switzerland,78.6872
+1999-06-30,CO,Colombia,82.8826
+1999-06-30,DE,Germany,119.2669
+1999-06-30,DK,Denmark,71.5798
+1999-06-30,ES,Spain,57.0732
 1999-06-30,FI,Finland,69.6589
-1999-06-30,FR,France,53.6734
-1999-06-30,GB,United Kingdom,56.1244
-1999-06-30,GR,Greece,
+1999-06-30,FR,France,53.6762
+1999-06-30,GB,United Kingdom,56.1057
+1999-06-30,GR,Greece,73.1085
 1999-06-30,HK,Hong Kong SAR,67.506
-1999-06-30,HR,Croatia,
-1999-06-30,HU,Hungary,
-1999-06-30,ID,Indonesia,
-1999-06-30,IE,Ireland,84.4281
+1999-06-30,HR,Croatia,73.8297
+1999-06-30,HU,Hungary,71.6779
+1999-06-30,IE,Ireland,84.447
 1999-06-30,IL,Israel,96.9303
-1999-06-30,IN,India,
-1999-06-30,IS,Iceland,NaN
-1999-06-30,IT,Italy,75.7648
+1999-06-30,IS,Iceland,78.2289
+1999-06-30,IT,Italy,75.7628
 1999-06-30,JP,Japan,144.096
-1999-06-30,KR,Korea,82.275
+1999-06-30,KR,Korea,82.2382
 1999-06-30,LT,Lithuania,43.1259
-1999-06-30,LU,Luxembourg,
-1999-06-30,LV,Latvia,
-1999-06-30,MA,Morocco,
-1999-06-30,MK,North Macedonia,
-1999-06-30,MT,Malta,
-1999-06-30,MX,Mexico,
 1999-06-30,MY,Malaysia,83.8401
-1999-06-30,NL,Netherlands,73.8218
-1999-06-30,NO,Norway,57.1106
+1999-06-30,NL,Netherlands,74.2779
+1999-06-30,NO,Norway,57.1238
 1999-06-30,NZ,New Zealand,63.3535
 1999-06-30,PE,Peru,86.953
-1999-06-30,PH,Philippines,
-1999-06-30,PL,Poland,
-1999-06-30,PT,Portugal,
-1999-06-30,RO,Romania,
-1999-06-30,RS,Serbia,
-1999-06-30,RU,Russia,
-1999-06-30,SE,Sweden,50.4538
-1999-06-30,SG,Singapore,75.5318
-1999-06-30,SI,Slovenia,
-1999-06-30,SK,Slovak Republic,
-1999-06-30,TH,Thailand,83.2244
-1999-06-30,TR,Türkiye,
-1999-06-30,US,United States,91.2679
-1999-06-30,XM,Euro area,78.3085
-1999-06-30,XW,World,
-1999-06-30,ZA,South Africa,48.5032
-1999-09-30,4T,Emerging market economies (aggregate),
-1999-09-30,5R,Advanced economies,
-1999-09-30,AE,United Arab Emirates,
-1999-09-30,AT,Austria,
-1999-09-30,AU,Australia,53.9905
-1999-09-30,BE,Belgium,66.1247
-1999-09-30,BG,Bulgaria,
-1999-09-30,BR,Brazil,
-1999-09-30,CA,Canada,58.9711
-1999-09-30,CH,Switzerland,78.1461
-1999-09-30,CL,Chile,
-1999-09-30,CN,China,
-1999-09-30,CO,Colombia,79.2258
-1999-09-30,CY,Cyprus,
-1999-09-30,CZ,Czechia,
-1999-09-30,DE,Germany,118.9177
-1999-09-30,DK,Denmark,72.5316
-1999-09-30,EE,Estonia,
-1999-09-30,ES,Spain,58.1658
+1999-06-30,PT,Portugal,113.4019
+1999-06-30,SE,Sweden,50.4488
+1999-06-30,SG,Singapore,75.5448
+1999-06-30,TH,Thailand,83.2223
+1999-06-30,US,United States,91.1716
+1999-06-30,XM,Euro area,78.2372
+1999-06-30,ZA,South Africa,48.44
+1999-09-30,AT,Austria,97.599
+1999-09-30,AU,Australia,53.9683
+1999-09-30,BE,Belgium,66.6874
+1999-09-30,BG,Bulgaria,63.6667
+1999-09-30,CA,Canada,59.4283
+1999-09-30,CH,Switzerland,78.1315
+1999-09-30,CO,Colombia,79.6839
+1999-09-30,DE,Germany,118.9251
+1999-09-30,DK,Denmark,72.5361
+1999-09-30,ES,Spain,58.1659
 1999-09-30,FI,Finland,72.1263
-1999-09-30,FR,France,56.1726
-1999-09-30,GB,United Kingdom,59.5499
-1999-09-30,GR,Greece,
+1999-09-30,FR,France,56.1736
+1999-09-30,GB,United Kingdom,59.5301
+1999-09-30,GR,Greece,75.126
 1999-09-30,HK,Hong Kong SAR,67.2553
-1999-09-30,HR,Croatia,
-1999-09-30,HU,Hungary,
-1999-09-30,ID,Indonesia,
-1999-09-30,IE,Ireland,92.2029
-1999-09-30,IL,Israel,97.0147
-1999-09-30,IN,India,
-1999-09-30,IS,Iceland,NaN
-1999-09-30,IT,Italy,75.7908
+1999-09-30,HR,Croatia,73.6782
+1999-09-30,HU,Hungary,74.8558
+1999-09-30,IE,Ireland,92.228
+1999-09-30,IL,Israel,97.0151
+1999-09-30,IS,Iceland,80.7836
+1999-09-30,IT,Italy,75.7953
 1999-09-30,JP,Japan,143.3202
-1999-09-30,KR,Korea,83.0842
+1999-09-30,KR,Korea,83.1499
 1999-09-30,LT,Lithuania,40.1719
-1999-09-30,LU,Luxembourg,
-1999-09-30,LV,Latvia,
-1999-09-30,MA,Morocco,
-1999-09-30,MK,North Macedonia,
-1999-09-30,MT,Malta,
-1999-09-30,MX,Mexico,
 1999-09-30,MY,Malaysia,85.1091
-1999-09-30,NL,Netherlands,77.6037
-1999-09-30,NO,Norway,58.3691
+1999-09-30,NL,Netherlands,77.9217
+1999-09-30,NO,Norway,58.3494
 1999-09-30,NZ,New Zealand,63.0089
 1999-09-30,PE,Peru,86.9342
-1999-09-30,PH,Philippines,
-1999-09-30,PL,Poland,
-1999-09-30,PT,Portugal,
-1999-09-30,RO,Romania,
-1999-09-30,RS,Serbia,
-1999-09-30,RU,Russia,
-1999-09-30,SE,Sweden,51.9774
-1999-09-30,SG,Singapore,81.4795
-1999-09-30,SI,Slovenia,
-1999-09-30,SK,Slovak Republic,
-1999-09-30,TH,Thailand,101.2889
-1999-09-30,TR,Türkiye,
-1999-09-30,US,United States,92.4847
-1999-09-30,XM,Euro area,79.8994
-1999-09-30,XW,World,
-1999-09-30,ZA,South Africa,49.0319
-1999-12-31,4T,Emerging market economies (aggregate),
-1999-12-31,5R,Advanced economies,
-1999-12-31,AE,United Arab Emirates,
-1999-12-31,AT,Austria,
-1999-12-31,AU,Australia,55.4416
-1999-12-31,BE,Belgium,64.7434
-1999-12-31,BG,Bulgaria,
-1999-12-31,BR,Brazil,
-1999-12-31,CA,Canada,59.6142
-1999-12-31,CH,Switzerland,77.7085
-1999-12-31,CL,Chile,
-1999-12-31,CN,China,
-1999-12-31,CO,Colombia,79.4293
-1999-12-31,CY,Cyprus,
-1999-12-31,CZ,Czechia,
-1999-12-31,DE,Germany,119.1314
-1999-12-31,DK,Denmark,72.0842
-1999-12-31,EE,Estonia,
-1999-12-31,ES,Spain,57.953
+1999-09-30,PT,Portugal,116.3277
+1999-09-30,SE,Sweden,51.974
+1999-09-30,SG,Singapore,81.4938
+1999-09-30,TH,Thailand,101.29
+1999-09-30,US,United States,92.389
+1999-09-30,XM,Euro area,79.8119
+1999-09-30,ZA,South Africa,48.9701
+1999-12-31,AT,Austria,95.7658
+1999-12-31,AU,Australia,55.4509
+1999-12-31,BE,Belgium,65.2944
+1999-12-31,BG,Bulgaria,62.6876
+1999-12-31,CA,Canada,60.0764
+1999-12-31,CH,Switzerland,77.6944
+1999-12-31,CO,Colombia,80.5734
+1999-12-31,DE,Germany,119.1058
+1999-12-31,DK,Denmark,72.0887
+1999-12-31,ES,Spain,57.9531
 1999-12-31,FI,Finland,73.3315
-1999-12-31,FR,France,55.9472
-1999-12-31,GB,United Kingdom,60.8697
-1999-12-31,GR,Greece,
+1999-12-31,FR,France,55.944
+1999-12-31,GB,United Kingdom,60.8495
+1999-12-31,GR,Greece,75.8307
 1999-12-31,HK,Hong Kong SAR,64.5391
-1999-12-31,HR,Croatia,
-1999-12-31,HU,Hungary,
-1999-12-31,ID,Indonesia,
-1999-12-31,IE,Ireland,95.2879
-1999-12-31,IL,Israel,95.6527
-1999-12-31,IN,India,
-1999-12-31,IS,Iceland,NaN
-1999-12-31,IT,Italy,75.7102
+1999-12-31,HR,Croatia,74.1011
+1999-12-31,HU,Hungary,76.6216
+1999-12-31,IE,Ireland,95.3226
+1999-12-31,IL,Israel,95.653
+1999-12-31,IS,Iceland,82.0024
+1999-12-31,IT,Italy,75.7141
 1999-12-31,JP,Japan,141.9233
-1999-12-31,KR,Korea,82.7487
+1999-12-31,KR,Korea,82.6876
 1999-12-31,LT,Lithuania,40.9945
-1999-12-31,LU,Luxembourg,
-1999-12-31,LV,Latvia,
-1999-12-31,MA,Morocco,
-1999-12-31,MK,North Macedonia,
-1999-12-31,MT,Malta,
-1999-12-31,MX,Mexico,
 1999-12-31,MY,Malaysia,86.3331
-1999-12-31,NL,Netherlands,80.5138
-1999-12-31,NO,Norway,59.776
+1999-12-31,NL,Netherlands,80.9223
+1999-12-31,NO,Norway,59.7783
 1999-12-31,NZ,New Zealand,62.9112
 1999-12-31,PE,Peru,90.0048
-1999-12-31,PH,Philippines,
-1999-12-31,PL,Poland,
-1999-12-31,PT,Portugal,
-1999-12-31,RO,Romania,
-1999-12-31,RS,Serbia,
-1999-12-31,RU,Russia,
-1999-12-31,SE,Sweden,51.7286
-1999-12-31,SG,Singapore,85.7711
-1999-12-31,SI,Slovenia,
-1999-12-31,SK,Slovak Republic,
-1999-12-31,TH,Thailand,97.1794
-1999-12-31,TR,Türkiye,
-1999-12-31,US,United States,93.8973
-1999-12-31,XM,Euro area,80.0993
-1999-12-31,XW,World,
-1999-12-31,ZA,South Africa,50.2722
-2000-03-31,4T,Emerging market economies (aggregate),
-2000-03-31,5R,Advanced economies,
-2000-03-31,AE,United Arab Emirates,
-2000-03-31,AT,Austria,98.2844
-2000-03-31,AU,Australia,55.9766
-2000-03-31,BE,Belgium,66.1672
-2000-03-31,BG,Bulgaria,
-2000-03-31,BR,Brazil,
-2000-03-31,CA,Canada,59.609
-2000-03-31,CH,Switzerland,77.5287
-2000-03-31,CL,Chile,
-2000-03-31,CN,China,
-2000-03-31,CO,Colombia,77.3288
-2000-03-31,CY,Cyprus,
-2000-03-31,CZ,Czechia,
-2000-03-31,DE,Germany,118.7552
-2000-03-31,DK,Denmark,72.6628
-2000-03-31,EE,Estonia,
-2000-03-31,ES,Spain,59.2992
+1999-12-31,PT,Portugal,116.7962
+1999-12-31,SE,Sweden,51.7254
+1999-12-31,SG,Singapore,85.7859
+1999-12-31,TH,Thailand,97.1816
+1999-12-31,US,United States,93.7944
+1999-12-31,XM,Euro area,80.0069
+1999-12-31,ZA,South Africa,50.2121
+2000-03-31,AT,Austria,98.2843
+2000-03-31,AU,Australia,55.9705
+2000-03-31,BE,Belgium,66.7303
+2000-03-31,BG,Bulgaria,59.6427
+2000-03-31,CA,Canada,60.0711
+2000-03-31,CH,Switzerland,77.5257
+2000-03-31,CO,Colombia,77.1354
+2000-03-31,DE,Germany,118.7461
+2000-03-31,DK,Denmark,72.6673
+2000-03-31,ES,Spain,59.2993
 2000-03-31,FI,Finland,73.7069
-2000-03-31,FR,France,57.0576
-2000-03-31,GB,United Kingdom,62.621
-2000-03-31,GR,Greece,
+2000-03-31,FR,France,57.0587
+2000-03-31,GB,United Kingdom,62.6002
+2000-03-31,GR,Greece,77.6642
 2000-03-31,HK,Hong Kong SAR,66.4739
-2000-03-31,HR,Croatia,
-2000-03-31,HU,Hungary,
-2000-03-31,ID,Indonesia,
-2000-03-31,IE,Ireland,94.4236
-2000-03-31,IL,Israel,92.3655
-2000-03-31,IN,India,
-2000-03-31,IS,Iceland,85.0655
-2000-03-31,IT,Italy,76.3039
+2000-03-31,HR,Croatia,74.2766
+2000-03-31,HU,Hungary,82.1241
+2000-03-31,IE,Ireland,94.446
+2000-03-31,IL,Israel,92.3658
+2000-03-31,IS,Iceland,85.0683
+2000-03-31,IT,Italy,76.3086
 2000-03-31,JP,Japan,141.4415
-2000-03-31,KR,Korea,82.5668
+2000-03-31,KR,Korea,82.5624
 2000-03-31,LT,Lithuania,41.9676
-2000-03-31,LU,Luxembourg,
-2000-03-31,LV,Latvia,
-2000-03-31,MA,Morocco,
-2000-03-31,MK,North Macedonia,72.5824
-2000-03-31,MT,Malta,
-2000-03-31,MX,Mexico,
+2000-03-31,MK,North Macedonia,72.6994
 2000-03-31,MY,Malaysia,86.2324
-2000-03-31,NL,Netherlands,83.9083
-2000-03-31,NO,Norway,62.681
+2000-03-31,NL,Netherlands,84.0759
+2000-03-31,NO,Norway,62.6612
 2000-03-31,NZ,New Zealand,62.5862
 2000-03-31,PE,Peru,83.508
-2000-03-31,PH,Philippines,
-2000-03-31,PL,Poland,
-2000-03-31,PT,Portugal,
-2000-03-31,RO,Romania,
+2000-03-31,PT,Portugal,118.7076
 2000-03-31,RS,Serbia,135.2788
-2000-03-31,RU,Russia,
-2000-03-31,SE,Sweden,53.3763
-2000-03-31,SG,Singapore,87.8084
-2000-03-31,SI,Slovenia,
-2000-03-31,SK,Slovak Republic,
-2000-03-31,TH,Thailand,96.7992
-2000-03-31,TR,Türkiye,
-2000-03-31,US,United States,95.2739
-2000-03-31,XM,Euro area,80.9327
-2000-03-31,XW,World,
-2000-03-31,ZA,South Africa,56.9359
-2000-06-30,4T,Emerging market economies (aggregate),
-2000-06-30,5R,Advanced economies,
-2000-06-30,AE,United Arab Emirates,
+2000-03-31,SE,Sweden,53.3734
+2000-03-31,SG,Singapore,87.8241
+2000-03-31,TH,Thailand,96.8028
+2000-03-31,US,United States,95.1611
+2000-03-31,XM,Euro area,80.8455
+2000-03-31,ZA,South Africa,56.8608
 2000-06-30,AT,Austria,95.9464
-2000-06-30,AU,Australia,56.8918
-2000-06-30,BE,Belgium,65.8523
-2000-06-30,BG,Bulgaria,
-2000-06-30,BR,Brazil,
-2000-06-30,CA,Canada,60.2371
-2000-06-30,CH,Switzerland,77.1739
-2000-06-30,CL,Chile,
-2000-06-30,CN,China,
-2000-06-30,CO,Colombia,76.4898
-2000-06-30,CY,Cyprus,
-2000-06-30,CZ,Czechia,
-2000-06-30,DE,Germany,118.8544
-2000-06-30,DK,Denmark,73.7952
-2000-06-30,EE,Estonia,
-2000-06-30,ES,Spain,60.3938
+2000-06-30,AU,Australia,56.859
+2000-06-30,BE,Belgium,66.4127
+2000-06-30,BG,Bulgaria,60.2858
+2000-06-30,CA,Canada,60.7041
+2000-06-30,CH,Switzerland,77.1705
+2000-06-30,CO,Colombia,76.7242
+2000-06-30,DE,Germany,118.862
+2000-06-30,DK,Denmark,73.7998
+2000-06-30,ES,Spain,60.3939
 2000-06-30,FI,Finland,73.8911
-2000-06-30,FR,France,58.3987
-2000-06-30,GB,United Kingdom,65.4916
-2000-06-30,GR,Greece,
+2000-06-30,FR,France,58.404
+2000-06-30,GB,United Kingdom,65.4699
+2000-06-30,GR,Greece,78.1938
 2000-06-30,HK,Hong Kong SAR,62.1616
-2000-06-30,HR,Croatia,
-2000-06-30,HU,Hungary,
-2000-06-30,ID,Indonesia,
-2000-06-30,IE,Ireland,94.0279
-2000-06-30,IL,Israel,92.679
-2000-06-30,IN,India,
-2000-06-30,IS,Iceland,88.073
-2000-06-30,IT,Italy,76.4064
+2000-06-30,HR,Croatia,71.488
+2000-06-30,HU,Hungary,88.8316
+2000-06-30,IE,Ireland,94.0316
+2000-06-30,IL,Israel,92.6793
+2000-06-30,IS,Iceland,88.0508
+2000-06-30,IT,Italy,76.4138
 2000-06-30,JP,Japan,139.7004
-2000-06-30,KR,Korea,82.9599
+2000-06-30,KR,Korea,82.9657
 2000-06-30,LT,Lithuania,38.7607
-2000-06-30,LU,Luxembourg,
-2000-06-30,LV,Latvia,
-2000-06-30,MA,Morocco,
-2000-06-30,MK,North Macedonia,72.8229
-2000-06-30,MT,Malta,
-2000-06-30,MX,Mexico,
+2000-06-30,MK,North Macedonia,72.7631
 2000-06-30,MY,Malaysia,88.6618
-2000-06-30,NL,Netherlands,86.243
-2000-06-30,NO,Norway,66.3673
+2000-06-30,NL,Netherlands,86.339
+2000-06-30,NO,Norway,66.3602
 2000-06-30,NZ,New Zealand,61.9752
 2000-06-30,PE,Peru,84.2299
-2000-06-30,PH,Philippines,
-2000-06-30,PL,Poland,
-2000-06-30,PT,Portugal,
-2000-06-30,RO,Romania,
+2000-06-30,PT,Portugal,119.5799
 2000-06-30,RS,Serbia,144.82
-2000-06-30,RU,Russia,
-2000-06-30,SE,Sweden,55.5597
-2000-06-30,SG,Singapore,89.2412
-2000-06-30,SI,Slovenia,
-2000-06-30,SK,Slovak Republic,
-2000-06-30,TH,Thailand,100.0233
-2000-06-30,TR,Türkiye,
-2000-06-30,US,United States,96.686
-2000-06-30,XM,Euro area,81.6786
-2000-06-30,XW,World,
-2000-06-30,ZA,South Africa,55.2266
-2000-09-30,4T,Emerging market economies (aggregate),
-2000-09-30,5R,Advanced economies,
-2000-09-30,AE,United Arab Emirates,
+2000-06-30,SE,Sweden,55.5566
+2000-06-30,SG,Singapore,89.257
+2000-06-30,TH,Thailand,100.0271
+2000-06-30,US,United States,96.5856
+2000-06-30,XM,Euro area,81.5947
+2000-06-30,ZA,South Africa,55.1623
 2000-09-30,AT,Austria,93.7325
-2000-09-30,AU,Australia,54.7093
-2000-09-30,BE,Belgium,66.2801
-2000-09-30,BG,Bulgaria,
-2000-09-30,BR,Brazil,
-2000-09-30,CA,Canada,59.5455
-2000-09-30,CH,Switzerland,77.3644
-2000-09-30,CL,Chile,
-2000-09-30,CN,China,
-2000-09-30,CO,Colombia,73.7548
-2000-09-30,CY,Cyprus,
-2000-09-30,CZ,Czechia,
-2000-09-30,DE,Germany,118.0858
-2000-09-30,DK,Denmark,75.4298
-2000-09-30,EE,Estonia,
-2000-09-30,ES,Spain,60.4706
+2000-09-30,AU,Australia,54.738
+2000-09-30,BE,Belgium,66.8442
+2000-09-30,BG,Bulgaria,58.8233
+2000-09-30,CA,Canada,60.0071
+2000-09-30,CH,Switzerland,77.3618
+2000-09-30,CO,Colombia,74.2846
+2000-09-30,DE,Germany,118.0817
+2000-09-30,DK,Denmark,75.4345
+2000-09-30,ES,Spain,60.4707
 2000-09-30,FI,Finland,72.0934
-2000-09-30,FR,France,60.1994
-2000-09-30,GB,United Kingdom,66.8152
-2000-09-30,GR,Greece,
+2000-09-30,FR,France,60.2041
+2000-09-30,GB,United Kingdom,66.793
+2000-09-30,GR,Greece,80.8527
 2000-09-30,HK,Hong Kong SAR,60.6452
-2000-09-30,HR,Croatia,
-2000-09-30,HU,Hungary,
-2000-09-30,ID,Indonesia,
-2000-09-30,IE,Ireland,97.0993
+2000-09-30,HR,Croatia,66.4158
+2000-09-30,HU,Hungary,92.2015
+2000-09-30,IE,Ireland,97.1681
 2000-09-30,IL,Israel,90.5467
-2000-09-30,IN,India,
-2000-09-30,IS,Iceland,88.1271
-2000-09-30,IT,Italy,76.9951
+2000-09-30,IS,Iceland,88.1217
+2000-09-30,IT,Italy,76.996
 2000-09-30,JP,Japan,138.6295
-2000-09-30,KR,Korea,81.8589
+2000-09-30,KR,Korea,81.8358
 2000-09-30,LT,Lithuania,36.238
-2000-09-30,LU,Luxembourg,
-2000-09-30,LV,Latvia,
-2000-09-30,MA,Morocco,
-2000-09-30,MK,North Macedonia,77.2454
-2000-09-30,MT,Malta,
-2000-09-30,MX,Mexico,
+2000-09-30,MK,North Macedonia,77.5977
 2000-09-30,MY,Malaysia,89.1301
-2000-09-30,NL,Netherlands,89.5291
-2000-09-30,NO,Norway,64.2491
+2000-09-30,NL,Netherlands,89.4398
+2000-09-30,NO,Norway,64.2064
 2000-09-30,NZ,New Zealand,60.6617
 2000-09-30,PE,Peru,81.3035
-2000-09-30,PH,Philippines,
-2000-09-30,PL,Poland,
-2000-09-30,PT,Portugal,
-2000-09-30,RO,Romania,
+2000-09-30,PT,Portugal,120.508
 2000-09-30,RS,Serbia,141.296
-2000-09-30,RU,Russia,
-2000-09-30,SE,Sweden,57.5035
-2000-09-30,SG,Singapore,86.0122
-2000-09-30,SI,Slovenia,
-2000-09-30,SK,Slovak Republic,
-2000-09-30,TH,Thailand,96.4453
-2000-09-30,TR,Türkiye,
-2000-09-30,US,United States,98.007
-2000-09-30,XM,Euro area,82.5529
-2000-09-30,XW,World,
-2000-09-30,ZA,South Africa,53.1521
-2000-12-31,4T,Emerging market economies (aggregate),
-2000-12-31,5R,Advanced economies,
-2000-12-31,AE,United Arab Emirates,
-2000-12-31,AT,Austria,92.7329
-2000-12-31,AU,Australia,55.8591
-2000-12-31,BE,Belgium,66.8815
-2000-12-31,BG,Bulgaria,
-2000-12-31,BR,Brazil,
-2000-12-31,CA,Canada,59.7549
-2000-12-31,CH,Switzerland,75.3896
-2000-12-31,CL,Chile,
-2000-12-31,CN,China,
-2000-12-31,CO,Colombia,72.1847
-2000-12-31,CY,Cyprus,
-2000-12-31,CZ,Czechia,
-2000-12-31,DE,Germany,117.6994
-2000-12-31,DK,Denmark,75.5524
-2000-12-31,EE,Estonia,
-2000-12-31,ES,Spain,60.0285
+2000-09-30,SE,Sweden,57.502
+2000-09-30,SG,Singapore,86.0276
+2000-09-30,TH,Thailand,96.4476
+2000-09-30,US,United States,97.8933
+2000-09-30,XM,Euro area,82.4566
+2000-09-30,ZA,South Africa,53.0929
+2000-12-31,AT,Austria,92.7328
+2000-12-31,AU,Australia,55.854
+2000-12-31,BE,Belgium,67.4507
+2000-12-31,BG,Bulgaria,55.1288
+2000-12-31,CA,Canada,60.2182
+2000-12-31,CH,Switzerland,75.3867
+2000-12-31,CO,Colombia,72.6406
+2000-12-31,DE,Germany,117.705
+2000-12-31,DK,Denmark,75.5571
+2000-12-31,ES,Spain,60.0286
 2000-12-31,FI,Finland,70.559
-2000-12-31,FR,France,59.7164
-2000-12-31,GB,United Kingdom,68.309
-2000-12-31,GR,Greece,
+2000-12-31,FR,France,59.7176
+2000-12-31,GB,United Kingdom,68.2863
+2000-12-31,GR,Greece,81.5257
 2000-12-31,HK,Hong Kong SAR,58.4462
-2000-12-31,HR,Croatia,
-2000-12-31,HU,Hungary,
-2000-12-31,ID,Indonesia,
-2000-12-31,IE,Ireland,101.7826
-2000-12-31,IL,Israel,89.1644
-2000-12-31,IN,India,
-2000-12-31,IS,Iceland,88.7567
-2000-12-31,IT,Italy,77.3332
+2000-12-31,HR,Croatia,63.8708
+2000-12-31,HU,Hungary,91.1393
+2000-12-31,IE,Ireland,101.8325
+2000-12-31,IL,Israel,89.1643
+2000-12-31,IS,Iceland,88.7598
+2000-12-31,IT,Italy,77.3361
 2000-12-31,JP,Japan,137.318
-2000-12-31,KR,Korea,81.1818
+2000-12-31,KR,Korea,81.2111
 2000-12-31,LT,Lithuania,39.844
-2000-12-31,LU,Luxembourg,
-2000-12-31,LV,Latvia,
-2000-12-31,MA,Morocco,
-2000-12-31,MK,North Macedonia,82.2729
-2000-12-31,MT,Malta,
-2000-12-31,MX,Mexico,
+2000-12-31,MK,North Macedonia,82.3484
 2000-12-31,MY,Malaysia,88.8271
-2000-12-31,NL,Netherlands,90.7641
-2000-12-31,NO,Norway,63.6592
+2000-12-31,NL,Netherlands,90.6848
+2000-12-31,NO,Norway,63.6649
 2000-12-31,NZ,New Zealand,59.8065
 2000-12-31,PE,Peru,81.1037
-2000-12-31,PH,Philippines,
-2000-12-31,PL,Poland,
-2000-12-31,PT,Portugal,
-2000-12-31,RO,Romania,
+2000-12-31,PT,Portugal,122.1871
 2000-12-31,RS,Serbia,101.6898
-2000-12-31,RU,Russia,
-2000-12-31,SE,Sweden,57.3055
-2000-12-31,SG,Singapore,83.2409
-2000-12-31,SI,Slovenia,
-2000-12-31,SK,Slovak Republic,
-2000-12-31,TH,Thailand,98.6067
-2000-12-31,TR,Türkiye,
-2000-12-31,US,United States,99.6911
-2000-12-31,XM,Euro area,82.5812
-2000-12-31,XW,World,
-2000-12-31,ZA,South Africa,52.0785
-2001-03-31,4T,Emerging market economies (aggregate),
-2001-03-31,5R,Advanced economies,
-2001-03-31,AE,United Arab Emirates,
+2000-12-31,SE,Sweden,57.304
+2000-12-31,SG,Singapore,83.2556
+2000-12-31,TH,Thailand,98.6081
+2000-12-31,US,United States,99.5801
+2000-12-31,XM,Euro area,82.4798
+2000-12-31,ZA,South Africa,52.0142
 2001-03-31,AT,Austria,96.5591
-2001-03-31,AU,Australia,56.4653
-2001-03-31,BE,Belgium,67.7401
-2001-03-31,BG,Bulgaria,
-2001-03-31,BR,Brazil,52.2925
-2001-03-31,CA,Canada,59.4684
-2001-03-31,CH,Switzerland,76.9674
-2001-03-31,CL,Chile,
-2001-03-31,CN,China,
-2001-03-31,CO,Colombia,74.5069
-2001-03-31,CY,Cyprus,
-2001-03-31,CZ,Czechia,
-2001-03-31,DE,Germany,116.9065
-2001-03-31,DK,Denmark,76.614
-2001-03-31,EE,Estonia,
-2001-03-31,ES,Spain,62.0726
+2001-03-31,AU,Australia,56.4773
+2001-03-31,BE,Belgium,68.3166
+2001-03-31,BG,Bulgaria,55.4607
+2001-03-31,BR,Brazil,52.2932
+2001-03-31,CA,Canada,59.9294
+2001-03-31,CH,Switzerland,76.9647
+2001-03-31,CO,Colombia,75.0836
+2001-03-31,DE,Germany,116.9216
+2001-03-31,DK,Denmark,76.6348
+2001-03-31,ES,Spain,62.0727
 2001-03-31,FI,Finland,70.4522
-2001-03-31,FR,France,60.4545
-2001-03-31,GB,United Kingdom,68.3875
-2001-03-31,GR,Greece,
+2001-03-31,FR,France,60.4561
+2001-03-31,GB,United Kingdom,68.3648
+2001-03-31,GR,Greece,85.6593
 2001-03-31,HK,Hong Kong SAR,56.7564
-2001-03-31,HR,Croatia,
-2001-03-31,HU,Hungary,
-2001-03-31,ID,Indonesia,
-2001-03-31,IE,Ireland,102.0842
-2001-03-31,IL,Israel,89.0051
-2001-03-31,IN,India,
-2001-03-31,IS,Iceland,88.5746
-2001-03-31,IT,Italy,77.5702
+2001-03-31,HR,Croatia,70.6395
+2001-03-31,HU,Hungary,93.3512
+2001-03-31,IE,Ireland,102.0875
+2001-03-31,IL,Israel,89.0052
+2001-03-31,IS,Iceland,88.594
+2001-03-31,IT,Italy,77.5747
 2001-03-31,JP,Japan,136.1901
-2001-03-31,KR,Korea,79.6259
+2001-03-31,KR,Korea,79.6217
 2001-03-31,LT,Lithuania,46.9793
-2001-03-31,LU,Luxembourg,
-2001-03-31,LV,Latvia,
-2001-03-31,MA,Morocco,
-2001-03-31,MK,North Macedonia,83.0858
-2001-03-31,MT,Malta,
-2001-03-31,MX,Mexico,
+2001-03-31,MK,North Macedonia,83.2088
 2001-03-31,MY,Malaysia,87.3048
-2001-03-31,NL,Netherlands,91.6729
-2001-03-31,NO,Norway,64.9057
+2001-03-31,NL,Netherlands,91.966
+2001-03-31,NO,Norway,64.8992
 2001-03-31,NZ,New Zealand,60.7455
 2001-03-31,PE,Peru,72.3135
-2001-03-31,PH,Philippines,
-2001-03-31,PL,Poland,
-2001-03-31,PT,Portugal,
-2001-03-31,RO,Romania,
+2001-03-31,PT,Portugal,122.0037
 2001-03-31,RS,Serbia,93.3871
-2001-03-31,RU,Russia,34.9444
-2001-03-31,SE,Sweden,58.9126
-2001-03-31,SG,Singapore,79.5194
-2001-03-31,SI,Slovenia,
-2001-03-31,SK,Slovak Republic,
-2001-03-31,TH,Thailand,99.5343
-2001-03-31,TR,Türkiye,
-2001-03-31,US,United States,101.1162
-2001-03-31,XM,Euro area,83.4566
-2001-03-31,XW,World,
-2001-03-31,ZA,South Africa,51.8205
-2001-06-30,4T,Emerging market economies (aggregate),
-2001-06-30,5R,Advanced economies,
-2001-06-30,AE,United Arab Emirates,
+2001-03-31,RU,Russia,34.9443
+2001-03-31,SE,Sweden,58.9102
+2001-03-31,SG,Singapore,79.533
+2001-03-31,TH,Thailand,99.5398
+2001-03-31,US,United States,100.9956
+2001-03-31,XM,Euro area,83.3674
+2001-03-31,ZA,South Africa,51.7569
 2001-06-30,AT,Austria,91.484
-2001-06-30,AU,Australia,58.0113
-2001-06-30,BE,Belgium,67.2505
-2001-06-30,BG,Bulgaria,
-2001-06-30,BR,Brazil,51.6636
-2001-06-30,CA,Canada,60.9922
-2001-06-30,CH,Switzerland,76.1074
-2001-06-30,CL,Chile,
-2001-06-30,CN,China,
-2001-06-30,CO,Colombia,71.8332
-2001-06-30,CY,Cyprus,
-2001-06-30,CZ,Czechia,
-2001-06-30,DE,Germany,115.873
-2001-06-30,DK,Denmark,76.653
-2001-06-30,EE,Estonia,
-2001-06-30,ES,Spain,63.3982
+2001-06-30,AU,Australia,58.0085
+2001-06-30,BE,Belgium,67.8228
+2001-06-30,BG,Bulgaria,54.6804
+2001-06-30,BR,Brazil,51.6642
+2001-06-30,CA,Canada,61.4651
+2001-06-30,CH,Switzerland,76.1056
+2001-06-30,CO,Colombia,72.4621
+2001-06-30,DE,Germany,115.8976
+2001-06-30,DK,Denmark,76.6412
+2001-06-30,ES,Spain,63.3983
 2001-06-30,FI,Finland,70.1398
-2001-06-30,FR,France,61.5375
-2001-06-30,GB,United Kingdom,69.8145
-2001-06-30,GR,Greece,
+2001-06-30,FR,France,61.5398
+2001-06-30,GB,United Kingdom,69.7913
+2001-06-30,GR,Greece,86.7088
 2001-06-30,HK,Hong Kong SAR,56.8153
-2001-06-30,HR,Croatia,
-2001-06-30,HU,Hungary,
-2001-06-30,ID,Indonesia,
-2001-06-30,IE,Ireland,100.0021
-2001-06-30,IL,Israel,86.6799
-2001-06-30,IN,India,
-2001-06-30,IS,Iceland,87.9195
-2001-06-30,IT,Italy,77.8781
+2001-06-30,HR,Croatia,70.0497
+2001-06-30,HU,Hungary,94.9606
+2001-06-30,IE,Ireland,100.0874
+2001-06-30,IL,Israel,86.6806
+2001-06-30,IS,Iceland,87.9385
+2001-06-30,IT,Italy,77.8795
 2001-06-30,JP,Japan,134.6917
-2001-06-30,KR,Korea,80.1825
-2001-06-30,LT,Lithuania,43.6463
-2001-06-30,LU,Luxembourg,
-2001-06-30,LV,Latvia,
-2001-06-30,MA,Morocco,
-2001-06-30,MK,North Macedonia,79.6274
-2001-06-30,MT,Malta,
-2001-06-30,MX,Mexico,
+2001-06-30,KR,Korea,80.2316
+2001-06-30,LT,Lithuania,43.6462
+2001-06-30,MK,North Macedonia,79.7946
 2001-06-30,MY,Malaysia,87.9271
-2001-06-30,NL,Netherlands,92.6667
-2001-06-30,NO,Norway,66.9288
+2001-06-30,NL,Netherlands,92.8529
+2001-06-30,NO,Norway,66.9065
 2001-06-30,NZ,New Zealand,60.4549
 2001-06-30,PE,Peru,80.3404
-2001-06-30,PH,Philippines,
-2001-06-30,PL,Poland,
-2001-06-30,PT,Portugal,
-2001-06-30,RO,Romania,
+2001-06-30,PT,Portugal,121.7378
 2001-06-30,RS,Serbia,80.8734
 2001-06-30,RU,Russia,34.9994
-2001-06-30,SE,Sweden,58.6452
-2001-06-30,SG,Singapore,78.917
-2001-06-30,SI,Slovenia,
-2001-06-30,SK,Slovak Republic,
-2001-06-30,TH,Thailand,95.2153
-2001-06-30,TR,Türkiye,
-2001-06-30,US,United States,101.8252
-2001-06-30,XM,Euro area,83.4365
-2001-06-30,XW,World,
-2001-06-30,ZA,South Africa,52.1203
-2001-09-30,4T,Emerging market economies (aggregate),
-2001-09-30,5R,Advanced economies,
-2001-09-30,AE,United Arab Emirates,
+2001-06-30,SE,Sweden,58.6388
+2001-06-30,SG,Singapore,78.9313
+2001-06-30,TH,Thailand,95.2134
+2001-06-30,US,United States,101.7146
+2001-06-30,XM,Euro area,83.349
+2001-06-30,ZA,South Africa,52.0621
 2001-09-30,AT,Austria,95.009
-2001-09-30,AU,Australia,60.8694
-2001-09-30,BE,Belgium,68.201
-2001-09-30,BG,Bulgaria,
-2001-09-30,BR,Brazil,50.5636
-2001-09-30,CA,Canada,61.1011
-2001-09-30,CH,Switzerland,76.1863
-2001-09-30,CL,Chile,
-2001-09-30,CN,China,
-2001-09-30,CO,Colombia,71.09
-2001-09-30,CY,Cyprus,
-2001-09-30,CZ,Czechia,
-2001-09-30,DE,Germany,115.5665
-2001-09-30,DK,Denmark,77.5766
-2001-09-30,EE,Estonia,
-2001-09-30,ES,Spain,64.2989
+2001-09-30,AU,Australia,60.8651
+2001-09-30,BE,Belgium,68.7814
+2001-09-30,BG,Bulgaria,55.3547
+2001-09-30,BR,Brazil,50.5641
+2001-09-30,CA,Canada,61.5748
+2001-09-30,CH,Switzerland,76.1846
+2001-09-30,CO,Colombia,71.5165
+2001-09-30,DE,Germany,115.5953
+2001-09-30,DK,Denmark,77.5916
+2001-09-30,ES,Spain,64.299
 2001-09-30,FI,Finland,69.8763
-2001-09-30,FR,France,63.2236
-2001-09-30,GB,United Kingdom,72.27
-2001-09-30,GR,Greece,
+2001-09-30,FR,France,63.2224
+2001-09-30,GB,United Kingdom,72.246
+2001-09-30,GR,Greece,89.5565
 2001-09-30,HK,Hong Kong SAR,55.1769
-2001-09-30,HR,Croatia,
-2001-09-30,HU,Hungary,
-2001-09-30,ID,Indonesia,
-2001-09-30,IE,Ireland,97.9733
-2001-09-30,IL,Israel,86.3695
-2001-09-30,IN,India,
-2001-09-30,IS,Iceland,86.3135
-2001-09-30,IT,Italy,79.271
+2001-09-30,HR,Croatia,64.2367
+2001-09-30,HU,Hungary,99.0393
+2001-09-30,IE,Ireland,98.0257
+2001-09-30,IL,Israel,86.3694
+2001-09-30,IS,Iceland,86.3241
+2001-09-30,IT,Italy,79.281
 2001-09-30,JP,Japan,133.4033
-2001-09-30,KR,Korea,82.8538
+2001-09-30,KR,Korea,82.8914
 2001-09-30,LT,Lithuania,48.2829
-2001-09-30,LU,Luxembourg,
-2001-09-30,LV,Latvia,
-2001-09-30,MA,Morocco,
-2001-09-30,MK,North Macedonia,79.0596
-2001-09-30,MT,Malta,
-2001-09-30,MX,Mexico,
+2001-09-30,MK,North Macedonia,78.8843
 2001-09-30,MY,Malaysia,88.8306
-2001-09-30,NL,Netherlands,94.7237
-2001-09-30,NO,Norway,67.62
+2001-09-30,NL,Netherlands,94.6541
+2001-09-30,NO,Norway,67.6203
 2001-09-30,NZ,New Zealand,60.6367
 2001-09-30,PE,Peru,72.3589
-2001-09-30,PH,Philippines,
-2001-09-30,PL,Poland,
-2001-09-30,PT,Portugal,
-2001-09-30,RO,Romania,
+2001-09-30,PT,Portugal,121.5652
 2001-09-30,RS,Serbia,76.5236
 2001-09-30,RU,Russia,36.7184
-2001-09-30,SE,Sweden,59.645
-2001-09-30,SG,Singapore,76.5489
-2001-09-30,SI,Slovenia,
-2001-09-30,SK,Slovak Republic,
-2001-09-30,TH,Thailand,93.4588
-2001-09-30,TR,Türkiye,
-2001-09-30,US,United States,103.6304
-2001-09-30,XM,Euro area,84.6856
-2001-09-30,XW,World,
-2001-09-30,ZA,South Africa,53.6209
-2001-12-31,4T,Emerging market economies (aggregate),
-2001-12-31,5R,Advanced economies,
-2001-12-31,AE,United Arab Emirates,
+2001-09-30,SE,Sweden,59.6424
+2001-09-30,SG,Singapore,76.5625
+2001-09-30,TH,Thailand,93.457
+2001-09-30,US,United States,103.5143
+2001-09-30,XM,Euro area,84.6056
+2001-09-30,ZA,South Africa,53.5547
 2001-12-31,AT,Austria,90.8217
-2001-12-31,AU,Australia,62.5687
-2001-12-31,BE,Belgium,68.1111
-2001-12-31,BG,Bulgaria,
-2001-12-31,BR,Brazil,49.6988
-2001-12-31,CA,Canada,62.4728
-2001-12-31,CH,Switzerland,77.3688
-2001-12-31,CL,Chile,
-2001-12-31,CN,China,
-2001-12-31,CO,Colombia,73.7858
-2001-12-31,CY,Cyprus,
-2001-12-31,CZ,Czechia,
-2001-12-31,DE,Germany,115.2273
-2001-12-31,DK,Denmark,76.7127
-2001-12-31,EE,Estonia,
-2001-12-31,ES,Spain,64.9258
+2001-12-31,AU,Australia,62.5715
+2001-12-31,BE,Belgium,68.6908
+2001-12-31,BG,Bulgaria,52.916
+2001-12-31,BR,Brazil,49.6993
+2001-12-31,CA,Canada,62.9571
+2001-12-31,CH,Switzerland,77.3675
+2001-12-31,CO,Colombia,74.1669
+2001-12-31,DE,Germany,115.1595
+2001-12-31,DK,Denmark,76.707
+2001-12-31,ES,Spain,64.9259
 2001-12-31,FI,Finland,70.1451
-2001-12-31,FR,France,63.428
-2001-12-31,GB,United Kingdom,70.7751
-2001-12-31,GR,Greece,
+2001-12-31,FR,France,63.4302
+2001-12-31,GB,United Kingdom,70.7516
+2001-12-31,GR,Greece,90.2583
 2001-12-31,HK,Hong Kong SAR,52.3583
-2001-12-31,HR,Croatia,
-2001-12-31,HU,Hungary,
-2001-12-31,ID,Indonesia,
-2001-12-31,IE,Ireland,98.4211
-2001-12-31,IL,Israel,86.1303
-2001-12-31,IN,India,
-2001-12-31,IS,Iceland,85.8711
-2001-12-31,IT,Italy,81.1367
+2001-12-31,HR,Croatia,65.891
+2001-12-31,HU,Hungary,101.2241
+2001-12-31,IE,Ireland,98.4494
+2001-12-31,IL,Israel,86.1305
+2001-12-31,IS,Iceland,85.9045
+2001-12-31,IT,Italy,81.1372
 2001-12-31,JP,Japan,132.0653
-2001-12-31,KR,Korea,85.4014
-2001-12-31,LT,Lithuania,55.1937
-2001-12-31,LU,Luxembourg,
-2001-12-31,LV,Latvia,
-2001-12-31,MA,Morocco,
-2001-12-31,MK,North Macedonia,79.0865
-2001-12-31,MT,Malta,
-2001-12-31,MX,Mexico,
+2001-12-31,KR,Korea,85.3712
+2001-12-31,LT,Lithuania,55.1938
+2001-12-31,MK,North Macedonia,79.1356
 2001-12-31,MY,Malaysia,88.4325
-2001-12-31,NL,Netherlands,94.9415
-2001-12-31,NO,Norway,67.2043
+2001-12-31,NL,Netherlands,94.9562
+2001-12-31,NO,Norway,67.2258
 2001-12-31,NZ,New Zealand,61.3206
 2001-12-31,PE,Peru,75.3653
-2001-12-31,PH,Philippines,
-2001-12-31,PL,Poland,
-2001-12-31,PT,Portugal,
-2001-12-31,RO,Romania,
+2001-12-31,PT,Portugal,120.5884
 2001-12-31,RS,Serbia,73.263
 2001-12-31,RU,Russia,39.0206
-2001-12-31,SE,Sweden,58.5683
-2001-12-31,SG,Singapore,73.6496
-2001-12-31,SI,Slovenia,
-2001-12-31,SK,Slovak Republic,
-2001-12-31,TH,Thailand,96.4548
-2001-12-31,TR,Türkiye,
-2001-12-31,US,United States,105.6375
-2001-12-31,XM,Euro area,84.8282
-2001-12-31,XW,World,
-2001-12-31,ZA,South Africa,55.2857
-2002-03-31,4T,Emerging market economies (aggregate),
-2002-03-31,5R,Advanced economies,
-2002-03-31,AE,United Arab Emirates,
+2001-12-31,SE,Sweden,58.5646
+2001-12-31,SG,Singapore,73.6625
+2001-12-31,TH,Thailand,96.4576
+2001-12-31,US,United States,105.5272
+2001-12-31,XM,Euro area,84.7497
+2001-12-31,ZA,South Africa,55.2159
 2002-03-31,AT,Austria,93.2916
-2002-03-31,AU,Australia,64.3451
-2002-03-31,BE,Belgium,69.1596
-2002-03-31,BG,Bulgaria,
-2002-03-31,BR,Brazil,49.0629
-2002-03-31,CA,Canada,64.7721
-2002-03-31,CH,Switzerland,77.4181
+2002-03-31,AU,Australia,64.3675
+2002-03-31,BE,Belgium,69.7482
+2002-03-31,BG,Bulgaria,50.8219
+2002-03-31,BR,Brazil,49.0636
+2002-03-31,CA,Canada,65.2743
+2002-03-31,CH,Switzerland,77.4172
 2002-03-31,CL,Chile,73.3761
-2002-03-31,CN,China,
-2002-03-31,CO,Colombia,68.9546
+2002-03-31,CO,Colombia,69.3606
 2002-03-31,CY,Cyprus,55.2744
-2002-03-31,CZ,Czechia,
-2002-03-31,DE,Germany,114.0475
-2002-03-31,DK,Denmark,77.1302
-2002-03-31,EE,Estonia,
-2002-03-31,ES,Spain,68.5006
+2002-03-31,DE,Germany,114.0264
+2002-03-31,DK,Denmark,77.1549
+2002-03-31,ES,Spain,68.5005
 2002-03-31,FI,Finland,72.4307
-2002-03-31,FR,France,63.5734
-2002-03-31,GB,United Kingdom,73.1478
-2002-03-31,GR,Greece,
-2002-03-31,HK,Hong Kong SAR,53.1028
-2002-03-31,HR,Croatia,68.9543
-2002-03-31,HU,Hungary,
+2002-03-31,FR,France,63.5753
+2002-03-31,GB,United Kingdom,73.1235
+2002-03-31,GR,Greece,93.9116
+2002-03-31,HK,Hong Kong SAR,53.0788
+2002-03-31,HR,Croatia,68.951
+2002-03-31,HU,Hungary,101.0969
 2002-03-31,ID,Indonesia,139.3968
-2002-03-31,IE,Ireland,101.0957
-2002-03-31,IL,Israel,89.3967
-2002-03-31,IN,India,
-2002-03-31,IS,Iceland,85.674
-2002-03-31,IT,Italy,85.0609
+2002-03-31,IE,Ireland,101.1838
+2002-03-31,IL,Israel,89.3963
+2002-03-31,IS,Iceland,85.677
+2002-03-31,IT,Italy,85.0619
 2002-03-31,JP,Japan,131.2198
-2002-03-31,KR,Korea,89.4302
+2002-03-31,KR,Korea,89.44
 2002-03-31,LT,Lithuania,51.5794
-2002-03-31,LU,Luxembourg,
-2002-03-31,LV,Latvia,
-2002-03-31,MA,Morocco,
-2002-03-31,MK,North Macedonia,81.7153
-2002-03-31,MT,Malta,
-2002-03-31,MX,Mexico,
+2002-03-31,MK,North Macedonia,81.4968
 2002-03-31,MY,Malaysia,87.5764
-2002-03-31,NL,Netherlands,95.5118
-2002-03-31,NO,Norway,69.0172
+2002-03-31,NL,Netherlands,95.3911
+2002-03-31,NO,Norway,69.0274
 2002-03-31,NZ,New Zealand,63.3968
 2002-03-31,PE,Peru,72.2726
-2002-03-31,PH,Philippines,
-2002-03-31,PL,Poland,
-2002-03-31,PT,Portugal,
-2002-03-31,RO,Romania,
+2002-03-31,PT,Portugal,120.052
 2002-03-31,RS,Serbia,72.1121
 2002-03-31,RU,Russia,39.7923
-2002-03-31,SE,Sweden,59.4368
-2002-03-31,SG,Singapore,72.9081
-2002-03-31,SI,Slovenia,
-2002-03-31,SK,Slovak Republic,
-2002-03-31,TH,Thailand,96.2423
-2002-03-31,TR,Türkiye,
-2002-03-31,US,United States,107.1828
-2002-03-31,XM,Euro area,86.0878
-2002-03-31,XW,World,
-2002-03-31,ZA,South Africa,55.2392
-2002-06-30,4T,Emerging market economies (aggregate),
-2002-06-30,5R,Advanced economies,
-2002-06-30,AE,United Arab Emirates,
+2002-03-31,SE,Sweden,59.435
+2002-03-31,SG,Singapore,72.9214
+2002-03-31,TH,Thailand,96.2443
+2002-03-31,US,United States,107.0575
+2002-03-31,XM,Euro area,86.0161
+2002-03-31,ZA,South Africa,55.1726
 2002-06-30,AT,Austria,91.0112
-2002-06-30,AU,Australia,67.729
-2002-06-30,BE,Belgium,70.2477
-2002-06-30,BG,Bulgaria,
-2002-06-30,BR,Brazil,48.6073
-2002-06-30,CA,Canada,66.3286
-2002-06-30,CH,Switzerland,75.8513
+2002-06-30,AU,Australia,67.7106
+2002-06-30,BE,Belgium,70.8455
+2002-06-30,BG,Bulgaria,52.0305
+2002-06-30,BR,Brazil,48.6079
+2002-06-30,CA,Canada,66.8429
+2002-06-30,CH,Switzerland,75.8507
 2002-06-30,CL,Chile,76.1783
-2002-06-30,CN,China,
-2002-06-30,CO,Colombia,69.5816
+2002-06-30,CO,Colombia,70.0169
 2002-06-30,CY,Cyprus,54.1254
-2002-06-30,CZ,Czechia,
-2002-06-30,DE,Germany,113.661
-2002-06-30,DK,Denmark,77.8229
-2002-06-30,EE,Estonia,
+2002-06-30,DE,Germany,113.6859
+2002-06-30,DK,Denmark,77.8182
 2002-06-30,ES,Spain,71.1724
 2002-06-30,FI,Finland,74.1808
 2002-06-30,FR,France,65.2558
-2002-06-30,GB,United Kingdom,78.438
-2002-06-30,GR,Greece,
-2002-06-30,HK,Hong Kong SAR,52.1315
-2002-06-30,HR,Croatia,67.8863
-2002-06-30,HU,Hungary,
+2002-06-30,GB,United Kingdom,78.4119
+2002-06-30,GR,Greece,96.7616
+2002-06-30,HK,Hong Kong SAR,52.1556
+2002-06-30,HR,Croatia,67.9122
+2002-06-30,HU,Hungary,104.9496
 2002-06-30,ID,Indonesia,140.2587
-2002-06-30,IE,Ireland,100.2774
-2002-06-30,IL,Israel,88.3564
-2002-06-30,IN,India,
-2002-06-30,IS,Iceland,85.6779
-2002-06-30,IT,Italy,86.2191
+2002-06-30,IE,Ireland,100.3197
+2002-06-30,IL,Israel,88.3567
+2002-06-30,IS,Iceland,85.7108
+2002-06-30,IT,Italy,86.2203
 2002-06-30,JP,Japan,128.8322
-2002-06-30,KR,Korea,91.7168
-2002-06-30,LT,Lithuania,52.4871
-2002-06-30,LU,Luxembourg,
-2002-06-30,LV,Latvia,
-2002-06-30,MA,Morocco,
-2002-06-30,MK,North Macedonia,85.2863
-2002-06-30,MT,Malta,
-2002-06-30,MX,Mexico,
+2002-06-30,KR,Korea,91.7566
+2002-06-30,LT,Lithuania,52.487
+2002-06-30,MK,North Macedonia,85.4266
 2002-06-30,MY,Malaysia,88.5303
-2002-06-30,NL,Netherlands,95.7416
-2002-06-30,NO,Norway,71.0579
+2002-06-30,NL,Netherlands,95.7928
+2002-06-30,NO,Norway,71.0336
 2002-06-30,NZ,New Zealand,64.2664
 2002-06-30,PE,Peru,73.1475
-2002-06-30,PH,Philippines,
-2002-06-30,PL,Poland,
-2002-06-30,PT,Portugal,
-2002-06-30,RO,Romania,
+2002-06-30,PT,Portugal,118.459
 2002-06-30,RS,Serbia,69.9859
 2002-06-30,RU,Russia,41.129
-2002-06-30,SE,Sweden,60.5544
-2002-06-30,SG,Singapore,72.142
-2002-06-30,SI,Slovenia,
-2002-06-30,SK,Slovak Republic,
-2002-06-30,TH,Thailand,96.4292
-2002-06-30,TR,Türkiye,
-2002-06-30,US,United States,108.7904
-2002-06-30,XM,Euro area,86.9034
-2002-06-30,XW,World,
-2002-06-30,ZA,South Africa,54.9895
-2002-09-30,4T,Emerging market economies (aggregate),
-2002-09-30,5R,Advanced economies,
-2002-09-30,AE,United Arab Emirates,
+2002-06-30,SE,Sweden,60.5527
+2002-06-30,SG,Singapore,72.1551
+2002-06-30,TH,Thailand,96.4321
+2002-06-30,US,United States,108.6661
+2002-06-30,XM,Euro area,86.8335
+2002-06-30,ZA,South Africa,54.9222
 2002-09-30,AT,Austria,93.9752
-2002-09-30,AU,Australia,70.0945
-2002-09-30,BE,Belgium,71.8639
-2002-09-30,BG,Bulgaria,
-2002-09-30,BR,Brazil,48.0808
-2002-09-30,CA,Canada,65.0736
+2002-09-30,AU,Australia,70.0589
+2002-09-30,BE,Belgium,72.4755
+2002-09-30,BG,Bulgaria,53.996
+2002-09-30,BR,Brazil,48.0813
+2002-09-30,CA,Canada,65.5781
 2002-09-30,CH,Switzerland,76.6159
-2002-09-30,CL,Chile,76.9416
-2002-09-30,CN,China,
-2002-09-30,CO,Colombia,68.0817
+2002-09-30,CL,Chile,76.9415
+2002-09-30,CO,Colombia,68.5383
 2002-09-30,CY,Cyprus,57.1872
-2002-09-30,CZ,Czechia,
-2002-09-30,DE,Germany,113.2678
-2002-09-30,DK,Denmark,78.3231
-2002-09-30,EE,Estonia,
-2002-09-30,ES,Spain,73.02
+2002-09-30,DE,Germany,113.2907
+2002-09-30,DK,Denmark,78.2908
+2002-09-30,ES,Spain,73.0203
 2002-09-30,FI,Finland,75.1253
-2002-09-30,FR,France,67.7271
-2002-09-30,GB,United Kingdom,83.6552
-2002-09-30,GR,Greece,
+2002-09-30,FR,France,67.7319
+2002-09-30,GB,United Kingdom,83.6274
+2002-09-30,GR,Greece,98.0545
 2002-09-30,HK,Hong Kong SAR,49.8731
-2002-09-30,HR,Croatia,72.0811
-2002-09-30,HU,Hungary,
+2002-09-30,HR,Croatia,72.0997
+2002-09-30,HU,Hungary,109.5736
 2002-09-30,ID,Indonesia,139.9494
-2002-09-30,IE,Ireland,104.6276
-2002-09-30,IL,Israel,85.2867
-2002-09-30,IN,India,
-2002-09-30,IS,Iceland,88.0657
-2002-09-30,IT,Italy,86.8406
+2002-09-30,IE,Ireland,104.5917
+2002-09-30,IL,Israel,85.2873
+2002-09-30,IS,Iceland,88.0763
+2002-09-30,IT,Italy,86.847
 2002-09-30,JP,Japan,127.2382
-2002-09-30,KR,Korea,94.5942
+2002-09-30,KR,Korea,94.5626
 2002-09-30,LT,Lithuania,55.3289
-2002-09-30,LU,Luxembourg,
-2002-09-30,LV,Latvia,
-2002-09-30,MA,Morocco,
-2002-09-30,MK,North Macedonia,91.6727
-2002-09-30,MT,Malta,
-2002-09-30,MX,Mexico,
+2002-09-30,MK,North Macedonia,92.2038
 2002-09-30,MY,Malaysia,89.734
-2002-09-30,NL,Netherlands,97.1343
-2002-09-30,NO,Norway,68.8191
+2002-09-30,NL,Netherlands,97.2005
+2002-09-30,NO,Norway,68.7774
 2002-09-30,NZ,New Zealand,65.9802
 2002-09-30,PE,Peru,84.955
-2002-09-30,PH,Philippines,
-2002-09-30,PL,Poland,
-2002-09-30,PT,Portugal,
-2002-09-30,RO,Romania,
+2002-09-30,PT,Portugal,117.3813
 2002-09-30,RS,Serbia,65.5127
 2002-09-30,RU,Russia,42.5727
-2002-09-30,SE,Sweden,62.8372
-2002-09-30,SG,Singapore,72.4901
-2002-09-30,SI,Slovenia,
-2002-09-30,SK,Slovak Republic,
-2002-09-30,TH,Thailand,96.2833
-2002-09-30,TR,Türkiye,
-2002-09-30,US,United States,111.0944
-2002-09-30,XM,Euro area,88.4744
-2002-09-30,XW,World,
-2002-09-30,ZA,South Africa,55.1555
-2002-12-31,4T,Emerging market economies (aggregate),
-2002-12-31,5R,Advanced economies,
-2002-12-31,AE,United Arab Emirates,
-2002-12-31,AT,Austria,91.0939
-2002-12-31,AU,Australia,72.1855
-2002-12-31,BE,Belgium,72.7152
-2002-12-31,BG,Bulgaria,
-2002-12-31,BR,Brazil,46.6892
-2002-12-31,CA,Canada,66.8076
-2002-12-31,CH,Switzerland,76.2194
+2002-09-30,SE,Sweden,62.8342
+2002-09-30,SG,Singapore,72.5028
+2002-09-30,TH,Thailand,96.2862
+2002-09-30,US,United States,110.9658
+2002-09-30,XM,Euro area,88.4029
+2002-09-30,ZA,South Africa,55.088
+2002-12-31,AT,Austria,91.094
+2002-12-31,AU,Australia,72.1318
+2002-12-31,BE,Belgium,73.334
+2002-12-31,BG,Bulgaria,53.3404
+2002-12-31,BR,Brazil,46.6898
+2002-12-31,CA,Canada,67.3256
+2002-12-31,CH,Switzerland,76.2202
 2002-12-31,CL,Chile,76.4799
-2002-12-31,CN,China,
-2002-12-31,CO,Colombia,67.4287
+2002-12-31,CO,Colombia,67.562
 2002-12-31,CY,Cyprus,56.5158
-2002-12-31,CZ,Czechia,
-2002-12-31,DE,Germany,112.9082
-2002-12-31,DK,Denmark,77.8367
-2002-12-31,EE,Estonia,
-2002-12-31,ES,Spain,73.284
+2002-12-31,DE,Germany,112.8811
+2002-12-31,DK,Denmark,77.8355
+2002-12-31,ES,Spain,73.2842
 2002-12-31,FI,Finland,75.0722
-2002-12-31,FR,France,68.1344
-2002-12-31,GB,United Kingdom,87.3155
-2002-12-31,GR,Greece,
+2002-12-31,FR,France,68.1369
+2002-12-31,GB,United Kingdom,87.2864
+2002-12-31,GR,Greece,98.2402
 2002-12-31,HK,Hong Kong SAR,47.5878
-2002-12-31,HR,Croatia,72.0499
-2002-12-31,HU,Hungary,
+2002-12-31,HR,Croatia,72.0766
+2002-12-31,HU,Hungary,109.5191
 2002-12-31,ID,Indonesia,137.5584
-2002-12-31,IE,Ireland,107.2465
-2002-12-31,IL,Israel,83.8813
-2002-12-31,IN,India,
-2002-12-31,IS,Iceland,89.3992
-2002-12-31,IT,Italy,86.9043
+2002-12-31,IE,Ireland,107.275
+2002-12-31,IL,Israel,83.8816
+2002-12-31,IS,Iceland,89.4245
+2002-12-31,IT,Italy,86.9047
 2002-12-31,JP,Japan,125.3229
-2002-12-31,KR,Korea,96.6839
+2002-12-31,KR,Korea,96.6922
 2002-12-31,LT,Lithuania,57.3898
-2002-12-31,LU,Luxembourg,
-2002-12-31,LV,Latvia,
-2002-12-31,MA,Morocco,
-2002-12-31,MK,North Macedonia,88.2006
-2002-12-31,MT,Malta,
-2002-12-31,MX,Mexico,
+2002-12-31,MK,North Macedonia,88.1911
 2002-12-31,MY,Malaysia,91.0691
-2002-12-31,NL,Netherlands,96.7665
-2002-12-31,NO,Norway,67.5567
+2002-12-31,NL,Netherlands,96.7853
+2002-12-31,NO,Norway,67.568
 2002-12-31,NZ,New Zealand,68.0284
 2002-12-31,PE,Peru,73.0858
-2002-12-31,PH,Philippines,
-2002-12-31,PL,Poland,
-2002-12-31,PT,Portugal,
-2002-12-31,RO,Romania,
+2002-12-31,PT,Portugal,116.104
 2002-12-31,RS,Serbia,69.8321
 2002-12-31,RU,Russia,43.2173
-2002-12-31,SE,Sweden,62.5837
-2002-12-31,SG,Singapore,72.2184
-2002-12-31,SI,Slovenia,
-2002-12-31,SK,Slovak Republic,
-2002-12-31,TH,Thailand,95.7083
-2002-12-31,TR,Türkiye,
-2002-12-31,US,United States,113.0059
-2002-12-31,XM,Euro area,88.4938
-2002-12-31,XW,World,
-2002-12-31,ZA,South Africa,55.752
-2003-03-31,4T,Emerging market economies (aggregate),
-2003-03-31,5R,Advanced economies,
-2003-03-31,AE,United Arab Emirates,92.2386
+2002-12-31,SE,Sweden,62.5782
+2002-12-31,SG,Singapore,72.2312
+2002-12-31,TH,Thailand,95.7114
+2002-12-31,US,United States,112.8631
+2002-12-31,XM,Euro area,88.4185
+2002-12-31,ZA,South Africa,55.6842
 2003-03-31,AT,Austria,92.167
-2003-03-31,AU,Australia,73.1789
-2003-03-31,BE,Belgium,73.1047
-2003-03-31,BG,Bulgaria,
-2003-03-31,BR,Brazil,45.0941
-2003-03-31,CA,Canada,67.3365
-2003-03-31,CH,Switzerland,75.8599
-2003-03-31,CL,Chile,76.0586
-2003-03-31,CN,China,
-2003-03-31,CO,Colombia,64.5208
+2003-03-31,AU,Australia,73.1176
+2003-03-31,BE,Belgium,73.7269
+2003-03-31,BG,Bulgaria,53.0994
+2003-03-31,BR,Brazil,45.0948
+2003-03-31,CA,Canada,67.8586
+2003-03-31,CH,Switzerland,75.8608
+2003-03-31,CL,Chile,76.0585
+2003-03-31,CO,Colombia,64.4684
 2003-03-31,CY,Cyprus,55.1552
-2003-03-31,CZ,Czechia,
-2003-03-31,DE,Germany,111.5994
-2003-03-31,DK,Denmark,76.8472
-2003-03-31,EE,Estonia,
-2003-03-31,ES,Spain,77.1916
+2003-03-31,DE,Germany,111.6164
+2003-03-31,DK,Denmark,76.8442
+2003-03-31,ES,Spain,77.1917
 2003-03-31,FI,Finland,75.998
-2003-03-31,FR,France,68.8788
-2003-03-31,GB,United Kingdom,88.9004
-2003-03-31,GR,Greece,
+2003-03-31,FR,France,68.8809
+2003-03-31,GB,United Kingdom,88.8708
+2003-03-31,GR,Greece,99.4764
 2003-03-31,HK,Hong Kong SAR,46.0408
-2003-03-31,HR,Croatia,77.5778
-2003-03-31,HU,Hungary,
+2003-03-31,HR,Croatia,77.6238
+2003-03-31,HU,Hungary,116.1906
 2003-03-31,ID,Indonesia,137.5344
-2003-03-31,IE,Ireland,108.5179
-2003-03-31,IL,Israel,82.9989
-2003-03-31,IN,India,
-2003-03-31,IS,Iceland,92.1204
-2003-03-31,IT,Italy,88.1578
+2003-03-31,IE,Ireland,108.5709
+2003-03-31,IL,Israel,82.9986
+2003-03-31,IS,Iceland,92.1014
+2003-03-31,IT,Italy,88.159
 2003-03-31,JP,Japan,123.7921
-2003-03-31,KR,Korea,95.5823
+2003-03-31,KR,Korea,95.6243
 2003-03-31,LT,Lithuania,64.9469
-2003-03-31,LU,Luxembourg,
-2003-03-31,LV,Latvia,
-2003-03-31,MA,Morocco,
-2003-03-31,MK,North Macedonia,91.2851
-2003-03-31,MT,Malta,
-2003-03-31,MX,Mexico,
+2003-03-31,MK,North Macedonia,91.3456
 2003-03-31,MY,Malaysia,90.5492
-2003-03-31,NL,Netherlands,96.9496
-2003-03-31,NO,Norway,67.1567
+2003-03-31,NL,Netherlands,97.0962
+2003-03-31,NO,Norway,67.1435
 2003-03-31,NZ,New Zealand,71.5063
 2003-03-31,PE,Peru,61.6596
-2003-03-31,PH,Philippines,
-2003-03-31,PL,Poland,
-2003-03-31,PT,Portugal,
-2003-03-31,RO,Romania,
+2003-03-31,PT,Portugal,116.1087
 2003-03-31,RS,Serbia,82.2187
 2003-03-31,RU,Russia,44.0181
-2003-03-31,SE,Sweden,62.3071
-2003-03-31,SG,Singapore,71.3684
-2003-03-31,SI,Slovenia,
-2003-03-31,SK,Slovak Republic,
-2003-03-31,TH,Thailand,96.3744
-2003-03-31,TR,Türkiye,
-2003-03-31,US,United States,114.1283
-2003-03-31,XM,Euro area,89.2762
-2003-03-31,XW,World,
-2003-03-31,ZA,South Africa,57.3049
-2003-06-30,4T,Emerging market economies (aggregate),
-2003-06-30,5R,Advanced economies,
-2003-06-30,AE,United Arab Emirates,89.2369
+2003-03-31,SE,Sweden,62.3073
+2003-03-31,SG,Singapore,71.3811
+2003-03-31,TH,Thailand,96.3721
+2003-03-31,US,United States,114.0009
+2003-03-31,XM,Euro area,89.2074
+2003-03-31,ZA,South Africa,57.2383
 2003-06-30,AT,Austria,91.1409
-2003-06-30,AU,Australia,77.127
-2003-06-30,BE,Belgium,73.7599
-2003-06-30,BG,Bulgaria,
-2003-06-30,BR,Brazil,45.3965
-2003-06-30,CA,Canada,69.6671
-2003-06-30,CH,Switzerland,77.3856
-2003-06-30,CL,Chile,76.9068
-2003-06-30,CN,China,
-2003-06-30,CO,Colombia,65.3
+2003-06-30,AU,Australia,77.0624
+2003-06-30,BE,Belgium,74.3877
+2003-06-30,BG,Bulgaria,55.705
+2003-06-30,BR,Brazil,45.3973
+2003-06-30,CA,Canada,70.2072
+2003-06-30,CH,Switzerland,77.3866
+2003-06-30,CL,Chile,76.9067
+2003-06-30,CO,Colombia,65.4363
 2003-06-30,CY,Cyprus,54.9203
-2003-06-30,CZ,Czechia,
-2003-06-30,DE,Germany,111.2947
-2003-06-30,DK,Denmark,78.0134
-2003-06-30,EE,Estonia,
-2003-06-30,ES,Spain,81.1514
+2003-06-30,DE,Germany,111.3089
+2003-06-30,DK,Denmark,78.0177
+2003-06-30,ES,Spain,81.151
 2003-06-30,FI,Finland,77.4488
-2003-06-30,FR,France,71.233
-2003-06-30,GB,United Kingdom,91.0713
-2003-06-30,GR,Greece,
+2003-06-30,FR,France,71.2389
+2003-06-30,GB,United Kingdom,91.0411
+2003-06-30,GR,Greece,97.071
 2003-06-30,HK,Hong Kong SAR,44.2881
-2003-06-30,HR,Croatia,79.7016
-2003-06-30,HU,Hungary,
+2003-06-30,HR,Croatia,79.713
+2003-06-30,HU,Hungary,120.9302
 2003-06-30,ID,Indonesia,139.124
-2003-06-30,IE,Ireland,109.2186
-2003-06-30,IL,Israel,79.883
-2003-06-30,IN,India,
-2003-06-30,IS,Iceland,93.8316
-2003-06-30,IT,Italy,88.7015
+2003-06-30,IE,Ireland,109.2534
+2003-06-30,IL,Israel,79.8832
+2003-06-30,IS,Iceland,93.8129
+2003-06-30,IT,Italy,88.7031
 2003-06-30,JP,Japan,121.1955
-2003-06-30,KR,Korea,97.8758
+2003-06-30,KR,Korea,97.85
 2003-06-30,LT,Lithuania,58.7429
-2003-06-30,LU,Luxembourg,
-2003-06-30,LV,Latvia,
-2003-06-30,MA,Morocco,
-2003-06-30,MK,North Macedonia,89.8891
-2003-06-30,MT,Malta,
-2003-06-30,MX,Mexico,
+2003-06-30,MK,North Macedonia,89.7995
 2003-06-30,MY,Malaysia,90.2849
-2003-06-30,NL,Netherlands,97.2373
-2003-06-30,NO,Norway,68.7476
+2003-06-30,NL,Netherlands,97.4103
+2003-06-30,NO,Norway,68.7825
 2003-06-30,NZ,New Zealand,73.9845
 2003-06-30,PE,Peru,66.4881
-2003-06-30,PH,Philippines,
-2003-06-30,PL,Poland,
-2003-06-30,PT,Portugal,
-2003-06-30,RO,Romania,
+2003-06-30,PT,Portugal,115.4209
 2003-06-30,RS,Serbia,87.2521
 2003-06-30,RU,Russia,43.9647
-2003-06-30,SE,Sweden,63.6364
-2003-06-30,SG,Singapore,71.07
-2003-06-30,SI,Slovenia,
-2003-06-30,SK,Slovak Republic,
-2003-06-30,TH,Thailand,96.0208
-2003-06-30,TR,Türkiye,
-2003-06-30,US,United States,116.1673
-2003-06-30,XM,Euro area,90.2927
-2003-06-30,XW,World,
-2003-06-30,ZA,South Africa,59.7071
-2003-09-30,4T,Emerging market economies (aggregate),
-2003-09-30,5R,Advanced economies,
-2003-09-30,AE,United Arab Emirates,86.7327
+2003-06-30,SE,Sweden,63.6361
+2003-06-30,SG,Singapore,71.0823
+2003-06-30,TH,Thailand,96.0188
+2003-06-30,US,United States,116.0256
+2003-06-30,XM,Euro area,90.2315
+2003-06-30,ZA,South Africa,59.6389
 2003-09-30,AT,Austria,89.9534
-2003-09-30,AU,Australia,81.1495
-2003-09-30,BE,Belgium,75.3373
-2003-09-30,BG,Bulgaria,
-2003-09-30,BR,Brazil,46.7491
-2003-09-30,CA,Canada,70.8677
-2003-09-30,CH,Switzerland,78.503
+2003-09-30,AU,Australia,81.1368
+2003-09-30,BE,Belgium,75.9785
+2003-09-30,BG,Bulgaria,59.7603
+2003-09-30,BR,Brazil,46.7499
+2003-09-30,CA,Canada,71.4171
+2003-09-30,CH,Switzerland,78.505
 2003-09-30,CL,Chile,77.5641
-2003-09-30,CN,China,
-2003-09-30,CO,Colombia,64.3089
+2003-09-30,CO,Colombia,64.7465
 2003-09-30,CY,Cyprus,56.7429
-2003-09-30,CZ,Czechia,
-2003-09-30,DE,Germany,110.4568
-2003-09-30,DK,Denmark,79.7549
-2003-09-30,EE,Estonia,
-2003-09-30,ES,Spain,83.4947
+2003-09-30,DE,Germany,110.4557
+2003-09-30,DK,Denmark,79.744
+2003-09-30,ES,Spain,83.4946
 2003-09-30,FI,Finland,79.3576
-2003-09-30,FR,France,74.0753
-2003-09-30,GB,United Kingdom,93.4122
-2003-09-30,GR,Greece,
+2003-09-30,FR,France,74.0757
+2003-09-30,GB,United Kingdom,93.3812
+2003-09-30,GR,Greece,99.1389
 2003-09-30,HK,Hong Kong SAR,44.7492
-2003-09-30,HR,Croatia,80.4101
-2003-09-30,HU,Hungary,
+2003-09-30,HR,Croatia,80.4448
+2003-09-30,HU,Hungary,123.0054
 2003-09-30,ID,Indonesia,140.0263
-2003-09-30,IE,Ireland,114.7442
-2003-09-30,IL,Israel,81.303
-2003-09-30,IN,India,
-2003-09-30,IS,Iceland,98.4835
-2003-09-30,IT,Italy,89.8766
+2003-09-30,IE,Ireland,114.7832
+2003-09-30,IL,Israel,81.3031
+2003-09-30,IS,Iceland,98.4575
+2003-09-30,IT,Italy,89.8852
 2003-09-30,JP,Japan,119.3445
-2003-09-30,KR,Korea,99.3102
+2003-09-30,KR,Korea,99.2905
 2003-09-30,LT,Lithuania,61.0576
-2003-09-30,LU,Luxembourg,
-2003-09-30,LV,Latvia,
-2003-09-30,MA,Morocco,
-2003-09-30,MK,North Macedonia,87.9273
-2003-09-30,MT,Malta,
-2003-09-30,MX,Mexico,
+2003-09-30,MK,North Macedonia,87.6757
 2003-09-30,MY,Malaysia,93.1243
-2003-09-30,NL,Netherlands,97.8464
-2003-09-30,NO,Norway,68.8834
+2003-09-30,NL,Netherlands,97.9999
+2003-09-30,NO,Norway,68.8293
 2003-09-30,NZ,New Zealand,78.5999
 2003-09-30,PE,Peru,62.9137
-2003-09-30,PH,Philippines,
-2003-09-30,PL,Poland,
-2003-09-30,PT,Portugal,
-2003-09-30,RO,Romania,
+2003-09-30,PT,Portugal,115.7929
 2003-09-30,RS,Serbia,86.2972
 2003-09-30,RU,Russia,45.2821
-2003-09-30,SE,Sweden,65.2594
-2003-09-30,SG,Singapore,70.491
-2003-09-30,SI,Slovenia,
-2003-09-30,SK,Slovak Republic,
-2003-09-30,TH,Thailand,97.3442
-2003-09-30,TR,Türkiye,
-2003-09-30,US,United States,118.9522
-2003-09-30,XM,Euro area,91.7353
-2003-09-30,XW,World,
-2003-09-30,ZA,South Africa,63.3735
-2003-12-31,4T,Emerging market economies (aggregate),
-2003-12-31,5R,Advanced economies,
-2003-12-31,AE,United Arab Emirates,88.6604
+2003-09-30,SE,Sweden,65.2609
+2003-09-30,SG,Singapore,70.5029
+2003-09-30,TH,Thailand,97.3427
+2003-09-30,US,United States,118.817
+2003-09-30,XM,Euro area,91.6658
+2003-09-30,ZA,South Africa,63.2956
 2003-12-31,AT,Austria,92.1174
-2003-12-31,AU,Australia,83.784
-2003-12-31,BE,Belgium,76.6024
-2003-12-31,BG,Bulgaria,
-2003-12-31,BR,Brazil,47.8513
-2003-12-31,CA,Canada,72.8292
-2003-12-31,CH,Switzerland,78.2728
-2003-12-31,CL,Chile,79.1848
-2003-12-31,CN,China,
-2003-12-31,CO,Colombia,67.0469
+2003-12-31,AU,Australia,83.7524
+2003-12-31,BE,Belgium,77.2544
+2003-12-31,BG,Bulgaria,61.6804
+2003-12-31,BR,Brazil,47.8521
+2003-12-31,CA,Canada,73.3939
+2003-12-31,CH,Switzerland,78.2748
+2003-12-31,CL,Chile,79.1847
+2003-12-31,CO,Colombia,67.4328
 2003-12-31,CY,Cyprus,56.7277
-2003-12-31,CZ,Czechia,
-2003-12-31,DE,Germany,109.7389
-2003-12-31,DK,Denmark,79.8117
-2003-12-31,EE,Estonia,
-2003-12-31,ES,Spain,84.5636
+2003-12-31,DE,Germany,109.7094
+2003-12-31,DK,Denmark,79.7992
+2003-12-31,ES,Spain,84.5637
 2003-12-31,FI,Finland,80.263
-2003-12-31,FR,France,74.8175
-2003-12-31,GB,United Kingdom,94.7985
-2003-12-31,GR,Greece,
+2003-12-31,FR,France,74.8182
+2003-12-31,GB,United Kingdom,94.767
+2003-12-31,GR,Greece,98.3198
 2003-12-31,HK,Hong Kong SAR,48.1525
-2003-12-31,HR,Croatia,85.632
-2003-12-31,HU,Hungary,
+2003-12-31,HR,Croatia,85.6544
+2003-12-31,HU,Hungary,126.8422
 2003-12-31,ID,Indonesia,138.1515
-2003-12-31,IE,Ireland,119.5619
-2003-12-31,IL,Israel,80.7388
-2003-12-31,IN,India,
-2003-12-31,IS,Iceland,97.9762
-2003-12-31,IT,Italy,90.0255
+2003-12-31,IE,Ireland,119.5605
+2003-12-31,IL,Israel,80.739
+2003-12-31,IS,Iceland,97.9941
+2003-12-31,IT,Italy,90.0229
 2003-12-31,JP,Japan,117.6417
-2003-12-31,KR,Korea,99.513
+2003-12-31,KR,Korea,99.5682
 2003-12-31,LT,Lithuania,64.7963
-2003-12-31,LU,Luxembourg,
-2003-12-31,LV,Latvia,
-2003-12-31,MA,Morocco,
-2003-12-31,MK,North Macedonia,91.7786
-2003-12-31,MT,Malta,
-2003-12-31,MX,Mexico,
+2003-12-31,MK,North Macedonia,91.7122
 2003-12-31,MY,Malaysia,93.296
-2003-12-31,NL,Netherlands,98.8401
-2003-12-31,NO,Norway,69.4389
+2003-12-31,NL,Netherlands,98.7768
+2003-12-31,NO,Norway,69.3732
 2003-12-31,NZ,New Zealand,83.3074
 2003-12-31,PE,Peru,64.1743
-2003-12-31,PH,Philippines,
-2003-12-31,PL,Poland,
-2003-12-31,PT,Portugal,
-2003-12-31,RO,Romania,
+2003-12-31,PT,Portugal,114.8392
 2003-12-31,RS,Serbia,87.5001
 2003-12-31,RU,Russia,46.4162
-2003-12-31,SE,Sweden,65.5763
-2003-12-31,SG,Singapore,70.2689
-2003-12-31,SI,Slovenia,
-2003-12-31,SK,Slovak Republic,
-2003-12-31,TH,Thailand,99.238
-2003-12-31,TR,Türkiye,
-2003-12-31,US,United States,122.8347
-2003-12-31,XM,Euro area,92.2054
-2003-12-31,XW,World,
-2003-12-31,ZA,South Africa,69.2683
-2004-03-31,4T,Emerging market economies (aggregate),
-2004-03-31,5R,Advanced economies,
-2004-03-31,AE,United Arab Emirates,98.7868
+2003-12-31,SE,Sweden,65.5782
+2003-12-31,SG,Singapore,70.2815
+2003-12-31,TH,Thailand,99.2363
+2003-12-31,US,United States,122.6807
+2003-12-31,XM,Euro area,92.1311
+2003-12-31,ZA,South Africa,69.1874
 2004-03-31,AT,Austria,84.6086
-2004-03-31,AU,Australia,82.7062
-2004-03-31,BE,Belgium,78.1845
-2004-03-31,BG,Bulgaria,
-2004-03-31,BR,Brazil,48.5747
-2004-03-31,CA,Canada,73.6823
-2004-03-31,CH,Switzerland,79.6953
-2004-03-31,CL,Chile,79.9124
-2004-03-31,CN,China,
-2004-03-31,CO,Colombia,65.976
+2004-03-31,AU,Australia,82.6694
+2004-03-31,BE,Belgium,78.8499
+2004-03-31,BG,Bulgaria,67.1518
+2004-03-31,BR,Brazil,48.5753
+2004-03-31,CA,Canada,74.2536
+2004-03-31,CH,Switzerland,79.6967
+2004-03-31,CL,Chile,79.9123
+2004-03-31,CO,Colombia,65.8737
 2004-03-31,CY,Cyprus,64.8656
-2004-03-31,CZ,Czechia,
-2004-03-31,DE,Germany,108.4347
-2004-03-31,DK,Denmark,82.0243
-2004-03-31,EE,Estonia,
-2004-03-31,ES,Spain,89.4175
+2004-03-31,DE,Germany,108.2837
+2004-03-31,DK,Denmark,82.017
+2004-03-31,ES,Spain,89.4174
 2004-03-31,FI,Finland,82.4051
-2004-03-31,FR,France,76.8672
-2004-03-31,GB,United Kingdom,95.7352
-2004-03-31,GR,Greece,
+2004-03-31,FR,France,76.8636
+2004-03-31,GB,United Kingdom,95.7034
+2004-03-31,GR,Greece,97.8569
 2004-03-31,HK,Hong Kong SAR,55.004
-2004-03-31,HR,Croatia,86.2734
-2004-03-31,HU,Hungary,
+2004-03-31,HR,Croatia,86.3023
+2004-03-31,HU,Hungary,119.5205
 2004-03-31,ID,Indonesia,137.0134
-2004-03-31,IE,Ireland,118.8656
-2004-03-31,IL,Israel,81.5752
-2004-03-31,IN,India,
-2004-03-31,IS,Iceland,97.8511
-2004-03-31,IT,Italy,90.4413
+2004-03-31,IE,Ireland,118.9152
+2004-03-31,IL,Israel,81.5751
+2004-03-31,IS,Iceland,97.8401
+2004-03-31,IT,Italy,90.444
 2004-03-31,JP,Japan,116.0141
-2004-03-31,KR,Korea,97.2506
-2004-03-31,LT,Lithuania,70.0539
-2004-03-31,LU,Luxembourg,
-2004-03-31,LV,Latvia,
-2004-03-31,MA,Morocco,
-2004-03-31,MK,North Macedonia,89.8552
-2004-03-31,MT,Malta,
-2004-03-31,MX,Mexico,
+2004-03-31,KR,Korea,97.2454
+2004-03-31,LT,Lithuania,70.0538
+2004-03-31,MK,North Macedonia,89.8689
 2004-03-31,MY,Malaysia,94.4143
-2004-03-31,NL,Netherlands,99.84
-2004-03-31,NO,Norway,74.4038
+2004-03-31,NL,Netherlands,99.8504
+2004-03-31,NO,Norway,74.3718
 2004-03-31,NZ,New Zealand,86.7023
 2004-03-31,PE,Peru,70.6295
-2004-03-31,PH,Philippines,
-2004-03-31,PL,Poland,
-2004-03-31,PT,Portugal,
-2004-03-31,RO,Romania,
+2004-03-31,PT,Portugal,114.8505
 2004-03-31,RS,Serbia,92.4387
 2004-03-31,RU,Russia,49.8843
-2004-03-31,SE,Sweden,67.0646
-2004-03-31,SG,Singapore,69.3809
-2004-03-31,SI,Slovenia,
-2004-03-31,SK,Slovak Republic,
-2004-03-31,TH,Thailand,99.0774
-2004-03-31,TR,Türkiye,
-2004-03-31,US,United States,125.8732
-2004-03-31,XM,Euro area,93.0185
-2004-03-31,XW,World,
-2004-03-31,ZA,South Africa,74.5253
-2004-06-30,4T,Emerging market economies (aggregate),
-2004-06-30,5R,Advanced economies,
-2004-06-30,AE,United Arab Emirates,101.3956
+2004-03-31,SE,Sweden,67.0624
+2004-03-31,SG,Singapore,69.3922
+2004-03-31,TH,Thailand,99.0763
+2004-03-31,US,United States,125.7093
+2004-03-31,XM,Euro area,92.954
+2004-03-31,ZA,South Africa,74.4389
 2004-06-30,AT,Austria,88.3345
-2004-06-30,AU,Australia,81.4878
-2004-06-30,BE,Belgium,77.8029
-2004-06-30,BG,Bulgaria,
-2004-06-30,BR,Brazil,49.2362
-2004-06-30,CA,Canada,76.2288
-2004-06-30,CH,Switzerland,79.451
+2004-06-30,AU,Australia,81.4775
+2004-06-30,BE,Belgium,78.465
+2004-06-30,BG,Bulgaria,75.3917
+2004-06-30,BR,Brazil,49.2367
+2004-06-30,CA,Canada,76.8199
+2004-06-30,CH,Switzerland,79.4526
 2004-06-30,CL,Chile,81.4256
-2004-06-30,CN,China,
-2004-06-30,CO,Colombia,66.6319
+2004-06-30,CO,Colombia,66.8311
 2004-06-30,CY,Cyprus,66.2619
-2004-06-30,CZ,Czechia,
-2004-06-30,DE,Germany,107.8523
-2004-06-30,DK,Denmark,85.0057
-2004-06-30,EE,Estonia,
-2004-06-30,ES,Spain,92.3776
+2004-06-30,DE,Germany,107.9492
+2004-06-30,DK,Denmark,85.0104
+2004-06-30,ES,Spain,92.3774
 2004-06-30,FI,Finland,84.2748
-2004-06-30,FR,France,79.2415
-2004-06-30,GB,United Kingdom,100.6037
-2004-06-30,GR,Greece,
+2004-06-30,FR,France,79.2413
+2004-06-30,GB,United Kingdom,100.5703
+2004-06-30,GR,Greece,96.3905
 2004-06-30,HK,Hong Kong SAR,57.6652
-2004-06-30,HR,Croatia,88.583
-2004-06-30,HU,Hungary,
+2004-06-30,HR,Croatia,88.6352
+2004-06-30,HU,Hungary,122.4251
 2004-06-30,ID,Indonesia,136.0705
-2004-06-30,IE,Ireland,118.75
-2004-06-30,IL,Israel,81.9582
-2004-06-30,IN,India,
-2004-06-30,IS,Iceland,101.9529
-2004-06-30,IT,Italy,91.5757
+2004-06-30,IE,Ireland,118.7867
+2004-06-30,IL,Israel,81.9587
+2004-06-30,IS,Iceland,101.928
+2004-06-30,IT,Italy,91.5761
 2004-06-30,JP,Japan,113.9703
-2004-06-30,KR,Korea,96.7853
+2004-06-30,KR,Korea,96.7999
 2004-06-30,LT,Lithuania,66.2078
-2004-06-30,LU,Luxembourg,
-2004-06-30,LV,Latvia,
-2004-06-30,MA,Morocco,
-2004-06-30,MK,North Macedonia,89.1496
-2004-06-30,MT,Malta,
-2004-06-30,MX,Mexico,
+2004-06-30,MK,North Macedonia,89.0479
 2004-06-30,MY,Malaysia,94.2931
-2004-06-30,NL,Netherlands,99.9779
-2004-06-30,NO,Norway,75.1639
+2004-06-30,NL,Netherlands,100.0612
+2004-06-30,NO,Norway,75.1386
 2004-06-30,NZ,New Zealand,87.5397
 2004-06-30,PE,Peru,70.7924
-2004-06-30,PH,Philippines,
-2004-06-30,PL,Poland,
-2004-06-30,PT,Portugal,
-2004-06-30,RO,Romania,
+2004-06-30,PT,Portugal,113.2547
 2004-06-30,RS,Serbia,91.9171
 2004-06-30,RU,Russia,51.3486
-2004-06-30,SE,Sweden,69.5382
-2004-06-30,SG,Singapore,69.1485
-2004-06-30,SI,Slovenia,
-2004-06-30,SK,Slovak Republic,
-2004-06-30,TH,Thailand,99.1583
-2004-06-30,TR,Türkiye,
-2004-06-30,US,United States,129.0104
-2004-06-30,XM,Euro area,93.9617
-2004-06-30,XW,World,
-2004-06-30,ZA,South Africa,79.3102
-2004-09-30,4T,Emerging market economies (aggregate),
-2004-09-30,5R,Advanced economies,
-2004-09-30,AE,United Arab Emirates,102.7829
-2004-09-30,AT,Austria,88.4583
-2004-09-30,AU,Australia,81.1856
-2004-09-30,BE,Belgium,80.3009
-2004-09-30,BG,Bulgaria,
-2004-09-30,BR,Brazil,49.3871
-2004-09-30,CA,Canada,74.2954
-2004-09-30,CH,Switzerland,81.4244
+2004-06-30,SE,Sweden,69.5404
+2004-06-30,SG,Singapore,69.1607
+2004-06-30,TH,Thailand,99.1584
+2004-06-30,US,United States,128.846
+2004-06-30,XM,Euro area,93.9055
+2004-06-30,ZA,South Africa,79.2118
+2004-09-30,AT,Austria,88.4584
+2004-09-30,AU,Australia,81.1441
+2004-09-30,BE,Belgium,80.9843
+2004-09-30,BG,Bulgaria,84.6487
+2004-09-30,BR,Brazil,49.3874
+2004-09-30,CA,Canada,74.8714
+2004-09-30,CH,Switzerland,81.4274
 2004-09-30,CL,Chile,82.4665
-2004-09-30,CN,China,
-2004-09-30,CO,Colombia,66.8658
+2004-09-30,CO,Colombia,67.0869
 2004-09-30,CY,Cyprus,68.6454
-2004-09-30,CZ,Czechia,
-2004-09-30,DE,Germany,107.2734
-2004-09-30,DK,Denmark,88.0631
-2004-09-30,EE,Estonia,
-2004-09-30,ES,Spain,94.4002
+2004-09-30,DE,Germany,107.293
+2004-09-30,DK,Denmark,88.0278
+2004-09-30,ES,Spain,94.3994
 2004-09-30,FI,Finland,84.2127
-2004-09-30,FR,France,82.9537
-2004-09-30,GB,United Kingdom,105.0057
-2004-09-30,GR,Greece,
+2004-09-30,FR,France,82.9563
+2004-09-30,GB,United Kingdom,104.9708
+2004-09-30,GR,Greece,98.6319
 2004-09-30,HK,Hong Kong SAR,58.2613
-2004-09-30,HR,Croatia,92.0957
-2004-09-30,HU,Hungary,
+2004-09-30,HR,Croatia,92.112
+2004-09-30,HU,Hungary,125.4482
 2004-09-30,ID,Indonesia,135.8428
-2004-09-30,IE,Ireland,123.719
-2004-09-30,IL,Israel,81.1545
-2004-09-30,IN,India,
-2004-09-30,IS,Iceland,103.7564
-2004-09-30,IT,Italy,93.5718
+2004-09-30,IE,Ireland,123.7792
+2004-09-30,IL,Israel,81.1549
+2004-09-30,IS,Iceland,103.76
+2004-09-30,IT,Italy,93.5779
 2004-09-30,JP,Japan,112.2116
-2004-09-30,KR,Korea,94.9452
+2004-09-30,KR,Korea,94.9415
 2004-09-30,LT,Lithuania,73.5797
-2004-09-30,LU,Luxembourg,
-2004-09-30,LV,Latvia,
-2004-09-30,MA,Morocco,
-2004-09-30,MK,North Macedonia,90.7902
-2004-09-30,MT,Malta,
-2004-09-30,MX,Mexico,
+2004-09-30,MK,North Macedonia,90.8159
 2004-09-30,MY,Malaysia,94.0624
-2004-09-30,NL,Netherlands,101.4508
-2004-09-30,NO,Norway,75.3434
+2004-09-30,NL,Netherlands,101.3591
+2004-09-30,NO,Norway,75.3297
 2004-09-30,NZ,New Zealand,88.7819
 2004-09-30,PE,Peru,67.8024
-2004-09-30,PH,Philippines,
-2004-09-30,PL,Poland,
-2004-09-30,PT,Portugal,
-2004-09-30,RO,Romania,
+2004-09-30,PT,Portugal,113.5898
 2004-09-30,RS,Serbia,87.8847
 2004-09-30,RU,Russia,52.6266
 2004-09-30,SE,Sweden,71.267
-2004-09-30,SG,Singapore,69.1729
-2004-09-30,SI,Slovenia,
-2004-09-30,SK,Slovak Republic,
-2004-09-30,TH,Thailand,98.994
-2004-09-30,TR,Türkiye,
-2004-09-30,US,United States,132.9347
-2004-09-30,XM,Euro area,95.8419
-2004-09-30,XW,World,
-2004-09-30,ZA,South Africa,84.4446
-2004-12-31,4T,Emerging market economies (aggregate),
-2004-12-31,5R,Advanced economies,
-2004-12-31,AE,United Arab Emirates,103.5232
+2004-09-30,SG,Singapore,69.1843
+2004-09-30,TH,Thailand,98.9962
+2004-09-30,US,United States,132.7587
+2004-09-30,XM,Euro area,95.7771
+2004-09-30,ZA,South Africa,84.3512
 2004-12-31,AT,Austria,89.631
-2004-12-31,AU,Australia,81.9577
-2004-12-31,BE,Belgium,81.7801
-2004-12-31,BG,Bulgaria,
-2004-12-31,BR,Brazil,49.6371
-2004-12-31,CA,Canada,76.8038
-2004-12-31,CH,Switzerland,81.1557
+2004-12-31,AU,Australia,81.8966
+2004-12-31,BE,Belgium,82.4761
+2004-12-31,BG,Bulgaria,92.7805
+2004-12-31,BR,Brazil,49.6375
+2004-12-31,CA,Canada,77.3993
+2004-12-31,CH,Switzerland,81.1598
 2004-12-31,CL,Chile,83.9202
-2004-12-31,CN,China,
-2004-12-31,CO,Colombia,70.8906
+2004-12-31,CO,Colombia,70.9919
 2004-12-31,CY,Cyprus,69.6985
-2004-12-31,CZ,Czechia,
-2004-12-31,DE,Germany,106.5857
-2004-12-31,DK,Denmark,89.7872
-2004-12-31,EE,Estonia,
+2004-12-31,DE,Germany,106.6183
+2004-12-31,DK,Denmark,89.7595
 2004-12-31,ES,Spain,95.8513
 2004-12-31,FI,Finland,84.4093
-2004-12-31,FR,France,84.5347
-2004-12-31,GB,United Kingdom,104.9802
-2004-12-31,GR,Greece,
+2004-12-31,FR,France,84.5335
+2004-12-31,GB,United Kingdom,104.9453
+2004-12-31,GR,Greece,98.861
 2004-12-31,HK,Hong Kong SAR,62.0508
-2004-12-31,HR,Croatia,96.8975
-2004-12-31,HU,Hungary,
+2004-12-31,HR,Croatia,96.9513
+2004-12-31,HU,Hungary,123.0764
 2004-12-31,ID,Indonesia,134.3467
-2004-12-31,IE,Ireland,129.472
-2004-12-31,IL,Israel,79.1726
-2004-12-31,IN,India,
-2004-12-31,IS,Iceland,107.1284
-2004-12-31,IT,Italy,94.8074
+2004-12-31,IE,Ireland,129.5681
+2004-12-31,IL,Israel,79.1729
+2004-12-31,IS,Iceland,107.1251
+2004-12-31,IT,Italy,94.8063
 2004-12-31,JP,Japan,110.326
-2004-12-31,KR,Korea,94.0935
+2004-12-31,KR,Korea,94.0975
 2004-12-31,LT,Lithuania,82.1327
-2004-12-31,LU,Luxembourg,
-2004-12-31,LV,Latvia,
-2004-12-31,MA,Morocco,
-2004-12-31,MK,North Macedonia,91.4889
-2004-12-31,MT,Malta,
-2004-12-31,MX,Mexico,
+2004-12-31,MK,North Macedonia,91.6188
 2004-12-31,MY,Malaysia,93.6078
-2004-12-31,NL,Netherlands,101.5018
-2004-12-31,NO,Norway,75.8295
+2004-12-31,NL,Netherlands,101.4041
+2004-12-31,NO,Norway,75.7918
 2004-12-31,NZ,New Zealand,91.1836
 2004-12-31,PE,Peru,63.2392
-2004-12-31,PH,Philippines,
-2004-12-31,PL,Poland,
-2004-12-31,PT,Portugal,
-2004-12-31,RO,Romania,
+2004-12-31,PT,Portugal,112.6822
 2004-12-31,RS,Serbia,87.9877
 2004-12-31,RU,Russia,53.3664
-2004-12-31,SE,Sweden,71.811
-2004-12-31,SG,Singapore,69.7202
-2004-12-31,SI,Slovenia,
-2004-12-31,SK,Slovak Republic,
-2004-12-31,TH,Thailand,101.6037
-2004-12-31,TR,Türkiye,
-2004-12-31,US,United States,137.131
-2004-12-31,XM,Euro area,96.6211
-2004-12-31,XW,World,
-2004-12-31,ZA,South Africa,90.7158
-2005-03-31,4T,Emerging market economies (aggregate),
-2005-03-31,5R,Advanced economies,
-2005-03-31,AE,United Arab Emirates,105.6021
+2004-12-31,SE,Sweden,71.8124
+2004-12-31,SG,Singapore,69.7321
+2004-12-31,TH,Thailand,101.6038
+2004-12-31,US,United States,136.9431
+2004-12-31,XM,Euro area,96.5496
+2004-12-31,ZA,South Africa,90.6099
 2005-03-31,AT,Austria,89.3076
-2005-03-31,AU,Australia,81.2455
-2005-03-31,BE,Belgium,84.9154
-2005-03-31,BG,Bulgaria,100.1581
-2005-03-31,BR,Brazil,49.6386
-2005-03-31,CA,Canada,79.2307
-2005-03-31,CH,Switzerland,82.344
-2005-03-31,CL,Chile,82.343
-2005-03-31,CN,China,
-2005-03-31,CO,Colombia,68.3894
+2005-03-31,AU,Australia,81.2375
+2005-03-31,BE,Belgium,85.6401
+2005-03-31,BG,Bulgaria,100.1744
+2005-03-31,BR,Brazil,49.6388
+2005-03-31,CA,Canada,79.9412
+2005-03-31,CH,Switzerland,82.3471
+2005-03-31,CL,Chile,82.3429
+2005-03-31,CO,Colombia,68.8458
 2005-03-31,CY,Cyprus,70.6359
-2005-03-31,CZ,Czechia,
-2005-03-31,DE,Germany,106.0967
-2005-03-31,DK,Denmark,93.5521
+2005-03-31,DE,Germany,106.1412
+2005-03-31,DK,Denmark,93.5159
 2005-03-31,EE,Estonia,101.9719
-2005-03-31,ES,Spain,100.2126
+2005-03-31,ES,Spain,100.2131
 2005-03-31,FI,Finland,86.2434
-2005-03-31,FR,France,87.0158
-2005-03-31,GB,United Kingdom,102.642
-2005-03-31,GR,Greece,
+2005-03-31,FR,France,87.0175
+2005-03-31,GB,United Kingdom,102.6092
+2005-03-31,GR,Greece,101.9492
 2005-03-31,HK,Hong Kong SAR,66.9475
-2005-03-31,HR,Croatia,95.0263
-2005-03-31,HU,Hungary,
+2005-03-31,HR,Croatia,95.0942
+2005-03-31,HU,Hungary,120.7547
 2005-03-31,ID,Indonesia,132.0823
-2005-03-31,IE,Ireland,129.4132
-2005-03-31,IL,Israel,79.4358
-2005-03-31,IN,India,
-2005-03-31,IS,Iceland,116.3376
-2005-03-31,IT,Italy,96.1263
+2005-03-31,IE,Ireland,129.4423
+2005-03-31,IL,Israel,79.4363
+2005-03-31,IS,Iceland,116.3139
+2005-03-31,IT,Italy,96.1278
 2005-03-31,JP,Japan,109.7487
-2005-03-31,KR,Korea,92.461
+2005-03-31,KR,Korea,92.4869
 2005-03-31,LT,Lithuania,95.3097
-2005-03-31,LU,Luxembourg,
-2005-03-31,LV,Latvia,
-2005-03-31,MA,Morocco,
-2005-03-31,MK,North Macedonia,88.1479
+2005-03-31,MK,North Macedonia,88.0925
 2005-03-31,MT,Malta,70.9393
 2005-03-31,MX,Mexico,90.9971
 2005-03-31,MY,Malaysia,93.8836
-2005-03-31,NL,Netherlands,102.0154
-2005-03-31,NO,Norway,78.9983
+2005-03-31,NL,Netherlands,102.0106
+2005-03-31,NO,Norway,78.9834
 2005-03-31,NZ,New Zealand,94.9854
 2005-03-31,PE,Peru,68.7127
-2005-03-31,PH,Philippines,
-2005-03-31,PL,Poland,
-2005-03-31,PT,Portugal,
-2005-03-31,RO,Romania,
+2005-03-31,PT,Portugal,112.6295
 2005-03-31,RS,Serbia,90.5808
 2005-03-31,RU,Russia,55.4741
-2005-03-31,SE,Sweden,72.5236
-2005-03-31,SG,Singapore,70.577
-2005-03-31,SI,Slovenia,
-2005-03-31,SK,Slovak Republic,
-2005-03-31,TH,Thailand,104.1278
-2005-03-31,TR,Türkiye,
-2005-03-31,US,United States,141.8835
-2005-03-31,XM,Euro area,98.0943
-2005-03-31,XW,World,
-2005-03-31,ZA,South Africa,96.7615
-2005-06-30,4T,Emerging market economies (aggregate),
-2005-06-30,5R,Advanced economies,
-2005-06-30,AE,United Arab Emirates,105.9965
-2005-06-30,AT,Austria,89.8171
-2005-06-30,AU,Australia,81.3168
-2005-06-30,BE,Belgium,85.8878
-2005-06-30,BG,Bulgaria,103.5904
-2005-06-30,BR,Brazil,49.7172
-2005-06-30,CA,Canada,80.5303
-2005-06-30,CH,Switzerland,82.0396
+2005-03-31,SE,Sweden,72.5265
+2005-03-31,SG,Singapore,70.5878
+2005-03-31,TH,Thailand,104.1274
+2005-03-31,US,United States,141.6915
+2005-03-31,XM,Euro area,98.0295
+2005-03-31,ZA,South Africa,96.648
+2005-06-30,AT,Austria,89.8172
+2005-06-30,AU,Australia,81.319
+2005-06-30,BE,Belgium,86.6113
+2005-06-30,BG,Bulgaria,103.6746
+2005-06-30,BR,Brazil,49.7173
+2005-06-30,CA,Canada,81.2524
+2005-06-30,CH,Switzerland,82.0418
 2005-06-30,CL,Chile,84.9689
 2005-06-30,CN,China,87.95
-2005-06-30,CO,Colombia,69.5776
+2005-06-30,CO,Colombia,69.6263
 2005-06-30,CY,Cyprus,71.6126
-2005-06-30,CZ,Czechia,
-2005-06-30,DE,Germany,105.2405
-2005-06-30,DK,Denmark,97.2986
+2005-06-30,DE,Germany,105.2077
+2005-06-30,DK,Denmark,97.313
 2005-06-30,EE,Estonia,113.3599
-2005-06-30,ES,Spain,101.9431
+2005-06-30,ES,Spain,101.9429
 2005-06-30,FI,Finland,88.3767
-2005-06-30,FR,France,89.9107
-2005-06-30,GB,United Kingdom,104.5846
-2005-06-30,GR,Greece,
+2005-06-30,FR,France,89.9172
+2005-06-30,GB,United Kingdom,104.4599
+2005-06-30,GR,Greece,103.0645
 2005-06-30,HK,Hong Kong SAR,70.1139
-2005-06-30,HR,Croatia,98.5644
-2005-06-30,HU,Hungary,
+2005-06-30,HR,Croatia,98.5764
+2005-06-30,HU,Hungary,121.4988
 2005-06-30,ID,Indonesia,131.0152
-2005-06-30,IE,Ireland,130.5205
-2005-06-30,IL,Israel,80.3424
-2005-06-30,IN,India,
-2005-06-30,IS,Iceland,127.3553
-2005-06-30,IT,Italy,97.2307
+2005-06-30,IE,Ireland,130.5077
+2005-06-30,IL,Israel,80.3426
+2005-06-30,IS,Iceland,127.3459
+2005-06-30,IT,Italy,97.2363
 2005-06-30,JP,Japan,108.3588
-2005-06-30,KR,Korea,93.4522
+2005-06-30,KR,Korea,93.5092
 2005-06-30,LT,Lithuania,89.9605
-2005-06-30,LU,Luxembourg,
-2005-06-30,LV,Latvia,
-2005-06-30,MA,Morocco,
-2005-06-30,MK,North Macedonia,90.9005
+2005-06-30,MK,North Macedonia,91.1096
 2005-06-30,MT,Malta,69.8565
 2005-06-30,MX,Mexico,93.6178
 2005-06-30,MY,Malaysia,94.633
-2005-06-30,NL,Netherlands,102.3163
-2005-06-30,NO,Norway,80.3292
+2005-06-30,NL,Netherlands,102.3204
+2005-06-30,NO,Norway,80.2962
 2005-06-30,NZ,New Zealand,96.8058
 2005-06-30,PE,Peru,60.905
-2005-06-30,PH,Philippines,
-2005-06-30,PL,Poland,
-2005-06-30,PT,Portugal,
-2005-06-30,RO,Romania,
+2005-06-30,PT,Portugal,113.0473
 2005-06-30,RS,Serbia,91.7851
 2005-06-30,RU,Russia,55.3353
-2005-06-30,SE,Sweden,74.5816
-2005-06-30,SG,Singapore,70.7441
-2005-06-30,SI,Slovenia,
-2005-06-30,SK,Slovak Republic,
+2005-06-30,SE,Sweden,74.5834
+2005-06-30,SG,Singapore,70.752
 2005-06-30,TH,Thailand,103.1178
-2005-06-30,TR,Türkiye,
-2005-06-30,US,United States,145.5503
-2005-06-30,XM,Euro area,98.7558
-2005-06-30,XW,World,
-2005-06-30,ZA,South Africa,100.536
-2005-09-30,4T,Emerging market economies (aggregate),
-2005-09-30,5R,Advanced economies,
-2005-09-30,AE,United Arab Emirates,105.3246
+2005-06-30,US,United States,145.3589
+2005-06-30,XM,Euro area,98.6929
+2005-06-30,ZA,South Africa,100.4241
 2005-09-30,AT,Austria,89.7071
-2005-09-30,AU,Australia,80.4252
-2005-09-30,BE,Belgium,88.1091
-2005-09-30,BG,Bulgaria,106.6786
-2005-09-30,BR,Brazil,50.4352
-2005-09-30,CA,Canada,81.3704
-2005-09-30,CH,Switzerland,83.7455
+2005-09-30,AU,Australia,80.4072
+2005-09-30,BE,Belgium,88.8244
+2005-09-30,BG,Bulgaria,106.67
+2005-09-30,BR,Brazil,50.4354
+2005-09-30,CA,Canada,81.9448
+2005-09-30,CH,Switzerland,83.7458
 2005-09-30,CL,Chile,85.2856
 2005-09-30,CN,China,89.5356
-2005-09-30,CO,Colombia,69.9826
+2005-09-30,CO,Colombia,70.3485
 2005-09-30,CY,Cyprus,72.7588
-2005-09-30,CZ,Czechia,
-2005-09-30,DE,Germany,104.263
-2005-09-30,DK,Denmark,104.5572
+2005-09-30,DE,Germany,104.2471
+2005-09-30,DK,Denmark,104.5491
 2005-09-30,EE,Estonia,118.0817
-2005-09-30,ES,Spain,103.5212
+2005-09-30,ES,Spain,103.5214
 2005-09-30,FI,Finland,89.8944
-2005-09-30,FR,France,93.8085
-2005-09-30,GB,United Kingdom,106.6044
-2005-09-30,GR,Greece,
-2005-09-30,HK,Hong Kong SAR,69.0297
-2005-09-30,HR,Croatia,100.2747
-2005-09-30,HU,Hungary,
+2005-09-30,FR,France,93.8134
+2005-09-30,GB,United Kingdom,106.582
+2005-09-30,GR,Greece,106.5434
+2005-09-30,HK,Hong Kong SAR,69.1528
+2005-09-30,HR,Croatia,100.2174
+2005-09-30,HU,Hungary,123.6852
 2005-09-30,ID,Indonesia,129.5311
-2005-09-30,IE,Ireland,134.4877
-2005-09-30,IL,Israel,80.2235
-2005-09-30,IN,India,
-2005-09-30,IS,Iceland,133.1694
-2005-09-30,IT,Italy,98.5355
+2005-09-30,IE,Ireland,134.5564
+2005-09-30,IL,Israel,80.2233
+2005-09-30,IS,Iceland,133.1535
+2005-09-30,IT,Italy,98.5362
 2005-09-30,JP,Japan,107.2963
-2005-09-30,KR,Korea,94.7835
+2005-09-30,KR,Korea,94.7652
 2005-09-30,LT,Lithuania,99.0317
-2005-09-30,LU,Luxembourg,
-2005-09-30,LV,Latvia,
-2005-09-30,MA,Morocco,
-2005-09-30,MK,North Macedonia,88.4996
+2005-09-30,MK,North Macedonia,88.5828
 2005-09-30,MT,Malta,76.008
 2005-09-30,MX,Mexico,94.9561
 2005-09-30,MY,Malaysia,93.4079
-2005-09-30,NL,Netherlands,103.4583
-2005-09-30,NO,Norway,80.897
+2005-09-30,NL,Netherlands,103.4629
+2005-09-30,NO,Norway,80.8472
 2005-09-30,NZ,New Zealand,98.7459
 2005-09-30,PE,Peru,60.587
-2005-09-30,PH,Philippines,
-2005-09-30,PL,Poland,
-2005-09-30,PT,Portugal,
-2005-09-30,RO,Romania,
+2005-09-30,PT,Portugal,114.7814
 2005-09-30,RS,Serbia,92.6089
 2005-09-30,RU,Russia,56.8652
-2005-09-30,SE,Sweden,77.4318
-2005-09-30,SG,Singapore,71.0764
-2005-09-30,SI,Slovenia,
-2005-09-30,SK,Slovak Republic,
-2005-09-30,TH,Thailand,102.2353
-2005-09-30,TR,Türkiye,
-2005-09-30,US,United States,148.7971
-2005-09-30,XM,Euro area,100.3383
-2005-09-30,XW,World,
-2005-09-30,ZA,South Africa,103.8621
-2005-12-31,4T,Emerging market economies (aggregate),
-2005-12-31,5R,Advanced economies,
-2005-12-31,AE,United Arab Emirates,103.3177
+2005-09-30,SE,Sweden,77.4307
+2005-09-30,SG,Singapore,71.0848
+2005-09-30,TH,Thailand,102.2338
+2005-09-30,US,United States,148.5776
+2005-09-30,XM,Euro area,100.267
+2005-09-30,ZA,South Africa,103.7293
 2005-12-31,AT,Austria,91.4958
-2005-12-31,AU,Australia,81.5955
-2005-12-31,BE,Belgium,89.9412
-2005-12-31,BG,Bulgaria,105.7884
-2005-12-31,BR,Brazil,50.8319
-2005-12-31,CA,Canada,82.473
-2005-12-31,CH,Switzerland,83.6607
-2005-12-31,CL,Chile,86.7881
+2005-12-31,AU,Australia,81.5461
+2005-12-31,BE,Belgium,90.7473
+2005-12-31,BG,Bulgaria,105.8353
+2005-12-31,BR,Brazil,50.832
+2005-12-31,CA,Canada,82.9798
+2005-12-31,CH,Switzerland,83.6595
+2005-12-31,CL,Chile,86.788
 2005-12-31,CN,China,89.7334
-2005-12-31,CO,Colombia,70.7227
+2005-12-31,CO,Colombia,71.1954
 2005-12-31,CY,Cyprus,72.2423
-2005-12-31,CZ,Czechia,
-2005-12-31,DE,Germany,104.1059
-2005-12-31,DK,Denmark,111.0899
+2005-12-31,DE,Germany,104.1107
+2005-12-31,DK,Denmark,111.0804
 2005-12-31,EE,Estonia,132.8971
-2005-12-31,ES,Spain,104.3454
+2005-12-31,ES,Spain,104.3458
 2005-12-31,FI,Finland,91.6647
-2005-12-31,FR,France,95.3833
-2005-12-31,GB,United Kingdom,106.2353
-2005-12-31,GR,Greece,
+2005-12-31,FR,France,95.3826
+2005-12-31,GB,United Kingdom,106.2747
+2005-12-31,GR,Greece,107.9165
 2005-12-31,HK,Hong Kong SAR,66.2491
-2005-12-31,HR,Croatia,103.9362
-2005-12-31,HU,Hungary,
+2005-12-31,HR,Croatia,103.9983
+2005-12-31,HU,Hungary,122.3663
 2005-12-31,ID,Indonesia,119.6483
-2005-12-31,IE,Ireland,139.5214
-2005-12-31,IL,Israel,80.286
-2005-12-31,IN,India,
-2005-12-31,IS,Iceland,135.3562
-2005-12-31,IT,Italy,99.0836
+2005-12-31,IE,Ireland,139.5555
+2005-12-31,IL,Israel,80.2861
+2005-12-31,IS,Iceland,135.3743
+2005-12-31,IT,Italy,99.084
 2005-12-31,JP,Japan,106.4341
-2005-12-31,KR,Korea,95.0156
+2005-12-31,KR,Korea,94.9964
 2005-12-31,LT,Lithuania,124.1761
-2005-12-31,LU,Luxembourg,
-2005-12-31,LV,Latvia,
-2005-12-31,MA,Morocco,
-2005-12-31,MK,North Macedonia,89.4529
+2005-12-31,MK,North Macedonia,89.57
 2005-12-31,MT,Malta,71.9065
 2005-12-31,MX,Mexico,93.5916
 2005-12-31,MY,Malaysia,92.9996
-2005-12-31,NL,Netherlands,103.6279
-2005-12-31,NO,Norway,80.4094
+2005-12-31,NL,Netherlands,103.6307
+2005-12-31,NO,Norway,80.4443
 2005-12-31,NZ,New Zealand,101.865
 2005-12-31,PE,Peru,65.8661
-2005-12-31,PH,Philippines,
-2005-12-31,PL,Poland,
-2005-12-31,PT,Portugal,
-2005-12-31,RO,Romania,
+2005-12-31,PT,Portugal,113.8377
 2005-12-31,RS,Serbia,89.4007
 2005-12-31,RU,Russia,59.2754
-2005-12-31,SE,Sweden,79.0143
-2005-12-31,SG,Singapore,71.6786
-2005-12-31,SI,Slovenia,
-2005-12-31,SK,Slovak Republic,
-2005-12-31,TH,Thailand,102.8001
-2005-12-31,TR,Türkiye,
-2005-12-31,US,United States,152.1377
-2005-12-31,XM,Euro area,101.0368
-2005-12-31,XW,World,
-2005-12-31,ZA,South Africa,108.058
-2006-03-31,4T,Emerging market economies (aggregate),
-2006-03-31,5R,Advanced economies,
-2006-03-31,AE,United Arab Emirates,108.2069
+2005-12-31,SE,Sweden,79.0146
+2005-12-31,SG,Singapore,71.6863
+2005-12-31,TH,Thailand,102.8036
+2005-12-31,US,United States,151.9373
+2005-12-31,XM,Euro area,100.9596
+2005-12-31,ZA,South Africa,107.9282
 2006-03-31,AT,Austria,92.3222
-2006-03-31,AU,Australia,81.8004
-2006-03-31,BE,Belgium,91.4269
-2006-03-31,BG,Bulgaria,106.7032
-2006-03-31,BR,Brazil,51.4557
-2006-03-31,CA,Canada,85.3555
-2006-03-31,CH,Switzerland,85.5036
+2006-03-31,AU,Australia,81.7318
+2006-03-31,BE,Belgium,92.2248
+2006-03-31,BG,Bulgaria,106.7326
+2006-03-31,BR,Brazil,51.4558
+2006-03-31,CA,Canada,85.6578
+2006-03-31,CH,Switzerland,85.5015
 2006-03-31,CL,Chile,85.1405
 2006-03-31,CN,China,88.5259
-2006-03-31,CO,Colombia,72.2199
+2006-03-31,CO,Colombia,71.7788
 2006-03-31,CY,Cyprus,76.355
-2006-03-31,CZ,Czechia,
 2006-03-31,DE,Germany,102.6415
-2006-03-31,DK,Denmark,118.5866
+2006-03-31,DK,Denmark,118.6123
 2006-03-31,EE,Estonia,148.7464
-2006-03-31,ES,Spain,105.26
+2006-03-31,ES,Spain,105.2598
 2006-03-31,FI,Finland,92.4703
-2006-03-31,FR,France,97.2748
-2006-03-31,GB,United Kingdom,107.043
+2006-03-31,FR,France,97.278
+2006-03-31,GB,United Kingdom,107.075
 2006-03-31,GR,Greece,112.0074
 2006-03-31,HK,Hong Kong SAR,67.086
-2006-03-31,HR,Croatia,106.3363
-2006-03-31,HU,Hungary,
+2006-03-31,HR,Croatia,106.3026
+2006-03-31,HU,Hungary,123.2488
 2006-03-31,ID,Indonesia,119.9825
-2006-03-31,IE,Ireland,141.4377
-2006-03-31,IL,Israel,80.9012
-2006-03-31,IN,India,
-2006-03-31,IS,Iceland,138.9555
-2006-03-31,IT,Italy,99.6567
+2006-03-31,IE,Ireland,141.4267
+2006-03-31,IL,Israel,80.9015
+2006-03-31,IS,Iceland,138.9603
+2006-03-31,IT,Italy,99.6645
 2006-03-31,JP,Japan,105.6829
-2006-03-31,KR,Korea,95.012
-2006-03-31,LT,Lithuania,129.7917
-2006-03-31,LU,Luxembourg,
-2006-03-31,LV,Latvia,149.1909
-2006-03-31,MA,Morocco,
-2006-03-31,MK,North Macedonia,87.7376
+2006-03-31,KR,Korea,94.9783
+2006-03-31,LT,Lithuania,129.7918
+2006-03-31,LV,Latvia,149.2465
+2006-03-31,MK,North Macedonia,87.9082
 2006-03-31,MT,Malta,76.0282
 2006-03-31,MX,Mexico,94.3061
 2006-03-31,MY,Malaysia,92.628
-2006-03-31,NL,Netherlands,105.0653
-2006-03-31,NO,Norway,85.2156
+2006-03-31,NL,Netherlands,105.0727
+2006-03-31,NO,Norway,85.2433
 2006-03-31,NZ,New Zealand,103.2014
 2006-03-31,PE,Peru,65.424
-2006-03-31,PH,Philippines,
-2006-03-31,PL,Poland,
-2006-03-31,PT,Portugal,
-2006-03-31,RO,Romania,
+2006-03-31,PT,Portugal,113.4216
 2006-03-31,RS,Serbia,85.3742
 2006-03-31,RU,Russia,65.6798
-2006-03-31,SE,Sweden,82.0304
-2006-03-31,SG,Singapore,72.9478
-2006-03-31,SI,Slovenia,
-2006-03-31,SK,Slovak Republic,82.399
-2006-03-31,TH,Thailand,103.3824
-2006-03-31,TR,Türkiye,
-2006-03-31,US,United States,154.1369
-2006-03-31,XM,Euro area,101.9454
-2006-03-31,XW,World,
-2006-03-31,ZA,South Africa,111.1412
-2006-06-30,4T,Emerging market economies (aggregate),
-2006-06-30,5R,Advanced economies,
-2006-06-30,AE,United Arab Emirates,110.1618
+2006-03-31,SE,Sweden,82.0326
+2006-03-31,SG,Singapore,72.9557
+2006-03-31,SK,Slovakia,82.1598
+2006-03-31,TH,Thailand,103.3837
+2006-03-31,US,United States,153.9416
+2006-03-31,XM,Euro area,101.8658
+2006-03-31,ZA,South Africa,111.0067
 2006-06-30,AT,Austria,92.29
-2006-06-30,AU,Australia,83.3913
-2006-06-30,BE,Belgium,93.1237
-2006-06-30,BG,Bulgaria,107.3177
-2006-06-30,BR,Brazil,52.7068
-2006-06-30,CA,Canada,88.6559
-2006-06-30,CH,Switzerland,86.0344
+2006-06-30,AU,Australia,83.3813
+2006-06-30,BE,Belgium,93.9116
+2006-06-30,BG,Bulgaria,107.2893
+2006-06-30,BR,Brazil,52.7069
+2006-06-30,CA,Canada,88.764
+2006-06-30,CH,Switzerland,86.0324
 2006-06-30,CL,Chile,87.0726
 2006-06-30,CN,China,90.6989
-2006-06-30,CO,Colombia,74.7158
+2006-06-30,CO,Colombia,75.0783
 2006-06-30,CY,Cyprus,79.5674
-2006-06-30,CZ,Czechia,
 2006-06-30,DE,Germany,103.6188
-2006-06-30,DK,Denmark,124.2829
+2006-06-30,DK,Denmark,124.3084
 2006-06-30,EE,Estonia,161.3083
-2006-06-30,ES,Spain,107.4006
+2006-06-30,ES,Spain,107.4005
 2006-06-30,FI,Finland,93.5678
-2006-06-30,FR,France,99.2514
-2006-06-30,GB,United Kingdom,109.626
+2006-06-30,FR,France,99.2571
+2006-06-30,GB,United Kingdom,109.5565
 2006-06-30,GR,Greece,113.0191
 2006-06-30,HK,Hong Kong SAR,67.7824
-2006-06-30,HR,Croatia,106.9212
-2006-06-30,HU,Hungary,
+2006-06-30,HR,Croatia,106.9687
+2006-06-30,HU,Hungary,122.5229
 2006-06-30,ID,Indonesia,119.601
-2006-06-30,IE,Ireland,144.2831
-2006-06-30,IL,Israel,78.5331
-2006-06-30,IN,India,
-2006-06-30,IS,Iceland,139.3928
-2006-06-30,IT,Italy,100.8067
+2006-06-30,IE,Ireland,144.2815
+2006-06-30,IL,Israel,78.5326
+2006-06-30,IS,Iceland,139.3912
+2006-06-30,IT,Italy,100.8111
 2006-06-30,JP,Japan,104.6338
-2006-06-30,KR,Korea,96.5679
+2006-06-30,KR,Korea,96.5792
 2006-06-30,LT,Lithuania,129.3785
-2006-06-30,LU,Luxembourg,
-2006-06-30,LV,Latvia,161.6375
-2006-06-30,MA,Morocco,
-2006-06-30,MK,North Macedonia,84.0819
+2006-06-30,LV,Latvia,161.701
+2006-06-30,MK,North Macedonia,84.1618
 2006-06-30,MT,Malta,82.5502
 2006-06-30,MX,Mexico,96.7634
 2006-06-30,MY,Malaysia,92.1291
-2006-06-30,NL,Netherlands,105.3465
-2006-06-30,NO,Norway,88.3148
+2006-06-30,NL,Netherlands,105.3394
+2006-06-30,NO,Norway,88.3193
 2006-06-30,NZ,New Zealand,102.5568
 2006-06-30,PE,Peru,62.3645
-2006-06-30,PH,Philippines,
-2006-06-30,PL,Poland,
-2006-06-30,PT,Portugal,
-2006-06-30,RO,Romania,
+2006-06-30,PT,Portugal,112.212
 2006-06-30,RS,Serbia,82.515
 2006-06-30,RU,Russia,70.7032
-2006-06-30,SE,Sweden,83.3381
-2006-06-30,SG,Singapore,74.1649
-2006-06-30,SI,Slovenia,
-2006-06-30,SK,Slovak Republic,85.0879
-2006-06-30,TH,Thailand,102.0363
-2006-06-30,TR,Türkiye,
-2006-06-30,US,United States,150.5074
-2006-06-30,XM,Euro area,102.9919
-2006-06-30,XW,World,
-2006-06-30,ZA,South Africa,113.4045
-2006-09-30,4T,Emerging market economies (aggregate),
-2006-09-30,5R,Advanced economies,
-2006-09-30,AE,United Arab Emirates,118.983
+2006-06-30,SE,Sweden,83.3403
+2006-06-30,SG,Singapore,74.1722
+2006-06-30,SK,Slovakia,84.8408
+2006-06-30,TH,Thailand,102.0381
+2006-06-30,US,United States,150.3056
+2006-06-30,XM,Euro area,102.9101
+2006-06-30,ZA,South Africa,113.2771
 2006-09-30,AT,Austria,92.8029
-2006-09-30,AU,Australia,84.124
-2006-09-30,BE,Belgium,95.3945
-2006-09-30,BG,Bulgaria,113.9943
-2006-09-30,BR,Brazil,54.4305
-2006-09-30,CA,Canada,91.0211
-2006-09-30,CH,Switzerland,87.2931
-2006-09-30,CL,Chile,87.567
+2006-09-30,AU,Australia,84.1496
+2006-09-30,BE,Belgium,96.2827
+2006-09-30,BG,Bulgaria,113.9896
+2006-09-30,BR,Brazil,54.4306
+2006-09-30,CA,Canada,90.9982
+2006-09-30,CH,Switzerland,87.2908
+2006-09-30,CL,Chile,87.5669
 2006-09-30,CN,China,92.4696
-2006-09-30,CO,Colombia,76.765
+2006-09-30,CO,Colombia,76.9223
 2006-09-30,CY,Cyprus,81.3354
-2006-09-30,CZ,Czechia,
 2006-09-30,DE,Germany,104.2189
-2006-09-30,DK,Denmark,126.7038
+2006-09-30,DK,Denmark,126.7507
 2006-09-30,EE,Estonia,170.2938
-2006-09-30,ES,Spain,111.2361
+2006-09-30,ES,Spain,111.2363
 2006-09-30,FI,Finland,94.0714
-2006-09-30,FR,France,102.2009
-2006-09-30,GB,United Kingdom,112.3089
+2006-09-30,FR,France,102.2034
+2006-09-30,GB,United Kingdom,112.2072
 2006-09-30,GR,Greece,115.5599
 2006-09-30,HK,Hong Kong SAR,67.0214
-2006-09-30,HR,Croatia,110.2183
-2006-09-30,HU,Hungary,
+2006-09-30,HR,Croatia,110.227
+2006-09-30,HU,Hungary,123.9562
 2006-09-30,ID,Indonesia,118.8713
-2006-09-30,IE,Ireland,151.1583
-2006-09-30,IL,Israel,78.3655
-2006-09-30,IN,India,
-2006-09-30,IS,Iceland,137.2748
-2006-09-30,IT,Italy,102.0859
+2006-09-30,IE,Ireland,151.2045
+2006-09-30,IL,Israel,78.3654
+2006-09-30,IS,Iceland,137.2669
+2006-09-30,IT,Italy,102.0911
 2006-09-30,JP,Japan,103.768
-2006-09-30,KR,Korea,96.9374
-2006-09-30,LT,Lithuania,141.4617
-2006-09-30,LU,Luxembourg,
-2006-09-30,LV,Latvia,176.2428
-2006-09-30,MA,Morocco,
-2006-09-30,MK,North Macedonia,86.4608
+2006-09-30,KR,Korea,96.9456
+2006-09-30,LT,Lithuania,141.4618
+2006-09-30,LV,Latvia,176.2668
+2006-09-30,MK,North Macedonia,86.3623
 2006-09-30,MT,Malta,85.8318
 2006-09-30,MX,Mexico,97.3767
 2006-09-30,MY,Malaysia,92.0585
-2006-09-30,NL,Netherlands,106.4641
-2006-09-30,NO,Norway,91.1368
+2006-09-30,NL,Netherlands,106.4634
+2006-09-30,NO,Norway,91.1279
 2006-09-30,NZ,New Zealand,104.2144
 2006-09-30,PE,Peru,57.159
-2006-09-30,PH,Philippines,
-2006-09-30,PL,Poland,
-2006-09-30,PT,Portugal,
-2006-09-30,RO,Romania,
+2006-09-30,PT,Portugal,112.274
 2006-09-30,RS,Serbia,84.1313
 2006-09-30,RU,Russia,80.0548
-2006-09-30,SE,Sweden,85.4746
-2006-09-30,SG,Singapore,75.8987
-2006-09-30,SI,Slovenia,
-2006-09-30,SK,Slovak Republic,87.0446
-2006-09-30,TH,Thailand,101.0239
-2006-09-30,TR,Türkiye,
-2006-09-30,US,United States,148.528
-2006-09-30,XM,Euro area,105.0759
-2006-09-30,XW,World,
-2006-09-30,ZA,South Africa,114.6679
-2006-12-31,4T,Emerging market economies (aggregate),
-2006-12-31,5R,Advanced economies,
-2006-12-31,AE,United Arab Emirates,113.0563
-2006-12-31,AT,Austria,92.3454
-2006-12-31,AU,Australia,85.7251
-2006-12-31,BE,Belgium,96.2585
-2006-12-31,BG,Bulgaria,117.0841
+2006-09-30,SE,Sweden,85.4745
+2006-09-30,SG,Singapore,75.9058
+2006-09-30,SK,Slovakia,86.7919
+2006-09-30,TH,Thailand,101.019
+2006-09-30,US,United States,148.3519
+2006-09-30,XM,Euro area,104.9851
+2006-09-30,ZA,South Africa,114.5269
+2006-12-31,AT,Austria,92.3455
+2006-12-31,AU,Australia,85.752
+2006-12-31,BE,Belgium,97.1506
+2006-12-31,BG,Bulgaria,117.0716
 2006-12-31,BR,Brazil,56.014
-2006-12-31,CA,Canada,91.9056
-2006-12-31,CH,Switzerland,90.899
-2006-12-31,CL,Chile,88.7705
+2006-12-31,CA,Canada,91.8116
+2006-12-31,CH,Switzerland,90.896
+2006-12-31,CL,Chile,88.7704
 2006-12-31,CN,China,92.4653
-2006-12-31,CO,Colombia,77.805
+2006-12-31,CO,Colombia,78.0293
 2006-12-31,CY,Cyprus,85.2321
-2006-12-31,CZ,Czechia,
 2006-12-31,DE,Germany,103.0737
-2006-12-31,DK,Denmark,125.288
+2006-12-31,DK,Denmark,125.2962
 2006-12-31,EE,Estonia,187.2086
-2006-12-31,ES,Spain,113.4087
+2006-12-31,ES,Spain,113.4086
 2006-12-31,FI,Finland,94.9536
-2006-12-31,FR,France,103.1594
-2006-12-31,GB,United Kingdom,113.5793
-2006-12-31,GR,Greece,118.6805
+2006-12-31,FR,France,103.1574
+2006-12-31,GB,United Kingdom,113.5805
+2006-12-31,GR,Greece,118.6806
 2006-12-31,HK,Hong Kong SAR,67.134
-2006-12-31,HR,Croatia,117.1738
-2006-12-31,HU,Hungary,
+2006-12-31,HR,Croatia,117.2594
+2006-12-31,HU,Hungary,121.7149
 2006-12-31,ID,Indonesia,117.3973
-2006-12-31,IE,Ireland,153.2026
-2006-12-31,IL,Israel,77.3274
-2006-12-31,IN,India,
-2006-12-31,IS,Iceland,136.2152
-2006-12-31,IT,Italy,102.7719
+2006-12-31,IE,Ireland,153.235
+2006-12-31,IL,Israel,77.3276
+2006-12-31,IS,Iceland,136.2136
+2006-12-31,IT,Italy,102.7772
 2006-12-31,JP,Japan,103.8191
-2006-12-31,KR,Korea,101.6384
-2006-12-31,LT,Lithuania,154.6389
-2006-12-31,LU,Luxembourg,
-2006-12-31,LV,Latvia,188.6275
-2006-12-31,MA,Morocco,
-2006-12-31,MK,North Macedonia,82.4987
+2006-12-31,KR,Korea,101.6473
+2006-12-31,LT,Lithuania,154.639
+2006-12-31,LV,Latvia,188.6409
+2006-12-31,MK,North Macedonia,82.4117
 2006-12-31,MT,Malta,91.9782
 2006-12-31,MX,Mexico,96.1317
 2006-12-31,MY,Malaysia,94.4684
-2006-12-31,NL,Netherlands,107.4487
-2006-12-31,NO,Norway,91.5197
+2006-12-31,NL,Netherlands,107.4426
+2006-12-31,NO,Norway,91.5228
 2006-12-31,NZ,New Zealand,108.107
 2006-12-31,PE,Peru,60.7773
-2006-12-31,PH,Philippines,
-2006-12-31,PL,Poland,
-2006-12-31,PT,Portugal,
-2006-12-31,RO,Romania,
+2006-12-31,PT,Portugal,112.0193
 2006-12-31,RS,Serbia,83.8056
 2006-12-31,RU,Russia,89.7713
-2006-12-31,SE,Sweden,85.5536
-2006-12-31,SG,Singapore,78.51
-2006-12-31,SI,Slovenia,
-2006-12-31,SK,Slovak Republic,91.6284
-2006-12-31,TH,Thailand,101.9938
-2006-12-31,TR,Türkiye,
-2006-12-31,US,United States,149.8013
-2006-12-31,XM,Euro area,105.5429
-2006-12-31,XW,World,
-2006-12-31,ZA,South Africa,117.3376
-2007-03-31,4T,Emerging market economies (aggregate),
-2007-03-31,5R,Advanced economies,
-2007-03-31,AE,United Arab Emirates,121.7267
+2006-12-31,SE,Sweden,85.5522
+2006-12-31,SG,Singapore,78.5163
+2006-12-31,SK,Slovakia,91.3624
+2006-12-31,TH,Thailand,101.9894
+2006-12-31,US,United States,149.6103
+2006-12-31,XM,Euro area,105.453
+2006-12-31,ZA,South Africa,117.1958
 2007-03-31,AT,Austria,94.5217
-2007-03-31,AU,Australia,86.4771
-2007-03-31,BE,Belgium,97.9616
-2007-03-31,BG,Bulgaria,124.3044
+2007-03-31,AU,Australia,86.4323
+2007-03-31,BE,Belgium,98.8093
+2007-03-31,BG,Bulgaria,124.3237
 2007-03-31,BR,Brazil,57.5619
-2007-03-31,CA,Canada,93.9737
-2007-03-31,CH,Switzerland,92.6594
+2007-03-31,CA,Canada,93.7553
+2007-03-31,CH,Switzerland,92.6561
 2007-03-31,CL,Chile,89.3411
 2007-03-31,CN,China,90.7212
-2007-03-31,CO,Colombia,81.1169
+2007-03-31,CO,Colombia,81.1475
 2007-03-31,CY,Cyprus,91.4446
-2007-03-31,CZ,Czechia,
 2007-03-31,DE,Germany,101.6453
-2007-03-31,DK,Denmark,125.088
+2007-03-31,DK,Denmark,125.1
 2007-03-31,EE,Estonia,189.9637
-2007-03-31,ES,Spain,116.2594
+2007-03-31,ES,Spain,116.2592
 2007-03-31,FI,Finland,96.5838
-2007-03-31,FR,France,103.7818
-2007-03-31,GB,United Kingdom,115.0455
-2007-03-31,GR,Greece,118.5488
+2007-03-31,FR,France,103.7874
+2007-03-31,GB,United Kingdom,115.0923
+2007-03-31,GR,Greece,118.5487
 2007-03-31,HK,Hong Kong SAR,69.5867
-2007-03-31,HR,Croatia,119.4849
-2007-03-31,HU,Hungary,120.2197
+2007-03-31,HR,Croatia,119.5646
+2007-03-31,HU,Hungary,120.2196
 2007-03-31,ID,Indonesia,114.8509
-2007-03-31,IE,Ireland,154.2954
-2007-03-31,IL,Israel,77.1125
-2007-03-31,IN,India,
-2007-03-31,IS,Iceland,138.1726
-2007-03-31,IT,Italy,103.7027
+2007-03-31,IE,Ireland,154.3365
+2007-03-31,IL,Israel,77.1126
+2007-03-31,IS,Iceland,138.1524
+2007-03-31,IT,Italy,103.7053
 2007-03-31,JP,Japan,104.1622
-2007-03-31,KR,Korea,104.2449
+2007-03-31,KR,Korea,104.252
 2007-03-31,LT,Lithuania,159.8405
-2007-03-31,LU,Luxembourg,97.3907
-2007-03-31,LV,Latvia,207.371
-2007-03-31,MA,Morocco,100.5929
-2007-03-31,MK,North Macedonia,86.2955
+2007-03-31,LU,Luxembourg,97.3951
+2007-03-31,LV,Latvia,207.4508
+2007-03-31,MA,Morocco,102.5642
+2007-03-31,MK,North Macedonia,86.3421
 2007-03-31,MT,Malta,97.8181
 2007-03-31,MX,Mexico,97.3447
 2007-03-31,MY,Malaysia,94.6202
-2007-03-31,NL,Netherlands,108.3531
-2007-03-31,NO,Norway,98.2655
+2007-03-31,NL,Netherlands,108.3441
+2007-03-31,NO,Norway,98.2514
 2007-03-31,NZ,New Zealand,112.047
 2007-03-31,PE,Peru,58.5583
-2007-03-31,PH,Philippines,
-2007-03-31,PL,Poland,
-2007-03-31,PT,Portugal,
-2007-03-31,RO,Romania,
+2007-03-31,PT,Portugal,112.2447
 2007-03-31,RS,Serbia,81.2945
-2007-03-31,RU,Russia,99.3766
-2007-03-31,SE,Sweden,88.7407
-2007-03-31,SG,Singapore,83.0887
-2007-03-31,SI,Slovenia,110.137
-2007-03-31,SK,Slovak Republic,97.6718
-2007-03-31,TH,Thailand,101.1903
-2007-03-31,TR,Türkiye,
-2007-03-31,US,United States,146.8463
-2007-03-31,XM,Euro area,106.4247
-2007-03-31,XW,World,
-2007-03-31,ZA,South Africa,120.2223
-2007-06-30,4T,Emerging market economies (aggregate),
-2007-06-30,5R,Advanced economies,
-2007-06-30,AE,United Arab Emirates,126.8266
+2007-03-31,RU,Russia,99.3765
+2007-03-31,SE,Sweden,88.7448
+2007-03-31,SG,Singapore,83.0921
+2007-03-31,SI,Slovenia,110.1683
+2007-03-31,SK,Slovakia,97.3882
+2007-03-31,TH,Thailand,101.1902
+2007-03-31,US,United States,146.6619
+2007-03-31,XM,Euro area,106.3358
+2007-03-31,ZA,South Africa,120.0798
 2007-06-30,AT,Austria,95.3553
-2007-06-30,AU,Australia,89.2112
-2007-06-30,BE,Belgium,99.3534
-2007-06-30,BG,Bulgaria,130.2616
+2007-06-30,AU,Australia,89.2004
+2007-06-30,BE,Belgium,100.25
+2007-06-30,BG,Bulgaria,130.2862
 2007-06-30,BR,Brazil,59.5324
-2007-06-30,CA,Canada,96.6728
-2007-06-30,CH,Switzerland,92.8995
-2007-06-30,CL,Chile,91.812
+2007-06-30,CA,Canada,96.4194
+2007-06-30,CH,Switzerland,92.895
+2007-06-30,CL,Chile,91.8119
 2007-06-30,CN,China,92.6815
-2007-06-30,CO,Colombia,82.8855
+2007-06-30,CO,Colombia,82.5481
 2007-06-30,CY,Cyprus,96.8305
-2007-06-30,CZ,Czechia,
 2007-06-30,DE,Germany,100.7383
-2007-06-30,DK,Denmark,125.6414
+2007-06-30,DK,Denmark,125.63
 2007-06-30,EE,Estonia,198.3038
-2007-06-30,ES,Spain,117.0491
+2007-06-30,ES,Spain,117.0499
 2007-06-30,FI,Finland,97.1541
-2007-06-30,FR,France,104.4941
-2007-06-30,GB,United Kingdom,118.3254
-2007-06-30,GR,Greece,117.6458
+2007-06-30,FR,France,104.4927
+2007-06-30,GB,United Kingdom,118.3291
+2007-06-30,GR,Greece,117.6459
 2007-06-30,HK,Hong Kong SAR,71.9708
-2007-06-30,HR,Croatia,122.4711
+2007-06-30,HR,Croatia,122.5417
 2007-06-30,HU,Hungary,120.7286
 2007-06-30,ID,Indonesia,115.228
-2007-06-30,IE,Ireland,152.0292
-2007-06-30,IL,Israel,77.088
-2007-06-30,IN,India,
-2007-06-30,IS,Iceland,143.4182
-2007-06-30,IT,Italy,104.2274
+2007-06-30,IE,Ireland,151.9434
+2007-06-30,IL,Israel,77.0885
+2007-06-30,IS,Iceland,143.4231
+2007-06-30,IT,Italy,104.2269
 2007-06-30,JP,Japan,103.5103
-2007-06-30,KR,Korea,103.6577
+2007-06-30,KR,Korea,103.6102
 2007-06-30,LT,Lithuania,163.6122
-2007-06-30,LU,Luxembourg,96.9684
-2007-06-30,LV,Latvia,207.8769
-2007-06-30,MA,Morocco,101.1562
-2007-06-30,MK,North Macedonia,85.8155
+2007-06-30,LU,Luxembourg,96.9771
+2007-06-30,LV,Latvia,208.0166
+2007-06-30,MA,Morocco,103.3111
+2007-06-30,MK,North Macedonia,85.6967
 2007-06-30,MT,Malta,101.1998
 2007-06-30,MX,Mexico,100.2313
 2007-06-30,MY,Malaysia,94.7816
-2007-06-30,NL,Netherlands,107.935
-2007-06-30,NO,Norway,101.4268
+2007-06-30,NL,Netherlands,107.9332
+2007-06-30,NO,Norway,101.3663
 2007-06-30,NZ,New Zealand,114.0587
 2007-06-30,PE,Peru,61.8216
-2007-06-30,PH,Philippines,
-2007-06-30,PL,Poland,
-2007-06-30,PT,Portugal,
-2007-06-30,RO,Romania,
+2007-06-30,PT,Portugal,109.8157
 2007-06-30,RS,Serbia,79.875
 2007-06-30,RU,Russia,100.6498
-2007-06-30,SE,Sweden,93.1278
-2007-06-30,SG,Singapore,88.7005
-2007-06-30,SI,Slovenia,109.6276
-2007-06-30,SK,Slovak Republic,104.1426
-2007-06-30,TH,Thailand,100.3931
-2007-06-30,TR,Türkiye,
-2007-06-30,US,United States,139.78
-2007-06-30,XM,Euro area,106.2563
-2007-06-30,XW,World,
-2007-06-30,ZA,South Africa,122.7693
-2007-09-30,4T,Emerging market economies (aggregate),
-2007-09-30,5R,Advanced economies,
-2007-09-30,AE,United Arab Emirates,134.7827
-2007-09-30,AT,Austria,95.8559
-2007-09-30,AU,Australia,91.7657
-2007-09-30,BE,Belgium,100.9112
-2007-09-30,BG,Bulgaria,133.9133
-2007-09-30,BR,Brazil,61.7715
-2007-09-30,CA,Canada,98.8195
-2007-09-30,CH,Switzerland,92.881
-2007-09-30,CL,Chile,91.6929
+2007-06-30,SE,Sweden,93.131
+2007-06-30,SG,Singapore,88.7066
+2007-06-30,SI,Slovenia,109.6109
+2007-06-30,SK,Slovakia,103.8402
+2007-06-30,TH,Thailand,100.396
+2007-06-30,US,United States,139.6236
+2007-06-30,XM,Euro area,106.1771
+2007-06-30,ZA,South Africa,122.6164
+2007-09-30,AT,Austria,95.8558
+2007-09-30,AU,Australia,91.7497
+2007-09-30,BE,Belgium,101.7298
+2007-09-30,BG,Bulgaria,134.0085
+2007-09-30,BR,Brazil,61.7716
+2007-09-30,CA,Canada,98.4359
+2007-09-30,CH,Switzerland,92.8783
+2007-09-30,CL,Chile,91.6928
 2007-09-30,CN,China,93.1592
-2007-09-30,CO,Colombia,83.3419
+2007-09-30,CO,Colombia,83.3362
 2007-09-30,CY,Cyprus,99.451
-2007-09-30,CZ,Czechia,
 2007-09-30,DE,Germany,100.8471
-2007-09-30,DK,Denmark,126.3606
+2007-09-30,DK,Denmark,126.3573
 2007-09-30,EE,Estonia,188.6369
-2007-09-30,ES,Spain,118.6859
+2007-09-30,ES,Spain,118.6858
 2007-09-30,FI,Finland,97.1601
-2007-09-30,FR,France,106.6731
-2007-09-30,GB,United Kingdom,121.7284
+2007-09-30,FR,France,106.6754
+2007-09-30,GB,United Kingdom,121.7
 2007-09-30,GR,Greece,119.5312
 2007-09-30,HK,Hong Kong SAR,73.9884
-2007-09-30,HR,Croatia,124.5621
+2007-09-30,HR,Croatia,124.5681
 2007-09-30,HU,Hungary,124.7018
 2007-09-30,ID,Indonesia,113.6946
-2007-09-30,IE,Ireland,150.3887
-2007-09-30,IL,Israel,77.8906
-2007-09-30,IN,India,
-2007-09-30,IS,Iceland,148.8756
-2007-09-30,IT,Italy,105.0506
+2007-09-30,IE,Ireland,150.4122
+2007-09-30,IL,Israel,77.8908
+2007-09-30,IS,Iceland,148.8989
+2007-09-30,IT,Italy,105.0489
 2007-09-30,JP,Japan,103.1501
-2007-09-30,KR,Korea,103.4739
+2007-09-30,KR,Korea,103.514
 2007-09-30,LT,Lithuania,171.3921
-2007-09-30,LU,Luxembourg,100.913
-2007-09-30,LV,Latvia,218.0919
-2007-09-30,MA,Morocco,101.2526
-2007-09-30,MK,North Macedonia,83.7198
+2007-09-30,LU,Luxembourg,100.9136
+2007-09-30,LV,Latvia,218.0392
+2007-09-30,MA,Morocco,103.2776
+2007-09-30,MK,North Macedonia,83.6345
 2007-09-30,MT,Malta,102.0334
 2007-09-30,MX,Mexico,101.27
 2007-09-30,MY,Malaysia,95.2767
-2007-09-30,NL,Netherlands,110.4925
-2007-09-30,NO,Norway,101.4043
+2007-09-30,NL,Netherlands,110.4959
+2007-09-30,NO,Norway,101.3339
 2007-09-30,NZ,New Zealand,113.9456
 2007-09-30,PE,Peru,62.5463
-2007-09-30,PH,Philippines,
-2007-09-30,PL,Poland,
-2007-09-30,PT,Portugal,
-2007-09-30,RO,Romania,
+2007-09-30,PT,Portugal,111.0735
 2007-09-30,RS,Serbia,80.112
 2007-09-30,RU,Russia,102.4334
-2007-09-30,SE,Sweden,96.2677
-2007-09-30,SG,Singapore,93.9532
-2007-09-30,SI,Slovenia,112.1823
-2007-09-30,SK,Slovak Republic,112.642
-2007-09-30,TH,Thailand,102.0559
-2007-09-30,TR,Türkiye,
-2007-09-30,US,United States,135.4898
-2007-09-30,XM,Euro area,107.6503
-2007-09-30,XW,World,
-2007-09-30,ZA,South Africa,123.5399
-2007-12-31,4T,Emerging market economies (aggregate),96.2021
-2007-12-31,5R,Advanced economies,114.5125
-2007-12-31,AE,United Arab Emirates,143.378
-2007-12-31,AT,Austria,93.1446
-2007-12-31,AU,Australia,94.3873
-2007-12-31,BE,Belgium,100.0377
-2007-12-31,BG,Bulgaria,140.1482
-2007-12-31,BR,Brazil,64.1668
-2007-12-31,CA,Canada,99.1451
-2007-12-31,CH,Switzerland,92.5375
+2007-09-30,SE,Sweden,96.2708
+2007-09-30,SG,Singapore,93.9598
+2007-09-30,SI,Slovenia,112.1849
+2007-09-30,SK,Slovakia,112.3149
+2007-09-30,TH,Thailand,102.0568
+2007-09-30,US,United States,135.4026
+2007-09-30,XM,Euro area,107.5807
+2007-09-30,ZA,South Africa,123.3989
+2007-12-31,4T,Emerging market economies (aggregate),95.7766
+2007-12-31,5R,Advanced economies,113.1201
+2007-12-31,AT,Austria,93.1447
+2007-12-31,AU,Australia,94.3487
+2007-12-31,BE,Belgium,100.9165
+2007-12-31,BG,Bulgaria,140.1663
+2007-12-31,BR,Brazil,64.1669
+2007-12-31,CA,Canada,98.7641
+2007-12-31,CH,Switzerland,92.5344
 2007-12-31,CL,Chile,90.3683
 2007-12-31,CN,China,94.4012
-2007-12-31,CO,Colombia,85.7479
+2007-12-31,CO,Colombia,85.3556
 2007-12-31,CY,Cyprus,100.5375
-2007-12-31,CZ,Czechia,
 2007-12-31,DE,Germany,100.1891
-2007-12-31,DK,Denmark,122.6253
+2007-12-31,DK,Denmark,122.6421
 2007-12-31,EE,Estonia,180.5511
-2007-12-31,ES,Spain,115.3087
+2007-12-31,ES,Spain,115.3089
 2007-12-31,FI,Finland,96.6425
-2007-12-31,FR,France,106.2858
-2007-12-31,GB,United Kingdom,120.33
-2007-12-31,GR,Greece,117.2876
+2007-12-31,FR,France,106.2879
+2007-12-31,GB,United Kingdom,120.4231
+2007-12-31,GR,Greece,117.2875
 2007-12-31,HK,Hong Kong SAR,78.7419
-2007-12-31,HR,Croatia,121.0109
+2007-12-31,HR,Croatia,121.0311
 2007-12-31,HU,Hungary,123.5352
 2007-12-31,ID,Indonesia,111.92
-2007-12-31,IE,Ireland,148.1821
-2007-12-31,IL,Israel,76.5475
-2007-12-31,IN,India,
-2007-12-31,IS,Iceland,149.0715
-2007-12-31,IT,Italy,104.863
+2007-12-31,IE,Ireland,148.2679
+2007-12-31,IL,Israel,76.5474
+2007-12-31,IS,Iceland,149.1064
+2007-12-31,IT,Italy,104.8637
 2007-12-31,JP,Japan,102.5543
-2007-12-31,KR,Korea,103.508
+2007-12-31,KR,Korea,103.5106
 2007-12-31,LT,Lithuania,168.7558
-2007-12-31,LU,Luxembourg,98.9683
-2007-12-31,LV,Latvia,204.3795
-2007-12-31,MA,Morocco,105.2338
-2007-12-31,MK,North Macedonia,87.5016
+2007-12-31,LU,Luxembourg,98.9696
+2007-12-31,LV,Latvia,204.4388
+2007-12-31,MA,Morocco,106.8907
+2007-12-31,MK,North Macedonia,87.5145
 2007-12-31,MT,Malta,101.1668
 2007-12-31,MX,Mexico,99.5035
 2007-12-31,MY,Malaysia,95.0927
-2007-12-31,NL,Netherlands,111.0288
-2007-12-31,NO,Norway,97.1284
+2007-12-31,NL,Netherlands,111.0265
+2007-12-31,NO,Norway,97.101
 2007-12-31,NZ,New Zealand,112.7904
 2007-12-31,PE,Peru,68.5049
-2007-12-31,PH,Philippines,
-2007-12-31,PL,Poland,
-2007-12-31,PT,Portugal,
-2007-12-31,RO,Romania,
+2007-12-31,PT,Portugal,108.0422
 2007-12-31,RS,Serbia,80.4624
 2007-12-31,RU,Russia,103.8981
-2007-12-31,SE,Sweden,91.9678
-2007-12-31,SG,Singapore,98.7713
-2007-12-31,SI,Slovenia,115.1662
-2007-12-31,SK,Slovak Republic,119.8599
-2007-12-31,TH,Thailand,100.4774
-2007-12-31,TR,Türkiye,
-2007-12-31,US,United States,130.2171
-2007-12-31,XM,Euro area,106.5792
-2007-12-31,XW,World,105.3219
-2007-12-31,ZA,South Africa,121.5578
-2008-03-31,4T,Emerging market economies (aggregate),95.698
-2008-03-31,5R,Advanced economies,112.1142
-2008-03-31,AE,United Arab Emirates,151.0587
+2007-12-31,SE,Sweden,91.9679
+2007-12-31,SG,Singapore,98.7721
+2007-12-31,SI,Slovenia,115.1741
+2007-12-31,SK,Slovakia,119.512
+2007-12-31,TH,Thailand,100.4803
+2007-12-31,US,United States,130.1579
+2007-12-31,XM,Euro area,106.5062
+2007-12-31,XW,World,105.4583
+2007-12-31,ZA,South Africa,121.4091
+2008-03-31,4T,Emerging market economies (aggregate),95.0609
+2008-03-31,5R,Advanced economies,111.0318
 2008-03-31,AT,Austria,93.1411
-2008-03-31,AU,Australia,93.5451
-2008-03-31,BE,Belgium,99.392
-2008-03-31,BG,Bulgaria,144.3692
-2008-03-31,BR,Brazil,66.4535
-2008-03-31,CA,Canada,100.2971
-2008-03-31,CH,Switzerland,93.5679
+2008-03-31,AU,Australia,93.5121
+2008-03-31,BE,Belgium,100.2148
+2008-03-31,BG,Bulgaria,144.2981
+2008-03-31,BR,Brazil,66.4537
+2008-03-31,CA,Canada,99.9306
+2008-03-31,CH,Switzerland,93.5648
 2008-03-31,CL,Chile,91.2852
 2008-03-31,CN,China,91.8193
-2008-03-31,CO,Colombia,88.4678
+2008-03-31,CO,Colombia,88.7069
 2008-03-31,CY,Cyprus,109.3745
-2008-03-31,CZ,Czechia,105.4173
+2008-03-31,CZ,Czechia,105.4167
 2008-03-31,DE,Germany,101.639
-2008-03-31,DK,Denmark,119.3087
+2008-03-31,DK,Denmark,119.3283
 2008-03-31,EE,Estonia,168.9261
 2008-03-31,ES,Spain,114.5481
 2008-03-31,FI,Finland,96.0886
-2008-03-31,FR,France,104.9238
-2008-03-31,GB,United Kingdom,116.5877
-2008-03-31,GR,Greece,116.9995
+2008-03-31,FR,France,104.9277
+2008-03-31,GB,United Kingdom,116.5328
+2008-03-31,GR,Greece,116.9994
 2008-03-31,HK,Hong Kong SAR,86.1734
-2008-03-31,HR,Croatia,117.4896
+2008-03-31,HR,Croatia,117.5854
 2008-03-31,HU,Hungary,119.0797
 2008-03-31,ID,Indonesia,109.0932
-2008-03-31,IE,Ireland,143.7515
-2008-03-31,IL,Israel,77.8062
-2008-03-31,IN,India,
-2008-03-31,IS,Iceland,146.977
-2008-03-31,IT,Italy,104.3853
+2008-03-31,IE,Ireland,143.8638
+2008-03-31,IL,Israel,77.806
+2008-03-31,IS,Iceland,147.0111
+2008-03-31,IT,Italy,104.3905
 2008-03-31,JP,Japan,102.3879
-2008-03-31,KR,Korea,103.1279
+2008-03-31,KR,Korea,103.1352
 2008-03-31,LT,Lithuania,168.6834
-2008-03-31,LU,Luxembourg,97.7961
-2008-03-31,LV,Latvia,207.866
-2008-03-31,MA,Morocco,100.9936
-2008-03-31,MK,North Macedonia,88.2244
+2008-03-31,LU,Luxembourg,97.7981
+2008-03-31,LV,Latvia,207.9118
+2008-03-31,MA,Morocco,102.4851
+2008-03-31,MK,North Macedonia,88.0742
 2008-03-31,MT,Malta,110.0488
 2008-03-31,MX,Mexico,99.5793
 2008-03-31,MY,Malaysia,96.2474
-2008-03-31,NL,Netherlands,110.1888
-2008-03-31,NO,Norway,98.375
+2008-03-31,NL,Netherlands,110.1883
+2008-03-31,NO,Norway,98.341
 2008-03-31,NZ,New Zealand,111.3629
 2008-03-31,PE,Peru,65.5528
 2008-03-31,PH,Philippines,107.833
-2008-03-31,PL,Poland,
 2008-03-31,PT,Portugal,103.3859
-2008-03-31,RO,Romania,
 2008-03-31,RS,Serbia,82.0664
 2008-03-31,RU,Russia,109.8381
-2008-03-31,SE,Sweden,92.0613
-2008-03-31,SG,Singapore,101.1515
-2008-03-31,SI,Slovenia,115.582
-2008-03-31,SK,Slovak Republic,125.2262
-2008-03-31,TH,Thailand,91.1199
-2008-03-31,TR,Türkiye,
-2008-03-31,US,United States,123.7165
-2008-03-31,XM,Euro area,106.7559
-2008-03-31,XW,World,103.8905
-2008-03-31,ZA,South Africa,116.2333
-2008-06-30,4T,Emerging market economies (aggregate),96.0402
-2008-06-30,5R,Advanced economies,108.2747
-2008-06-30,AE,United Arab Emirates,156.1909
+2008-03-31,SE,Sweden,92.0601
+2008-03-31,SG,Singapore,101.1445
+2008-03-31,SI,Slovenia,115.5779
+2008-03-31,SK,Slovakia,124.8626
+2008-03-31,TH,Thailand,91.1224
+2008-03-31,US,United States,123.6731
+2008-03-31,XM,Euro area,106.694
+2008-03-31,XW,World,103.9866
+2008-03-31,ZA,South Africa,116.0704
+2008-06-30,4T,Emerging market economies (aggregate),95.3492
+2008-06-30,5R,Advanced economies,107.5481
 2008-06-30,AT,Austria,91.1346
-2008-06-30,AU,Australia,91.405
-2008-06-30,BE,Belgium,99.0731
-2008-06-30,BG,Bulgaria,149.8004
-2008-06-30,BR,Brazil,68.8233
-2008-06-30,CA,Canada,98.861
-2008-06-30,CH,Switzerland,93.37
+2008-06-30,AU,Australia,91.3627
+2008-06-30,BE,Belgium,99.8087
+2008-06-30,BG,Bulgaria,149.868
+2008-06-30,BR,Brazil,68.8236
+2008-06-30,CA,Canada,98.653
+2008-06-30,CH,Switzerland,93.3695
 2008-06-30,CL,Chile,92.6964
 2008-06-30,CN,China,92.6727
-2008-06-30,CO,Colombia,90.4287
+2008-06-30,CO,Colombia,89.6278
 2008-06-30,CY,Cyprus,110.1619
-2008-06-30,CZ,Czechia,108.949
+2008-06-30,CZ,Czechia,108.9481
 2008-06-30,DE,Germany,101.8112
-2008-06-30,DK,Denmark,118.1789
+2008-06-30,DK,Denmark,118.1947
 2008-06-30,EE,Estonia,160.2789
-2008-06-30,ES,Spain,111.5936
+2008-06-30,ES,Spain,111.5931
 2008-06-30,FI,Finland,95.6217
-2008-06-30,FR,France,103.8905
-2008-06-30,GB,United Kingdom,113.581
-2008-06-30,GR,Greece,114.2615
+2008-06-30,FR,France,103.8913
+2008-06-30,GB,United Kingdom,113.534
+2008-06-30,GR,Greece,114.2616
 2008-06-30,HK,Hong Kong SAR,85.4493
-2008-06-30,HR,Croatia,115.8928
+2008-06-30,HR,Croatia,115.9432
 2008-06-30,HU,Hungary,118.4445
 2008-06-30,ID,Indonesia,106.5868
-2008-06-30,IE,Ireland,137.3946
-2008-06-30,IL,Israel,78.1704
-2008-06-30,IN,India,
-2008-06-30,IS,Iceland,136.9169
-2008-06-30,IT,Italy,104.2421
+2008-06-30,IE,Ireland,137.4005
+2008-06-30,IL,Israel,78.1707
+2008-06-30,IS,Iceland,136.9271
+2008-06-30,IT,Italy,104.2496
 2008-06-30,JP,Japan,100.8809
-2008-06-30,KR,Korea,103.1872
-2008-06-30,LT,Lithuania,169.4604
-2008-06-30,LU,Luxembourg,98.9122
-2008-06-30,LV,Latvia,196.5136
-2008-06-30,MA,Morocco,98.6376
-2008-06-30,MK,North Macedonia,93.5181
+2008-06-30,KR,Korea,103.1623
+2008-06-30,LT,Lithuania,169.4603
+2008-06-30,LU,Luxembourg,98.9148
+2008-06-30,LV,Latvia,196.5539
+2008-06-30,MA,Morocco,100.687
+2008-06-30,MK,North Macedonia,93.4703
 2008-06-30,MT,Malta,104.0699
 2008-06-30,MX,Mexico,101.52
 2008-06-30,MY,Malaysia,94.2039
-2008-06-30,NL,Netherlands,108.796
-2008-06-30,NO,Norway,99.3539
+2008-06-30,NL,Netherlands,108.802
+2008-06-30,NO,Norway,99.3761
 2008-06-30,NZ,New Zealand,104.767
 2008-06-30,PE,Peru,73.9181
 2008-06-30,PH,Philippines,109.6433
-2008-06-30,PL,Poland,
 2008-06-30,PT,Portugal,101.9253
-2008-06-30,RO,Romania,
 2008-06-30,RS,Serbia,83.7913
 2008-06-30,RU,Russia,110.8672
-2008-06-30,SE,Sweden,92.3253
-2008-06-30,SG,Singapore,99.1108
-2008-06-30,SI,Slovenia,112.3336
-2008-06-30,SK,Slovak Republic,128.154
-2008-06-30,TH,Thailand,90.9247
-2008-06-30,TR,Türkiye,
-2008-06-30,US,United States,115.5421
-2008-06-30,XM,Euro area,105.551
-2008-06-30,XW,World,102.1725
-2008-06-30,ZA,South Africa,110.494
-2008-09-30,4T,Emerging market economies (aggregate),96.1751
-2008-09-30,5R,Advanced economies,104.9284
-2008-09-30,AE,United Arab Emirates,149.483
+2008-06-30,SE,Sweden,92.3242
+2008-06-30,SG,Singapore,99.1069
+2008-06-30,SI,Slovenia,112.3516
+2008-06-30,SK,Slovakia,127.7819
+2008-06-30,TH,Thailand,90.9242
+2008-06-30,US,United States,115.5494
+2008-06-30,XM,Euro area,105.4964
+2008-06-30,XW,World,102.1911
+2008-06-30,ZA,South Africa,110.3885
+2008-09-30,4T,Emerging market economies (aggregate),95.635
+2008-09-30,5R,Advanced economies,104.4644
 2008-09-30,AT,Austria,92.6293
-2008-09-30,AU,Australia,88.3133
-2008-09-30,BE,Belgium,99.6613
-2008-09-30,BG,Bulgaria,151.3384
-2008-09-30,BR,Brazil,71.5105
-2008-09-30,CA,Canada,95.8317
-2008-09-30,CH,Switzerland,94.5623
+2008-09-30,AU,Australia,88.3054
+2008-09-30,BE,Belgium,100.5061
+2008-09-30,BG,Bulgaria,151.3111
+2008-09-30,BR,Brazil,71.5108
+2008-09-30,CA,Canada,95.68
+2008-09-30,CH,Switzerland,94.5607
 2008-09-30,CL,Chile,91.8075
 2008-09-30,CN,China,93.3268
-2008-09-30,CO,Colombia,90.4879
+2008-09-30,CO,Colombia,89.9915
 2008-09-30,CY,Cyprus,110.3764
-2008-09-30,CZ,Czechia,109.7975
+2008-09-30,CZ,Czechia,109.7997
 2008-09-30,DE,Germany,100.6326
-2008-09-30,DK,Denmark,114.8022
+2008-09-30,DK,Denmark,114.8012
 2008-09-30,EE,Estonia,157.5516
-2008-09-30,ES,Spain,109.8453
+2008-09-30,ES,Spain,109.8451
 2008-09-30,FI,Finland,93.6643
-2008-09-30,FR,France,103.9231
-2008-09-30,GB,United Kingdom,107.7688
+2008-09-30,FR,France,103.924
+2008-09-30,GB,United Kingdom,107.8233
 2008-09-30,GR,Greece,115.9146
 2008-09-30,HK,Hong Kong SAR,83.7555
-2008-09-30,HR,Croatia,117.0475
+2008-09-30,HR,Croatia,117.1067
 2008-09-30,HU,Hungary,118.5797
 2008-09-30,ID,Indonesia,102.817
-2008-09-30,IE,Ireland,132.7654
+2008-09-30,IE,Ireland,132.7688
 2008-09-30,IL,Israel,80.3115
-2008-09-30,IN,India,
-2008-09-30,IS,Iceland,131.9862
-2008-09-30,IT,Italy,103.6755
+2008-09-30,IS,Iceland,131.9747
+2008-09-30,IT,Italy,103.6779
 2008-09-30,JP,Japan,99.1951
-2008-09-30,KR,Korea,102.9969
+2008-09-30,KR,Korea,103.031
 2008-09-30,LT,Lithuania,164.1763
-2008-09-30,LU,Luxembourg,98.2059
-2008-09-30,LV,Latvia,181.2243
-2008-09-30,MA,Morocco,100.3985
-2008-09-30,MK,North Macedonia,96.1738
+2008-09-30,LU,Luxembourg,98.2068
+2008-09-30,LV,Latvia,181.2314
+2008-09-30,MA,Morocco,101.0589
+2008-09-30,MK,North Macedonia,95.9237
 2008-09-30,MT,Malta,109.2451
 2008-09-30,MX,Mexico,102.6049
 2008-09-30,MY,Malaysia,92.247
-2008-09-30,NL,Netherlands,109.7215
-2008-09-30,NO,Norway,94.8108
+2008-09-30,NL,Netherlands,109.7196
+2008-09-30,NO,Norway,94.7176
 2008-09-30,NZ,New Zealand,101.2158
 2008-09-30,PE,Peru,81.8715
 2008-09-30,PH,Philippines,106.7644
-2008-09-30,PL,Poland,
-2008-09-30,PT,Portugal,99.3673
-2008-09-30,RO,Romania,
+2008-09-30,PT,Portugal,99.3672
 2008-09-30,RS,Serbia,89.7353
 2008-09-30,RU,Russia,113.1404
-2008-09-30,SE,Sweden,91.0346
-2008-09-30,SG,Singapore,95.4676
-2008-09-30,SI,Slovenia,113.8827
-2008-09-30,SK,Slovak Republic,121.1676
-2008-09-30,TH,Thailand,95.3489
-2008-09-30,TR,Türkiye,
-2008-09-30,US,United States,109.1568
-2008-09-30,XM,Euro area,105.0641
-2008-09-30,XW,World,100.5605
-2008-09-30,ZA,South Africa,104.9055
-2008-12-31,4T,Emerging market economies (aggregate),95.6337
-2008-12-31,5R,Advanced economies,102.7703
-2008-12-31,AE,United Arab Emirates,134.2605
+2008-09-30,SE,Sweden,91.0373
+2008-09-30,SG,Singapore,95.4672
+2008-09-30,SI,Slovenia,113.8818
+2008-09-30,SK,Slovakia,120.8157
+2008-09-30,TH,Thailand,95.349
+2008-09-30,US,United States,109.1551
+2008-09-30,XM,Euro area,105.0152
+2008-09-30,XW,World,100.5881
+2008-09-30,ZA,South Africa,104.832
+2008-12-31,4T,Emerging market economies (aggregate),95.376
+2008-12-31,5R,Advanced economies,102.3222
 2008-12-31,AT,Austria,94.1003
-2008-12-31,AU,Australia,87.3918
-2008-12-31,BE,Belgium,99.854
-2008-12-31,BG,Bulgaria,143.3031
-2008-12-31,BR,Brazil,74.7328
-2008-12-31,CA,Canada,93.3657
-2008-12-31,CH,Switzerland,95.8206
-2008-12-31,CL,Chile,91.9195
+2008-12-31,AU,Australia,87.3864
+2008-12-31,BE,Belgium,100.6476
+2008-12-31,BG,Bulgaria,143.3336
+2008-12-31,BR,Brazil,74.7332
+2008-12-31,CA,Canada,93.3232
+2008-12-31,CH,Switzerland,95.8183
+2008-12-31,CL,Chile,91.9196
 2008-12-31,CN,China,93.6743
-2008-12-31,CO,Colombia,91.4576
+2008-12-31,CO,Colombia,91.3118
 2008-12-31,CY,Cyprus,106.499
-2008-12-31,CZ,Czechia,109.8372
+2008-12-31,CZ,Czechia,109.8357
 2008-12-31,DE,Germany,101.9201
-2008-12-31,DK,Denmark,105.9308
+2008-12-31,DK,Denmark,105.9404
 2008-12-31,EE,Estonia,134.0197
 2008-12-31,ES,Spain,106.6655
 2008-12-31,FI,Finland,90.1046
-2008-12-31,FR,France,100.9857
-2008-12-31,GB,United Kingdom,100.5213
+2008-12-31,FR,France,100.9884
+2008-12-31,GB,United Kingdom,100.587
 2008-12-31,GR,Greece,114.6558
 2008-12-31,HK,Hong Kong SAR,73.4021
-2008-12-31,HR,Croatia,114.4506
+2008-12-31,HR,Croatia,114.5538
 2008-12-31,HU,Hungary,116.4921
 2008-12-31,ID,Indonesia,101.9431
-2008-12-31,IE,Ireland,127.0743
-2008-12-31,IL,Israel,81.0542
-2008-12-31,IN,India,
-2008-12-31,IS,Iceland,123.8897
-2008-12-31,IT,Italy,102.5444
+2008-12-31,IE,Ireland,127.1434
+2008-12-31,IL,Israel,81.0544
+2008-12-31,IS,Iceland,123.9092
+2008-12-31,IT,Italy,102.5475
 2008-12-31,JP,Japan,98.911
-2008-12-31,KR,Korea,102.9553
-2008-12-31,LT,Lithuania,150.4949
-2008-12-31,LU,Luxembourg,99.1081
-2008-12-31,LV,Latvia,150.0413
-2008-12-31,MA,Morocco,100.8115
-2008-12-31,MK,North Macedonia,102.7254
+2008-12-31,KR,Korea,102.9575
+2008-12-31,LT,Lithuania,150.495
+2008-12-31,LU,Luxembourg,99.1108
+2008-12-31,LV,Latvia,150.0473
+2008-12-31,MA,Morocco,100.5941
+2008-12-31,MK,North Macedonia,102.5175
 2008-12-31,MT,Malta,105.2529
 2008-12-31,MX,Mexico,101.3082
 2008-12-31,MY,Malaysia,91.9938
-2008-12-31,NL,Netherlands,107.869
-2008-12-31,NO,Norway,87.3128
+2008-12-31,NL,Netherlands,107.8659
+2008-12-31,NO,Norway,87.2793
 2008-12-31,NZ,New Zealand,99.3679
 2008-12-31,PE,Peru,82.4275
 2008-12-31,PH,Philippines,107.0321
-2008-12-31,PL,Poland,
 2008-12-31,PT,Portugal,98.2116
-2008-12-31,RO,Romania,
 2008-12-31,RS,Serbia,93.4292
 2008-12-31,RU,Russia,109.3202
-2008-12-31,SE,Sweden,86.4614
-2008-12-31,SG,Singapore,89.0182
-2008-12-31,SI,Slovenia,111.234
-2008-12-31,SK,Slovak Republic,115.4864
-2008-12-31,TH,Thailand,101.5071
-2008-12-31,TR,Türkiye,
-2008-12-31,US,United States,106.5491
-2008-12-31,XM,Euro area,103.7785
-2008-12-31,XW,World,99.1956
-2008-12-31,ZA,South Africa,103.9933
-2009-03-31,4T,Emerging market economies (aggregate),94.5184
-2009-03-31,5R,Advanced economies,101.0181
-2009-03-31,AE,United Arab Emirates,123.4448
+2008-12-31,SE,Sweden,86.4637
+2008-12-31,SG,Singapore,89.0192
+2008-12-31,SI,Slovenia,111.255
+2008-12-31,SK,Slovakia,115.1511
+2008-12-31,TH,Thailand,101.5101
+2008-12-31,US,United States,106.561
+2008-12-31,XM,Euro area,103.7366
+2008-12-31,XW,World,99.2595
+2008-12-31,ZA,South Africa,103.9673
+2009-03-31,4T,Emerging market economies (aggregate),94.4771
+2009-03-31,5R,Advanced economies,100.4952
 2009-03-31,AT,Austria,96.2574
-2009-03-31,AU,Australia,87.0962
-2009-03-31,BE,Belgium,98.7634
-2009-03-31,BG,Bulgaria,126.2601
-2009-03-31,BR,Brazil,78.0714
-2009-03-31,CA,Canada,90.6784
-2009-03-31,CH,Switzerland,97.4683
-2009-03-31,CL,Chile,88.6449
+2009-03-31,AU,Australia,87.09
+2009-03-31,BE,Belgium,99.5764
+2009-03-31,BG,Bulgaria,126.2071
+2009-03-31,BR,Brazil,78.0717
+2009-03-31,CA,Canada,90.6825
+2009-03-31,CH,Switzerland,97.47
+2009-03-31,CL,Chile,88.6448
 2009-03-31,CN,China,92.2225
-2009-03-31,CO,Colombia,92.7775
+2009-03-31,CO,Colombia,92.8088
 2009-03-31,CY,Cyprus,103.8864
-2009-03-31,CZ,Czechia,106.1072
+2009-03-31,CZ,Czechia,106.1096
 2009-03-31,DE,Germany,101.7331
-2009-03-31,DK,Denmark,98.955
+2009-03-31,DK,Denmark,98.9368
 2009-03-31,EE,Estonia,106.5547
-2009-03-31,ES,Spain,105.5597
+2009-03-31,ES,Spain,105.5601
 2009-03-31,FI,Finland,92.7232
-2009-03-31,FR,France,97.6274
-2009-03-31,GB,United Kingdom,95.7193
+2009-03-31,FR,France,97.6312
+2009-03-31,GB,United Kingdom,95.7192
 2009-03-31,GR,Greece,111.4224
 2009-03-31,HK,Hong Kong SAR,73.2217
-2009-03-31,HR,Croatia,112.628
+2009-03-31,HR,Croatia,112.6789
 2009-03-31,HU,Hungary,114.5563
 2009-03-31,ID,Indonesia,102.2484
-2009-03-31,IE,Ireland,121.8483
-2009-03-31,IL,Israel,83.1212
+2009-03-31,IE,Ireland,121.8602
+2009-03-31,IL,Israel,83.1214
 2009-03-31,IN,India,88.9013
-2009-03-31,IS,Iceland,111.6146
-2009-03-31,IT,Italy,103.1062
+2009-03-31,IS,Iceland,111.6234
+2009-03-31,IT,Italy,103.1083
 2009-03-31,JP,Japan,98.19
-2009-03-31,KR,Korea,100.7846
-2009-03-31,LT,Lithuania,117.0766
-2009-03-31,LU,Luxembourg,97.4159
-2009-03-31,LV,Latvia,119.9556
-2009-03-31,MA,Morocco,104.2007
-2009-03-31,MK,North Macedonia,99.4145
+2009-03-31,KR,Korea,100.798
+2009-03-31,LT,Lithuania,117.0767
+2009-03-31,LU,Luxembourg,97.4233
+2009-03-31,LV,Latvia,119.982
+2009-03-31,MA,Morocco,101.2616
+2009-03-31,MK,North Macedonia,99.3466
 2009-03-31,MT,Malta,102.7936
 2009-03-31,MX,Mexico,101.2684
 2009-03-31,MY,Malaysia,93.3274
-2009-03-31,NL,Netherlands,106.2678
-2009-03-31,NO,Norway,91.0245
+2009-03-31,NL,Netherlands,106.2747
+2009-03-31,NO,Norway,91.0152
 2009-03-31,NZ,New Zealand,98.4173
 2009-03-31,PE,Peru,79.7936
 2009-03-31,PH,Philippines,105.4092
-2009-03-31,PL,Poland,
-2009-03-31,PT,Portugal,100.0275
+2009-03-31,PT,Portugal,100.0276
 2009-03-31,RO,Romania,119.3204
 2009-03-31,RS,Serbia,96.3338
 2009-03-31,RU,Russia,106.8099
-2009-03-31,SE,Sweden,90.1226
-2009-03-31,SG,Singapore,77.2412
-2009-03-31,SI,Slovenia,104.7894
-2009-03-31,SK,Slovak Republic,107.8436
-2009-03-31,TH,Thailand,100.182
-2009-03-31,TR,Türkiye,
-2009-03-31,US,United States,103.9763
-2009-03-31,XM,Euro area,102.7907
-2009-03-31,XW,World,97.7631
-2009-03-31,ZA,South Africa,102.2432
-2009-06-30,4T,Emerging market economies (aggregate),94.9377
-2009-06-30,5R,Advanced economies,99.9389
-2009-06-30,AE,United Arab Emirates,117.2325
+2009-03-31,SE,Sweden,90.1271
+2009-03-31,SG,Singapore,77.2445
+2009-03-31,SI,Slovenia,104.7806
+2009-03-31,SK,Slovakia,107.5304
+2009-03-31,TH,Thailand,100.1807
+2009-03-31,US,United States,103.9849
+2009-03-31,XM,Euro area,102.7633
+2009-03-31,XW,World,97.8429
+2009-03-31,ZA,South Africa,102.1721
+2009-06-30,4T,Emerging market economies (aggregate),94.9447
+2009-06-30,5R,Advanced economies,99.4594
 2009-06-30,AT,Austria,96.1098
-2009-06-30,AU,Australia,90.3262
-2009-06-30,BE,Belgium,97.9772
-2009-06-30,BG,Bulgaria,113.8115
-2009-06-30,BR,Brazil,81.6833
-2009-06-30,CA,Canada,91.9371
-2009-06-30,CH,Switzerland,96.0579
+2009-06-30,AU,Australia,90.2606
+2009-06-30,BE,Belgium,98.8441
+2009-06-30,BG,Bulgaria,113.795
+2009-06-30,BR,Brazil,81.6836
+2009-06-30,CA,Canada,91.9593
+2009-06-30,CH,Switzerland,96.0593
 2009-06-30,CL,Chile,91.1138
 2009-06-30,CN,China,93.6717
-2009-06-30,CO,Colombia,94.1801
+2009-06-30,CO,Colombia,94.4092
 2009-06-30,CY,Cyprus,102.6155
-2009-06-30,CZ,Czechia,102.6712
+2009-06-30,CZ,Czechia,102.6646
 2009-06-30,DE,Germany,100.184
-2009-06-30,DK,Denmark,99.4005
+2009-06-30,DK,Denmark,99.3547
 2009-06-30,EE,Estonia,100.2697
 2009-06-30,ES,Spain,103.8245
 2009-06-30,FI,Finland,94.1247
-2009-06-30,FR,France,95.769
-2009-06-30,GB,United Kingdom,95.9597
+2009-06-30,FR,France,95.7699
+2009-06-30,GB,United Kingdom,95.8899
 2009-06-30,GR,Greece,110.6971
 2009-06-30,HK,Hong Kong SAR,79.4908
-2009-06-30,HR,Croatia,107.6494
+2009-06-30,HR,Croatia,107.6516
 2009-06-30,HU,Hungary,108.3564
 2009-06-30,ID,Indonesia,102.9899
-2009-06-30,IE,Ireland,115.0223
-2009-06-30,IL,Israel,85.1959
+2009-06-30,IE,Ireland,115.048
+2009-06-30,IL,Israel,85.1964
 2009-06-30,IN,India,91.8104
-2009-06-30,IS,Iceland,109.4902
-2009-06-30,IT,Italy,102.4725
+2009-06-30,IS,Iceland,109.494
+2009-06-30,IT,Italy,102.4753
 2009-06-30,JP,Japan,96.7052
-2009-06-30,KR,Korea,99.7796
+2009-06-30,KR,Korea,99.841
 2009-06-30,LT,Lithuania,111.1014
-2009-06-30,LU,Luxembourg,97.095
-2009-06-30,LV,Latvia,108.3479
-2009-06-30,MA,Morocco,103.4203
-2009-06-30,MK,North Macedonia,100.9446
+2009-06-30,LU,Luxembourg,97.0993
+2009-06-30,LV,Latvia,108.4
+2009-06-30,MA,Morocco,101.3484
+2009-06-30,MK,North Macedonia,100.7257
 2009-06-30,MT,Malta,99.838
 2009-06-30,MX,Mexico,101.8548
 2009-06-30,MY,Malaysia,95.3437
-2009-06-30,NL,Netherlands,102.0939
-2009-06-30,NO,Norway,94.8647
+2009-06-30,NL,Netherlands,102.0973
+2009-06-30,NO,Norway,94.8622
 2009-06-30,NZ,New Zealand,99.6446
 2009-06-30,PE,Peru,79.6834
 2009-06-30,PH,Philippines,104.437
-2009-06-30,PL,Poland,
 2009-06-30,PT,Portugal,100.2976
 2009-06-30,RO,Romania,112.8518
 2009-06-30,RS,Serbia,96.1195
 2009-06-30,RU,Russia,99.0476
-2009-06-30,SE,Sweden,92.5334
-2009-06-30,SG,Singapore,74.2939
-2009-06-30,SI,Slovenia,101.0682
-2009-06-30,SK,Slovak Republic,102.9788
-2009-06-30,TH,Thailand,99.3643
-2009-06-30,TR,Türkiye,
-2009-06-30,US,United States,102.8765
-2009-06-30,XM,Euro area,100.6426
-2009-06-30,XW,World,97.4344
-2009-06-30,ZA,South Africa,99.706
-2009-09-30,4T,Emerging market economies (aggregate),96.1482
-2009-09-30,5R,Advanced economies,100.5377
-2009-09-30,AE,United Arab Emirates,113.1705
+2009-06-30,SE,Sweden,92.5323
+2009-06-30,SG,Singapore,74.2987
+2009-06-30,SI,Slovenia,101.0691
+2009-06-30,SK,Slovakia,102.6798
+2009-06-30,TH,Thailand,99.3666
+2009-06-30,US,United States,102.8903
+2009-06-30,XM,Euro area,100.6293
+2009-06-30,XW,World,97.4692
+2009-06-30,ZA,South Africa,99.5847
+2009-09-30,4T,Emerging market economies (aggregate),96.0183
+2009-09-30,5R,Advanced economies,100.2177
 2009-09-30,AT,Austria,95.5889
-2009-09-30,AU,Australia,93.2284
-2009-09-30,BE,Belgium,100.3678
-2009-09-30,BG,Bulgaria,109.6243
-2009-09-30,BR,Brazil,85.9266
-2009-09-30,CA,Canada,95.0789
-2009-09-30,CH,Switzerland,96.5535
+2009-09-30,AU,Australia,93.1827
+2009-09-30,BE,Belgium,101.2324
+2009-09-30,BG,Bulgaria,109.6608
+2009-09-30,BR,Brazil,85.9268
+2009-09-30,CA,Canada,95.0574
+2009-09-30,CH,Switzerland,96.5548
 2009-09-30,CL,Chile,95.7428
 2009-09-30,CN,China,95.6501
-2009-09-30,CO,Colombia,95.7937
+2009-09-30,CO,Colombia,95.7289
 2009-09-30,CY,Cyprus,104.2532
-2009-09-30,CZ,Czechia,102.4154
+2009-09-30,CZ,Czechia,102.4194
 2009-09-30,DE,Germany,99.9545
-2009-09-30,DK,Denmark,100.1528
+2009-09-30,DK,Denmark,100.1787
 2009-09-30,EE,Estonia,92.0611
-2009-09-30,ES,Spain,103.317
+2009-09-30,ES,Spain,103.3165
 2009-09-30,FI,Finland,95.8955
-2009-09-30,FR,France,97.3461
-2009-09-30,GB,United Kingdom,99.0186
+2009-09-30,FR,France,97.3453
+2009-09-30,GB,United Kingdom,99.0275
 2009-09-30,GR,Greece,109.2424
 2009-09-30,HK,Hong Kong SAR,87.2121
-2009-09-30,HR,Croatia,106.5839
+2009-09-30,HR,Croatia,106.6169
 2009-09-30,HU,Hungary,104.9886
 2009-09-30,ID,Indonesia,102.1505
-2009-09-30,IE,Ireland,111.3576
-2009-09-30,IL,Israel,88.2402
+2009-09-30,IE,Ireland,111.3268
+2009-09-30,IL,Israel,88.2404
 2009-09-30,IN,India,93.1466
-2009-09-30,IS,Iceland,105.4302
-2009-09-30,IT,Italy,102.3805
+2009-09-30,IS,Iceland,105.4194
+2009-09-30,IT,Italy,102.3824
 2009-09-30,JP,Japan,98.4322
-2009-09-30,KR,Korea,100.161
+2009-09-30,KR,Korea,100.1653
 2009-09-30,LT,Lithuania,107.0447
-2009-09-30,LU,Luxembourg,95.9219
-2009-09-30,LV,Latvia,108.637
-2009-09-30,MA,Morocco,100.777
-2009-09-30,MK,North Macedonia,99.678
+2009-09-30,LU,Luxembourg,95.9327
+2009-09-30,LV,Latvia,108.6525
+2009-09-30,MA,Morocco,100.5604
+2009-09-30,MK,North Macedonia,99.5884
 2009-09-30,MT,Malta,101.5837
 2009-09-30,MX,Mexico,101.4754
 2009-09-30,MY,Malaysia,96.265
-2009-09-30,NL,Netherlands,102.1046
-2009-09-30,NO,Norway,96.6041
+2009-09-30,NL,Netherlands,102.1052
+2009-09-30,NO,Norway,96.6016
 2009-09-30,NZ,New Zealand,100.5998
 2009-09-30,PE,Peru,86.8411
 2009-09-30,PH,Philippines,102.3312
-2009-09-30,PL,Poland,
 2009-09-30,PT,Portugal,101.0263
 2009-09-30,RO,Romania,112.767
 2009-09-30,RS,Serbia,96.5402
 2009-09-30,RU,Russia,95.3373
-2009-09-30,SE,Sweden,95.2055
-2009-09-30,SG,Singapore,85.2558
-2009-09-30,SI,Slovenia,99.7494
-2009-09-30,SK,Slovak Republic,107.6491
-2009-09-30,TH,Thailand,100.508
-2009-09-30,TR,Türkiye,
-2009-09-30,US,United States,102.5019
-2009-09-30,XM,Euro area,100.8974
-2009-09-30,XW,World,98.3371
-2009-09-30,ZA,South Africa,98.3538
-2009-12-31,4T,Emerging market economies (aggregate),97.1969
-2009-12-31,5R,Advanced economies,100.7936
-2009-12-31,AE,United Arab Emirates,111.053
+2009-09-30,SE,Sweden,95.208
+2009-09-30,SG,Singapore,85.2601
+2009-09-30,SI,Slovenia,99.7763
+2009-09-30,SK,Slovakia,107.3366
+2009-09-30,TH,Thailand,100.5075
+2009-09-30,US,United States,102.4829
+2009-09-30,XM,Euro area,100.8879
+2009-09-30,XW,World,98.3649
+2009-09-30,ZA,South Africa,98.2914
+2009-12-31,4T,Emerging market economies (aggregate),97.0058
+2009-12-31,5R,Advanced economies,100.571
 2009-12-31,AT,Austria,95.5617
-2009-12-31,AU,Australia,97.864
-2009-12-31,BE,Belgium,99.2211
-2009-12-31,BG,Bulgaria,106.368
-2009-12-31,BR,Brazil,90.3365
-2009-12-31,CA,Canada,97.6803
-2009-12-31,CH,Switzerland,96.3014
+2009-12-31,AU,Australia,97.812
+2009-12-31,BE,Belgium,100.0917
+2009-12-31,BG,Bulgaria,106.4038
+2009-12-31,BR,Brazil,90.3367
+2009-12-31,CA,Canada,97.6107
+2009-12-31,CH,Switzerland,96.3022
 2009-12-31,CL,Chile,100.5696
 2009-12-31,CN,China,97.3105
-2009-12-31,CO,Colombia,97.1787
+2009-12-31,CO,Colombia,97.2829
 2009-12-31,CY,Cyprus,103.6233
-2009-12-31,CZ,Czechia,101.9279
+2009-12-31,CZ,Czechia,101.9253
 2009-12-31,DE,Germany,100.2817
-2009-12-31,DK,Denmark,99.557
+2009-12-31,DK,Denmark,99.5696
 2009-12-31,EE,Estonia,90.8472
 2009-12-31,ES,Spain,101.8545
 2009-12-31,FI,Finland,98.0789
-2009-12-31,FR,France,97.3731
-2009-12-31,GB,United Kingdom,100.2457
+2009-12-31,FR,France,97.3771
+2009-12-31,GB,United Kingdom,100.1791
 2009-12-31,GR,Greece,107.9627
 2009-12-31,HK,Hong Kong SAR,88.8877
-2009-12-31,HR,Croatia,104.6231
+2009-12-31,HR,Croatia,104.6426
 2009-12-31,HU,Hungary,102.0464
 2009-12-31,ID,Indonesia,101.6649
-2009-12-31,IE,Ireland,109.3011
+2009-12-31,IE,Ireland,109.3506
 2009-12-31,IL,Israel,92.5261
 2009-12-31,IN,India,94.6526
-2009-12-31,IS,Iceland,104.5827
-2009-12-31,IT,Italy,101.6107
+2009-12-31,IS,Iceland,104.5676
+2009-12-31,IT,Italy,101.6164
 2009-12-31,JP,Japan,98.0852
-2009-12-31,KR,Korea,101.2139
+2009-12-31,KR,Korea,101.2001
 2009-12-31,LT,Lithuania,102.2759
-2009-12-31,LU,Luxembourg,97.6366
-2009-12-31,LV,Latvia,107.2214
-2009-12-31,MA,Morocco,100.7292
-2009-12-31,MK,North Macedonia,96.6268
+2009-12-31,LU,Luxembourg,97.639
+2009-12-31,LV,Latvia,107.1816
+2009-12-31,MA,Morocco,101.7691
+2009-12-31,MK,North Macedonia,96.2914
 2009-12-31,MT,Malta,97.5365
 2009-12-31,MX,Mexico,100.1913
 2009-12-31,MY,Malaysia,96.8476
-2009-12-31,NL,Netherlands,101.7444
-2009-12-31,NO,Norway,96.0704
+2009-12-31,NL,Netherlands,101.7482
+2009-12-31,NO,Norway,96.0625
 2009-12-31,NZ,New Zealand,102.7142
 2009-12-31,PE,Peru,87.9023
 2009-12-31,PH,Philippines,100.7028
-2009-12-31,PL,Poland,
 2009-12-31,PT,Portugal,101.1617
 2009-12-31,RO,Romania,114.9363
 2009-12-31,RS,Serbia,97.5271
 2009-12-31,RU,Russia,93.7268
-2009-12-31,SE,Sweden,97.2077
-2009-12-31,SG,Singapore,91.2241
-2009-12-31,SI,Slovenia,101.0666
-2009-12-31,SK,Slovak Republic,102.1066
-2009-12-31,TH,Thailand,102.1223
-2009-12-31,TR,Türkiye,
-2009-12-31,US,United States,102.885
-2009-12-31,XM,Euro area,100.3849
-2009-12-31,XW,World,98.9856
-2009-12-31,ZA,South Africa,99.4933
-2010-03-31,4T,Emerging market economies (aggregate),98.5231
-2010-03-31,5R,Advanced economies,100.4955
-2010-03-31,AE,United Arab Emirates,105.1652
+2009-12-31,SE,Sweden,97.2091
+2009-12-31,SG,Singapore,91.2281
+2009-12-31,SI,Slovenia,101.0801
+2009-12-31,SK,Slovakia,101.8102
+2009-12-31,TH,Thailand,102.1225
+2009-12-31,US,United States,102.8757
+2009-12-31,XM,Euro area,100.375
+2009-12-31,XW,World,98.9944
+2009-12-31,ZA,South Africa,99.3525
+2010-03-31,4T,Emerging market economies (aggregate),98.424
+2010-03-31,5R,Advanced economies,100.3623
 2010-03-31,AT,Austria,100.2528
-2010-03-31,AU,Australia,99.9682
-2010-03-31,BE,Belgium,99.2586
-2010-03-31,BG,Bulgaria,102.5561
+2010-03-31,AU,Australia,99.9381
+2010-03-31,BE,Belgium,99.4178
+2010-03-31,BG,Bulgaria,102.5328
 2010-03-31,BR,Brazil,93.9314
-2010-03-31,CA,Canada,100.2854
-2010-03-31,CH,Switzerland,98.3525
+2010-03-31,CA,Canada,100.2438
+2010-03-31,CH,Switzerland,98.353
 2010-03-31,CL,Chile,97.1334
 2010-03-31,CN,China,98.4735
-2010-03-31,CO,Colombia,98.124
+2010-03-31,CO,Colombia,97.9697
 2010-03-31,CY,Cyprus,101.9884
-2010-03-31,CZ,Czechia,100.4597
+2010-03-31,CZ,Czechia,100.4567
 2010-03-31,DE,Germany,99.1342
-2010-03-31,DK,Denmark,99.1487
+2010-03-31,DK,Denmark,99.1517
 2010-03-31,EE,Estonia,100.4538
-2010-03-31,ES,Spain,101.306
+2010-03-31,ES,Spain,101.3059
 2010-03-31,FI,Finland,99.6381
-2010-03-31,FR,France,97.5619
-2010-03-31,GB,United Kingdom,99.8286
-2010-03-31,GR,Greece,106.228
+2010-03-31,FR,France,97.5617
+2010-03-31,GB,United Kingdom,99.7592
+2010-03-31,GR,Greece,106.2279
 2010-03-31,HK,Hong Kong SAR,93.4491
-2010-03-31,HR,Croatia,102.0921
+2010-03-31,HR,Croatia,102.0834
 2010-03-31,HU,Hungary,102.6162
 2010-03-31,ID,Indonesia,101.1526
-2010-03-31,IE,Ireland,106.1877
+2010-03-31,IE,Ireland,106.1786
 2010-03-31,IL,Israel,96.7735
 2010-03-31,IN,India,96.2271
-2010-03-31,IS,Iceland,99.2231
-2010-03-31,IT,Italy,99.6538
+2010-03-31,IS,Iceland,99.2311
+2010-03-31,IT,Italy,99.656
 2010-03-31,JP,Japan,99.451
-2010-03-31,KR,Korea,100.4909
+2010-03-31,KR,Korea,100.496
 2010-03-31,LT,Lithuania,99.1576
-2010-03-31,LU,Luxembourg,101.2364
-2010-03-31,LV,Latvia,98.8691
-2010-03-31,MA,Morocco,99.3235
-2010-03-31,MK,North Macedonia,100.6283
+2010-03-31,LU,Luxembourg,101.2382
+2010-03-31,LV,Latvia,98.8298
+2010-03-31,MA,Morocco,100.5604
+2010-03-31,MK,North Macedonia,100.5605
 2010-03-31,MT,Malta,101.9142
 2010-03-31,MX,Mexico,98.8179
 2010-03-31,MY,Malaysia,96.8586
-2010-03-31,NL,Netherlands,101.0185
-2010-03-31,NO,Norway,97.8581
+2010-03-31,NL,Netherlands,101.0205
+2010-03-31,NO,Norway,97.8654
 2010-03-31,NZ,New Zealand,102.4238
 2010-03-31,PE,Peru,95.7671
 2010-03-31,PH,Philippines,99.6264
 2010-03-31,PL,Poland,100.0602
-2010-03-31,PT,Portugal,101.6862
+2010-03-31,PT,Portugal,101.6861
 2010-03-31,RO,Romania,106.346
 2010-03-31,RS,Serbia,99.0219
 2010-03-31,RU,Russia,101.6916
-2010-03-31,SE,Sweden,98.6619
-2010-03-31,SG,Singapore,95.7477
-2010-03-31,SI,Slovenia,101.665
-2010-03-31,SK,Slovak Republic,101.2206
-2010-03-31,TH,Thailand,99.1465
-2010-03-31,TR,Türkiye,99.3658
-2010-03-31,US,United States,101.5252
-2010-03-31,XM,Euro area,100.041
-2010-03-31,XW,World,99.5092
-2010-03-31,ZA,South Africa,100.3992
-2010-06-30,4T,Emerging market economies (aggregate),100.1456
-2010-06-30,5R,Advanced economies,100.4629
-2010-06-30,AE,United Arab Emirates,102.0352
+2010-03-31,SE,Sweden,98.6638
+2010-03-31,SG,Singapore,95.7487
+2010-03-31,SI,Slovenia,101.6593
+2010-03-31,SK,Slovakia,101.2206
+2010-03-31,TH,Thailand,99.1453
+2010-03-31,TR,Türkiye,98.638
+2010-03-31,US,United States,101.5279
+2010-03-31,XM,Euro area,100.0334
+2010-03-31,XW,World,99.5102
+2010-03-31,ZA,South Africa,100.2246
+2010-06-30,4T,Emerging market economies (aggregate),100.1265
+2010-06-30,5R,Advanced economies,100.3966
 2010-06-30,AT,Austria,99.5266
-2010-06-30,AU,Australia,101.2842
-2010-06-30,BE,Belgium,99.1893
-2010-06-30,BG,Bulgaria,100.8851
-2010-06-30,BR,Brazil,97.7444
-2010-06-30,CA,Canada,101.3631
-2010-06-30,CH,Switzerland,98.3984
+2010-06-30,AU,Australia,101.2793
+2010-06-30,BE,Belgium,99.2191
+2010-06-30,BG,Bulgaria,100.8509
+2010-06-30,BR,Brazil,97.7445
+2010-06-30,CA,Canada,101.3371
+2010-06-30,CH,Switzerland,98.3985
 2010-06-30,CL,Chile,100.5626
 2010-06-30,CN,China,100.8828
-2010-06-30,CO,Colombia,99.2871
+2010-06-30,CO,Colombia,99.0323
 2010-06-30,CY,Cyprus,100.1073
-2010-06-30,CZ,Czechia,100.0225
+2010-06-30,CZ,Czechia,100.0198
 2010-06-30,DE,Germany,99.8472
-2010-06-30,DK,Denmark,100.3592
+2010-06-30,DK,Denmark,100.3687
 2010-06-30,EE,Estonia,99.7083
-2010-06-30,ES,Spain,101.2193
+2010-06-30,ES,Spain,101.2195
 2010-06-30,FI,Finland,99.7295
-2010-06-30,FR,France,98.6505
-2010-06-30,GB,United Kingdom,100.3546
+2010-06-30,FR,France,98.6502
+2010-06-30,GB,United Kingdom,100.3242
 2010-06-30,GR,Greece,100.3345
 2010-06-30,HK,Hong Kong SAR,96.7947
-2010-06-30,HR,Croatia,99.7014
+2010-06-30,HR,Croatia,99.7116
 2010-06-30,HU,Hungary,100.3191
 2010-06-30,ID,Indonesia,101.5211
-2010-06-30,IE,Ireland,101.7947
+2010-06-30,IE,Ireland,101.8253
 2010-06-30,IL,Israel,98.926
 2010-06-30,IN,India,99.1165
-2010-06-30,IS,Iceland,100.4538
-2010-06-30,IT,Italy,99.9677
+2010-06-30,IS,Iceland,100.439
+2010-06-30,IT,Italy,99.9658
 2010-06-30,JP,Japan,99.5475
-2010-06-30,KR,Korea,100.3644
+2010-06-30,KR,Korea,100.3475
 2010-06-30,LT,Lithuania,100.5869
-2010-06-30,LU,Luxembourg,98.6599
-2010-06-30,LV,Latvia,97.9777
-2010-06-30,MA,Morocco,101.5051
-2010-06-30,MK,North Macedonia,100.1747
+2010-06-30,LU,Luxembourg,98.6634
+2010-06-30,LV,Latvia,98.0037
+2010-06-30,MA,Morocco,100.037
+2010-06-30,MK,North Macedonia,100.0774
 2010-06-30,MT,Malta,100.0845
 2010-06-30,MX,Mexico,99.9587
 2010-06-30,MY,Malaysia,99.8799
-2010-06-30,NL,Netherlands,99.7261
-2010-06-30,NO,Norway,100.9446
+2010-06-30,NL,Netherlands,99.7221
+2010-06-30,NO,Norway,100.9327
 2010-06-30,NZ,New Zealand,101.1164
 2010-06-30,PE,Peru,99.4244
 2010-06-30,PH,Philippines,99.6697
@@ -20697,184 +5179,181 @@ date,country_code,country,price
 2010-06-30,RO,Romania,103.9016
 2010-06-30,RS,Serbia,99.7649
 2010-06-30,RU,Russia,100.5569
-2010-06-30,SE,Sweden,99.3769
-2010-06-30,SG,Singapore,99.6303
-2010-06-30,SI,Slovenia,100.0224
-2010-06-30,SK,Slovak Republic,100.1314
-2010-06-30,TH,Thailand,98.8907
-2010-06-30,TR,Türkiye,99.6284
-2010-06-30,US,United States,101.3705
-2010-06-30,XM,Euro area,99.6599
-2010-06-30,XW,World,100.3071
-2010-06-30,ZA,South Africa,100.3799
-2010-09-30,4T,Emerging market economies (aggregate),100.9265
-2010-09-30,5R,Advanced economies,99.979
-2010-09-30,AE,United Arab Emirates,98.1515
+2010-06-30,SE,Sweden,99.3746
+2010-06-30,SG,Singapore,99.6304
+2010-06-30,SI,Slovenia,100.0204
+2010-06-30,SK,Slovakia,100.1314
+2010-06-30,TH,Thailand,98.8895
+2010-06-30,TR,Türkiye,99.619
+2010-06-30,US,United States,101.3757
+2010-06-30,XM,Euro area,99.6617
+2010-06-30,XW,World,100.2805
+2010-06-30,ZA,South Africa,100.0647
+2010-09-30,4T,Emerging market economies (aggregate),101.0179
+2010-09-30,5R,Advanced economies,100.0207
 2010-09-30,AT,Austria,99.764
-2010-09-30,AU,Australia,99.2963
-2010-09-30,BE,Belgium,100.765
-2010-09-30,BG,Bulgaria,99.7544
-2010-09-30,BR,Brazil,102.5245
-2010-09-30,CA,Canada,99.6792
-2010-09-30,CH,Switzerland,101.1498
+2010-09-30,AU,Australia,99.3003
+2010-09-30,BE,Belgium,101.0517
+2010-09-30,BG,Bulgaria,99.7716
+2010-09-30,BR,Brazil,102.5244
+2010-09-30,CA,Canada,99.7146
+2010-09-30,CH,Switzerland,101.1493
 2010-09-30,CL,Chile,100.8188
 2010-09-30,CN,China,100.6863
-2010-09-30,CO,Colombia,99.3894
+2010-09-30,CO,Colombia,99.671
 2010-09-30,CY,Cyprus,100.056
-2010-09-30,CZ,Czechia,99.6366
+2010-09-30,CZ,Czechia,99.6389
 2010-09-30,DE,Germany,100.4955
-2010-09-30,DK,Denmark,100.915
+2010-09-30,DK,Denmark,100.9053
 2010-09-30,EE,Estonia,102.494
 2010-09-30,ES,Spain,99.6126
 2010-09-30,FI,Finland,100.9364
-2010-09-30,FR,France,101.4767
-2010-09-30,GB,United Kingdom,101.5077
+2010-09-30,FR,France,101.4766
+2010-09-30,GB,United Kingdom,101.5186
 2010-09-30,GR,Greece,98.1406
 2010-09-30,HK,Hong Kong SAR,104.0607
-2010-09-30,HR,Croatia,99.1884
-2010-09-30,HU,Hungary,99.7524
+2010-09-30,HR,Croatia,99.1889
+2010-09-30,HU,Hungary,99.7525
 2010-09-30,ID,Indonesia,99.0352
-2010-09-30,IE,Ireland,98.2918
-2010-09-30,IL,Israel,100.8579
+2010-09-30,IE,Ireland,98.2932
+2010-09-30,IL,Israel,100.8584
 2010-09-30,IN,India,103.5176
-2010-09-30,IS,Iceland,99.9798
-2010-09-30,IT,Italy,100.2773
+2010-09-30,IS,Iceland,99.9924
+2010-09-30,IT,Italy,100.2743
 2010-09-30,JP,Japan,100.6759
-2010-09-30,KR,Korea,99.4961
+2010-09-30,KR,Korea,99.5085
 2010-09-30,LT,Lithuania,99.6819
-2010-09-30,LU,Luxembourg,99.7299
-2010-09-30,LV,Latvia,100.3866
-2010-09-30,MA,Morocco,100.6005
-2010-09-30,MK,North Macedonia,98.7581
+2010-09-30,LU,Luxembourg,99.7282
+2010-09-30,LV,Latvia,100.3691
+2010-09-30,MA,Morocco,100.3821
+2010-09-30,MK,North Macedonia,98.6703
 2010-09-30,MT,Malta,103.3552
 2010-09-30,MX,Mexico,100.8718
 2010-09-30,MY,Malaysia,100.7967
-2010-09-30,NL,Netherlands,100.1242
-2010-09-30,NO,Norway,101.1533
+2010-09-30,NL,Netherlands,100.1248
+2010-09-30,NO,Norway,101.1657
 2010-09-30,NZ,New Zealand,99.4213
 2010-09-30,PE,Peru,101.4599
 2010-09-30,PH,Philippines,100.3991
 2010-09-30,PL,Poland,100.356
-2010-09-30,PT,Portugal,99.6735
+2010-09-30,PT,Portugal,99.6734
 2010-09-30,RO,Romania,96.647
 2010-09-30,RS,Serbia,101.647
 2010-09-30,RU,Russia,99.5132
-2010-09-30,SE,Sweden,100.8327
-2010-09-30,SG,Singapore,101.3334
-2010-09-30,SI,Slovenia,99.0568
-2010-09-30,SK,Slovak Republic,99.4036
-2010-09-30,TH,Thailand,100.9987
-2010-09-30,TR,Türkiye,100.5713
-2010-09-30,US,United States,99.1245
-2010-09-30,XM,Euro area,100.448
-2010-09-30,XW,World,100.4525
-2010-09-30,ZA,South Africa,99.7025
-2010-12-31,4T,Emerging market economies (aggregate),100.4048
-2010-12-31,5R,Advanced economies,99.0626
-2010-12-31,AE,United Arab Emirates,94.7804
-2010-12-31,AT,Austria,100.4565
-2010-12-31,AU,Australia,99.4624
-2010-12-31,BE,Belgium,100.7703
-2010-12-31,BG,Bulgaria,96.887
-2010-12-31,BR,Brazil,105.5822
-2010-12-31,CA,Canada,98.6905
-2010-12-31,CH,Switzerland,102.1072
-2010-12-31,CL,Chile,101.4361
+2010-09-30,SE,Sweden,100.8318
+2010-09-30,SG,Singapore,101.3332
+2010-09-30,SI,Slovenia,99.0832
+2010-09-30,SK,Slovakia,99.4036
+2010-09-30,TH,Thailand,100.9973
+2010-09-30,TR,Türkiye,101.2849
+2010-09-30,US,United States,99.1227
+2010-09-30,XM,Euro area,100.4485
+2010-09-30,XW,World,100.4584
+2010-09-30,ZA,South Africa,99.393
+2010-12-31,4T,Emerging market economies (aggregate),100.4316
+2010-12-31,5R,Advanced economies,99.2205
+2010-12-31,AT,Austria,100.4564
+2010-12-31,AU,Australia,99.4926
+2010-12-31,BE,Belgium,100.2996
+2010-12-31,BG,Bulgaria,96.9242
+2010-12-31,BR,Brazil,105.5821
+2010-12-31,CA,Canada,98.7219
+2010-12-31,CH,Switzerland,102.1071
+2010-12-31,CL,Chile,101.436
 2010-12-31,CN,China,99.9567
-2010-12-31,CO,Colombia,103.1716
+2010-12-31,CO,Colombia,103.2971
 2010-12-31,CY,Cyprus,97.9136
-2010-12-31,CZ,Czechia,99.8842
+2010-12-31,CZ,Czechia,99.8877
 2010-12-31,DE,Germany,100.5153
-2010-12-31,DK,Denmark,99.5699
+2010-12-31,DK,Denmark,99.5671
 2010-12-31,EE,Estonia,97.3936
-2010-12-31,ES,Spain,97.9162
+2010-12-31,ES,Spain,97.9161
 2010-12-31,FI,Finland,99.6978
-2010-12-31,FR,France,102.2866
-2010-12-31,GB,United Kingdom,98.3237
-2010-12-31,GR,Greece,95.5632
+2010-12-31,FR,France,102.287
+2010-12-31,GB,United Kingdom,98.4106
+2010-12-31,GR,Greece,95.5631
 2010-12-31,HK,Hong Kong SAR,105.6681
-2010-12-31,HR,Croatia,99.0345
+2010-12-31,HR,Croatia,99.0325
 2010-12-31,HU,Hungary,97.3738
 2010-12-31,ID,Indonesia,98.3973
-2010-12-31,IE,Ireland,93.8251
-2010-12-31,IL,Israel,103.3274
+2010-12-31,IE,Ireland,93.8037
+2010-12-31,IL,Israel,103.327
 2010-12-31,IN,India,100.9531
-2010-12-31,IS,Iceland,100.3331
-2010-12-31,IT,Italy,100.097
+2010-12-31,IS,Iceland,100.3274
+2010-12-31,IT,Italy,100.0999
 2010-12-31,JP,Japan,100.3299
-2010-12-31,KR,Korea,99.6599
+2010-12-31,KR,Korea,99.6593
 2010-12-31,LT,Lithuania,100.5611
-2010-12-31,LU,Luxembourg,100.3852
-2010-12-31,LV,Latvia,102.7311
-2010-12-31,MA,Morocco,98.5834
-2010-12-31,MK,North Macedonia,100.4355
+2010-12-31,LU,Luxembourg,100.3817
+2010-12-31,LV,Latvia,102.7619
+2010-12-31,MA,Morocco,99.0352
+2010-12-31,MK,North Macedonia,100.6864
 2010-12-31,MT,Malta,94.7511
 2010-12-31,MX,Mexico,100.3425
 2010-12-31,MY,Malaysia,102.4224
-2010-12-31,NL,Netherlands,99.1442
-2010-12-31,NO,Norway,100.0397
+2010-12-31,NL,Netherlands,99.1458
+2010-12-31,NO,Norway,100.032
 2010-12-31,NZ,New Zealand,97.1478
 2010-12-31,PE,Peru,103.2882
 2010-12-31,PH,Philippines,100.2939
 2010-12-31,PL,Poland,99.3129
-2010-12-31,PT,Portugal,97.9585
+2010-12-31,PT,Portugal,97.9586
 2010-12-31,RO,Romania,93.5556
 2010-12-31,RS,Serbia,99.5331
 2010-12-31,RU,Russia,98.3305
-2010-12-31,SE,Sweden,101.106
-2010-12-31,SG,Singapore,103.158
-2010-12-31,SI,Slovenia,99.2863
-2010-12-31,SK,Slovak Republic,99.2526
-2010-12-31,TH,Thailand,100.9427
-2010-12-31,TR,Türkiye,100.4196
-2010-12-31,US,United States,97.9955
-2010-12-31,XM,Euro area,99.8533
-2010-12-31,XW,World,99.7312
-2010-12-31,ZA,South Africa,99.5307
-2011-03-31,4T,Emerging market economies (aggregate),98.8366
-2011-03-31,5R,Advanced economies,97.6096
-2011-03-31,AE,United Arab Emirates,96.8506
+2010-12-31,SE,Sweden,101.1073
+2010-12-31,SG,Singapore,103.1571
+2010-12-31,SI,Slovenia,99.2673
+2010-12-31,SK,Slovakia,99.2526
+2010-12-31,TH,Thailand,100.9464
+2010-12-31,TR,Türkiye,100.4375
+2010-12-31,US,United States,97.9895
+2010-12-31,XM,Euro area,99.8585
+2010-12-31,XW,World,99.751
+2010-12-31,ZA,South Africa,100.3209
+2011-03-31,4T,Emerging market economies (aggregate),98.4107
+2011-03-31,5R,Advanced economies,97.9224
 2011-03-31,AT,Austria,101.977
-2011-03-31,AU,Australia,97.1941
-2011-03-31,BE,Belgium,100.0476
-2011-03-31,BG,Bulgaria,92.8843
+2011-03-31,AU,Australia,97.1266
+2011-03-31,BE,Belgium,99.7994
+2011-03-31,BG,Bulgaria,92.9194
 2011-03-31,BR,Brazil,107.8365
-2011-03-31,CA,Canada,100.7516
-2011-03-31,CH,Switzerland,104.8033
+2011-03-31,CA,Canada,100.5969
+2011-03-31,CH,Switzerland,104.8037
 2011-03-31,CL,Chile,103.5488
 2011-03-31,CN,China,99.1316
-2011-03-31,CO,Colombia,100.7505
+2011-03-31,CO,Colombia,100.9153
 2011-03-31,CY,Cyprus,97.3315
-2011-03-31,CZ,Czechia,98.9253
+2011-03-31,CZ,Czechia,98.922
 2011-03-31,DE,Germany,100.2208
-2011-03-31,DK,Denmark,97.4073
+2011-03-31,DK,Denmark,97.4371
 2011-03-31,EE,Estonia,101.6175
-2011-03-31,ES,Spain,94.4117
+2011-03-31,ES,Spain,94.4114
 2011-03-31,FI,Finland,99.6476
-2011-03-31,FR,France,102.1835
-2011-03-31,GB,United Kingdom,95.1522
-2011-03-31,GR,Greece,95.9736
+2011-03-31,FR,France,102.1842
+2011-03-31,GB,United Kingdom,95.2008
+2011-03-31,GR,Greece,95.9735
 2011-03-31,HK,Hong Kong SAR,111.9423
-2011-03-31,HR,Croatia,96.8886
+2011-03-31,HR,Croatia,96.9254
 2011-03-31,HU,Hungary,95.3703
 2011-03-31,ID,Indonesia,98.9325
-2011-03-31,IE,Ireland,88.8522
-2011-03-31,IL,Israel,106.2643
+2011-03-31,IE,Ireland,88.8813
+2011-03-31,IL,Israel,106.2648
 2011-03-31,IN,India,104.84
-2011-03-31,IS,Iceland,100.6207
-2011-03-31,IT,Italy,98.6254
+2011-03-31,IS,Iceland,100.6151
+2011-03-31,IT,Italy,98.6249
 2011-03-31,JP,Japan,100.8138
-2011-03-31,KR,Korea,99.5045
+2011-03-31,KR,Korea,99.5193
 2011-03-31,LT,Lithuania,103.5105
-2011-03-31,LU,Luxembourg,98.8499
-2011-03-31,LV,Latvia,105.3416
-2011-03-31,MA,Morocco,99.3059
-2011-03-31,MK,North Macedonia,93.533
+2011-03-31,LU,Luxembourg,98.8458
+2011-03-31,LV,Latvia,105.3841
+2011-03-31,MA,Morocco,99.3751
+2011-03-31,MK,North Macedonia,93.3805
 2011-03-31,MT,Malta,96.327
 2011-03-31,MX,Mexico,100.8657
 2011-03-31,MY,Malaysia,103.1552
-2011-03-31,NL,Netherlands,98.69
-2011-03-31,NO,Norway,104.678
+2011-03-31,NL,Netherlands,98.6844
+2011-03-31,NO,Norway,104.6642
 2011-03-31,NZ,New Zealand,96.62
 2011-03-31,PE,Peru,110.8822
 2011-03-31,PH,Philippines,99.2431
@@ -20882,61 +5361,60 @@ date,country_code,country,price
 2011-03-31,PT,Portugal,95.945
 2011-03-31,RO,Romania,87.7159
 2011-03-31,RS,Serbia,94.4648
-2011-03-31,RU,Russia,72.6459
-2011-03-31,SE,Sweden,101.3081
-2011-03-31,SG,Singapore,103.548
-2011-03-31,SI,Slovenia,104.057
-2011-03-31,SK,Slovak Republic,96.9183
-2011-03-31,TH,Thailand,102.2433
-2011-03-31,TR,Türkiye,101.4393
-2011-03-31,US,United States,95.0953
-2011-03-31,XM,Euro area,99.1529
-2011-03-31,XW,World,98.2201
-2011-03-31,ZA,South Africa,98.9766
-2011-06-30,4T,Emerging market economies (aggregate),100.151
-2011-06-30,5R,Advanced economies,96.7172
-2011-06-30,AE,United Arab Emirates,96.8005
+2011-03-31,RU,Russia,72.6385
+2011-03-31,SE,Sweden,101.308
+2011-03-31,SG,Singapore,103.5468
+2011-03-31,SI,Slovenia,104.0528
+2011-03-31,SK,Slovakia,96.9183
+2011-03-31,TH,Thailand,100.7552
+2011-03-31,TR,Türkiye,102.3239
+2011-03-31,US,United States,95.1083
+2011-03-31,XM,Euro area,99.1631
+2011-03-31,XW,World,98.1316
+2011-03-31,ZA,South Africa,99.7537
+2011-06-30,4T,Emerging market economies (aggregate),99.7254
+2011-06-30,5R,Advanced economies,97.1841
 2011-06-30,AT,Austria,97.6315
-2011-06-30,AU,Australia,95.6559
-2011-06-30,BE,Belgium,99.8622
-2011-06-30,BG,Bulgaria,90.621
-2011-06-30,BR,Brazil,110.1759
-2011-06-30,CA,Canada,102.7604
-2011-06-30,CH,Switzerland,105.7751
-2011-06-30,CL,Chile,108.2746
+2011-06-30,AU,Australia,95.5829
+2011-06-30,BE,Belgium,99.3982
+2011-06-30,BG,Bulgaria,90.665
+2011-06-30,BR,Brazil,110.176
+2011-06-30,CA,Canada,102.5685
+2011-06-30,CH,Switzerland,105.7758
+2011-06-30,CL,Chile,108.2745
 2011-06-30,CN,China,99.3216
-2011-06-30,CO,Colombia,103.8587
+2011-06-30,CO,Colombia,104.1918
 2011-06-30,CY,Cyprus,93.902
-2011-06-30,CZ,Czechia,98.8143
+2011-06-30,CZ,Czechia,98.8113
 2011-06-30,DE,Germany,99.9811
-2011-06-30,DK,Denmark,98.3667
+2011-06-30,DK,Denmark,98.3969
 2011-06-30,EE,Estonia,103.0792
-2011-06-30,ES,Spain,91.7022
+2011-06-30,ES,Spain,91.7021
 2011-06-30,FI,Finland,100.6222
-2011-06-30,FR,France,103.0256
-2011-06-30,GB,United Kingdom,94.4074
+2011-06-30,FR,France,103.0302
+2011-06-30,GB,United Kingdom,94.3417
 2011-06-30,GR,Greece,91.965
 2011-06-30,HK,Hong Kong SAR,116.7599
-2011-06-30,HR,Croatia,97.4758
+2011-06-30,HR,Croatia,97.4729
 2011-06-30,HU,Hungary,93.1647
 2011-06-30,ID,Indonesia,100.2263
-2011-06-30,IE,Ireland,83.1644
-2011-06-30,IL,Israel,107.4343
+2011-06-30,IE,Ireland,83.1854
+2011-06-30,IL,Israel,107.4339
 2011-06-30,IN,India,111.0931
-2011-06-30,IS,Iceland,100.7418
-2011-06-30,IT,Italy,99.6764
+2011-06-30,IS,Iceland,100.7408
+2011-06-30,IT,Italy,99.6767
 2011-06-30,JP,Japan,100.1334
-2011-06-30,KR,Korea,101.0492
+2011-06-30,KR,Korea,101.1052
 2011-06-30,LT,Lithuania,102.0445
-2011-06-30,LU,Luxembourg,99.9118
-2011-06-30,LV,Latvia,105.0432
-2011-06-30,MA,Morocco,100.3222
-2011-06-30,MK,North Macedonia,94.1798
+2011-06-30,LU,Luxembourg,99.9127
+2011-06-30,LV,Latvia,105.0205
+2011-06-30,MA,Morocco,100.7712
+2011-06-30,MK,North Macedonia,94.144
 2011-06-30,MT,Malta,96.7954
 2011-06-30,MX,Mexico,102.7014
 2011-06-30,MY,Malaysia,105.1153
-2011-06-30,NL,Netherlands,95.9669
-2011-06-30,NO,Norway,106.8358
+2011-06-30,NL,Netherlands,95.9653
+2011-06-30,NO,Norway,106.8253
 2011-06-30,NZ,New Zealand,96.1673
 2011-06-30,PE,Peru,115.2551
 2011-06-30,PH,Philippines,100.638
@@ -20944,61 +5422,60 @@ date,country_code,country,price
 2011-06-30,PT,Portugal,92.6038
 2011-06-30,RO,Romania,84.955
 2011-06-30,RS,Serbia,88.7036
-2011-06-30,RU,Russia,72.3635
-2011-06-30,SE,Sweden,100.195
-2011-06-30,SG,Singapore,104.8153
-2011-06-30,SI,Slovenia,101.4359
-2011-06-30,SK,Slovak Republic,94.4914
-2011-06-30,TH,Thailand,101.2296
-2011-06-30,TR,Türkiye,100.5491
-2011-06-30,US,United States,93.9931
-2011-06-30,XM,Euro area,97.9847
-2011-06-30,XW,World,98.4443
-2011-06-30,ZA,South Africa,98.3574
-2011-09-30,4T,Emerging market economies (aggregate),100.3448
-2011-09-30,5R,Advanced economies,96.9897
-2011-09-30,AE,United Arab Emirates,98.5504
+2011-06-30,RU,Russia,72.3559
+2011-06-30,SE,Sweden,100.1963
+2011-06-30,SG,Singapore,104.812
+2011-06-30,SI,Slovenia,101.4854
+2011-06-30,SK,Slovakia,94.4914
+2011-06-30,TH,Thailand,100.8653
+2011-06-30,TR,Türkiye,102.669
+2011-06-30,US,United States,93.9905
+2011-06-30,XM,Euro area,98.0025
+2011-06-30,XW,World,98.3099
+2011-06-30,ZA,South Africa,98.5159
+2011-09-30,4T,Emerging market economies (aggregate),99.867
+2011-09-30,5R,Advanced economies,97.4569
 2011-09-30,AT,Austria,102.1472
-2011-09-30,AU,Australia,93.4029
-2011-09-30,BE,Belgium,101.3545
-2011-09-30,BG,Bulgaria,90.6601
-2011-09-30,BR,Brazil,113.2289
-2011-09-30,CA,Canada,103.8689
-2011-09-30,CH,Switzerland,109.0958
+2011-09-30,AU,Australia,93.341
+2011-09-30,BE,Belgium,100.9206
+2011-09-30,BG,Bulgaria,90.6517
+2011-09-30,BR,Brazil,113.229
+2011-09-30,CA,Canada,103.7585
+2011-09-30,CH,Switzerland,109.0976
 2011-09-30,CL,Chile,110.3611
 2011-09-30,CN,China,98.4485
-2011-09-30,CO,Colombia,105.9489
+2011-09-30,CO,Colombia,105.9996
 2011-09-30,CY,Cyprus,93.4722
-2011-09-30,CZ,Czechia,98.0927
+2011-09-30,CZ,Czechia,98.0862
 2011-09-30,DE,Germany,100.7473
-2011-09-30,DK,Denmark,95.2546
+2011-09-30,DK,Denmark,95.2648
 2011-09-30,EE,Estonia,103.997
-2011-09-30,ES,Spain,88.8539
+2011-09-30,ES,Spain,88.8543
 2011-09-30,FI,Finland,99.987
-2011-09-30,FR,France,105.2365
-2011-09-30,GB,United Kingdom,94.9375
+2011-09-30,FR,France,105.2395
+2011-09-30,GB,United Kingdom,95.0732
 2011-09-30,GR,Greece,91.314
 2011-09-30,HK,Hong Kong SAR,117.4072
-2011-09-30,HR,Croatia,98.8019
-2011-09-30,HU,Hungary,92.3522
+2011-09-30,HR,Croatia,98.8258
+2011-09-30,HU,Hungary,92.3521
 2011-09-30,ID,Indonesia,98.9294
-2011-09-30,IE,Ireland,78.0855
-2011-09-30,IL,Israel,107.4
+2011-09-30,IE,Ireland,78.1243
+2011-09-30,IL,Israel,107.4002
 2011-09-30,IN,India,112.4555
-2011-09-30,IS,Iceland,101.3075
-2011-09-30,IT,Italy,98.7695
+2011-09-30,IS,Iceland,101.3284
+2011-09-30,IT,Italy,98.7747
 2011-09-30,JP,Japan,100.7678
-2011-09-30,KR,Korea,101.4651
+2011-09-30,KR,Korea,101.4968
 2011-09-30,LT,Lithuania,101.8896
-2011-09-30,LU,Luxembourg,99.8819
-2011-09-30,LV,Latvia,108.5327
-2011-09-30,MA,Morocco,99.8682
-2011-09-30,MK,North Macedonia,95.8527
+2011-09-30,LU,Luxembourg,99.8836
+2011-09-30,LV,Latvia,108.5171
+2011-09-30,MA,Morocco,99.4569
+2011-09-30,MK,North Macedonia,95.9132
 2011-09-30,MT,Malta,97.2207
 2011-09-30,MX,Mexico,103.3862
 2011-09-30,MY,Malaysia,107.0821
-2011-09-30,NL,Netherlands,95.1061
-2011-09-30,NO,Norway,107.9514
+2011-09-30,NL,Netherlands,95.1071
+2011-09-30,NO,Norway,107.9518
 2011-09-30,NZ,New Zealand,97.0456
 2011-09-30,PE,Peru,120.6692
 2011-09-30,PH,Philippines,101.1119
@@ -21006,61 +5483,60 @@ date,country_code,country,price
 2011-09-30,PT,Portugal,91.332
 2011-09-30,RO,Romania,80.8815
 2011-09-30,RS,Serbia,85.1457
-2011-09-30,RU,Russia,72.984
-2011-09-30,SE,Sweden,99.854
-2011-09-30,SG,Singapore,104.1636
-2011-09-30,SI,Slovenia,99.8994
-2011-09-30,SK,Slovak Republic,94.9304
-2011-09-30,TH,Thailand,99.3725
-2011-09-30,TR,Türkiye,102.0055
-2011-09-30,US,United States,93.9931
-2011-09-30,XM,Euro area,98.4942
-2011-09-30,XW,World,98.6774
-2011-09-30,ZA,South Africa,97.9984
-2011-12-31,4T,Emerging market economies (aggregate),100.6676
-2011-12-31,5R,Advanced economies,96.01
-2011-12-31,AE,United Arab Emirates,100.7426
+2011-09-30,RU,Russia,72.99
+2011-09-30,SE,Sweden,99.8541
+2011-09-30,SG,Singapore,104.1597
+2011-09-30,SI,Slovenia,99.8951
+2011-09-30,SK,Slovakia,94.8343
+2011-09-30,TH,Thailand,99.3122
+2011-09-30,TR,Türkiye,103.5025
+2011-09-30,US,United States,93.965
+2011-09-30,XM,Euro area,98.5128
+2011-09-30,XW,World,98.5248
+2011-09-30,ZA,South Africa,98.1729
+2011-12-31,4T,Emerging market economies (aggregate),100.2395
+2011-12-31,5R,Advanced economies,96.4883
 2011-12-31,AT,Austria,102.0126
-2011-12-31,AU,Australia,92.6571
-2011-12-31,BE,Belgium,100.5998
-2011-12-31,BG,Bulgaria,88.5018
-2011-12-31,BR,Brazil,115.0544
-2011-12-31,CA,Canada,103.8565
-2011-12-31,CH,Switzerland,109.4076
+2011-12-31,AU,Australia,92.5957
+2011-12-31,BE,Belgium,100.0634
+2011-12-31,BG,Bulgaria,88.5088
+2011-12-31,BR,Brazil,115.0546
+2011-12-31,CA,Canada,103.6796
+2011-12-31,CH,Switzerland,109.4102
 2011-12-31,CL,Chile,112.0833
 2011-12-31,CN,China,97.6907
-2011-12-31,CO,Colombia,106.6864
+2011-12-31,CO,Colombia,106.8731
 2011-12-31,CY,Cyprus,89.8505
-2011-12-31,CZ,Czechia,96.7584
+2011-12-31,CZ,Czechia,96.7592
 2011-12-31,DE,Germany,100.4737
-2011-12-31,DK,Denmark,91.6035
+2011-12-31,DK,Denmark,91.5665
 2011-12-31,EE,Estonia,104.5753
-2011-12-31,ES,Spain,83.1478
+2011-12-31,ES,Spain,83.1479
 2011-12-31,FI,Finland,98.79
-2011-12-31,FR,France,103.5496
-2011-12-31,GB,United Kingdom,92.7677
+2011-12-31,FR,France,103.5555
+2011-12-31,GB,United Kingdom,92.7574
 2011-12-31,GR,Greece,86.8191
 2011-12-31,HK,Hong Kong SAR,112.1547
-2011-12-31,HR,Croatia,98.5584
+2011-12-31,HR,Croatia,98.6577
 2011-12-31,HU,Hungary,90.8245
 2011-12-31,ID,Indonesia,99.2897
-2011-12-31,IE,Ireland,73.3829
-2011-12-31,IL,Israel,106.231
+2011-12-31,IE,Ireland,73.4192
+2011-12-31,IL,Israel,106.2311
 2011-12-31,IN,India,116.5977
-2011-12-31,IS,Iceland,103.013
-2011-12-31,IT,Italy,97.3849
+2011-12-31,IS,Iceland,103.0339
+2011-12-31,IT,Italy,97.3914
 2011-12-31,JP,Japan,99.6445
-2011-12-31,KR,Korea,102.5678
+2011-12-31,KR,Korea,102.6014
 2011-12-31,LT,Lithuania,102.0912
-2011-12-31,LU,Luxembourg,102.35
-2011-12-31,LV,Latvia,104.2682
-2011-12-31,MA,Morocco,99.2037
-2011-12-31,MK,North Macedonia,95.5034
+2011-12-31,LU,Luxembourg,102.3447
+2011-12-31,LV,Latvia,104.3155
+2011-12-31,MA,Morocco,99.1749
+2011-12-31,MK,North Macedonia,95.6212
 2011-12-31,MT,Malta,93.7423
 2011-12-31,MX,Mexico,102.2768
 2011-12-31,MY,Malaysia,110.3737
-2011-12-31,NL,Netherlands,93.3883
-2011-12-31,NO,Norway,107.0883
+2011-12-31,NL,Netherlands,93.3928
+2011-12-31,NO,Norway,107.0115
 2011-12-31,NZ,New Zealand,97.5604
 2011-12-31,PE,Peru,119.0424
 2011-12-31,PH,Philippines,102.3436
@@ -21068,61 +5544,60 @@ date,country_code,country,price
 2011-12-31,PT,Portugal,87.2035
 2011-12-31,RO,Romania,77.91
 2011-12-31,RS,Serbia,83.2574
-2011-12-31,RU,Russia,74.109
-2011-12-31,SE,Sweden,97.2093
-2011-12-31,SG,Singapore,103.5041
-2011-12-31,SI,Slovenia,98.1933
-2011-12-31,SK,Slovak Republic,92.7851
-2011-12-31,TH,Thailand,99.8763
-2011-12-31,TR,Türkiye,97.8905
-2011-12-31,US,United States,94.0452
-2011-12-31,XM,Euro area,96.3864
-2011-12-31,XW,World,98.3497
-2011-12-31,ZA,South Africa,97.9405
-2012-03-31,4T,Emerging market economies (aggregate),101.3274
-2012-03-31,5R,Advanced economies,95.8715
-2012-03-31,AE,United Arab Emirates,102.9097
+2011-12-31,RU,Russia,74.1185
+2011-12-31,SE,Sweden,97.2135
+2011-12-31,SG,Singapore,103.4993
+2011-12-31,SI,Slovenia,98.2047
+2011-12-31,SK,Slovakia,92.7851
+2011-12-31,TH,Thailand,100.8094
+2011-12-31,TR,Türkiye,100.3757
+2011-12-31,US,United States,94.0095
+2011-12-31,XM,Euro area,96.4061
+2011-12-31,XW,World,98.1486
+2011-12-31,ZA,South Africa,98.2947
+2012-03-31,4T,Emerging market economies (aggregate),100.978
+2012-03-31,5R,Advanced economies,96.3233
 2012-03-31,AT,Austria,110.0836
-2012-03-31,AU,Australia,93.1231
-2012-03-31,BE,Belgium,99.9589
-2012-03-31,BG,Bulgaria,87.6577
+2012-03-31,AU,Australia,93.1009
+2012-03-31,BE,Belgium,99.463
+2012-03-31,BG,Bulgaria,87.6741
 2012-03-31,BR,Brazil,116.4024
-2012-03-31,CA,Canada,105.6938
-2012-03-31,CH,Switzerland,112.3718
+2012-03-31,CA,Canada,105.5386
+2012-03-31,CH,Switzerland,112.3725
 2012-03-31,CL,Chile,112.0303
 2012-03-31,CN,China,95.6192
-2012-03-31,CO,Colombia,108.1506
+2012-03-31,CO,Colombia,108.4606
 2012-03-31,CY,Cyprus,89.5897
-2012-03-31,CZ,Czechia,93.9458
+2012-03-31,CZ,Czechia,93.9432
 2012-03-31,DE,Germany,100.6459
-2012-03-31,DK,Denmark,90.4146
+2012-03-31,DK,Denmark,90.4007
 2012-03-31,EE,Estonia,104.4173
-2012-03-31,ES,Spain,79.4662
+2012-03-31,ES,Spain,79.4663
 2012-03-31,FI,Finland,99.2969
-2012-03-31,FR,France,101.6158
-2012-03-31,GB,United Kingdom,91.5269
+2012-03-31,FR,France,101.6241
+2012-03-31,GB,United Kingdom,91.5258
 2012-03-31,GR,Greece,84.1442
 2012-03-31,HK,Hong Kong SAR,112.5497
-2012-03-31,HR,Croatia,97.7583
+2012-03-31,HR,Croatia,97.7638
 2012-03-31,HU,Hungary,88.8187
 2012-03-31,ID,Indonesia,98.8626
-2012-03-31,IE,Ireland,69.9481
-2012-03-31,IL,Israel,106.6784
+2012-03-31,IE,Ireland,69.9288
+2012-03-31,IL,Israel,106.6785
 2012-03-31,IN,India,122.6886
-2012-03-31,IS,Iceland,101.4751
-2012-03-31,IT,Italy,96.0858
+2012-03-31,IS,Iceland,101.4786
+2012-03-31,IT,Italy,96.0855
 2012-03-31,JP,Japan,99.9944
-2012-03-31,KR,Korea,102.1803
+2012-03-31,KR,Korea,102.2067
 2012-03-31,LT,Lithuania,100.8363
-2012-03-31,LU,Luxembourg,100.4411
-2012-03-31,LV,Latvia,104.4883
-2012-03-31,MA,Morocco,99.2685
-2012-03-31,MK,North Macedonia,93.3539
+2012-03-31,LU,Luxembourg,100.4376
+2012-03-31,LV,Latvia,104.4769
+2012-03-31,MA,Morocco,99.6147
+2012-03-31,MK,North Macedonia,93.4223
 2012-03-31,MT,Malta,96.2313
 2012-03-31,MX,Mexico,101.0428
 2012-03-31,MY,Malaysia,113.6479
-2012-03-31,NL,Netherlands,91.1009
-2012-03-31,NO,Norway,110.3677
+2012-03-31,NL,Netherlands,91.0997
+2012-03-31,NO,Norway,110.3369
 2012-03-31,NZ,New Zealand,98.0829
 2012-03-31,PE,Peru,127.0881
 2012-03-31,PH,Philippines,106.1227
@@ -21130,61 +5605,60 @@ date,country_code,country,price
 2012-03-31,PT,Portugal,85.1988
 2012-03-31,RO,Romania,79.2848
 2012-03-31,RS,Serbia,84.2782
-2012-03-31,RU,Russia,78.6565
-2012-03-31,SE,Sweden,98.5383
-2012-03-31,SG,Singapore,102.1264
-2012-03-31,SI,Slovenia,94.342
-2012-03-31,SK,Slovak Republic,90.5278
-2012-03-31,TH,Thailand,101.0728
-2012-03-31,TR,Türkiye,99.3022
-2012-03-31,US,United States,94.0864
-2012-03-31,XM,Euro area,95.5828
-2012-03-31,XW,World,98.6166
-2012-03-31,ZA,South Africa,97.6825
-2012-06-30,4T,Emerging market economies (aggregate),102.2856
-2012-06-30,5R,Advanced economies,96.085
-2012-06-30,AE,United Arab Emirates,108.802
+2012-03-31,RU,Russia,78.6479
+2012-03-31,SE,Sweden,98.5416
+2012-03-31,SG,Singapore,102.119
+2012-03-31,SI,Slovenia,94.3332
+2012-03-31,SK,Slovakia,90.4342
+2012-03-31,TH,Thailand,101.3053
+2012-03-31,TR,Türkiye,101.8223
+2012-03-31,US,United States,94.107
+2012-03-31,XM,Euro area,95.6047
+2012-03-31,XW,World,98.3893
+2012-03-31,ZA,South Africa,98.4155
+2012-06-30,4T,Emerging market economies (aggregate),101.8242
+2012-06-30,5R,Advanced economies,96.5327
 2012-06-30,AT,Austria,110.347
-2012-06-30,AU,Australia,93.03
-2012-06-30,BE,Belgium,99.7405
-2012-06-30,BG,Bulgaria,87.7712
-2012-06-30,BR,Brazil,117.8143
-2012-06-30,CA,Canada,107.0662
-2012-06-30,CH,Switzerland,113.2242
+2012-06-30,AU,Australia,92.9908
+2012-06-30,BE,Belgium,99.3698
+2012-06-30,BG,Bulgaria,87.7974
+2012-06-30,BR,Brazil,117.8142
+2012-06-30,CA,Canada,106.9303
+2012-06-30,CH,Switzerland,113.2257
 2012-06-30,CL,Chile,115.111
 2012-06-30,CN,China,95.5014
-2012-06-30,CO,Colombia,110.9234
+2012-06-30,CO,Colombia,110.8564
 2012-06-30,CY,Cyprus,86.1851
-2012-06-30,CZ,Czechia,93.694
+2012-06-30,CZ,Czechia,93.691
 2012-06-30,DE,Germany,101.5315
-2012-06-30,DK,Denmark,91.1325
+2012-06-30,DK,Denmark,91.1278
 2012-06-30,EE,Estonia,106.7227
-2012-06-30,ES,Spain,75.5807
+2012-06-30,ES,Spain,75.5808
 2012-06-30,FI,Finland,99.4951
-2012-06-30,FR,France,100.8134
-2012-06-30,GB,United Kingdom,92.4661
+2012-06-30,FR,France,100.8152
+2012-06-30,GB,United Kingdom,92.5006
 2012-06-30,GR,Greece,80.7683
 2012-06-30,HK,Hong Kong SAR,121.9704
-2012-06-30,HR,Croatia,93.7106
-2012-06-30,HU,Hungary,84.5114
+2012-06-30,HR,Croatia,93.7429
+2012-06-30,HU,Hungary,84.5113
 2012-06-30,ID,Indonesia,99.5703
-2012-06-30,IE,Ireland,67.703
-2012-06-30,IL,Israel,106.9499
+2012-06-30,IE,Ireland,67.7156
+2012-06-30,IL,Israel,106.9501
 2012-06-30,IN,India,126.9924
-2012-06-30,IS,Iceland,102.553
-2012-06-30,IT,Italy,94.4295
+2012-06-30,IS,Iceland,102.5608
+2012-06-30,IT,Italy,94.4326
 2012-06-30,JP,Japan,98.8575
-2012-06-30,KR,Korea,102.2572
+2012-06-30,KR,Korea,102.2854
 2012-06-30,LT,Lithuania,98.4104
-2012-06-30,LU,Luxembourg,101.3956
-2012-06-30,LV,Latvia,104.7489
-2012-06-30,MA,Morocco,99.9026
-2012-06-30,MK,North Macedonia,90.7012
+2012-06-30,LU,Luxembourg,101.3871
+2012-06-30,LV,Latvia,104.8022
+2012-06-30,MA,Morocco,100.524
+2012-06-30,MK,North Macedonia,90.7034
 2012-06-30,MT,Malta,93.3829
 2012-06-30,MX,Mexico,101.9097
 2012-06-30,MY,Malaysia,117.2523
-2012-06-30,NL,Netherlands,88.5648
-2012-06-30,NO,Norway,113.7187
+2012-06-30,NL,Netherlands,88.5681
+2012-06-30,NO,Norway,113.7067
 2012-06-30,NZ,New Zealand,98.9006
 2012-06-30,PE,Peru,132.9462
 2012-06-30,PH,Philippines,106.3843
@@ -21192,61 +5666,60 @@ date,country_code,country,price
 2012-06-30,PT,Portugal,82.6223
 2012-06-30,RO,Romania,77.9943
 2012-06-30,RS,Serbia,82.6326
-2012-06-30,RU,Russia,79.6848
-2012-06-30,SE,Sweden,99.5021
-2012-06-30,SG,Singapore,101.5012
-2012-06-30,SI,Slovenia,93.3756
-2012-06-30,SK,Slovak Republic,89.0634
-2012-06-30,TH,Thailand,98.9379
-2012-06-30,TR,Türkiye,100.9362
-2012-06-30,US,United States,95.7593
-2012-06-30,XM,Euro area,94.0232
-2012-06-30,XW,World,99.2067
-2012-06-30,ZA,South Africa,97.5518
-2012-09-30,4T,Emerging market economies (aggregate),102.7238
-2012-09-30,5R,Advanced economies,96.7564
-2012-09-30,AE,United Arab Emirates,112.7309
+2012-06-30,RU,Russia,79.6741
+2012-06-30,SE,Sweden,99.5016
+2012-06-30,SG,Singapore,101.4925
+2012-06-30,SI,Slovenia,93.3878
+2012-06-30,SK,Slovakia,88.9704
+2012-06-30,TH,Thailand,99.5548
+2012-06-30,TR,Türkiye,103.5498
+2012-06-30,US,United States,95.7193
+2012-06-30,XM,Euro area,94.0342
+2012-06-30,XW,World,98.8831
+2012-06-30,ZA,South Africa,97.6157
+2012-09-30,4T,Emerging market economies (aggregate),102.196
+2012-09-30,5R,Advanced economies,97.1691
 2012-09-30,AT,Austria,111.6216
-2012-09-30,AU,Australia,91.5678
-2012-09-30,BE,Belgium,100.5001
-2012-09-30,BG,Bulgaria,86.355
-2012-09-30,BR,Brazil,119.3067
-2012-09-30,CA,Canada,106.154
-2012-09-30,CH,Switzerland,115.5585
+2012-09-30,AU,Australia,91.5583
+2012-09-30,BE,Belgium,100.0835
+2012-09-30,BG,Bulgaria,86.3435
+2012-09-30,BR,Brazil,119.3066
+2012-09-30,CA,Canada,106.0767
+2012-09-30,CH,Switzerland,115.5594
 2012-09-30,CL,Chile,117.7152
 2012-09-30,CN,China,95.5394
-2012-09-30,CO,Colombia,111.9719
+2012-09-30,CO,Colombia,112.0372
 2012-09-30,CY,Cyprus,86.0557
-2012-09-30,CZ,Czechia,93.4945
+2012-09-30,CZ,Czechia,93.4915
 2012-09-30,DE,Germany,101.3629
-2012-09-30,DK,Denmark,91.292
+2012-09-30,DK,Denmark,91.2734
 2012-09-30,EE,Estonia,108.6414
 2012-09-30,ES,Spain,72.5438
 2012-09-30,FI,Finland,99.3799
-2012-09-30,FR,France,101.5615
-2012-09-30,GB,United Kingdom,93.2514
+2012-09-30,FR,France,101.5626
+2012-09-30,GB,United Kingdom,93.1725
 2012-09-30,GR,Greece,78.7745
 2012-09-30,HK,Hong Kong SAR,130.1397
-2012-09-30,HR,Croatia,93.0285
+2012-09-30,HR,Croatia,93.0605
 2012-09-30,HU,Hungary,83.7142
 2012-09-30,ID,Indonesia,99.1251
-2012-09-30,IE,Ireland,68.4013
-2012-09-30,IL,Israel,108.2438
+2012-09-30,IE,Ireland,68.4153
+2012-09-30,IL,Israel,108.244
 2012-09-30,IN,India,128.4417
-2012-09-30,IS,Iceland,103.5219
-2012-09-30,IT,Italy,92.2334
+2012-09-30,IS,Iceland,103.5338
+2012-09-30,IT,Italy,92.2332
 2012-09-30,JP,Japan,99.72
-2012-09-30,KR,Korea,101.7741
+2012-09-30,KR,Korea,101.7513
 2012-09-30,LT,Lithuania,99.0529
-2012-09-30,LU,Luxembourg,101.5388
-2012-09-30,LV,Latvia,108.0594
-2012-09-30,MA,Morocco,99.3619
-2012-09-30,MK,North Macedonia,89.5545
+2012-09-30,LU,Luxembourg,101.5281
+2012-09-30,LV,Latvia,108.0324
+2012-09-30,MA,Morocco,98.5771
+2012-09-30,MK,North Macedonia,89.6593
 2012-09-30,MT,Malta,100.1439
 2012-09-30,MX,Mexico,101.6888
 2012-09-30,MY,Malaysia,119.6158
-2012-09-30,NL,Netherlands,84.6866
-2012-09-30,NO,Norway,115.1756
+2012-09-30,NL,Netherlands,84.6906
+2012-09-30,NO,Norway,115.134
 2012-09-30,NZ,New Zealand,100.6002
 2012-09-30,PE,Peru,135.7141
 2012-09-30,PH,Philippines,105.8356
@@ -21254,61 +5727,60 @@ date,country_code,country,price
 2012-09-30,PT,Portugal,81.938
 2012-09-30,RO,Romania,73.9069
 2012-09-30,RS,Serbia,79.8598
-2012-09-30,RU,Russia,80.1036
-2012-09-30,SE,Sweden,101.0535
-2012-09-30,SG,Singapore,101.1937
-2012-09-30,SI,Slovenia,91.2981
-2012-09-30,SK,Slovak Republic,89.352
-2012-09-30,TH,Thailand,99.2519
-2012-09-30,TR,Türkiye,102.6033
-2012-09-30,US,United States,97.4472
-2012-09-30,XM,Euro area,93.5627
-2012-09-30,XW,World,99.7605
-2012-09-30,ZA,South Africa,98.0629
-2012-12-31,4T,Emerging market economies (aggregate),103.9861
-2012-12-31,5R,Advanced economies,97.0108
-2012-12-31,AE,United Arab Emirates,117.7608
-2012-12-31,AT,Austria,110.6541
-2012-12-31,AU,Australia,93.3948
-2012-12-31,BE,Belgium,99.3165
-2012-12-31,BG,Bulgaria,83.8275
+2012-09-30,RU,Russia,80.0997
+2012-09-30,SE,Sweden,101.0545
+2012-09-30,SG,Singapore,101.1846
+2012-09-30,SI,Slovenia,91.3219
+2012-09-30,SK,Slovakia,89.2593
+2012-09-30,TH,Thailand,99.1888
+2012-09-30,TR,Türkiye,106.4797
+2012-09-30,US,United States,97.4292
+2012-09-30,XM,Euro area,93.558
+2012-09-30,XW,World,99.4016
+2012-09-30,ZA,South Africa,97.5113
+2012-12-31,4T,Emerging market economies (aggregate),103.3667
+2012-12-31,5R,Advanced economies,97.4133
+2012-12-31,AT,Austria,110.6542
+2012-12-31,AU,Australia,93.331
+2012-12-31,BE,Belgium,99.3677
+2012-12-31,BG,Bulgaria,83.8425
 2012-12-31,BR,Brazil,119.9238
-2012-12-31,CA,Canada,104.7259
-2012-12-31,CH,Switzerland,115.854
-2012-12-31,CL,Chile,121.1596
+2012-12-31,CA,Canada,104.7044
+2012-12-31,CH,Switzerland,115.8542
+2012-12-31,CL,Chile,121.1595
 2012-12-31,CN,China,95.3053
-2012-12-31,CO,Colombia,114.7728
+2012-12-31,CO,Colombia,114.6042
 2012-12-31,CY,Cyprus,84.4816
-2012-12-31,CZ,Czechia,93.3631
+2012-12-31,CZ,Czechia,93.3623
 2012-12-31,DE,Germany,101.7974
-2012-12-31,DK,Denmark,90.843
+2012-12-31,DK,Denmark,90.8478
 2012-12-31,EE,Estonia,106.7123
-2012-12-31,ES,Spain,70.373
+2012-12-31,ES,Spain,70.3733
 2012-12-31,FI,Finland,99.2816
-2012-12-31,FR,France,99.876
-2012-12-31,GB,United Kingdom,91.2776
+2012-12-31,FR,France,99.8752
+2012-12-31,GB,United Kingdom,91.2587
 2012-12-31,GR,Greece,74.8793
-2012-12-31,HK,Hong Kong SAR,134.1121
-2012-12-31,HR,Croatia,88.6776
+2012-12-31,HK,Hong Kong SAR,134.033
+2012-12-31,HR,Croatia,88.7009
 2012-12-31,HU,Hungary,81.7287
 2012-12-31,ID,Indonesia,102.0747
-2012-12-31,IE,Ireland,69.1023
-2012-12-31,IL,Israel,111.8561
+2012-12-31,IE,Ireland,69.1535
+2012-12-31,IL,Israel,111.8568
 2012-12-31,IN,India,135.9487
-2012-12-31,IS,Iceland,103.2796
-2012-12-31,IT,Italy,90.3482
+2012-12-31,IS,Iceland,103.279
+2012-12-31,IT,Italy,90.3468
 2012-12-31,JP,Japan,99.4551
-2012-12-31,KR,Korea,101.1246
-2012-12-31,LT,Lithuania,98.0485
-2012-12-31,LU,Luxembourg,103.6163
-2012-12-31,LV,Latvia,108.8933
-2012-12-31,MA,Morocco,99.4904
-2012-12-31,MK,North Macedonia,87.0753
+2012-12-31,KR,Korea,101.1592
+2012-12-31,LT,Lithuania,98.0484
+2012-12-31,LU,Luxembourg,103.6008
+2012-12-31,LV,Latvia,108.8796
+2012-12-31,MA,Morocco,98.2423
+2012-12-31,MK,North Macedonia,87.0133
 2012-12-31,MT,Malta,96.6104
 2012-12-31,MX,Mexico,100.9679
 2012-12-31,MY,Malaysia,124.5337
-2012-12-31,NL,Netherlands,84.5478
-2012-12-31,NO,Norway,113.0696
+2012-12-31,NL,Netherlands,84.5512
+2012-12-31,NO,Norway,113.0817
 2012-12-31,NZ,New Zealand,102.867
 2012-12-31,PE,Peru,138.4365
 2012-12-31,PH,Philippines,107.3184
@@ -21316,123 +5788,121 @@ date,country_code,country,price
 2012-12-31,PT,Portugal,82.0815
 2012-12-31,RO,Romania,73.5773
 2012-12-31,RS,Serbia,74.6439
-2012-12-31,RU,Russia,81.298
-2012-12-31,SE,Sweden,100.8581
-2012-12-31,SG,Singapore,102.2991
-2012-12-31,SI,Slovenia,87.2796
-2012-12-31,SK,Slovak Republic,87.1003
-2012-12-31,TH,Thailand,102.2505
-2012-12-31,TR,Türkiye,100.9948
-2012-12-31,US,United States,99.5417
-2012-12-31,XM,Euro area,92.2838
-2012-12-31,XW,World,100.5236
-2012-12-31,ZA,South Africa,97.9861
-2013-03-31,4T,Emerging market economies (aggregate),104.3704
-2013-03-31,5R,Advanced economies,97.5353
-2013-03-31,AE,United Arab Emirates,118.5551
+2012-12-31,RU,Russia,81.2636
+2012-12-31,SE,Sweden,100.8576
+2012-12-31,SG,Singapore,102.2908
+2012-12-31,SI,Slovenia,87.2837
+2012-12-31,SK,Slovakia,87.0081
+2012-12-31,TH,Thailand,102.5606
+2012-12-31,TR,Türkiye,104.4404
+2012-12-31,US,United States,99.5386
+2012-12-31,XM,Euro area,92.2712
+2012-12-31,XW,World,100.059
+2012-12-31,ZA,South Africa,97.4363
+2013-03-31,4T,Emerging market economies (aggregate),103.7748
+2013-03-31,5R,Advanced economies,97.8825
 2013-03-31,AT,Austria,112.5841
-2013-03-31,AU,Australia,93.666
-2013-03-31,BE,Belgium,99.7459
-2013-03-31,BG,Bulgaria,82.7179
+2013-03-31,AU,Australia,93.6518
+2013-03-31,BE,Belgium,99.616
+2013-03-31,BG,Bulgaria,82.7219
 2013-03-31,BR,Brazil,120.0411
-2013-03-31,CA,Canada,105.4203
-2013-03-31,CH,Switzerland,118.3026
-2013-03-31,CL,Chile,122.7236
+2013-03-31,CA,Canada,105.4775
+2013-03-31,CH,Switzerland,118.302
+2013-03-31,CL,Chile,122.7235
 2013-03-31,CN,China,95.1768
-2013-03-31,CO,Colombia,116.9935
+2013-03-31,CO,Colombia,116.0004
 2013-03-31,CY,Cyprus,83.6732
-2013-03-31,CZ,Czechia,91.9812
+2013-03-31,CZ,Czechia,91.9821
 2013-03-31,DE,Germany,102.2659
-2013-03-31,DK,Denmark,91.7755
+2013-03-31,DK,Denmark,91.7834
 2013-03-31,EE,Estonia,108.6563
-2013-03-31,ES,Spain,67.5136
+2013-03-31,ES,Spain,67.514
 2013-03-31,FI,Finland,99.5415
-2013-03-31,FR,France,98.5358
-2013-03-31,GB,United Kingdom,90.2889
+2013-03-31,FR,France,98.5396
+2013-03-31,GB,United Kingdom,90.276
 2013-03-31,GR,Greece,74.4672
 2013-03-31,HK,Hong Kong SAR,139.2015
-2013-03-31,HR,Croatia,88.329
+2013-03-31,HR,Croatia,88.3408
 2013-03-31,HU,Hungary,81.2453
 2013-03-31,ID,Indonesia,105.0269
-2013-03-31,IE,Ireland,67.0416
-2013-03-31,IL,Israel,115.4071
-2013-03-31,IN,India,139.7861
-2013-03-31,IS,Iceland,101.717
-2013-03-31,IT,Italy,87.5526
+2013-03-31,IE,Ireland,67.0866
+2013-03-31,IL,Israel,115.4078
+2013-03-31,IN,India,140.2135
+2013-03-31,IS,Iceland,101.7246
+2013-03-31,IT,Italy,87.5561
 2013-03-31,JP,Japan,100.1971
-2013-03-31,KR,Korea,100.1866
-2013-03-31,LT,Lithuania,98.5986
-2013-03-31,LU,Luxembourg,103.6579
-2013-03-31,LV,Latvia,109.0998
-2013-03-31,MA,Morocco,98.795
-2013-03-31,MK,North Macedonia,85.3747
+2013-03-31,KR,Korea,100.1824
+2013-03-31,LT,Lithuania,98.5987
+2013-03-31,LU,Luxembourg,103.6478
+2013-03-31,LV,Latvia,109.1119
+2013-03-31,MA,Morocco,97.5545
+2013-03-31,MK,North Macedonia,85.3585
 2013-03-31,MT,Malta,95.2254
 2013-03-31,MX,Mexico,101.1349
 2013-03-31,MY,Malaysia,124.2961
-2013-03-31,NL,Netherlands,81.7
-2013-03-31,NO,Norway,115.8573
+2013-03-31,NL,Netherlands,81.6936
+2013-03-31,NO,Norway,115.8481
 2013-03-31,NZ,New Zealand,104.7769
 2013-03-31,PE,Peru,147.379
 2013-03-31,PH,Philippines,110.7215
 2013-03-31,PL,Poland,84.91
-2013-03-31,PT,Portugal,81.1727
+2013-03-31,PT,Portugal,81.1726
 2013-03-31,RO,Romania,74.349
 2013-03-31,RS,Serbia,71.1626
-2013-03-31,RU,Russia,78.4004
-2013-03-31,SE,Sweden,102.6991
-2013-03-31,SG,Singapore,101.675
-2013-03-31,SI,Slovenia,88.2269
-2013-03-31,SK,Slovak Republic,88.6122
-2013-03-31,TH,Thailand,103.3125
-2013-03-31,TR,Türkiye,102.0633
-2013-03-31,US,United States,101.432
-2013-03-31,XM,Euro area,91.2508
-2013-03-31,XW,World,100.9769
-2013-03-31,ZA,South Africa,98.0022
-2013-06-30,4T,Emerging market economies (aggregate),105.948
-2013-06-30,5R,Advanced economies,98.4145
-2013-06-30,AE,United Arab Emirates,125.5026
+2013-03-31,RU,Russia,78.3961
+2013-03-31,SE,Sweden,102.6997
+2013-03-31,SG,Singapore,101.6618
+2013-03-31,SI,Slovenia,88.2102
+2013-03-31,SK,Slovakia,88.5206
+2013-03-31,TH,Thailand,103.7089
+2013-03-31,TR,Türkiye,105.3201
+2013-03-31,US,United States,101.4522
+2013-03-31,XM,Euro area,91.228
+2013-03-31,XW,World,100.5003
+2013-03-31,ZA,South Africa,97.7648
+2013-06-30,4T,Emerging market economies (aggregate),105.296
+2013-06-30,5R,Advanced economies,98.7059
 2013-06-30,AT,Austria,113.4456
-2013-06-30,AU,Australia,95.6544
-2013-06-30,BE,Belgium,99.6928
-2013-06-30,BG,Bulgaria,83.9806
+2013-06-30,AU,Australia,95.6504
+2013-06-30,BE,Belgium,99.7773
+2013-06-30,BG,Bulgaria,83.9647
 2013-06-30,BR,Brazil,120.9585
-2013-06-30,CA,Canada,106.9943
-2013-06-30,CH,Switzerland,118.6773
+2013-06-30,CA,Canada,107.0699
+2013-06-30,CH,Switzerland,118.6762
 2013-06-30,CL,Chile,126.2033
 2013-06-30,CN,China,98.2806
-2013-06-30,CO,Colombia,119.3594
+2013-06-30,CO,Colombia,118.9872
 2013-06-30,CY,Cyprus,81.6985
-2013-06-30,CZ,Czechia,92.3796
+2013-06-30,CZ,Czechia,92.3822
 2013-06-30,DE,Germany,103.0375
-2013-06-30,DK,Denmark,94.729
+2013-06-30,DK,Denmark,94.7376
 2013-06-30,EE,Estonia,111.6681
 2013-06-30,ES,Spain,66.4184
 2013-06-30,FI,Finland,99.303
-2013-06-30,FR,France,97.9094
-2013-06-30,GB,United Kingdom,91.478
-2013-06-30,GR,Greece,71.4452
+2013-06-30,FR,France,97.9136
+2013-06-30,GB,United Kingdom,91.4474
+2013-06-30,GR,Greece,71.4453
 2013-06-30,HK,Hong Kong SAR,139.8101
-2013-06-30,HR,Croatia,87.1924
+2013-06-30,HR,Croatia,87.249
 2013-06-30,HU,Hungary,81.1249
 2013-06-30,ID,Indonesia,106.2543
-2013-06-30,IE,Ireland,66.746
+2013-06-30,IE,Ireland,66.7638
 2013-06-30,IL,Israel,115.577
-2013-06-30,IN,India,138.2987
-2013-06-30,IS,Iceland,104.0884
-2013-06-30,IT,Italy,87.1016
+2013-06-30,IN,India,138.5209
+2013-06-30,IS,Iceland,104.0839
+2013-06-30,IT,Italy,87.1034
 2013-06-30,JP,Japan,100.8409
-2013-06-30,KR,Korea,100.2695
-2013-06-30,LT,Lithuania,99.5235
-2013-06-30,LU,Luxembourg,104.2286
-2013-06-30,LV,Latvia,113.1035
-2013-06-30,MA,Morocco,98.4979
-2013-06-30,MK,North Macedonia,84.0254
+2013-06-30,KR,Korea,100.2427
+2013-06-30,LT,Lithuania,99.5236
+2013-06-30,LU,Luxembourg,104.2114
+2013-06-30,LV,Latvia,113.0954
+2013-06-30,MA,Morocco,97.811
+2013-06-30,MK,North Macedonia,84.0815
 2013-06-30,MT,Malta,92.5132
 2013-06-30,MX,Mexico,102.533
 2013-06-30,MY,Malaysia,128.4005
-2013-06-30,NL,Netherlands,79.2635
-2013-06-30,NO,Norway,117.9502
+2013-06-30,NL,Netherlands,79.2639
+2013-06-30,NO,Norway,117.8773
 2013-06-30,NZ,New Zealand,106.8315
 2013-06-30,PE,Peru,148.5212
 2013-06-30,PH,Philippines,114.0867
@@ -21440,61 +5910,60 @@ date,country_code,country,price
 2013-06-30,PT,Portugal,80.0374
 2013-06-30,RO,Romania,73.3235
 2013-06-30,RS,Serbia,69.2056
-2013-06-30,RU,Russia,78.0346
-2013-06-30,SE,Sweden,104.3015
-2013-06-30,SG,Singapore,104
-2013-06-30,SI,Slovenia,87.7037
-2013-06-30,SK,Slovak Republic,88.6351
-2013-06-30,TH,Thailand,105.1031
-2013-06-30,TR,Türkiye,104.5298
-2013-06-30,US,United States,103.5118
-2013-06-30,XM,Euro area,90.5252
-2013-06-30,XW,World,102.21
-2013-06-30,ZA,South Africa,98.0618
-2013-09-30,4T,Emerging market economies (aggregate),106.875
-2013-09-30,5R,Advanced economies,99.7233
-2013-09-30,AE,United Arab Emirates,135.3688
+2013-06-30,RU,Russia,78.0333
+2013-06-30,SE,Sweden,104.3058
+2013-06-30,SG,Singapore,103.9846
+2013-06-30,SI,Slovenia,87.7187
+2013-06-30,SK,Slovakia,88.5436
+2013-06-30,TH,Thailand,104.732
+2013-06-30,TR,Türkiye,107.5125
+2013-06-30,US,United States,103.5195
+2013-06-30,XM,Euro area,90.4971
+2013-06-30,XW,World,101.6395
+2013-06-30,ZA,South Africa,98.0389
+2013-09-30,4T,Emerging market economies (aggregate),106.1598
+2013-09-30,5R,Advanced economies,99.9225
 2013-09-30,AT,Austria,114.8091
-2013-09-30,AU,Australia,96.8764
-2013-09-30,BE,Belgium,100.6812
-2013-09-30,BG,Bulgaria,84.1966
-2013-09-30,BR,Brazil,122.7082
-2013-09-30,CA,Canada,107.3677
-2013-09-30,CH,Switzerland,119.1095
-2013-09-30,CL,Chile,125.8071
+2013-09-30,AU,Australia,96.8231
+2013-09-30,BE,Belgium,100.6686
+2013-09-30,BG,Bulgaria,84.2214
+2013-09-30,BR,Brazil,122.7083
+2013-09-30,CA,Canada,107.4486
+2013-09-30,CH,Switzerland,119.108
+2013-09-30,CL,Chile,125.807
 2013-09-30,CN,China,100.0011
-2013-09-30,CO,Colombia,121.1215
+2013-09-30,CO,Colombia,120.7765
 2013-09-30,CY,Cyprus,80.7006
-2013-09-30,CZ,Czechia,92.5295
+2013-09-30,CZ,Czechia,92.5292
 2013-09-30,DE,Germany,103.319
-2013-09-30,DK,Denmark,94.8885
+2013-09-30,DK,Denmark,94.8844
 2013-09-30,EE,Estonia,117.3956
-2013-09-30,ES,Spain,67.0733
+2013-09-30,ES,Spain,67.0732
 2013-09-30,FI,Finland,99.1486
-2013-09-30,FR,France,98.7113
-2013-09-30,GB,United Kingdom,93.4001
+2013-09-30,FR,France,98.7157
+2013-09-30,GB,United Kingdom,93.3982
 2013-09-30,GR,Greece,71.4849
 2013-09-30,HK,Hong Kong SAR,143.4171
-2013-09-30,HR,Croatia,87.9607
+2013-09-30,HR,Croatia,88.0109
 2013-09-30,HU,Hungary,81.4416
 2013-09-30,ID,Indonesia,104.1581
-2013-09-30,IE,Ireland,70.546
-2013-09-30,IL,Israel,116.6328
-2013-09-30,IN,India,138.3616
-2013-09-30,IS,Iceland,105.5104
-2013-09-30,IT,Italy,85.4596
+2013-09-30,IE,Ireland,70.5928
+2013-09-30,IL,Israel,116.6329
+2013-09-30,IN,India,138.0677
+2013-09-30,IS,Iceland,105.5261
+2013-09-30,IT,Italy,85.4635
 2013-09-30,JP,Japan,101.3057
-2013-09-30,KR,Korea,99.7882
+2013-09-30,KR,Korea,99.7659
 2013-09-30,LT,Lithuania,98.2583
-2013-09-30,LU,Luxembourg,105.5193
-2013-09-30,LV,Latvia,115.1345
-2013-09-30,MA,Morocco,98.1261
-2013-09-30,MK,North Macedonia,85.404
+2013-09-30,LU,Luxembourg,105.506
+2013-09-30,LV,Latvia,115.1767
+2013-09-30,MA,Morocco,97.1678
+2013-09-30,MK,North Macedonia,85.3427
 2013-09-30,MT,Malta,96.9794
 2013-09-30,MX,Mexico,103.9157
 2013-09-30,MY,Malaysia,132.6014
-2013-09-30,NL,Netherlands,79.3484
-2013-09-30,NO,Norway,115.3283
+2013-09-30,NL,Netherlands,79.3424
+2013-09-30,NO,Norway,115.2866
 2013-09-30,NZ,New Zealand,109.1498
 2013-09-30,PE,Peru,148.1684
 2013-09-30,PH,Philippines,117.0171
@@ -21502,61 +5971,60 @@ date,country_code,country,price
 2013-09-30,PT,Portugal,80.8308
 2013-09-30,RO,Romania,72.2607
 2013-09-30,RS,Serbia,70.0846
-2013-09-30,RU,Russia,77.2268
-2013-09-30,SE,Sweden,106.1478
-2013-09-30,SG,Singapore,103.2439
-2013-09-30,SI,Slovenia,82.5803
-2013-09-30,SK,Slovak Republic,88.502
-2013-09-30,TH,Thailand,106.658
-2013-09-30,TR,Türkiye,105.8266
-2013-09-30,US,United States,105.7066
-2013-09-30,XM,Euro area,91.2047
-2013-09-30,XW,World,103.3256
-2013-09-30,ZA,South Africa,98.2308
-2013-12-31,4T,Emerging market economies (aggregate),107.4061
-2013-12-31,5R,Advanced economies,100.3496
-2013-12-31,AE,United Arab Emirates,145.3546
+2013-09-30,RU,Russia,77.2286
+2013-09-30,SE,Sweden,106.15
+2013-09-30,SG,Singapore,103.2293
+2013-09-30,SI,Slovenia,82.5695
+2013-09-30,SK,Slovakia,88.2275
+2013-09-30,TH,Thailand,106.8426
+2013-09-30,TR,Türkiye,109.4549
+2013-09-30,US,United States,105.7122
+2013-09-30,XM,Euro area,91.1621
+2013-09-30,XW,World,102.6962
+2013-09-30,ZA,South Africa,98.3588
+2013-12-31,4T,Emerging market economies (aggregate),106.6233
+2013-12-31,5R,Advanced economies,100.4695
 2013-12-31,AT,Austria,113.388
-2013-12-31,AU,Australia,99.954
-2013-12-31,BE,Belgium,99.6429
-2013-12-31,BG,Bulgaria,84.0788
+2013-12-31,AU,Australia,99.9481
+2013-12-31,BE,Belgium,99.6875
+2013-12-31,BG,Bulgaria,84.0476
 2013-12-31,BR,Brazil,123.1759
-2013-12-31,CA,Canada,107.9375
-2013-12-31,CH,Switzerland,120.3506
+2013-12-31,CA,Canada,108.0217
+2013-12-31,CH,Switzerland,120.3492
 2013-12-31,CL,Chile,129.1589
 2013-12-31,CN,China,101.0089
-2013-12-31,CO,Colombia,122.0442
+2013-12-31,CO,Colombia,122.4603
 2013-12-31,CY,Cyprus,78.8814
-2013-12-31,CZ,Czechia,92.3946
+2013-12-31,CZ,Czechia,92.3901
 2013-12-31,DE,Germany,102.7744
-2013-12-31,DK,Denmark,93.3787
+2013-12-31,DK,Denmark,93.3758
 2013-12-31,EE,Estonia,121.5297
-2013-12-31,ES,Spain,65.8622
+2013-12-31,ES,Spain,65.8621
 2013-12-31,FI,Finland,98.217
-2013-12-31,FR,France,97.7057
-2013-12-31,GB,United Kingdom,93.3397
+2013-12-31,FR,France,97.7071
+2013-12-31,GB,United Kingdom,93.283
 2013-12-31,GR,Greece,69.1792
 2013-12-31,HK,Hong Kong SAR,139.49
-2013-12-31,HR,Croatia,86.9319
+2013-12-31,HR,Croatia,86.9533
 2013-12-31,HU,Hungary,80.5554
 2013-12-31,ID,Indonesia,105.3673
-2013-12-31,IE,Ireland,72.8313
-2013-12-31,IL,Israel,118.3692
-2013-12-31,IN,India,137.8301
-2013-12-31,IS,Iceland,108.1096
+2013-12-31,IE,Ireland,72.8341
+2013-12-31,IL,Israel,118.3694
+2013-12-31,IN,India,137.5208
+2013-12-31,IS,Iceland,108.1333
 2013-12-31,IT,Italy,84.5976
 2013-12-31,JP,Japan,100.8131
-2013-12-31,KR,Korea,100.1976
+2013-12-31,KR,Korea,100.2023
 2013-12-31,LT,Lithuania,100.587
-2013-12-31,LU,Luxembourg,106.621
-2013-12-31,LV,Latvia,118.1716
-2013-12-31,MA,Morocco,99.261
-2013-12-31,MK,North Macedonia,83.6725
+2013-12-31,LU,Luxembourg,106.6045
+2013-12-31,LV,Latvia,118.2334
+2013-12-31,MA,Morocco,97.9265
+2013-12-31,MK,North Macedonia,83.8738
 2013-12-31,MT,Malta,94.8804
 2013-12-31,MX,Mexico,103.1217
 2013-12-31,MY,Malaysia,132.2503
-2013-12-31,NL,Netherlands,79.5703
-2013-12-31,NO,Norway,111.656
+2013-12-31,NL,Netherlands,79.562
+2013-12-31,NO,Norway,111.6774
 2013-12-31,NZ,New Zealand,110.2959
 2013-12-31,PE,Peru,147.2723
 2013-12-31,PH,Philippines,119.5822
@@ -21564,61 +6032,60 @@ date,country_code,country,price
 2013-12-31,PT,Portugal,82.6428
 2013-12-31,RO,Romania,72.3209
 2013-12-31,RS,Serbia,71.7322
-2013-12-31,RU,Russia,76.5394
-2013-12-31,SE,Sweden,107.619
-2013-12-31,SG,Singapore,101.4057
-2013-12-31,SI,Slovenia,82.5436
-2013-12-31,SK,Slovak Republic,88.5977
-2013-12-31,TH,Thailand,108.7082
-2013-12-31,TR,Türkiye,105.9661
-2013-12-31,US,United States,108.0613
-2013-12-31,XM,Euro area,90.3362
-2013-12-31,XW,World,103.9035
-2013-12-31,ZA,South Africa,99.6165
-2014-03-31,4T,Emerging market economies (aggregate),108.172
-2014-03-31,5R,Advanced economies,100.9748
-2014-03-31,AE,United Arab Emirates,160.8274
+2013-12-31,RU,Russia,76.5472
+2013-12-31,SE,Sweden,107.6241
+2013-12-31,SG,Singapore,101.392
+2013-12-31,SI,Slovenia,82.5518
+2013-12-31,SK,Slovakia,88.4142
+2013-12-31,TH,Thailand,109.2643
+2013-12-31,TR,Türkiye,109.2455
+2013-12-31,US,United States,108.0538
+2013-12-31,XM,Euro area,90.2858
+2013-12-31,XW,World,103.2051
+2013-12-31,ZA,South Africa,99.3883
+2014-03-31,4T,Emerging market economies (aggregate),107.2472
+2014-03-31,5R,Advanced economies,101.0526
 2014-03-31,AT,Austria,115.399
-2014-03-31,AU,Australia,100.7972
-2014-03-31,BE,Belgium,97.4123
-2014-03-31,BG,Bulgaria,85.3172
+2014-03-31,AU,Australia,100.7728
+2014-03-31,BE,Belgium,98.186
+2014-03-31,BG,Bulgaria,85.3128
 2014-03-31,BR,Brazil,123.0558
-2014-03-31,CA,Canada,109.2505
-2014-03-31,CH,Switzerland,121.1146
-2014-03-31,CL,Chile,130.2572
+2014-03-31,CA,Canada,109.3543
+2014-03-31,CH,Switzerland,121.1133
+2014-03-31,CL,Chile,130.2571
 2014-03-31,CN,China,100.7569
-2014-03-31,CO,Colombia,124.8885
+2014-03-31,CO,Colombia,124.303
 2014-03-31,CY,Cyprus,77.7729
-2014-03-31,CZ,Czechia,93.2007
+2014-03-31,CZ,Czechia,93.1979
 2014-03-31,DE,Germany,103.3807
-2014-03-31,DK,Denmark,94.5383
+2014-03-31,DK,Denmark,94.5259
 2014-03-31,EE,Estonia,126.8905
-2014-03-31,ES,Spain,66.4244
+2014-03-31,ES,Spain,66.4245
 2014-03-31,FI,Finland,98.0463
-2014-03-31,FR,France,96.3972
-2014-03-31,GB,United Kingdom,94.4542
+2014-03-31,FR,France,96.4032
+2014-03-31,GB,United Kingdom,94.5354
 2014-03-31,GR,Greece,68.6038
 2014-03-31,HK,Hong Kong SAR,137.4699
-2014-03-31,HR,Croatia,86.5742
-2014-03-31,HU,Hungary,81.9806
+2014-03-31,HR,Croatia,86.597
+2014-03-31,HU,Hungary,81.9807
 2014-03-31,ID,Indonesia,105.1854
-2014-03-31,IE,Ireland,73.9951
-2014-03-31,IL,Israel,122.6066
-2014-03-31,IN,India,145.7431
-2014-03-31,IS,Iceland,108.9223
-2014-03-31,IT,Italy,83.333
+2014-03-31,IE,Ireland,73.9763
+2014-03-31,IL,Israel,122.6067
+2014-03-31,IN,India,145.5673
+2014-03-31,IS,Iceland,108.9339
+2014-03-31,IT,Italy,83.3345
 2014-03-31,JP,Japan,101.7371
-2014-03-31,KR,Korea,99.8658
+2014-03-31,KR,Korea,99.8539
 2014-03-31,LT,Lithuania,102.2287
-2014-03-31,LU,Luxembourg,105.0815
-2014-03-31,LV,Latvia,120.1441
-2014-03-31,MA,Morocco,99.2813
-2014-03-31,MK,North Macedonia,82.9353
+2014-03-31,LU,Luxembourg,105.0705
+2014-03-31,LV,Latvia,120.1364
+2014-03-31,MA,Morocco,97.7629
+2014-03-31,MK,North Macedonia,83.0916
 2014-03-31,MT,Malta,95.7737
 2014-03-31,MX,Mexico,102.6296
 2014-03-31,MY,Malaysia,132.4189
-2014-03-31,NL,Netherlands,79.7981
-2014-03-31,NO,Norway,113.8409
+2014-03-31,NL,Netherlands,79.7998
+2014-03-31,NO,Norway,113.7542
 2014-03-31,NZ,New Zealand,111.0691
 2014-03-31,PE,Peru,152.3553
 2014-03-31,PH,Philippines,121.1723
@@ -21626,61 +6093,60 @@ date,country_code,country,price
 2014-03-31,PT,Portugal,84.541
 2014-03-31,RO,Romania,71.3844
 2014-03-31,RS,Serbia,73.0603
-2014-03-31,RU,Russia,74.3532
-2014-03-31,SE,Sweden,111.5512
-2014-03-31,SG,Singapore,99.9487
-2014-03-31,SI,Slovenia,81.9629
-2014-03-31,SK,Slovak Republic,88.4792
-2014-03-31,TH,Thailand,109.8457
-2014-03-31,TR,Türkiye,106.3064
-2014-03-31,US,United States,108.6173
-2014-03-31,XM,Euro area,90.6118
-2014-03-31,XW,World,104.6002
-2014-03-31,ZA,South Africa,99.9431
-2014-06-30,4T,Emerging market economies (aggregate),108.995
-2014-06-30,5R,Advanced economies,100.8119
-2014-06-30,AE,United Arab Emirates,166.2997
+2014-03-31,RU,Russia,74.3407
+2014-03-31,SE,Sweden,111.5503
+2014-03-31,SG,Singapore,99.929
+2014-03-31,SI,Slovenia,81.9407
+2014-03-31,SK,Slovakia,88.2042
+2014-03-31,TH,Thailand,110.2955
+2014-03-31,TR,Türkiye,109.0032
+2014-03-31,US,United States,108.6461
+2014-03-31,XM,Euro area,90.5574
+2014-03-31,XW,World,103.8064
+2014-03-31,ZA,South Africa,99.6185
+2014-06-30,4T,Emerging market economies (aggregate),108.0572
+2014-06-30,5R,Advanced economies,100.918
 2014-06-30,AT,Austria,116.8706
-2014-06-30,AU,Australia,102.2539
-2014-06-30,BE,Belgium,98.3425
-2014-06-30,BG,Bulgaria,85.9785
+2014-06-30,AU,Australia,102.1976
+2014-06-30,BE,Belgium,98.4335
+2014-06-30,BG,Bulgaria,85.9778
 2014-06-30,BR,Brazil,122.4608
-2014-06-30,CA,Canada,110.2689
-2014-06-30,CH,Switzerland,121.981
+2014-06-30,CA,Canada,110.5261
+2014-06-30,CH,Switzerland,121.9788
 2014-06-30,CL,Chile,133.1782
 2014-06-30,CN,China,101.245
-2014-06-30,CO,Colombia,124.796
-2014-06-30,CY,Cyprus,75.2896
-2014-06-30,CZ,Czechia,93.8913
+2014-06-30,CO,Colombia,124.6013
+2014-06-30,CY,Cyprus,75.2704
+2014-06-30,CZ,Czechia,93.8901
 2014-06-30,DE,Germany,105.2256
-2014-06-30,DK,Denmark,97.7727
+2014-06-30,DK,Denmark,97.7882
 2014-06-30,EE,Estonia,127.8623
-2014-06-30,ES,Spain,66.8253
+2014-06-30,ES,Spain,66.8252
 2014-06-30,FI,Finland,98.199
-2014-06-30,FR,France,96.1602
-2014-06-30,GB,United Kingdom,97.1935
-2014-06-30,GR,Greece,66.5536
+2014-06-30,FR,France,96.1621
+2014-06-30,GB,United Kingdom,97.1421
+2014-06-30,GR,Greece,66.5535
 2014-06-30,HK,Hong Kong SAR,138.4453
-2014-06-30,HR,Croatia,86.8691
-2014-06-30,HU,Hungary,83.5558
+2014-06-30,HR,Croatia,86.8506
+2014-06-30,HU,Hungary,83.5557
 2014-06-30,ID,Indonesia,106.5637
-2014-06-30,IE,Ireland,77.5575
-2014-06-30,IL,Israel,123.5233
-2014-06-30,IN,India,149.0913
-2014-06-30,IS,Iceland,110.2809
-2014-06-30,IT,Italy,82.3933
+2014-06-30,IE,Ireland,77.5017
+2014-06-30,IL,Israel,123.5232
+2014-06-30,IN,India,148.8004
+2014-06-30,IS,Iceland,110.2886
+2014-06-30,IT,Italy,82.3944
 2014-06-30,JP,Japan,98.8267
-2014-06-30,KR,Korea,100.038
+2014-06-30,KR,Korea,100.0261
 2014-06-30,LT,Lithuania,105.8775
-2014-06-30,LU,Luxembourg,108.4067
-2014-06-30,LV,Latvia,121.0395
-2014-06-30,MA,Morocco,99.5794
-2014-06-30,MK,North Macedonia,84.6978
+2014-06-30,LU,Luxembourg,108.3902
+2014-06-30,LV,Latvia,121.1055
+2014-06-30,MA,Morocco,98.3319
+2014-06-30,MK,North Macedonia,84.9632
 2014-06-30,MT,Malta,95.3306
 2014-06-30,MX,Mexico,103.1446
 2014-06-30,MY,Malaysia,136.8289
-2014-06-30,NL,Netherlands,79.4879
-2014-06-30,NO,Norway,117.3793
+2014-06-30,NL,Netherlands,79.4832
+2014-06-30,NO,Norway,117.3742
 2014-06-30,NZ,New Zealand,111.8857
 2014-06-30,PE,Peru,156.972
 2014-06-30,PH,Philippines,123.3626
@@ -21688,61 +6154,60 @@ date,country_code,country,price
 2014-06-30,PT,Portugal,85.0492
 2014-06-30,RO,Romania,70.4676
 2014-06-30,RS,Serbia,73.3724
-2014-06-30,RU,Russia,73.3548
-2014-06-30,SE,Sweden,113.3242
-2014-06-30,SG,Singapore,98.9623
-2014-06-30,SI,Slovenia,78.6246
-2014-06-30,SK,Slovak Republic,89.7114
-2014-06-30,TH,Thailand,111.9745
-2014-06-30,TR,Türkiye,107.5309
-2014-06-30,US,United States,108.0668
-2014-06-30,XM,Euro area,90.7596
-2014-06-30,XW,World,104.9396
-2014-06-30,ZA,South Africa,99.5996
-2014-09-30,4T,Emerging market economies (aggregate),108.0619
-2014-09-30,5R,Advanced economies,101.9265
-2014-09-30,AE,United Arab Emirates,163.6592
+2014-06-30,RU,Russia,73.348
+2014-06-30,SE,Sweden,113.3264
+2014-06-30,SG,Singapore,98.9428
+2014-06-30,SI,Slovenia,78.6113
+2014-06-30,SK,Slovakia,89.5284
+2014-06-30,TH,Thailand,113.0618
+2014-06-30,TR,Türkiye,109.8925
+2014-06-30,US,United States,108.0764
+2014-06-30,XM,Euro area,90.6942
+2014-06-30,XW,World,104.1066
+2014-06-30,ZA,South Africa,99.4507
+2014-09-30,4T,Emerging market economies (aggregate),107.004
+2014-09-30,5R,Advanced economies,101.9855
 2014-09-30,AT,Austria,115.6509
-2014-09-30,AU,Australia,102.9975
-2014-09-30,BE,Belgium,99.7341
-2014-09-30,BG,Bulgaria,86.3785
+2014-09-30,AU,Australia,102.9928
+2014-09-30,BE,Belgium,99.9309
+2014-09-30,BG,Bulgaria,86.4101
 2014-09-30,BR,Brazil,122.6648
-2014-09-30,CA,Canada,110.8398
-2014-09-30,CH,Switzerland,122.187
-2014-09-30,CL,Chile,140.8393
+2014-09-30,CA,Canada,111.0363
+2014-09-30,CH,Switzerland,122.1852
+2014-09-30,CL,Chile,140.8392
 2014-09-30,CN,China,98.5642
-2014-09-30,CO,Colombia,126.8926
+2014-09-30,CO,Colombia,126.4869
 2014-09-30,CY,Cyprus,74.4816
-2014-09-30,CZ,Czechia,94.5173
+2014-09-30,CZ,Czechia,94.5124
 2014-09-30,DE,Germany,105.34
-2014-09-30,DK,Denmark,97.4519
+2014-09-30,DK,Denmark,97.4533
 2014-09-30,EE,Estonia,133.6735
-2014-09-30,ES,Spain,67.4829
+2014-09-30,ES,Spain,67.483
 2014-09-30,FI,Finland,97.5806
-2014-09-30,FR,France,97.0861
-2014-09-30,GB,United Kingdom,100.2599
+2014-09-30,FR,France,97.0841
+2014-09-30,GB,United Kingdom,100.228
 2014-09-30,GR,Greece,66.976
 2014-09-30,HK,Hong Kong SAR,145.5168
-2014-09-30,HR,Croatia,86.4571
+2014-09-30,HR,Croatia,86.4882
 2014-09-30,HU,Hungary,85.2208
 2014-09-30,ID,Indonesia,106.3295
-2014-09-30,IE,Ireland,83.8741
+2014-09-30,IE,Ireland,83.8631
 2014-09-30,IL,Israel,122.731
-2014-09-30,IN,India,147.9489
-2014-09-30,IS,Iceland,112.2508
-2014-09-30,IT,Italy,81.4979
+2014-09-30,IN,India,147.5988
+2014-09-30,IS,Iceland,112.2468
+2014-09-30,IT,Italy,81.5
 2014-09-30,JP,Japan,99.069
-2014-09-30,KR,Korea,100.2007
+2014-09-30,KR,Korea,100.157
 2014-09-30,LT,Lithuania,108.0758
-2014-09-30,LU,Luxembourg,110.1067
-2014-09-30,LV,Latvia,126.5638
-2014-09-30,MA,Morocco,100.006
-2014-09-30,MK,North Macedonia,87.7263
+2014-09-30,LU,Luxembourg,110.0957
+2014-09-30,LV,Latvia,126.3902
+2014-09-30,MA,Morocco,97.2072
+2014-09-30,MK,North Macedonia,87.7649
 2014-09-30,MT,Malta,97.2678
 2014-09-30,MX,Mexico,103.1213
 2014-09-30,MY,Malaysia,140.1055
-2014-09-30,NL,Netherlands,79.6293
-2014-09-30,NO,Norway,116.8248
+2014-09-30,NL,Netherlands,79.6215
+2014-09-30,NO,Norway,116.7837
 2014-09-30,NZ,New Zealand,113.2593
 2014-09-30,PE,Peru,148.508
 2014-09-30,PH,Philippines,124.8826
@@ -21750,61 +6215,60 @@ date,country_code,country,price
 2014-09-30,PT,Portugal,85.2614
 2014-09-30,RO,Romania,70.0283
 2014-09-30,RS,Serbia,72.2708
-2014-09-30,RU,Russia,72.8332
-2014-09-30,SE,Sweden,117.3161
-2014-09-30,SG,Singapore,98.241
-2014-09-30,SI,Slovenia,78.3409
-2014-09-30,SK,Slovak Republic,89.7128
-2014-09-30,TH,Thailand,113.2415
-2014-09-30,TR,Türkiye,110.7853
-2014-09-30,US,United States,109.3769
-2014-09-30,XM,Euro area,91.6727
-2014-09-30,XW,World,105.0153
-2014-09-30,ZA,South Africa,99.5059
-2014-12-31,4T,Emerging market economies (aggregate),107.6867
-2014-12-31,5R,Advanced economies,102.7734
-2014-12-31,AE,United Arab Emirates,159.2344
+2014-09-30,RU,Russia,72.8418
+2014-09-30,SE,Sweden,117.3197
+2014-09-30,SG,Singapore,98.2196
+2014-09-30,SI,Slovenia,78.3384
+2014-09-30,SK,Slovakia,89.5296
+2014-09-30,TH,Thailand,114.0466
+2014-09-30,TR,Türkiye,112.9472
+2014-09-30,US,United States,109.3651
+2014-09-30,XM,Euro area,91.5861
+2014-09-30,XW,World,104.2018
+2014-09-30,ZA,South Africa,99.2013
+2014-12-31,4T,Emerging market economies (aggregate),106.6559
+2014-12-31,5R,Advanced economies,102.8213
 2014-12-31,AT,Austria,114.5364
-2014-12-31,AU,Australia,104.8988
-2014-12-31,BE,Belgium,100.7347
-2014-12-31,BG,Bulgaria,86.9714
+2014-12-31,AU,Australia,104.8923
+2014-12-31,BE,Belgium,100.499
+2014-12-31,BG,Bulgaria,86.9539
 2014-12-31,BR,Brazil,121.4491
-2014-12-31,CA,Canada,111.7815
-2014-12-31,CH,Switzerland,123.9526
+2014-12-31,CA,Canada,111.8501
+2014-12-31,CH,Switzerland,123.9503
 2014-12-31,CL,Chile,140.9161
 2014-12-31,CN,China,95.9506
-2014-12-31,CO,Colombia,126.5394
+2014-12-31,CO,Colombia,126.8801
 2014-12-31,CY,Cyprus,73.063
-2014-12-31,CZ,Czechia,95.4252
+2014-12-31,CZ,Czechia,95.4245
 2014-12-31,DE,Germany,105.6013
-2014-12-31,DK,Denmark,96.9731
+2014-12-31,DK,Denmark,97.0158
 2014-12-31,EE,Estonia,134.3949
-2014-12-31,ES,Spain,67.3601
+2014-12-31,ES,Spain,67.3597
 2014-12-31,FI,Finland,96.9307
-2014-12-31,FR,France,95.3437
-2014-12-31,GB,United Kingdom,100.3929
+2014-12-31,FR,France,95.3513
+2014-12-31,GB,United Kingdom,100.3097
 2014-12-31,GR,Greece,66.5695
 2014-12-31,HK,Hong Kong SAR,148.6109
-2014-12-31,HR,Croatia,85.6448
+2014-12-31,HR,Croatia,85.6562
 2014-12-31,HU,Hungary,87.9572
 2014-12-31,ID,Indonesia,105.1779
-2014-12-31,IE,Ireland,87.0597
-2014-12-31,IL,Israel,124.4195
-2014-12-31,IN,India,154.8481
-2014-12-31,IS,Iceland,113.2726
-2014-12-31,IT,Italy,80.4122
+2014-12-31,IE,Ireland,87.1173
+2014-12-31,IL,Israel,124.4194
+2014-12-31,IN,India,154.4816
+2014-12-31,IS,Iceland,113.2962
+2014-12-31,IT,Italy,80.411
 2014-12-31,JP,Japan,98.8562
-2014-12-31,KR,Korea,101.2826
+2014-12-31,KR,Korea,101.3078
 2014-12-31,LT,Lithuania,105.8597
-2014-12-31,LU,Luxembourg,112.1168
-2014-12-31,LV,Latvia,112.2497
-2014-12-31,MA,Morocco,96.9495
-2014-12-31,MK,North Macedonia,82.9204
+2014-12-31,LU,Luxembourg,112.1022
+2014-12-31,LV,Latvia,112.2662
+2014-12-31,MA,Morocco,96.6342
+2014-12-31,MK,North Macedonia,82.9679
 2014-12-31,MT,Malta,99.6505
 2014-12-31,MX,Mexico,102.785
 2014-12-31,MY,Malaysia,139.7949
-2014-12-31,NL,Netherlands,80.4544
-2014-12-31,NO,Norway,115.7797
+2014-12-31,NL,Netherlands,80.4589
+2014-12-31,NO,Norway,115.7383
 2014-12-31,NZ,New Zealand,117.3017
 2014-12-31,PE,Peru,148.4147
 2014-12-31,PH,Philippines,127.9389
@@ -21812,61 +6276,60 @@ date,country_code,country,price
 2014-12-31,PT,Portugal,84.5574
 2014-12-31,RO,Romania,71.4725
 2014-12-31,RS,Serbia,73.4091
-2014-12-31,RU,Russia,71.8378
-2014-12-31,SE,Sweden,119.0753
-2014-12-31,SG,Singapore,97.3411
-2014-12-31,SI,Slovenia,78.9995
-2014-12-31,SK,Slovak Republic,91.6389
-2014-12-31,TH,Thailand,115.6702
-2014-12-31,TR,Türkiye,111.9842
-2014-12-31,US,United States,111.9476
-2014-12-31,XM,Euro area,91.0318
-2014-12-31,XW,World,105.236
-2014-12-31,ZA,South Africa,100.6402
-2015-03-31,4T,Emerging market economies (aggregate),107.2916
-2015-03-31,5R,Advanced economies,104.5028
-2015-03-31,AE,United Arab Emirates,149.6971
+2014-12-31,RU,Russia,71.8413
+2014-12-31,SE,Sweden,119.0773
+2014-12-31,SG,Singapore,97.3157
+2014-12-31,SI,Slovenia,79.0107
+2014-12-31,SK,Slovakia,91.3638
+2014-12-31,TH,Thailand,119.0853
+2014-12-31,TR,Türkiye,113.9372
+2014-12-31,US,United States,111.9425
+2014-12-31,XM,Euro area,90.9405
+2014-12-31,XW,World,104.4886
+2014-12-31,ZA,South Africa,100.2094
+2015-03-31,4T,Emerging market economies (aggregate),106.2332
+2015-03-31,5R,Advanced economies,104.4865
 2015-03-31,AT,Austria,118.4722
-2015-03-31,AU,Australia,106.3573
-2015-03-31,BE,Belgium,98.2861
-2015-03-31,BG,Bulgaria,87.6672
-2015-03-31,BR,Brazil,117.7051
-2015-03-31,CA,Canada,114.6291
-2015-03-31,CH,Switzerland,126.2388
-2015-03-31,CL,Chile,141.5537
+2015-03-31,AU,Australia,106.3492
+2015-03-31,BE,Belgium,99.1763
+2015-03-31,BG,Bulgaria,87.6893
+2015-03-31,BR,Brazil,117.7052
+2015-03-31,CA,Canada,114.857
+2015-03-31,CH,Switzerland,126.2366
+2015-03-31,CL,Chile,141.5536
 2015-03-31,CN,China,93.7689
-2015-03-31,CO,Colombia,128.4162
+2015-03-31,CO,Colombia,128.5518
 2015-03-31,CY,Cyprus,73.9266
-2015-03-31,CZ,Czechia,96.3415
+2015-03-31,CZ,Czechia,96.3803
 2015-03-31,DE,Germany,107.7635
-2015-03-31,DK,Denmark,101.005
+2015-03-31,DK,Denmark,100.9963
 2015-03-31,EE,Estonia,138.3905
-2015-03-31,ES,Spain,68.1443
+2015-03-31,ES,Spain,68.1441
 2015-03-31,FI,Finland,97.5758
 2015-03-31,FR,France,94.8173
-2015-03-31,GB,United Kingdom,100.7974
+2015-03-31,GB,United Kingdom,100.7165
 2015-03-31,GR,Greece,67.3849
 2015-03-31,HK,Hong Kong SAR,156.0895
-2015-03-31,HR,Croatia,85.4293
+2015-03-31,HR,Croatia,85.4636
 2015-03-31,HU,Hungary,90.4769
 2015-03-31,ID,Indonesia,104.9153
-2015-03-31,IE,Ireland,87.4412
-2015-03-31,IL,Israel,128.6823
-2015-03-31,IN,India,162.6809
-2015-03-31,IS,Iceland,117.8811
-2015-03-31,IT,Italy,78.7998
+2015-03-31,IE,Ireland,87.4601
+2015-03-31,IL,Israel,128.6822
+2015-03-31,IN,India,162.4629
+2015-03-31,IS,Iceland,117.9009
+2015-03-31,IT,Italy,78.8008
 2015-03-31,JP,Japan,101.8079
-2015-03-31,KR,Korea,101.3169
+2015-03-31,KR,Korea,101.3552
 2015-03-31,LT,Lithuania,108.4835
-2015-03-31,LU,Luxembourg,112.4928
-2015-03-31,LV,Latvia,112.3038
-2015-03-31,MA,Morocco,101.2669
-2015-03-31,MK,North Macedonia,84.9228
+2015-03-31,LU,Luxembourg,112.4828
+2015-03-31,LV,Latvia,112.341
+2015-03-31,MA,Morocco,95.9532
+2015-03-31,MK,North Macedonia,85.0713
 2015-03-31,MT,Malta,97.7045
 2015-03-31,MX,Mexico,103.875
 2015-03-31,MY,Malaysia,143.6448
-2015-03-31,NL,Netherlands,81.7231
-2015-03-31,NO,Norway,119.6901
+2015-03-31,NL,Netherlands,81.6362
+2015-03-31,NO,Norway,119.6771
 2015-03-31,NZ,New Zealand,121.203
 2015-03-31,PE,Peru,147.3179
 2015-03-31,PH,Philippines,131.356
@@ -21874,61 +6337,60 @@ date,country_code,country,price
 2015-03-31,PT,Portugal,85.3079
 2015-03-31,RO,Romania,73.1635
 2015-03-31,RS,Serbia,76.5816
-2015-03-31,RU,Russia,67.173
-2015-03-31,SE,Sweden,124.6836
-2015-03-31,SG,Singapore,96.4287
-2015-03-31,SI,Slovenia,81.1308
-2015-03-31,SK,Slovak Republic,93.4595
-2015-03-31,TH,Thailand,117.4838
-2015-03-31,TR,Türkiye,115.3317
-2015-03-31,US,United States,113.9713
-2015-03-31,XM,Euro area,91.9382
-2015-03-31,XW,World,105.8734
-2015-03-31,ZA,South Africa,101.8531
-2015-06-30,4T,Emerging market economies (aggregate),107.2709
-2015-06-30,5R,Advanced economies,104.6252
-2015-06-30,AE,United Arab Emirates,143.0902
+2015-03-31,RU,Russia,67.1665
+2015-03-31,SE,Sweden,124.6826
+2015-03-31,SG,Singapore,96.407
+2015-03-31,SI,Slovenia,81.1321
+2015-03-31,SK,Slovakia,93.1833
+2015-03-31,TH,Thailand,122.2406
+2015-03-31,TR,Türkiye,116.9876
+2015-03-31,US,United States,113.9869
+2015-03-31,XM,Euro area,91.8434
+2015-03-31,XW,World,105.1677
+2015-03-31,ZA,South Africa,101.5567
+2015-06-30,4T,Emerging market economies (aggregate),106.1868
+2015-06-30,5R,Advanced economies,104.6866
 2015-06-30,AT,Austria,117.3504
-2015-06-30,AU,Australia,110.5975
-2015-06-30,BE,Belgium,99.7552
-2015-06-30,BG,Bulgaria,87.9122
-2015-06-30,BR,Brazil,114.1413
-2015-06-30,CA,Canada,117.3176
-2015-06-30,CH,Switzerland,125.5653
+2015-06-30,AU,Australia,110.524
+2015-06-30,BE,Belgium,99.6713
+2015-06-30,BG,Bulgaria,87.9603
+2015-06-30,BR,Brazil,114.1392
+2015-06-30,CA,Canada,117.4469
+2015-06-30,CH,Switzerland,125.5649
 2015-06-30,CL,Chile,145.1211
 2015-06-30,CN,China,93.8242
-2015-06-30,CO,Colombia,131.3881
+2015-06-30,CO,Colombia,131.2323
 2015-06-30,CY,Cyprus,73.0083
-2015-06-30,CZ,Czechia,96.7723
+2015-06-30,CZ,Czechia,96.7559
 2015-06-30,DE,Germany,108.7442
-2015-06-30,DK,Denmark,103.6535
+2015-06-30,DK,Denmark,103.656
 2015-06-30,EE,Estonia,141.3513
-2015-06-30,ES,Spain,69.6883
+2015-06-30,ES,Spain,69.6881
 2015-06-30,FI,Finland,98.2222
-2015-06-30,FR,France,94.0651
-2015-06-30,GB,United Kingdom,102.3272
+2015-06-30,FR,France,94.0629
+2015-06-30,GB,United Kingdom,102.3749
 2015-06-30,GR,Greece,64.6323
 2015-06-30,HK,Hong Kong SAR,162.5425
-2015-06-30,HR,Croatia,82.9358
-2015-06-30,HU,Hungary,94.0055
+2015-06-30,HR,Croatia,82.9549
+2015-06-30,HU,Hungary,94.0054
 2015-06-30,ID,Indonesia,105.4536
-2015-06-30,IE,Ireland,88.5753
-2015-06-30,IL,Israel,130.0981
-2015-06-30,IN,India,162.4682
-2015-06-30,IS,Iceland,117.1257
-2015-06-30,IT,Italy,78.4876
+2015-06-30,IE,Ireland,88.6005
+2015-06-30,IL,Israel,130.0986
+2015-06-30,IN,India,162.1712
+2015-06-30,IS,Iceland,117.1453
+2015-06-30,IT,Italy,78.4902
 2015-06-30,JP,Japan,100.729
-2015-06-30,KR,Korea,102.4049
-2015-06-30,LT,Lithuania,110.3103
-2015-06-30,LU,Luxembourg,113.6954
-2015-06-30,LV,Latvia,114.5402
-2015-06-30,MA,Morocco,96.9125
-2015-06-30,MK,North Macedonia,84.8374
+2015-06-30,KR,Korea,102.4084
+2015-06-30,LT,Lithuania,110.3104
+2015-06-30,LU,Luxembourg,113.6833
+2015-06-30,LV,Latvia,114.5347
+2015-06-30,MA,Morocco,96.2358
+2015-06-30,MK,North Macedonia,84.767
 2015-06-30,MT,Malta,97.4922
 2015-06-30,MX,Mexico,107.8755
 2015-06-30,MY,Malaysia,143.4652
-2015-06-30,NL,Netherlands,81.1766
-2015-06-30,NO,Norway,122.431
+2015-06-30,NL,Netherlands,81.2001
+2015-06-30,NO,Norway,122.3799
 2015-06-30,NZ,New Zealand,124.8561
 2015-06-30,PE,Peru,143.3556
 2015-06-30,PH,Philippines,134.4341
@@ -21936,61 +6398,60 @@ date,country_code,country,price
 2015-06-30,PT,Portugal,86.9233
 2015-06-30,RO,Romania,72.5727
 2015-06-30,RS,Serbia,76.0408
-2015-06-30,RU,Russia,65.2188
-2015-06-30,SE,Sweden,128.2916
-2015-06-30,SG,Singapore,95.7262
-2015-06-30,SI,Slovenia,81.9533
-2015-06-30,SK,Slovak Republic,94.837
-2015-06-30,TH,Thailand,118.5239
-2015-06-30,TR,Türkiye,116.9324
-2015-06-30,US,United States,113.9385
-2015-06-30,XM,Euro area,91.6649
-2015-06-30,XW,World,105.9215
-2015-06-30,ZA,South Africa,101.1983
-2015-09-30,4T,Emerging market economies (aggregate),107.0768
-2015-09-30,5R,Advanced economies,106.0778
-2015-09-30,AE,United Arab Emirates,139.5383
-2015-09-30,AT,Austria,119.2213
-2015-09-30,AU,Australia,112.3251
-2015-09-30,BE,Belgium,101.7242
-2015-09-30,BG,Bulgaria,88.1943
+2015-06-30,RU,Russia,65.22
+2015-06-30,SE,Sweden,128.2947
+2015-06-30,SG,Singapore,95.7053
+2015-06-30,SI,Slovenia,81.9648
+2015-06-30,SK,Slovakia,94.5621
+2015-06-30,TH,Thailand,122.1398
+2015-06-30,TR,Türkiye,118.9048
+2015-06-30,US,United States,113.9359
+2015-06-30,XM,Euro area,91.5728
+2015-06-30,XW,World,105.2501
+2015-06-30,ZA,South Africa,100.9063
+2015-09-30,4T,Emerging market economies (aggregate),105.9372
+2015-09-30,5R,Advanced economies,106.0908
+2015-09-30,AT,Austria,119.2214
+2015-09-30,AU,Australia,112.3364
+2015-09-30,BE,Belgium,101.8188
+2015-09-30,BG,Bulgaria,88.1879
 2015-09-30,BR,Brazil,111.5488
-2015-09-30,CA,Canada,119.2303
-2015-09-30,CH,Switzerland,126.5709
-2015-09-30,CL,Chile,150.4978
+2015-09-30,CA,Canada,119.1831
+2015-09-30,CH,Switzerland,126.5707
+2015-09-30,CL,Chile,150.4979
 2015-09-30,CN,China,93.8338
-2015-09-30,CO,Colombia,132.1364
+2015-09-30,CO,Colombia,131.6645
 2015-09-30,CY,Cyprus,73.8514
-2015-09-30,CZ,Czechia,98.0709
+2015-09-30,CZ,Czechia,98.0755
 2015-09-30,DE,Germany,109.1101
-2015-09-30,DK,Denmark,103.6548
+2015-09-30,DK,Denmark,103.6801
 2015-09-30,EE,Estonia,139.6696
-2015-09-30,ES,Spain,70.8008
+2015-09-30,ES,Spain,70.8007
 2015-09-30,FI,Finland,98.2029
-2015-09-30,FR,France,95.6777
-2015-09-30,GB,United Kingdom,105.6225
-2015-09-30,GR,Greece,64.2538
-2015-09-30,HK,Hong Kong SAR,165.6687
-2015-09-30,HR,Croatia,84.3871
+2015-09-30,FR,France,95.6784
+2015-09-30,GB,United Kingdom,105.5383
+2015-09-30,GR,Greece,64.2259
+2015-09-30,HK,Hong Kong SAR,165.7412
+2015-09-30,HR,Croatia,84.3735
 2015-09-30,HU,Hungary,98.4927
 2015-09-30,ID,Indonesia,104.7136
-2015-09-30,IE,Ireland,91.2669
-2015-09-30,IL,Israel,131.6408
-2015-09-30,IN,India,160.9124
-2015-09-30,IS,Iceland,118.0635
-2015-09-30,IT,Italy,79.1453
+2015-09-30,IE,Ireland,91.3004
+2015-09-30,IL,Israel,131.6413
+2015-09-30,IN,India,160.681
+2015-09-30,IS,Iceland,118.0521
+2015-09-30,IT,Italy,79.1463
 2015-09-30,JP,Japan,101.7951
-2015-09-30,KR,Korea,103.4023
+2015-09-30,KR,Korea,103.4131
 2015-09-30,LT,Lithuania,112.8326
-2015-09-30,LU,Luxembourg,115.5201
-2015-09-30,LV,Latvia,116.5211
-2015-09-30,MA,Morocco,96.1726
-2015-09-30,MK,North Macedonia,84.8683
+2015-09-30,LU,Luxembourg,115.5086
+2015-09-30,LV,Latvia,116.4959
+2015-09-30,MA,Morocco,95.4123
+2015-09-30,MK,North Macedonia,84.9616
 2015-09-30,MT,Malta,104.2943
 2015-09-30,MX,Mexico,110.8657
 2015-09-30,MY,Malaysia,145.443
-2015-09-30,NL,Netherlands,82.5511
-2015-09-30,NO,Norway,121.5022
+2015-09-30,NL,Netherlands,82.3533
+2015-09-30,NO,Norway,121.5065
 2015-09-30,NZ,New Zealand,130.242
 2015-09-30,PE,Peru,141.1768
 2015-09-30,PH,Philippines,137.4626
@@ -21998,61 +6459,60 @@ date,country_code,country,price
 2015-09-30,PT,Portugal,87.5167
 2015-09-30,RO,Romania,73.5028
 2015-09-30,RS,Serbia,73.6151
-2015-09-30,RU,Russia,63.0812
-2015-09-30,SE,Sweden,133.2329
-2015-09-30,SG,Singapore,94.6681
-2015-09-30,SI,Slovenia,79.5114
-2015-09-30,SK,Slovak Republic,95.2199
-2015-09-30,TH,Thailand,119.0309
-2015-09-30,TR,Türkiye,118.9746
-2015-09-30,US,United States,115.2537
-2015-09-30,XM,Euro area,92.9392
-2015-09-30,XW,World,106.5186
-2015-09-30,ZA,South Africa,100.9062
-2015-12-31,4T,Emerging market economies (aggregate),106.9416
-2015-12-31,5R,Advanced economies,107.0268
-2015-12-31,AE,United Arab Emirates,137.4472
+2015-09-30,RU,Russia,63.079
+2015-09-30,SE,Sweden,133.2371
+2015-09-30,SG,Singapore,94.6465
+2015-09-30,SI,Slovenia,79.5073
+2015-09-30,SK,Slovakia,94.9441
+2015-09-30,TH,Thailand,121.4245
+2015-09-30,TR,Türkiye,121.5732
+2015-09-30,US,United States,115.2507
+2015-09-30,XM,Euro area,92.8396
+2015-09-30,XW,World,105.8639
+2015-09-30,ZA,South Africa,100.5541
+2015-12-31,4T,Emerging market economies (aggregate),105.8424
+2015-12-31,5R,Advanced economies,107.0015
 2015-12-31,AT,Austria,122.3019
-2015-12-31,AU,Australia,112.0823
-2015-12-31,BE,Belgium,100.8155
-2015-12-31,BG,Bulgaria,90.8489
+2015-12-31,AU,Australia,112.0752
+2015-12-31,BE,Belgium,101.3075
+2015-12-31,BG,Bulgaria,90.8724
 2015-12-31,BR,Brazil,108.3145
-2015-12-31,CA,Canada,121.2082
-2015-12-31,CH,Switzerland,127.1681
-2015-12-31,CL,Chile,153.5575
+2015-12-31,CA,Canada,120.847
+2015-12-31,CH,Switzerland,127.168
+2015-12-31,CL,Chile,153.5574
 2015-12-31,CN,China,94.2591
-2015-12-31,CO,Colombia,129.4093
+2015-12-31,CO,Colombia,128.8953
 2015-12-31,CY,Cyprus,73.0045
-2015-12-31,CZ,Czechia,99.6404
+2015-12-31,CZ,Czechia,99.6105
 2015-12-31,DE,Germany,111.273
-2015-12-31,DK,Denmark,103.4501
+2015-12-31,DK,Denmark,103.4271
 2015-12-31,EE,Estonia,141.9979
-2015-12-31,ES,Spain,70.4493
+2015-12-31,ES,Spain,70.4492
 2015-12-31,FI,Finland,97.5637
-2015-12-31,FR,France,95.1597
-2015-12-31,GB,United Kingdom,106.7795
+2015-12-31,FR,France,95.164
+2015-12-31,GB,United Kingdom,106.7322
 2015-12-31,GR,Greece,63.5543
 2015-12-31,HK,Hong Kong SAR,155.5354
-2015-12-31,HR,Croatia,84.5563
+2015-12-31,HR,Croatia,84.5716
 2015-12-31,HU,Hungary,100.3886
 2015-12-31,ID,Indonesia,104.9789
-2015-12-31,IE,Ireland,93.1969
-2015-12-31,IL,Israel,135.0675
-2015-12-31,IN,India,161.3355
-2015-12-31,IS,Iceland,121.1664
-2015-12-31,IT,Italy,78.6342
+2015-12-31,IE,Ireland,93.2067
+2015-12-31,IL,Israel,135.068
+2015-12-31,IN,India,161.0488
+2015-12-31,IS,Iceland,121.1667
+2015-12-31,IT,Italy,78.6346
 2015-12-31,JP,Japan,100.552
-2015-12-31,KR,Korea,104.7209
-2015-12-31,LT,Lithuania,109.7553
-2015-12-31,LU,Luxembourg,115.3369
-2015-12-31,LV,Latvia,119.5183
-2015-12-31,MA,Morocco,96.749
-2015-12-31,MK,North Macedonia,84.1883
+2015-12-31,KR,Korea,104.7438
+2015-12-31,LT,Lithuania,109.7552
+2015-12-31,LU,Luxembourg,115.3215
+2015-12-31,LV,Latvia,119.5856
+2015-12-31,MA,Morocco,96.0721
+2015-12-31,MK,North Macedonia,84.2086
 2015-12-31,MT,Malta,106.6143
 2015-12-31,MX,Mexico,110.7715
 2015-12-31,MY,Malaysia,145.0749
-2015-12-31,NL,Netherlands,83.4114
-2015-12-31,NO,Norway,118.0773
+2015-12-31,NL,Netherlands,83.4322
+2015-12-31,NO,Norway,118.0211
 2015-12-31,NZ,New Zealand,131.9997
 2015-12-31,PE,Peru,137.1429
 2015-12-31,PH,Philippines,140.3737
@@ -22060,61 +6520,60 @@ date,country_code,country,price
 2015-12-31,PT,Portugal,88.302
 2015-12-31,RO,Romania,73.8276
 2015-12-31,RS,Serbia,73.1088
-2015-12-31,RU,Russia,60.8131
-2015-12-31,SE,Sweden,135.7943
-2015-12-31,SG,Singapore,94.4498
-2015-12-31,SI,Slovenia,79.4873
-2015-12-31,SK,Slovak Republic,96.512
-2015-12-31,TH,Thailand,120.9403
-2015-12-31,TR,Türkiye,119.6784
-2015-12-31,US,United States,117.4743
-2015-12-31,XM,Euro area,93.2921
-2015-12-31,XW,World,106.9
-2015-12-31,ZA,South Africa,101.9711
-2016-03-31,4T,Emerging market economies (aggregate),106.718
-2016-03-31,5R,Advanced economies,108.9322
-2016-03-31,AE,United Arab Emirates,138.1049
+2015-12-31,RU,Russia,60.8107
+2015-12-31,SE,Sweden,135.7939
+2015-12-31,SG,Singapore,94.4284
+2015-12-31,SI,Slovenia,79.5178
+2015-12-31,SK,Slovakia,96.2355
+2015-12-31,TH,Thailand,127.1941
+2015-12-31,TR,Türkiye,121.8425
+2015-12-31,US,United States,117.4907
+2015-12-31,XM,Euro area,93.1879
+2015-12-31,XW,World,106.2899
+2015-12-31,ZA,South Africa,101.9824
+2016-03-31,4T,Emerging market economies (aggregate),105.6439
+2016-03-31,5R,Advanced economies,108.7178
 2016-03-31,AT,Austria,126.8194
-2016-03-31,AU,Australia,112.1175
-2016-03-31,BE,Belgium,99.6896
-2016-03-31,BG,Bulgaria,92.3069
-2016-03-31,BR,Brazil,104.3565
-2016-03-31,CA,Canada,127.3972
-2016-03-31,CH,Switzerland,129.2806
-2016-03-31,CL,Chile,151.8915
+2016-03-31,AU,Australia,112.1271
+2016-03-31,BE,Belgium,99.8489
+2016-03-31,BG,Bulgaria,92.3179
+2016-03-31,BR,Brazil,104.3545
+2016-03-31,CA,Canada,126.8984
+2016-03-31,CH,Switzerland,129.2808
+2016-03-31,CL,Chile,151.8916
 2016-03-31,CN,China,94.9072
-2016-03-31,CO,Colombia,131.8104
+2016-03-31,CO,Colombia,131.506
 2016-03-31,CY,Cyprus,74.321
-2016-03-31,CZ,Czechia,100.4774
+2016-03-31,CZ,Czechia,100.5191
 2016-03-31,DE,Germany,114.1153
-2016-03-31,DK,Denmark,106.0615
+2016-03-31,DK,Denmark,106.0624
 2016-03-31,EE,Estonia,141.7709
 2016-03-31,ES,Spain,72.9028
 2016-03-31,FI,Finland,98.5894
-2016-03-31,FR,France,95.1417
-2016-03-31,GB,United Kingdom,108.4817
+2016-03-31,FR,France,95.1382
+2016-03-31,GB,United Kingdom,108.4225
 2016-03-31,GR,Greece,65.0473
-2016-03-31,HK,Hong Kong SAR,144.2056
-2016-03-31,HR,Croatia,86.6134
-2016-03-31,HU,Hungary,105.3979
+2016-03-31,HK,Hong Kong SAR,144.2406
+2016-03-31,HR,Croatia,86.6354
+2016-03-31,HU,Hungary,105.398
 2016-03-31,ID,Indonesia,104.7312
-2016-03-31,IE,Ireland,94.0672
-2016-03-31,IL,Israel,139.0698
-2016-03-31,IN,India,159.6542
-2016-03-31,IS,Iceland,123.4101
-2016-03-31,IT,Italy,78.9528
+2016-03-31,IE,Ireland,94.1976
+2016-03-31,IL,Israel,139.0704
+2016-03-31,IN,India,159.3198
+2016-03-31,IS,Iceland,123.3989
+2016-03-31,IT,Italy,78.9544
 2016-03-31,JP,Japan,103.4215
-2016-03-31,KR,Korea,104.6547
+2016-03-31,KR,Korea,104.6391
 2016-03-31,LT,Lithuania,111.0524
-2016-03-31,LU,Luxembourg,117.772
-2016-03-31,LV,Latvia,120.8222
-2016-03-31,MA,Morocco,96.4017
-2016-03-31,MK,North Macedonia,86.9726
+2016-03-31,LU,Luxembourg,117.7645
+2016-03-31,LV,Latvia,120.8166
+2016-03-31,MA,Morocco,95.5494
+2016-03-31,MK,North Macedonia,87.0755
 2016-03-31,MT,Malta,102.3661
 2016-03-31,MX,Mexico,110.8209
 2016-03-31,MY,Malaysia,148.9231
-2016-03-31,NL,Netherlands,85.0028
-2016-03-31,NO,Norway,121.3254
+2016-03-31,NL,Netherlands,84.7278
+2016-03-31,NO,Norway,121.3255
 2016-03-31,NZ,New Zealand,136.5858
 2016-03-31,PE,Peru,133.0081
 2016-03-31,PH,Philippines,144.8195
@@ -22122,61 +6581,60 @@ date,country_code,country,price
 2016-03-31,PT,Portugal,90.7366
 2016-03-31,RO,Romania,77.3609
 2016-03-31,RS,Serbia,74.2884
-2016-03-31,RU,Russia,58.4299
-2016-03-31,SE,Sweden,137.4725
-2016-03-31,SG,Singapore,93.9724
-2016-03-31,SI,Slovenia,82.3838
-2016-03-31,SK,Slovak Republic,98.6681
-2016-03-31,TH,Thailand,121.4941
-2016-03-31,TR,Türkiye,121.3121
-2016-03-31,US,United States,118.8196
-2016-03-31,XM,Euro area,95.1309
-2016-03-31,XW,World,107.6822
-2016-03-31,ZA,South Africa,101.5915
-2016-06-30,4T,Emerging market economies (aggregate),108.2137
-2016-06-30,5R,Advanced economies,109.4247
-2016-06-30,AE,United Arab Emirates,137.5121
+2016-03-31,RU,Russia,58.431
+2016-03-31,SE,Sweden,137.4792
+2016-03-31,SG,Singapore,93.9503
+2016-03-31,SI,Slovenia,82.3956
+2016-03-31,SK,Slovakia,98.3903
+2016-03-31,TH,Thailand,128.92
+2016-03-31,TR,Türkiye,123.1277
+2016-03-31,US,United States,118.8405
+2016-03-31,XM,Euro area,95.0294
+2016-03-31,XW,World,107.0655
+2016-03-31,ZA,South Africa,100.9714
+2016-06-30,4T,Emerging market economies (aggregate),107.2254
+2016-06-30,5R,Advanced economies,109.1943
 2016-06-30,AT,Austria,127.7919
-2016-06-30,AU,Australia,113.9318
-2016-06-30,BE,Belgium,99.8215
-2016-06-30,BG,Bulgaria,95.4353
+2016-06-30,AU,Australia,113.8625
+2016-06-30,BE,Belgium,99.8454
+2016-06-30,BG,Bulgaria,95.409
 2016-06-30,BR,Brazil,101.6998
-2016-06-30,CA,Canada,134.1792
-2016-06-30,CH,Switzerland,127.0589
-2016-06-30,CL,Chile,149.6454
+2016-06-30,CA,Canada,133.3705
+2016-06-30,CH,Switzerland,127.0587
+2016-06-30,CL,Chile,149.6453
 2016-06-30,CN,China,97.1635
-2016-06-30,CO,Colombia,132.8999
+2016-06-30,CO,Colombia,131.3508
 2016-06-30,CY,Cyprus,73.4364
-2016-06-30,CZ,Czechia,102.0503
+2016-06-30,CZ,Czechia,102.0939
 2016-06-30,DE,Germany,116.2022
-2016-06-30,DK,Denmark,107.718
+2016-06-30,DK,Denmark,107.6992
 2016-06-30,EE,Estonia,144.9237
-2016-06-30,ES,Spain,73.0648
+2016-06-30,ES,Spain,73.065
 2016-06-30,FI,Finland,99.0892
-2016-06-30,FR,France,94.7332
-2016-06-30,GB,United Kingdom,110.1624
+2016-06-30,FR,France,94.7361
+2016-06-30,GB,United Kingdom,110.1801
 2016-06-30,GR,Greece,63.5975
-2016-06-30,HK,Hong Kong SAR,145.7515
-2016-06-30,HR,Croatia,85.4097
+2016-06-30,HK,Hong Kong SAR,145.7869
+2016-06-30,HR,Croatia,85.4383
 2016-06-30,HU,Hungary,106.6991
 2016-06-30,ID,Indonesia,105.3797
-2016-06-30,IE,Ireland,94.0241
-2016-06-30,IL,Israel,140.8344
-2016-06-30,IN,India,165.0287
-2016-06-30,IS,Iceland,124.5329
-2016-06-30,IT,Italy,79.3472
+2016-06-30,IE,Ireland,94.0526
+2016-06-30,IL,Israel,140.8346
+2016-06-30,IN,India,164.81
+2016-06-30,IS,Iceland,124.5525
+2016-06-30,IT,Italy,79.3485
 2016-06-30,JP,Japan,104.1009
-2016-06-30,KR,Korea,104.5926
+2016-06-30,KR,Korea,104.608
 2016-06-30,LT,Lithuania,113.223
-2016-06-30,LU,Luxembourg,120.0068
-2016-06-30,LV,Latvia,126.2686
-2016-06-30,MA,Morocco,95.6259
-2016-06-30,MK,North Macedonia,85.9819
+2016-06-30,LU,Luxembourg,119.993
+2016-06-30,LV,Latvia,126.3123
+2016-06-30,MA,Morocco,95.2216
+2016-06-30,MK,North Macedonia,86.057
 2016-06-30,MT,Malta,103.6299
 2016-06-30,MX,Mexico,113.3785
 2016-06-30,MY,Malaysia,150.781
-2016-06-30,NL,Netherlands,84.8093
-2016-06-30,NO,Norway,124.8504
+2016-06-30,NL,Netherlands,85.0854
+2016-06-30,NO,Norway,124.8275
 2016-06-30,NZ,New Zealand,143.2079
 2016-06-30,PE,Peru,134.594
 2016-06-30,PH,Philippines,150.6483
@@ -22185,60 +6643,59 @@ date,country_code,country,price
 2016-06-30,RO,Romania,79.6426
 2016-06-30,RS,Serbia,78.9242
 2016-06-30,RU,Russia,57.0877
-2016-06-30,SE,Sweden,138.2795
-2016-06-30,SG,Singapore,93.803
-2016-06-30,SI,Slovenia,82.5403
-2016-06-30,SK,Slovak Republic,101.1065
-2016-06-30,TH,Thailand,121.4524
-2016-06-30,TR,Türkiye,123.8642
-2016-06-30,US,United States,118.7671
-2016-06-30,XM,Euro area,95.2255
-2016-06-30,XW,World,108.708
-2016-06-30,ZA,South Africa,100.9865
-2016-09-30,4T,Emerging market economies (aggregate),108.8508
-2016-09-30,5R,Advanced economies,110.7552
-2016-09-30,AE,United Arab Emirates,135.4347
-2016-09-30,AT,Austria,126.7774
-2016-09-30,AU,Australia,114.7994
-2016-09-30,BE,Belgium,102.138
-2016-09-30,BG,Bulgaria,96.2892
-2016-09-30,BR,Brazil,99.6334
-2016-09-30,CA,Canada,138.0315
-2016-09-30,CH,Switzerland,126.7077
+2016-06-30,SE,Sweden,138.283
+2016-06-30,SG,Singapore,93.7797
+2016-06-30,SI,Slovenia,82.5256
+2016-06-30,SK,Slovakia,100.8297
+2016-06-30,TH,Thailand,128.7875
+2016-06-30,TR,Türkiye,125.404
+2016-06-30,US,United States,118.785
+2016-06-30,XM,Euro area,95.125
+2016-06-30,XW,World,108.0879
+2016-06-30,ZA,South Africa,99.7454
+2016-09-30,4T,Emerging market economies (aggregate),107.9259
+2016-09-30,5R,Advanced economies,110.4743
+2016-09-30,AT,Austria,126.9887
+2016-09-30,AU,Australia,114.7686
+2016-09-30,BE,Belgium,101.8267
+2016-09-30,BG,Bulgaria,96.2914
+2016-09-30,BR,Brazil,99.6335
+2016-09-30,CA,Canada,137.1935
+2016-09-30,CH,Switzerland,126.7078
 2016-09-30,CL,Chile,150.5975
 2016-09-30,CN,China,99.1101
-2016-09-30,CO,Colombia,133.9251
+2016-09-30,CO,Colombia,132.5036
 2016-09-30,CY,Cyprus,73.1868
-2016-09-30,CZ,Czechia,104.4365
+2016-09-30,CZ,Czechia,104.4584
 2016-09-30,DE,Germany,117.7171
-2016-09-30,DK,Denmark,109.0263
+2016-09-30,DK,Denmark,109.0278
 2016-09-30,EE,Estonia,149.3299
-2016-09-30,ES,Spain,73.78
+2016-09-30,ES,Spain,73.7797
 2016-09-30,FI,Finland,99.3389
-2016-09-30,FR,France,96.8292
-2016-09-30,GB,United Kingdom,111.9351
-2016-09-30,GR,Greece,63.7544
+2016-09-30,FR,France,96.8278
+2016-09-30,GB,United Kingdom,111.8814
+2016-09-30,GR,Greece,63.7566
 2016-09-30,HK,Hong Kong SAR,151.94
-2016-09-30,HR,Croatia,86.6991
+2016-09-30,HR,Croatia,86.721
 2016-09-30,HU,Hungary,109.9867
 2016-09-30,ID,Indonesia,104.4301
-2016-09-30,IE,Ireland,97.9339
-2016-09-30,IL,Israel,143.2149
-2016-09-30,IN,India,164.7229
-2016-09-30,IS,Iceland,131.5174
-2016-09-30,IT,Italy,79.1611
+2016-09-30,IE,Ireland,98.0032
+2016-09-30,IL,Israel,143.2157
+2016-09-30,IN,India,164.3757
+2016-09-30,IS,Iceland,131.5219
+2016-09-30,IT,Italy,79.1592
 2016-09-30,JP,Japan,104.0876
-2016-09-30,KR,Korea,104.7176
-2016-09-30,LT,Lithuania,117.9778
-2016-09-30,LU,Luxembourg,121.885
-2016-09-30,LV,Latvia,127.4295
-2016-09-30,MA,Morocco,96.7344
-2016-09-30,MK,North Macedonia,85.3354
+2016-09-30,KR,Korea,104.7684
+2016-09-30,LT,Lithuania,117.9777
+2016-09-30,LU,Luxembourg,121.8742
+2016-09-30,LV,Latvia,127.4901
+2016-09-30,MA,Morocco,97.1944
+2016-09-30,MK,North Macedonia,85.3466
 2016-09-30,MT,Malta,108.4392
 2016-09-30,MX,Mexico,114.4312
 2016-09-30,MY,Malaysia,153.2999
-2016-09-30,NL,Netherlands,86.6428
-2016-09-30,NO,Norway,126.0834
+2016-09-30,NL,Netherlands,86.9312
+2016-09-30,NO,Norway,126.0382
 2016-09-30,NZ,New Zealand,147.9502
 2016-09-30,PE,Peru,135.0849
 2016-09-30,PH,Philippines,147.0285
@@ -22246,61 +6703,60 @@ date,country_code,country,price
 2016-09-30,PT,Portugal,93.5646
 2016-09-30,RO,Romania,79.0976
 2016-09-30,RS,Serbia,87.0145
-2016-09-30,RU,Russia,55.9356
-2016-09-30,SE,Sweden,141.2067
-2016-09-30,SG,Singapore,92.0964
-2016-09-30,SI,Slovenia,83.3332
-2016-09-30,SK,Slovak Republic,103.1491
-2016-09-30,TH,Thailand,118.9106
-2016-09-30,TR,Türkiye,125.0857
-2016-09-30,US,United States,120.0205
-2016-09-30,XM,Euro area,96.7628
-2016-09-30,XW,World,109.6703
-2016-09-30,ZA,South Africa,100.3989
-2016-12-31,4T,Emerging market economies (aggregate),109.8815
-2016-12-31,5R,Advanced economies,111.2837
-2016-12-31,AE,United Arab Emirates,134.7665
+2016-09-30,RU,Russia,55.9319
+2016-09-30,SE,Sweden,141.2079
+2016-09-30,SG,Singapore,92.0725
+2016-09-30,SI,Slovenia,83.3376
+2016-09-30,SK,Slovakia,102.7787
+2016-09-30,TH,Thailand,126.8303
+2016-09-30,TR,Türkiye,126.6117
+2016-09-30,US,United States,120.0325
+2016-09-30,XM,Euro area,96.649
+2016-09-30,XW,World,109.0812
+2016-09-30,ZA,South Africa,99.4722
+2016-12-31,4T,Emerging market economies (aggregate),109.0398
+2016-12-31,5R,Advanced economies,111.0631
 2016-12-31,AT,Austria,126.212
-2016-12-31,AU,Australia,118.9093
-2016-12-31,BE,Belgium,101.5527
-2016-12-31,BG,Bulgaria,98.5271
+2016-12-31,AU,Australia,118.9033
+2016-12-31,BE,Belgium,101.8682
+2016-12-31,BG,Bulgaria,98.5426
 2016-12-31,BR,Brazil,98.3245
-2016-12-31,CA,Canada,138.7821
-2016-12-31,CH,Switzerland,125.7055
+2016-12-31,CA,Canada,138.2738
+2016-12-31,CH,Switzerland,125.7053
 2016-12-31,CL,Chile,154.7079
 2016-12-31,CN,China,100.9351
-2016-12-31,CO,Colombia,134.2812
+2016-12-31,CO,Colombia,133.2916
 2016-12-31,CY,Cyprus,73.0145
-2016-12-31,CZ,Czechia,108.9134
+2016-12-31,CZ,Czechia,108.9574
 2016-12-31,DE,Germany,119.4624
-2016-12-31,DK,Denmark,107.3481
+2016-12-31,DK,Denmark,107.3291
 2016-12-31,EE,Estonia,150.9889
-2016-12-31,ES,Spain,72.8481
+2016-12-31,ES,Spain,72.848
 2016-12-31,FI,Finland,98.1322
-2016-12-31,FR,France,96.198
-2016-12-31,GB,United Kingdom,111.138
-2016-12-31,GR,Greece,63.1803
+2016-12-31,FR,France,96.1986
+2016-12-31,GB,United Kingdom,111.1833
+2016-12-31,GR,Greece,63.1824
 2016-12-31,HK,Hong Kong SAR,160.2309
-2016-12-31,HR,Croatia,85.4041
-2016-12-31,HU,Hungary,110.8266
+2016-12-31,HR,Croatia,85.4398
+2016-12-31,HU,Hungary,110.8267
 2016-12-31,ID,Indonesia,104.04
-2016-12-31,IE,Ireland,101.2985
-2016-12-31,IL,Israel,144.6414
-2016-12-31,IN,India,168.4824
-2016-12-31,IS,Iceland,136.3322
-2016-12-31,IT,Italy,78.6632
+2016-12-31,IE,Ireland,101.2336
+2016-12-31,IL,Israel,144.6408
+2016-12-31,IN,India,168.1657
+2016-12-31,IS,Iceland,136.3407
+2016-12-31,IT,Italy,78.6924
 2016-12-31,JP,Japan,102.7801
-2016-12-31,KR,Korea,104.7769
+2016-12-31,KR,Korea,104.7794
 2016-12-31,LT,Lithuania,118.7229
-2016-12-31,LU,Luxembourg,123.4053
-2016-12-31,LV,Latvia,126.9249
-2016-12-31,MA,Morocco,99.8377
-2016-12-31,MK,North Macedonia,85.5857
+2016-12-31,LU,Luxembourg,123.3913
+2016-12-31,LV,Latvia,126.942
+2016-12-31,MA,Morocco,98.5991
+2016-12-31,MK,North Macedonia,85.7432
 2016-12-31,MT,Malta,111.0507
 2016-12-31,MX,Mexico,113.5879
 2016-12-31,MY,Malaysia,152.7023
-2016-12-31,NL,Netherlands,87.805
-2016-12-31,NO,Norway,125.5212
+2016-12-31,NL,Netherlands,88.153
+2016-12-31,NO,Norway,125.4854
 2016-12-31,NZ,New Zealand,148.8505
 2016-12-31,PE,Peru,135.6076
 2016-12-31,PH,Philippines,147.953
@@ -22308,1688 +6764,2203 @@ date,country_code,country,price
 2016-12-31,PT,Portugal,94.27
 2016-12-31,RO,Romania,80.1849
 2016-12-31,RS,Serbia,88.7529
-2016-12-31,RU,Russia,55.1554
-2016-12-31,SE,Sweden,142.5549
-2016-12-31,SG,Singapore,91.4926
-2016-12-31,SI,Slovenia,84.4828
-2016-12-31,SK,Slovak Republic,104.661
-2016-12-31,TH,Thailand,119.4554
-2016-12-31,TR,Türkiye,124.8225
-2016-12-31,US,United States,121.6295
-2016-12-31,XM,Euro area,96.8221
-2016-12-31,XW,World,110.4653
-2016-12-31,ZA,South Africa,100.2411
-2017-03-31,4T,Emerging market economies (aggregate),109.7341
-2017-03-31,5R,Advanced economies,112.6805
-2017-03-31,AE,United Arab Emirates,132.6617
-2017-03-31,AT,Austria,127.2064
-2017-03-31,AU,Australia,120.9811
-2017-03-31,BE,Belgium,101.4311
-2017-03-31,BG,Bulgaria,98.9568
+2016-12-31,RU,Russia,55.1516
+2016-12-31,SE,Sweden,142.5635
+2016-12-31,SG,Singapore,91.4693
+2016-12-31,SI,Slovenia,84.4984
+2016-12-31,SK,Slovakia,104.2919
+2016-12-31,TH,Thailand,130.7242
+2016-12-31,TR,Türkiye,126.49
+2016-12-31,US,United States,121.6329
+2016-12-31,XM,Euro area,96.7068
+2016-12-31,XW,World,109.9283
+2016-12-31,ZA,South Africa,99.3518
+2017-03-31,4T,Emerging market economies (aggregate),108.8966
+2017-03-31,5R,Advanced economies,112.3305
+2017-03-31,AT,Austria,127.2065
+2017-03-31,AU,Australia,120.9706
+2017-03-31,BE,Belgium,101.1554
+2017-03-31,BG,Bulgaria,98.9839
 2017-03-31,BR,Brazil,96.8943
-2017-03-31,CA,Canada,146.9695
-2017-03-31,CH,Switzerland,125.6572
+2017-03-31,CA,Canada,146.4193
+2017-03-31,CH,Switzerland,125.6575
 2017-03-31,CL,Chile,156.7517
 2017-03-31,CN,China,101.1945
-2017-03-31,CO,Colombia,132.8559
+2017-03-31,CO,Colombia,132.2785
 2017-03-31,CY,Cyprus,73.3779
-2017-03-31,CZ,Czechia,110.6649
+2017-03-31,CZ,Czechia,110.7133
 2017-03-31,DE,Germany,119.8911
-2017-03-31,DK,Denmark,108.8221
+2017-03-31,DK,Denmark,108.8342
 2017-03-31,EE,Estonia,148.2779
 2017-03-31,ES,Spain,74.7271
 2017-03-31,FI,Finland,98.8126
-2017-03-31,FR,France,96.6222
-2017-03-31,GB,United Kingdom,110.8876
+2017-03-31,FR,France,96.6274
+2017-03-31,GB,United Kingdom,110.784
 2017-03-31,GR,Greece,62.9425
 2017-03-31,HK,Hong Kong SAR,164.4446
-2017-03-31,HR,Croatia,85.4316
+2017-03-31,HR,Croatia,85.4094
 2017-03-31,HU,Hungary,114.7862
 2017-03-31,ID,Indonesia,103.7015
-2017-03-31,IE,Ireland,102.3968
-2017-03-31,IL,Israel,145.6045
-2017-03-31,IN,India,170.2668
-2017-03-31,IS,Iceland,142.8079
-2017-03-31,IT,Italy,77.3627
+2017-03-31,IE,Ireland,102.3971
+2017-03-31,IL,Israel,145.6051
+2017-03-31,IN,India,170.0027
+2017-03-31,IS,Iceland,142.8128
+2017-03-31,IT,Italy,77.3648
 2017-03-31,JP,Japan,107.0964
-2017-03-31,KR,Korea,103.6666
+2017-03-31,KR,Korea,103.6661
 2017-03-31,LT,Lithuania,119.0881
-2017-03-31,LU,Luxembourg,123.8363
-2017-03-31,LV,Latvia,127.9683
-2017-03-31,MA,Morocco,102.1557
-2017-03-31,MK,North Macedonia,83.3041
+2017-03-31,LU,Luxembourg,123.8225
+2017-03-31,LV,Latvia,128.0058
+2017-03-31,MA,Morocco,99.3076
+2017-03-31,MK,North Macedonia,83.2971
 2017-03-31,MT,Malta,106.0508
 2017-03-31,MX,Mexico,113.3391
 2017-03-31,MY,Malaysia,152.529
-2017-03-31,NL,Netherlands,89.3094
-2017-03-31,NO,Norway,130.2383
+2017-03-31,NL,Netherlands,89.6685
+2017-03-31,NO,Norway,130.2011
 2017-03-31,NZ,New Zealand,149.8681
 2017-03-31,PE,Peru,135.1832
 2017-03-31,PH,Philippines,150.1675
 2017-03-31,PL,Poland,89.2423
 2017-03-31,PT,Portugal,96.5625
 2017-03-31,RO,Romania,80.9663
-2017-03-31,RS,Serbia,81.749
-2017-03-31,RU,Russia,53.5169
-2017-03-31,SE,Sweden,146.1865
-2017-03-31,SG,Singapore,90.7981
-2017-03-31,SI,Slovenia,86.3389
-2017-03-31,SK,Slovak Republic,101.3941
-2017-03-31,TH,Thailand,118.5831
-2017-03-31,TR,Türkiye,123.1535
-2017-03-31,US,United States,122.2883
-2017-03-31,XM,Euro area,97.6287
-2017-03-31,XW,World,111.0379
-2017-03-31,ZA,South Africa,99.8724
-2017-06-30,4T,Emerging market economies (aggregate),111.4178
-2017-06-30,5R,Advanced economies,113.3977
-2017-06-30,AE,United Arab Emirates,133.4464
-2017-06-30,AT,Austria,129.9272
-2017-06-30,AU,Australia,123.1156
-2017-06-30,BE,Belgium,100.7592
-2017-06-30,BG,Bulgaria,101.3376
-2017-06-30,BR,Brazil,96.0084
-2017-06-30,CA,Canada,154.4155
-2017-06-30,CH,Switzerland,126.6214
+2017-03-31,RS,Serbia,81.2486
+2017-03-31,RU,Russia,53.5263
+2017-03-31,SE,Sweden,146.1832
+2017-03-31,SG,Singapore,90.7751
+2017-03-31,SI,Slovenia,86.3422
+2017-03-31,SK,Slovakia,100.9357
+2017-03-31,TH,Thailand,129.1879
+2017-03-31,TR,Türkiye,125.0384
+2017-03-31,US,United States,122.3023
+2017-03-31,XM,Euro area,97.5146
+2017-03-31,XW,World,110.4904
+2017-03-31,ZA,South Africa,98.4935
+2017-06-30,4T,Emerging market economies (aggregate),110.6116
+2017-06-30,5R,Advanced economies,113.0792
+2017-06-30,AT,Austria,129.9271
+2017-06-30,AU,Australia,123.0872
+2017-06-30,BE,Belgium,100.9276
+2017-06-30,BG,Bulgaria,101.3649
+2017-06-30,BR,Brazil,96.0103
+2017-06-30,CA,Canada,153.8374
+2017-06-30,CH,Switzerland,126.6217
 2017-06-30,CL,Chile,158.1646
 2017-06-30,CN,China,103.497
-2017-06-30,CO,Colombia,135.8612
+2017-06-30,CO,Colombia,134.3204
 2017-06-30,CY,Cyprus,73.4856
-2017-06-30,CZ,Czechia,113.1326
+2017-06-30,CZ,Czechia,113.191
 2017-06-30,DE,Germany,121.2749
-2017-06-30,DK,Denmark,112.3209
+2017-06-30,DK,Denmark,112.3082
 2017-06-30,EE,Estonia,147.3002
-2017-06-30,ES,Spain,75.6353
+2017-06-30,ES,Spain,75.6351
 2017-06-30,FI,Finland,99.8801
-2017-06-30,FR,France,96.9934
-2017-06-30,GB,United Kingdom,112.0592
+2017-06-30,FR,France,96.9954
+2017-06-30,GB,United Kingdom,111.9813
 2017-06-30,GR,Greece,62.1274
-2017-06-30,HK,Hong Kong SAR,173.1294
-2017-06-30,HR,Croatia,88.1218
+2017-06-30,HK,Hong Kong SAR,173.0602
+2017-06-30,HR,Croatia,88.1457
 2017-06-30,HU,Hungary,117.1602
 2017-06-30,ID,Indonesia,104.2506
-2017-06-30,IE,Ireland,103.7205
-2017-06-30,IL,Israel,146.8258
-2017-06-30,IN,India,175.5281
-2017-06-30,IS,Iceland,150.7527
-2017-06-30,IT,Italy,77.4714
+2017-06-30,IE,Ireland,103.735
+2017-06-30,IL,Israel,146.8261
+2017-06-30,IN,India,175.1898
+2017-06-30,IS,Iceland,150.7654
+2017-06-30,IT,Italy,77.4725
 2017-06-30,JP,Japan,105.7634
-2017-06-30,KR,Korea,103.8862
+2017-06-30,KR,Korea,103.9078
 2017-06-30,LT,Lithuania,120.5646
-2017-06-30,LU,Luxembourg,125.5558
-2017-06-30,LV,Latvia,133.6761
-2017-06-30,MA,Morocco,101.3499
-2017-06-30,MK,North Macedonia,83.0492
+2017-06-30,LU,Luxembourg,125.5447
+2017-06-30,LV,Latvia,133.6923
+2017-06-30,MA,Morocco,98.8661
+2017-06-30,MK,North Macedonia,83.0153
 2017-06-30,MT,Malta,108.3142
 2017-06-30,MX,Mexico,114.8572
 2017-06-30,MY,Malaysia,155.1122
-2017-06-30,NL,Netherlands,90.0796
-2017-06-30,NO,Norway,130.7348
+2017-06-30,NL,Netherlands,90.557
+2017-06-30,NO,Norway,130.608
 2017-06-30,NZ,New Zealand,150.157
 2017-06-30,PE,Peru,132.5438
 2017-06-30,PH,Philippines,146.7657
 2017-06-30,PL,Poland,90.8343
 2017-06-30,PT,Portugal,97.9715
 2017-06-30,RO,Romania,84.2565
-2017-06-30,RS,Serbia,82.277
-2017-06-30,RU,Russia,52.7546
-2017-06-30,SE,Sweden,147.4009
-2017-06-30,SG,Singapore,90.8225
-2017-06-30,SI,Slovenia,88.0959
-2017-06-30,SK,Slovak Republic,106.8188
-2017-06-30,TH,Thailand,120.9614
-2017-06-30,TR,Türkiye,123.1229
-2017-06-30,US,United States,123.3602
-2017-06-30,XM,Euro area,97.8612
-2017-06-30,XW,World,112.2733
-2017-06-30,ZA,South Africa,99.981
-2017-09-30,4T,Emerging market economies (aggregate),111.4704
-2017-09-30,5R,Advanced economies,114.7306
-2017-09-30,AE,United Arab Emirates,130.7094
+2017-06-30,RS,Serbia,82.123
+2017-06-30,RU,Russia,52.758
+2017-06-30,SE,Sweden,147.3989
+2017-06-30,SG,Singapore,90.7991
+2017-06-30,SI,Slovenia,88.1103
+2017-06-30,SK,Slovakia,106.3619
+2017-06-30,TH,Thailand,129.6981
+2017-06-30,TR,Türkiye,125.6784
+2017-06-30,US,United States,123.3762
+2017-06-30,XM,Euro area,97.7525
+2017-06-30,XW,World,111.7236
+2017-06-30,ZA,South Africa,98.7842
+2017-09-30,4T,Emerging market economies (aggregate),110.6782
+2017-09-30,5R,Advanced economies,114.3589
 2017-09-30,AT,Austria,129.8126
-2017-09-30,AU,Australia,122.0914
-2017-09-30,BE,Belgium,103.9565
-2017-09-30,BG,Bulgaria,103.2889
-2017-09-30,BR,Brazil,95.4622
-2017-09-30,CA,Canada,156.2472
-2017-09-30,CH,Switzerland,129.3801
-2017-09-30,CL,Chile,161.0927
+2017-09-30,AU,Australia,122.0887
+2017-09-30,BE,Belgium,103.9629
+2017-09-30,BG,Bulgaria,103.2898
+2017-09-30,BR,Brazil,95.4659
+2017-09-30,CA,Canada,155.6623
+2017-09-30,CH,Switzerland,129.3804
+2017-09-30,CL,Chile,161.0926
 2017-09-30,CN,China,104.2838
-2017-09-30,CO,Colombia,137.849
+2017-09-30,CO,Colombia,136.2382
 2017-09-30,CY,Cyprus,74.6698
-2017-09-30,CZ,Czechia,114.6072
+2017-09-30,CZ,Czechia,114.6677
 2017-09-30,DE,Germany,122.4409
-2017-09-30,DK,Denmark,112.2382
+2017-09-30,DK,Denmark,112.2352
 2017-09-30,EE,Estonia,150.8406
-2017-09-30,ES,Spain,77.4133
+2017-09-30,ES,Spain,77.4138
 2017-09-30,FI,Finland,99.2484
-2017-09-30,FR,France,99.0877
-2017-09-30,GB,United Kingdom,113.9924
-2017-09-30,GR,Greece,62.7282
+2017-09-30,FR,France,99.0887
+2017-09-30,GB,United Kingdom,113.9862
+2017-09-30,GR,Greece,62.7325
 2017-09-30,HK,Hong Kong SAR,175.6699
-2017-09-30,HR,Croatia,89.0473
+2017-09-30,HR,Croatia,89.0845
 2017-09-30,HU,Hungary,120.5118
 2017-09-30,ID,Indonesia,103.9382
-2017-09-30,IE,Ireland,109.3133
-2017-09-30,IL,Israel,148.889
-2017-09-30,IN,India,171.8791
-2017-09-30,IS,Iceland,155.7661
-2017-09-30,IT,Italy,77.1095
+2017-09-30,IE,Ireland,109.288
+2017-09-30,IL,Israel,148.8897
+2017-09-30,IN,India,171.5682
+2017-09-30,IS,Iceland,155.7527
+2017-09-30,IT,Italy,77.1116
 2017-09-30,JP,Japan,105.9879
-2017-09-30,KR,Korea,103.9749
+2017-09-30,KR,Korea,103.9857
 2017-09-30,LT,Lithuania,122.7022
-2017-09-30,LU,Luxembourg,125.5325
-2017-09-30,LV,Latvia,134.7492
-2017-09-30,MA,Morocco,101.842
-2017-09-30,MK,North Macedonia,83.3094
+2017-09-30,LU,Luxembourg,125.523
+2017-09-30,LV,Latvia,134.76
+2017-09-30,MA,Morocco,98.7446
+2017-09-30,MK,North Macedonia,83.2845
 2017-09-30,MT,Malta,112.5235
 2017-09-30,MX,Mexico,115.9527
 2017-09-30,MY,Malaysia,157.5258
-2017-09-30,NL,Netherlands,91.7822
-2017-09-30,NO,Norway,127.2899
+2017-09-30,NL,Netherlands,92.6885
+2017-09-30,NO,Norway,127.1962
 2017-09-30,NZ,New Zealand,150.4882
 2017-09-30,PE,Peru,134.4119
 2017-09-30,PH,Philippines,145.765
 2017-09-30,PL,Poland,91.9622
 2017-09-30,PT,Portugal,102.1503
 2017-09-30,RO,Romania,82.3608
-2017-09-30,RS,Serbia,83.7631
-2017-09-30,RU,Russia,52.1878
-2017-09-30,SE,Sweden,148.6443
-2017-09-30,SG,Singapore,91.4868
-2017-09-30,SI,Slovenia,89.0816
-2017-09-30,SK,Slovak Republic,108.9856
-2017-09-30,TH,Thailand,122.409
-2017-09-30,TR,Türkiye,123.6287
-2017-09-30,US,United States,124.7544
-2017-09-30,XM,Euro area,99.5161
-2017-09-30,XW,World,112.9213
-2017-09-30,ZA,South Africa,99.7611
-2017-12-31,4T,Emerging market economies (aggregate),111.4646
-2017-12-31,5R,Advanced economies,115.0797
-2017-12-31,AE,United Arab Emirates,126.8403
+2017-09-30,RS,Serbia,83.9321
+2017-09-30,RU,Russia,52.1967
+2017-09-30,SE,Sweden,148.6423
+2017-09-30,SG,Singapore,91.4638
+2017-09-30,SI,Slovenia,89.0908
+2017-09-30,SK,Slovakia,108.6208
+2017-09-30,TH,Thailand,131.7749
+2017-09-30,TR,Türkiye,125.9984
+2017-09-30,US,United States,124.774
+2017-09-30,XM,Euro area,99.3937
+2017-09-30,XW,World,112.3955
+2017-09-30,ZA,South Africa,98.8883
+2017-12-31,4T,Emerging market economies (aggregate),110.7019
+2017-12-31,5R,Advanced economies,114.7316
 2017-12-31,AT,Austria,129.258
-2017-12-31,AU,Australia,122.4909
-2017-12-31,BE,Belgium,103.0263
-2017-12-31,BG,Bulgaria,103.7147
-2017-12-31,BR,Brazil,94.566
-2017-12-31,CA,Canada,155.2728
-2017-12-31,CH,Switzerland,128.8807
-2017-12-31,CL,Chile,166.317
+2017-12-31,AU,Australia,122.4347
+2017-12-31,BE,Belgium,102.9155
+2017-12-31,BG,Bulgaria,103.7144
+2017-12-31,BR,Brazil,94.5733
+2017-12-31,CA,Canada,154.6915
+2017-12-31,CH,Switzerland,128.881
+2017-12-31,CL,Chile,166.3169
 2017-12-31,CN,China,104.2285
-2017-12-31,CO,Colombia,138.4338
+2017-12-31,CO,Colombia,136.8978
 2017-12-31,CY,Cyprus,74.361
-2017-12-31,CZ,Czechia,115.0904
+2017-12-31,CZ,Czechia,115.1319
 2017-12-31,DE,Germany,125.1533
-2017-12-31,DK,Denmark,110.7731
+2017-12-31,DK,Denmark,110.7841
 2017-12-31,EE,Estonia,152.57
-2017-12-31,ES,Spain,76.9739
+2017-12-31,ES,Spain,76.9742
 2017-12-31,FI,Finland,98.5103
-2017-12-31,FR,France,98.289
-2017-12-31,GB,United Kingdom,112.9519
-2017-12-31,GR,Greece,62.3916
+2017-12-31,FR,France,98.2912
+2017-12-31,GB,United Kingdom,112.8992
+2017-12-31,GR,Greece,62.3937
 2017-12-31,HK,Hong Kong SAR,179.2275
-2017-12-31,HR,Croatia,90.7125
+2017-12-31,HR,Croatia,90.7027
 2017-12-31,HU,Hungary,122.2486
 2017-12-31,ID,Indonesia,104.0476
-2017-12-31,IE,Ireland,112.5516
-2017-12-31,IL,Israel,147.1808
-2017-12-31,IN,India,172.7489
-2017-12-31,IS,Iceland,153.97
-2017-12-31,IT,Italy,77.0267
+2017-12-31,IE,Ireland,112.6013
+2017-12-31,IL,Israel,147.181
+2017-12-31,IN,India,172.367
+2017-12-31,IS,Iceland,153.9865
+2017-12-31,IT,Italy,77.0275
 2017-12-31,JP,Japan,104.0423
-2017-12-31,KR,Korea,104.5509
+2017-12-31,KR,Korea,104.5912
 2017-12-31,LT,Lithuania,121.7658
-2017-12-31,LU,Luxembourg,126.5726
-2017-12-31,LV,Latvia,133.5694
-2017-12-31,MA,Morocco,100.2864
-2017-12-31,MK,North Macedonia,83.4884
+2017-12-31,LU,Luxembourg,126.5589
+2017-12-31,LV,Latvia,133.6121
+2017-12-31,MA,Morocco,97.5708
+2017-12-31,MK,North Macedonia,83.4368
 2017-12-31,MT,Malta,115.0784
 2017-12-31,MX,Mexico,115.6889
 2017-12-31,MY,Malaysia,156.5043
-2017-12-31,NL,Netherlands,93.982
-2017-12-31,NO,Norway,124.7727
+2017-12-31,NL,Netherlands,94.7414
+2017-12-31,NO,Norway,124.7639
 2017-12-31,NZ,New Zealand,152.4579
 2017-12-31,PE,Peru,133.6873
 2017-12-31,PH,Philippines,151.5943
 2017-12-31,PL,Poland,92.0592
 2017-12-31,PT,Portugal,102.6476
 2017-12-31,RO,Romania,82.1107
-2017-12-31,RS,Serbia,84.6877
-2017-12-31,RU,Russia,52.1465
-2017-12-31,SE,Sweden,143.9583
-2017-12-31,SG,Singapore,92.0695
-2017-12-31,SI,Slovenia,91.6396
-2017-12-31,SK,Slovak Republic,108.7414
-2017-12-31,TH,Thailand,124.5681
-2017-12-31,TR,Türkiye,121.2706
-2017-12-31,US,United States,126.2716
-2017-12-31,XM,Euro area,99.9551
-2017-12-31,XW,World,113.0795
-2017-12-31,ZA,South Africa,99.4881
-2018-03-31,4T,Emerging market economies (aggregate),111.4111
-2018-03-31,5R,Advanced economies,116.1911
-2018-03-31,AE,United Arab Emirates,120.4333
+2017-12-31,RS,Serbia,85.1686
+2017-12-31,RU,Russia,52.1435
+2017-12-31,SE,Sweden,143.9579
+2017-12-31,SG,Singapore,92.0459
+2017-12-31,SI,Slovenia,91.6261
+2017-12-31,SK,Slovakia,108.4696
+2017-12-31,TH,Thailand,135.8129
+2017-12-31,TR,Türkiye,123.4802
+2017-12-31,US,United States,126.2954
+2017-12-31,XM,Euro area,99.8298
+2017-12-31,XW,World,112.5924
+2017-12-31,ZA,South Africa,98.9193
+2018-03-31,4T,Emerging market economies (aggregate),110.6183
+2018-03-31,5R,Advanced economies,115.8214
 2018-03-31,AT,Austria,134.0595
-2018-03-31,AU,Australia,121.1208
-2018-03-31,BE,Belgium,102.4371
-2018-03-31,BG,Bulgaria,103.8886
-2018-03-31,BR,Brazil,93.8421
-2018-03-31,CA,Canada,154.7263
-2018-03-31,CH,Switzerland,128.5359
+2018-03-31,AU,Australia,121.0765
+2018-03-31,BE,Belgium,102.5085
+2018-03-31,BG,Bulgaria,103.8598
+2018-03-31,BR,Brazil,93.8511
+2018-03-31,CA,Canada,154.147
+2018-03-31,CH,Switzerland,128.5361
 2018-03-31,CL,Chile,166.7
 2018-03-31,CN,China,103.5601
-2018-03-31,CO,Colombia,137.4862
+2018-03-31,CO,Colombia,136.1284
 2018-03-31,CY,Cyprus,75.3149
-2018-03-31,CZ,Czechia,116.8804
+2018-03-31,CZ,Czechia,116.9162
 2018-03-31,DE,Germany,126.2463
-2018-03-31,DK,Denmark,114.4705
+2018-03-31,DK,Denmark,114.4634
 2018-03-31,EE,Estonia,153.2383
-2018-03-31,ES,Spain,78.6458
+2018-03-31,ES,Spain,78.6459
 2018-03-31,FI,Finland,99.0566
-2018-03-31,FR,France,98.1154
-2018-03-31,GB,United Kingdom,112.5452
-2018-03-31,GR,Greece,63.3131
+2018-03-31,FR,France,98.116
+2018-03-31,GB,United Kingdom,112.5418
+2018-03-31,GR,Greece,63.3173
 2018-03-31,HK,Hong Kong SAR,185.6542
-2018-03-31,HR,Croatia,91.7378
+2018-03-31,HR,Croatia,91.6989
 2018-03-31,HU,Hungary,127.6353
 2018-03-31,ID,Indonesia,104.1168
-2018-03-31,IE,Ireland,114.6507
+2018-03-31,IE,Ireland,114.7648
 2018-03-31,IL,Israel,145.8647
-2018-03-31,IN,India,173.7036
-2018-03-31,IS,Iceland,157.758
-2018-03-31,IT,Italy,76.4168
+2018-03-31,IN,India,173.4163
+2018-03-31,IS,Iceland,157.7624
+2018-03-31,IT,Italy,76.417
 2018-03-31,JP,Japan,107.3534
-2018-03-31,KR,Korea,104.2161
+2018-03-31,KR,Korea,104.2236
 2018-03-31,LT,Lithuania,124.187
-2018-03-31,LU,Luxembourg,130.3163
-2018-03-31,LV,Latvia,139.77
-2018-03-31,MA,Morocco,100.3505
-2018-03-31,MK,North Macedonia,85.3065
+2018-03-31,LU,Luxembourg,130.3024
+2018-03-31,LV,Latvia,139.7979
+2018-03-31,MA,Morocco,97.3778
+2018-03-31,MK,North Macedonia,85.3983
 2018-03-31,MT,Malta,110.79
 2018-03-31,MX,Mexico,116.6998
 2018-03-31,MY,Malaysia,156.3015
-2018-03-31,NL,Netherlands,96.4555
-2018-03-31,NO,Norway,126.3232
+2018-03-31,NL,Netherlands,96.6843
+2018-03-31,NO,Norway,126.2733
 2018-03-31,NZ,New Zealand,153.549
 2018-03-31,PE,Peru,132.9332
 2018-03-31,PH,Philippines,147.2966
 2018-03-31,PL,Poland,93.0472
-2018-03-31,PT,Portugal,107.5538
+2018-03-31,PT,Portugal,107.5537
 2018-03-31,RO,Romania,82.3379
-2018-03-31,RS,Serbia,85.4121
-2018-03-31,RU,Russia,52.4801
-2018-03-31,SE,Sweden,142.7638
-2018-03-31,SG,Singapore,95.4813
-2018-03-31,SI,Slovenia,93.4178
-2018-03-31,SK,Slovak Republic,110.6918
-2018-03-31,TH,Thailand,126.0459
-2018-03-31,TR,Türkiye,120.5715
-2018-03-31,US,United States,127.116
-2018-03-31,XM,Euro area,101.1866
-2018-03-31,XW,World,113.5559
-2018-03-31,ZA,South Africa,99.3566
-2018-06-30,4T,Emerging market economies (aggregate),112.8053
-2018-06-30,5R,Advanced economies,116.1756
-2018-06-30,AE,United Arab Emirates,119.898
-2018-06-30,AT,Austria,133.7195
-2018-06-30,AU,Australia,119.8688
-2018-06-30,BE,Belgium,102.81
-2018-06-30,BG,Bulgaria,106.2022
-2018-06-30,BR,Brazil,93.1084
-2018-06-30,CA,Canada,155.4361
-2018-06-30,CH,Switzerland,129.4829
+2018-03-31,RS,Serbia,86.1539
+2018-03-31,RU,Russia,52.4785
+2018-03-31,SE,Sweden,142.7663
+2018-03-31,SG,Singapore,95.4577
+2018-03-31,SI,Slovenia,93.4408
+2018-03-31,SK,Slovakia,110.4229
+2018-03-31,TH,Thailand,136.4653
+2018-03-31,TR,Türkiye,122.6089
+2018-03-31,US,United States,127.1209
+2018-03-31,XM,Euro area,101.0608
+2018-03-31,XW,World,113.0808
+2018-03-31,ZA,South Africa,98.4068
+2018-06-30,4T,Emerging market economies (aggregate),112.0164
+2018-06-30,5R,Advanced economies,115.935
+2018-06-30,AT,Austria,133.7194
+2018-06-30,AU,Australia,119.8216
+2018-06-30,BE,Belgium,102.9604
+2018-06-30,BG,Bulgaria,106.1932
+2018-06-30,BR,Brazil,93.1208
+2018-06-30,CA,Canada,154.8542
+2018-06-30,CH,Switzerland,129.4833
 2018-06-30,CL,Chile,169.8549
 2018-06-30,CN,China,105.8087
-2018-06-30,CO,Colombia,141.0578
+2018-06-30,CO,Colombia,139.5583
 2018-06-30,CY,Cyprus,73.9176
-2018-06-30,CZ,Czechia,119.5392
+2018-06-30,CZ,Czechia,119.5485
 2018-06-30,DE,Germany,127.0859
-2018-06-30,DK,Denmark,116.3563
+2018-06-30,DK,Denmark,116.3378
 2018-06-30,EE,Estonia,153.0713
-2018-06-30,ES,Spain,79.3512
+2018-06-30,ES,Spain,79.3508
 2018-06-30,FI,Finland,99.6786
-2018-06-30,FR,France,97.8563
-2018-06-30,GB,United Kingdom,112.8181
-2018-06-30,GR,Greece,62.5783
+2018-06-30,FR,France,97.8553
+2018-06-30,GB,United Kingdom,112.8496
+2018-06-30,GR,Greece,62.5845
 2018-06-30,HK,Hong Kong SAR,195.1355
-2018-06-30,HR,Croatia,90.3656
+2018-06-30,HR,Croatia,90.4097
 2018-06-30,HU,Hungary,129.5149
 2018-06-30,ID,Indonesia,104.0773
-2018-06-30,IE,Ireland,116.5736
-2018-06-30,IL,Israel,145.2744
-2018-06-30,IN,India,176.4252
-2018-06-30,IS,Iceland,157.5456
-2018-06-30,IT,Italy,76.4554
+2018-06-30,IE,Ireland,116.6199
+2018-06-30,IL,Israel,145.2751
+2018-06-30,IN,India,176.13
+2018-06-30,IS,Iceland,157.54
+2018-06-30,IT,Italy,76.4575
 2018-06-30,JP,Japan,107.06
-2018-06-30,KR,Korea,104.3629
+2018-06-30,KR,Korea,104.4072
 2018-06-30,LT,Lithuania,126.1828
-2018-06-30,LU,Luxembourg,130.2631
-2018-06-30,LV,Latvia,141.9375
-2018-06-30,MA,Morocco,99.2049
-2018-06-30,MK,North Macedonia,83.8669
+2018-06-30,LU,Luxembourg,130.2483
+2018-06-30,LV,Latvia,141.9212
+2018-06-30,MA,Morocco,96.6044
+2018-06-30,MK,North Macedonia,83.8779
 2018-06-30,MT,Malta,113.8345
 2018-06-30,MX,Mexico,119.3621
 2018-06-30,MY,Malaysia,158.6842
-2018-06-30,NL,Netherlands,96.9137
-2018-06-30,NO,Norway,129.7867
+2018-06-30,NL,Netherlands,97.5739
+2018-06-30,NO,Norway,129.7833
 2018-06-30,NZ,New Zealand,153.2842
 2018-06-30,PE,Peru,131.0152
 2018-06-30,PH,Philippines,146.5649
 2018-06-30,PL,Poland,94.6378
 2018-06-30,PT,Portugal,107.9185
 2018-06-30,RO,Romania,84.1906
-2018-06-30,RS,Serbia,85.8977
-2018-06-30,RU,Russia,52.3338
-2018-06-30,SE,Sweden,142.2417
-2018-06-30,SG,Singapore,98.744
-2018-06-30,SI,Slovenia,93.1618
-2018-06-30,SK,Slovak Republic,111.1342
-2018-06-30,TH,Thailand,126.0586
-2018-06-30,TR,Türkiye,118.7339
-2018-06-30,US,United States,127.2528
-2018-06-30,XM,Euro area,100.9765
-2018-06-30,XW,World,114.3121
-2018-06-30,ZA,South Africa,99.1832
-2018-09-30,4T,Emerging market economies (aggregate),113.3119
-2018-09-30,5R,Advanced economies,116.9565
-2018-09-30,AE,United Arab Emirates,116.1359
+2018-06-30,RS,Serbia,86.7457
+2018-06-30,RU,Russia,52.3306
+2018-06-30,SE,Sweden,142.248
+2018-06-30,SG,Singapore,98.7191
+2018-06-30,SI,Slovenia,93.1665
+2018-06-30,SK,Slovakia,110.8674
+2018-06-30,TH,Thailand,135.7611
+2018-06-30,TR,Türkiye,120.7564
+2018-06-30,US,United States,127.2807
+2018-06-30,XM,Euro area,100.8473
+2018-06-30,XW,World,113.8552
+2018-06-30,ZA,South Africa,97.8362
+2018-09-30,4T,Emerging market economies (aggregate),112.7039
+2018-09-30,5R,Advanced economies,116.6998
 2018-09-30,AT,Austria,137.226
-2018-09-30,AU,Australia,117.5375
-2018-09-30,BE,Belgium,104.2496
-2018-09-30,BG,Bulgaria,106.0289
-2018-09-30,BR,Brazil,92.2103
-2018-09-30,CA,Canada,154.9999
-2018-09-30,CH,Switzerland,130.4208
+2018-09-30,AU,Australia,117.5022
+2018-09-30,BE,Belgium,104.3403
+2018-09-30,BG,Bulgaria,106.0266
+2018-09-30,BR,Brazil,92.2244
+2018-09-30,CA,Canada,154.4196
+2018-09-30,CH,Switzerland,130.4211
 2018-09-30,CL,Chile,175.1666
 2018-09-30,CN,China,108.0745
-2018-09-30,CO,Colombia,139.8511
+2018-09-30,CO,Colombia,138.4948
 2018-09-30,CY,Cyprus,74.2231
-2018-09-30,CZ,Czechia,121.8163
+2018-09-30,CZ,Czechia,121.8618
 2018-09-30,DE,Germany,128.6006
-2018-09-30,DK,Denmark,116.3667
+2018-09-30,DK,Denmark,116.3454
 2018-09-30,EE,Estonia,151.6256
-2018-09-30,ES,Spain,81.1454
+2018-09-30,ES,Spain,81.1451
 2018-09-30,FI,Finland,98.9346
-2018-09-30,FR,France,99.5677
-2018-09-30,GB,United Kingdom,114.3116
-2018-09-30,GR,Greece,63.5408
+2018-09-30,FR,France,99.5714
+2018-09-30,GB,United Kingdom,114.2754
+2018-09-30,GR,Greece,63.543
 2018-09-30,HK,Hong Kong SAR,198.5265
-2018-09-30,HR,Croatia,93.3955
+2018-09-30,HR,Croatia,93.3827
 2018-09-30,HU,Hungary,133.8199
 2018-09-30,ID,Indonesia,103.7329
-2018-09-30,IE,Ireland,118.3211
-2018-09-30,IL,Israel,144.3485
-2018-09-30,IN,India,174.9039
-2018-09-30,IS,Iceland,159.2769
-2018-09-30,IT,Italy,75.3716
+2018-09-30,IE,Ireland,118.3497
+2018-09-30,IL,Israel,144.3486
+2018-09-30,IN,India,174.6793
+2018-09-30,IS,Iceland,159.283
+2018-09-30,IT,Italy,75.3734
 2018-09-30,JP,Japan,106.6895
-2018-09-30,KR,Korea,104.5619
-2018-09-30,LT,Lithuania,127.7915
-2018-09-30,LU,Luxembourg,132.7825
-2018-09-30,LV,Latvia,140.4202
-2018-09-30,MA,Morocco,99.835
-2018-09-30,MK,North Macedonia,84.5086
+2018-09-30,KR,Korea,104.5649
+2018-09-30,LT,Lithuania,127.7914
+2018-09-30,LU,Luxembourg,132.7652
+2018-09-30,LV,Latvia,140.4765
+2018-09-30,MA,Morocco,96.9622
+2018-09-30,MK,North Macedonia,84.7056
 2018-09-30,MT,Malta,117.3276
 2018-09-30,MX,Mexico,120.5239
 2018-09-30,MY,Malaysia,161.0711
-2018-09-30,NL,Netherlands,99.0842
-2018-09-30,NO,Norway,126.8881
+2018-09-30,NL,Netherlands,99.6997
+2018-09-30,NO,Norway,126.824
 2018-09-30,NZ,New Zealand,153.3845
 2018-09-30,PE,Peru,133.2119
 2018-09-30,PH,Philippines,143.09
 2018-09-30,PL,Poland,95.8706
 2018-09-30,PT,Portugal,109.2675
 2018-09-30,RO,Romania,83.456
-2018-09-30,RS,Serbia,87.4841
-2018-09-30,RU,Russia,52.2861
-2018-09-30,SE,Sweden,142.544
-2018-09-30,SG,Singapore,98.8418
-2018-09-30,SI,Slovenia,95.6131
-2018-09-30,SK,Slovak Republic,110.7171
-2018-09-30,TH,Thailand,127.0925
-2018-09-30,TR,Türkiye,110.0411
-2018-09-30,US,United States,128.0819
-2018-09-30,XM,Euro area,102.3068
-2018-09-30,XW,World,114.9436
-2018-09-30,ZA,South Africa,98.8175
-2018-12-31,4T,Emerging market economies (aggregate),113.9421
-2018-12-31,5R,Advanced economies,117.2836
-2018-12-31,AE,United Arab Emirates,114.2922
-2018-12-31,AT,Austria,135.9874
-2018-12-31,AU,Australia,114.1473
-2018-12-31,BE,Belgium,102.9231
-2018-12-31,BG,Bulgaria,106.1226
-2018-12-31,BR,Brazil,92.1589
-2018-12-31,CA,Canada,154.8658
-2018-12-31,CH,Switzerland,132.3948
-2018-12-31,CL,Chile,178.0262
+2018-09-30,RS,Serbia,88.3564
+2018-09-30,RU,Russia,52.282
+2018-09-30,SE,Sweden,142.5448
+2018-09-30,SG,Singapore,98.8157
+2018-09-30,SI,Slovenia,95.6156
+2018-09-30,SK,Slovakia,110.3619
+2018-09-30,TH,Thailand,137.2127
+2018-09-30,TR,Türkiye,113.9403
+2018-09-30,US,United States,128.1328
+2018-09-30,XM,Euro area,102.1804
+2018-09-30,XW,World,114.5801
+2018-09-30,ZA,South Africa,97.3354
+2018-12-31,4T,Emerging market economies (aggregate),113.4424
+2018-12-31,5R,Advanced economies,117.0129
+2018-12-31,AT,Austria,135.9873
+2018-12-31,AU,Australia,114.1226
+2018-12-31,BE,Belgium,103.0205
+2018-12-31,BG,Bulgaria,106.1335
+2018-12-31,BR,Brazil,92.1763
+2018-12-31,CA,Canada,154.286
+2018-12-31,CH,Switzerland,132.3951
+2018-12-31,CL,Chile,178.0261
 2018-12-31,CN,China,109.4386
-2018-12-31,CO,Colombia,138.8427
+2018-12-31,CO,Colombia,136.6023
 2018-12-31,CY,Cyprus,74.411
-2018-12-31,CZ,Czechia,123.891
+2018-12-31,CZ,Czechia,123.9897
 2018-12-31,DE,Germany,130.3818
-2018-12-31,DK,Denmark,114.131
+2018-12-31,DK,Denmark,114.1344
 2018-12-31,EE,Estonia,155.4546
-2018-12-31,ES,Spain,80.739
+2018-12-31,ES,Spain,80.7391
 2018-12-31,FI,Finland,98.2704
-2018-12-31,FR,France,99.5774
-2018-12-31,GB,United Kingdom,113.0729
-2018-12-31,GR,Greece,63.6839
+2018-12-31,FR,France,99.5792
+2018-12-31,GB,United Kingdom,113.0424
+2018-12-31,GR,Greece,63.6859
 2018-12-31,HK,Hong Kong SAR,184.9372
-2018-12-31,HR,Croatia,93.7155
+2018-12-31,HR,Croatia,93.7604
 2018-12-31,HU,Hungary,136.6918
 2018-12-31,ID,Indonesia,103.5621
-2018-12-31,IE,Ireland,119.8399
-2018-12-31,IL,Israel,143.4864
-2018-12-31,IN,India,177.0084
-2018-12-31,IS,Iceland,159.3666
-2018-12-31,IT,Italy,75.5645
+2018-12-31,IE,Ireland,119.8911
+2018-12-31,IL,Israel,143.4869
+2018-12-31,IN,India,176.6471
+2018-12-31,IS,Iceland,159.3714
+2018-12-31,IT,Italy,75.5673
 2018-12-31,JP,Japan,105.733
-2018-12-31,KR,Korea,106.0377
+2018-12-31,KR,Korea,106.019
 2018-12-31,LT,Lithuania,127.6438
-2018-12-31,LU,Luxembourg,135.4041
-2018-12-31,LV,Latvia,144.165
-2018-12-31,MA,Morocco,100.4542
-2018-12-31,MK,North Macedonia,84.2602
+2018-12-31,LU,Luxembourg,135.3882
+2018-12-31,LV,Latvia,144.1942
+2018-12-31,MA,Morocco,97.5784
+2018-12-31,MK,North Macedonia,84.4038
 2018-12-31,MT,Malta,120.3047
 2018-12-31,MX,Mexico,120.655
 2018-12-31,MY,Malaysia,159.9612
-2018-12-31,NL,Netherlands,100.5123
-2018-12-31,NO,Norway,123.4595
+2018-12-31,NL,Netherlands,101.1537
+2018-12-31,NO,Norway,123.4341
 2018-12-31,NZ,New Zealand,154.5951
 2018-12-31,PE,Peru,132.9888
 2018-12-31,PH,Philippines,143.68
 2018-12-31,PL,Poland,97.6324
 2018-12-31,PT,Portugal,111.2915
 2018-12-31,RO,Romania,83.4046
-2018-12-31,RS,Serbia,89.5374
-2018-12-31,RU,Russia,52.6685
-2018-12-31,SE,Sweden,142.0299
-2018-12-31,SG,Singapore,98.8243
-2018-12-31,SI,Slovenia,97.3771
-2018-12-31,SK,Slovak Republic,113.7099
-2018-12-31,TH,Thailand,127.5882
-2018-12-31,TR,Türkiye,103.5119
-2018-12-31,US,United States,129.2718
-2018-12-31,XM,Euro area,102.8058
-2018-12-31,XW,World,115.4358
-2018-12-31,ZA,South Africa,98.653
-2019-03-31,4T,Emerging market economies (aggregate),114.2498
-2019-03-31,5R,Advanced economies,118.1776
-2019-03-31,AE,United Arab Emirates,114.4298
+2018-12-31,RS,Serbia,90.6075
+2018-12-31,RU,Russia,52.6711
+2018-12-31,SE,Sweden,142.0319
+2018-12-31,SG,Singapore,98.7985
+2018-12-31,SI,Slovenia,97.3813
+2018-12-31,SK,Slovakia,113.3551
+2018-12-31,TH,Thailand,137.8962
+2018-12-31,TR,Türkiye,107.8877
+2018-12-31,US,United States,129.2983
+2018-12-31,XM,Euro area,102.6786
+2018-12-31,XW,World,115.1106
+2018-12-31,ZA,South Africa,97.3577
+2019-03-31,4T,Emerging market economies (aggregate),113.6713
+2019-03-31,5R,Advanced economies,117.8687
 2019-03-31,AT,Austria,138.2831
-2019-03-31,AU,Australia,110.7228
-2019-03-31,BE,Belgium,103.873
-2019-03-31,BG,Bulgaria,107.9216
-2019-03-31,BR,Brazil,92.0879
-2019-03-31,CA,Canada,153.1635
-2019-03-31,CH,Switzerland,133.8148
-2019-03-31,CL,Chile,179.2207
+2019-03-31,AU,Australia,110.7129
+2019-03-31,BE,Belgium,103.7313
+2019-03-31,BG,Bulgaria,107.9212
+2019-03-31,BR,Brazil,92.1051
+2019-03-31,CA,Canada,152.5901
+2019-03-31,CH,Switzerland,133.8151
+2019-03-31,CL,Chile,179.2206
 2019-03-31,CN,China,109.4584
-2019-03-31,CO,Colombia,140.8264
+2019-03-31,CO,Colombia,139.2592
 2019-03-31,CY,Cyprus,76.1534
-2019-03-31,CZ,Czechia,124.9005
+2019-03-31,CZ,Czechia,124.9259
 2019-03-31,DE,Germany,131.1792
-2019-03-31,DK,Denmark,116.3419
+2019-03-31,DK,Denmark,116.3503
 2019-03-31,EE,Estonia,158.6708
-2019-03-31,ES,Spain,83.1197
+2019-03-31,ES,Spain,83.1199
 2019-03-31,FI,Finland,98.3059
-2019-03-31,FR,France,99.7798
-2019-03-31,GB,United Kingdom,112.0069
-2019-03-31,GR,Greece,66.352
+2019-03-31,FR,France,99.7812
+2019-03-31,GB,United Kingdom,112.0354
+2019-03-31,GR,Greece,66.3542
 2019-03-31,HK,Hong Kong SAR,183.9822
-2019-03-31,HR,Croatia,98.0612
+2019-03-31,HR,Croatia,98.0926
 2019-03-31,HU,Hungary,147.2772
 2019-03-31,ID,Indonesia,103.1088
-2019-03-31,IE,Ireland,118.803
-2019-03-31,IL,Israel,145.2187
-2019-03-31,IN,India,175.6768
-2019-03-31,IS,Iceland,159.6996
-2019-03-31,IT,Italy,75.0057
+2019-03-31,IE,Ireland,118.8369
+2019-03-31,IL,Israel,145.2189
+2019-03-31,IN,India,175.401
+2019-03-31,IS,Iceland,159.7042
+2019-03-31,IT,Italy,75.0073
 2019-03-31,JP,Japan,109.5032
-2019-03-31,KR,Korea,106.4097
+2019-03-31,KR,Korea,106.4373
 2019-03-31,LT,Lithuania,131.1385
-2019-03-31,LU,Luxembourg,136.676
-2019-03-31,LV,Latvia,144.5069
-2019-03-31,MA,Morocco,100.5494
-2019-03-31,MK,North Macedonia,85.7691
+2019-03-31,LU,Luxembourg,136.6612
+2019-03-31,LV,Latvia,144.5873
+2019-03-31,MA,Morocco,97.0499
+2019-03-31,MK,North Macedonia,85.7801
 2019-03-31,MT,Malta,115.9062
 2019-03-31,MX,Mexico,122.2262
 2019-03-31,MY,Malaysia,160.7118
-2019-03-31,NL,Netherlands,101.7226
-2019-03-31,NO,Norway,126.3705
+2019-03-31,NL,Netherlands,102.1897
+2019-03-31,NO,Norway,126.3582
 2019-03-31,NZ,New Zealand,155.2219
 2019-03-31,PE,Peru,133.5102
-2019-03-31,PH,Philippines,146.3727
+2019-03-31,PH,Philippines,146.1543
 2019-03-31,PL,Poland,99.3755
 2019-03-31,PT,Portugal,116.5755
 2019-03-31,RO,Romania,82.0987
-2019-03-31,RS,Serbia,90.8656
-2019-03-31,RU,Russia,53.5154
-2019-03-31,SE,Sweden,142.2722
-2019-03-31,SG,Singapore,97.9771
-2019-03-31,SI,Slovenia,99.1932
-2019-03-31,SK,Slovak Republic,114.3215
-2019-03-31,TH,Thailand,127.7995
-2019-03-31,TR,Türkiye,103.69
-2019-03-31,US,United States,129.806
-2019-03-31,XM,Euro area,103.93
-2019-03-31,XW,World,116.0074
-2019-03-31,ZA,South Africa,98.8222
-2019-06-30,4T,Emerging market economies (aggregate),114.8116
-2019-06-30,5R,Advanced economies,117.8818
-2019-06-30,AE,United Arab Emirates,110.5272
+2019-03-31,RS,Serbia,92.1973
+2019-03-31,RU,Russia,53.52
+2019-03-31,SE,Sweden,142.2731
+2019-03-31,SG,Singapore,97.95
+2019-03-31,SI,Slovenia,99.1961
+2019-03-31,SK,Slovakia,113.9714
+2019-03-31,TH,Thailand,136.7499
+2019-03-31,TR,Türkiye,106.4243
+2019-03-31,US,United States,129.8451
+2019-03-31,XM,Euro area,103.8111
+2019-03-31,XW,World,115.6424
+2019-03-31,ZA,South Africa,97.5336
+2019-06-30,4T,Emerging market economies (aggregate),114.2898
+2019-06-30,5R,Advanced economies,117.6638
 2019-06-30,AT,Austria,138.8249
-2019-06-30,AU,Australia,109.2373
-2019-06-30,BE,Belgium,103.9371
-2019-06-30,BG,Bulgaria,107.9306
-2019-06-30,BR,Brazil,91.8844
-2019-06-30,CA,Canada,152.4601
-2019-06-30,CH,Switzerland,133.3529
+2019-06-30,AU,Australia,109.2496
+2019-06-30,BE,Belgium,104.142
+2019-06-30,BG,Bulgaria,107.9262
+2019-06-30,BR,Brazil,91.8981
+2019-06-30,CA,Canada,151.8894
+2019-06-30,CH,Switzerland,133.3532
 2019-06-30,CL,Chile,178.441
 2019-06-30,CN,China,110.5525
-2019-06-30,CO,Colombia,141.1212
+2019-06-30,CO,Colombia,139.3336
 2019-06-30,CY,Cyprus,75.7153
-2019-06-30,CZ,Czechia,127.0093
+2019-06-30,CZ,Czechia,127.1029
 2019-06-30,DE,Germany,132.4337
-2019-06-30,DK,Denmark,118.5879
+2019-06-30,DK,Denmark,118.5969
 2019-06-30,EE,Estonia,157.3163
-2019-06-30,ES,Spain,82.8779
+2019-06-30,ES,Spain,82.878
 2019-06-30,FI,Finland,99.1298
-2019-06-30,FR,France,99.861
-2019-06-30,GB,United Kingdom,111.6996
-2019-06-30,GR,Greece,67.1165
-2019-06-30,HK,Hong Kong SAR,194.8008
-2019-06-30,HR,Croatia,98.9961
+2019-06-30,FR,France,99.8628
+2019-06-30,GB,United Kingdom,111.7198
+2019-06-30,GR,Greece,67.1188
+2019-06-30,HK,Hong Kong SAR,194.735
+2019-06-30,HR,Croatia,98.9753
 2019-06-30,HU,Hungary,149.3897
 2019-06-30,ID,Indonesia,102.1774
-2019-06-30,IE,Ireland,118.0356
-2019-06-30,IL,Israel,145.2851
-2019-06-30,IN,India,177.0669
-2019-06-30,IS,Iceland,158.714
-2019-06-30,IT,Italy,75.7359
+2019-06-30,IE,Ireland,118.1429
+2019-06-30,IL,Israel,145.2855
+2019-06-30,IN,India,176.6823
+2019-06-30,IS,Iceland,158.7195
+2019-06-30,IT,Italy,75.738
 2019-06-30,JP,Japan,108.3303
-2019-06-30,KR,Korea,105.6338
-2019-06-30,LT,Lithuania,131.0206
-2019-06-30,LU,Luxembourg,142.2081
-2019-06-30,LV,Latvia,148.3204
-2019-06-30,MA,Morocco,98.7833
-2019-06-30,MK,North Macedonia,87.4058
+2019-06-30,KR,Korea,105.6499
+2019-06-30,LT,Lithuania,131.0205
+2019-06-30,LU,Luxembourg,142.1895
+2019-06-30,LV,Latvia,148.296
+2019-06-30,MA,Morocco,95.8467
+2019-06-30,MK,North Macedonia,87.4781
 2019-06-30,MT,Malta,118.7833
 2019-06-30,MX,Mexico,125.0465
 2019-06-30,MY,Malaysia,161.3558
-2019-06-30,NL,Netherlands,102.2649
-2019-06-30,NO,Norway,129.2009
+2019-06-30,NL,Netherlands,102.4188
+2019-06-30,NO,Norway,129.1091
 2019-06-30,NZ,New Zealand,153.7778
 2019-06-30,PE,Peru,133.8241
-2019-06-30,PH,Philippines,143.3986
+2019-06-30,PH,Philippines,150.9074
 2019-06-30,PL,Poland,100.0423
 2019-06-30,PT,Portugal,117.5135
 2019-06-30,RO,Romania,82.2977
-2019-06-30,RS,Serbia,92.1829
-2019-06-30,RU,Russia,53.2935
-2019-06-30,SE,Sweden,142.4407
-2019-06-30,SG,Singapore,99.1613
-2019-06-30,SI,Slovenia,98.4513
-2019-06-30,SK,Slovak Republic,117.3971
-2019-06-30,TH,Thailand,125.7184
-2019-06-30,TR,Türkiye,102.4174
-2019-06-30,US,United States,129.5226
-2019-06-30,XM,Euro area,103.9227
-2019-06-30,XW,World,116.184
-2019-06-30,ZA,South Africa,98.2723
-2019-09-30,4T,Emerging market economies (aggregate),114.9864
-2019-09-30,5R,Advanced economies,118.9815
-2019-09-30,AE,United Arab Emirates,109.8041
+2019-06-30,RS,Serbia,94.0178
+2019-06-30,RU,Russia,53.2881
+2019-06-30,SE,Sweden,142.4416
+2019-06-30,SG,Singapore,99.1338
+2019-06-30,SI,Slovenia,98.4506
+2019-06-30,SK,Slovakia,117.0503
+2019-06-30,TH,Thailand,136.4993
+2019-06-30,TR,Türkiye,104.9669
+2019-06-30,US,United States,129.5932
+2019-06-30,XM,Euro area,103.805
+2019-06-30,XW,World,115.8637
+2019-06-30,ZA,South Africa,96.1274
+2019-09-30,4T,Emerging market economies (aggregate),114.3705
+2019-09-30,5R,Advanced economies,118.6953
 2019-09-30,AT,Austria,138.4329
-2019-09-30,AU,Australia,111.3297
-2019-09-30,BE,Belgium,107.7245
-2019-09-30,BG,Bulgaria,108.9857
-2019-09-30,BR,Brazil,92.8682
-2019-09-30,CA,Canada,152.3435
-2019-09-30,CH,Switzerland,134.1785
-2019-09-30,CL,Chile,184.5621
+2019-09-30,AU,Australia,111.2957
+2019-09-30,BE,Belgium,107.5508
+2019-09-30,BG,Bulgaria,108.9807
+2019-09-30,BR,Brazil,92.8716
+2019-09-30,CA,Canada,151.7732
+2019-09-30,CH,Switzerland,134.1788
+2019-09-30,CL,Chile,184.562
 2019-09-30,CN,China,110.3512
-2019-09-30,CO,Colombia,143.3867
+2019-09-30,CO,Colombia,141.1491
 2019-09-30,CY,Cyprus,76.7896
-2019-09-30,CZ,Czechia,128.7843
+2019-09-30,CZ,Czechia,128.8327
 2019-09-30,DE,Germany,133.4876
-2019-09-30,DK,Denmark,118.6725
+2019-09-30,DK,Denmark,118.6759
 2019-09-30,EE,Estonia,160.365
-2019-09-30,ES,Spain,84.7735
+2019-09-30,ES,Spain,84.7731
 2019-09-30,FI,Finland,98.4861
-2019-09-30,FR,France,101.9361
-2019-09-30,GB,United Kingdom,113.0672
+2019-09-30,FR,France,101.9358
+2019-09-30,GB,United Kingdom,113.0235
 2019-09-30,GR,Greece,68.8516
 2019-09-30,HK,Hong Kong SAR,189.6288
-2019-09-30,HR,Croatia,100.075
-2019-09-30,HU,Hungary,151.438
+2019-09-30,HR,Croatia,100.0673
+2019-09-30,HU,Hungary,151.4379
 2019-09-30,ID,Indonesia,101.5732
-2019-09-30,IE,Ireland,119.532
-2019-09-30,IL,Israel,146.485
-2019-09-30,IN,India,174.5278
-2019-09-30,IS,Iceland,159.6587
-2019-09-30,IT,Italy,75.409
+2019-09-30,IE,Ireland,119.5683
+2019-09-30,IL,Israel,146.4848
+2019-09-30,IN,India,174.1405
+2019-09-30,IS,Iceland,159.6643
+2019-09-30,IT,Italy,75.41
 2019-09-30,JP,Japan,107.6618
-2019-09-30,KR,Korea,105.6667
-2019-09-30,LT,Lithuania,132.706
-2019-09-30,LU,Luxembourg,145.4324
-2019-09-30,LV,Latvia,153.7351
-2019-09-30,MA,Morocco,99.823
-2019-09-30,MK,North Macedonia,85.6166
+2019-09-30,KR,Korea,105.6927
+2019-09-30,LT,Lithuania,132.7059
+2019-09-30,LU,Luxembourg,145.4141
+2019-09-30,LV,Latvia,153.7854
+2019-09-30,MA,Morocco,96.6992
+2019-09-30,MK,North Macedonia,85.6011
 2019-09-30,MT,Malta,122.3369
 2019-09-30,MX,Mexico,126.5091
 2019-09-30,MY,Malaysia,162.3719
-2019-09-30,NL,Netherlands,102.542
-2019-09-30,NO,Norway,127.7594
+2019-09-30,NL,Netherlands,103.3035
+2019-09-30,NO,Norway,127.7064
 2019-09-30,NZ,New Zealand,155.8488
 2019-09-30,PE,Peru,133.1767
-2019-09-30,PH,Philippines,155.8566
+2019-09-30,PH,Philippines,151.044
 2019-09-30,PL,Poland,101.8332
 2019-09-30,PT,Portugal,121.2252
 2019-09-30,RO,Romania,83.7472
-2019-09-30,RS,Serbia,95.067
-2019-09-30,RU,Russia,54.1923
-2019-09-30,SE,Sweden,144.5396
-2019-09-30,SG,Singapore,100.5344
-2019-09-30,SI,Slovenia,100.365
-2019-09-30,SK,Slovak Republic,119.9645
-2019-09-30,TH,Thailand,125.7771
-2019-09-30,TR,Türkiye,103.5841
-2019-09-30,US,United States,130.7021
-2019-09-30,XM,Euro area,105.4727
-2019-09-30,XW,World,116.7759
-2019-09-30,ZA,South Africa,98.4112
-2019-12-31,4T,Emerging market economies (aggregate),114.4502
-2019-12-31,5R,Advanced economies,119.7925
-2019-12-31,AE,United Arab Emirates,109.0724
+2019-09-30,RS,Serbia,97.4621
+2019-09-30,RU,Russia,54.1946
+2019-09-30,SE,Sweden,144.5439
+2019-09-30,SG,Singapore,100.5055
+2019-09-30,SI,Slovenia,100.3694
+2019-09-30,SK,Slovakia,119.7056
+2019-09-30,TH,Thailand,134.2889
+2019-09-30,TR,Türkiye,105.1551
+2019-09-30,US,United States,130.7586
+2019-09-30,XM,Euro area,105.353
+2019-09-30,XW,World,116.4043
+2019-09-30,ZA,South Africa,95.4692
+2019-12-31,4T,Emerging market economies (aggregate),113.8684
+2019-12-31,5R,Advanced economies,119.4572
 2019-12-31,AT,Austria,138.3018
-2019-12-31,AU,Australia,114.8865
-2019-12-31,BE,Belgium,107.258
-2019-12-31,BG,Bulgaria,109.3553
-2019-12-31,BR,Brazil,93.6148
-2019-12-31,CA,Canada,154.1774
-2019-12-31,CH,Switzerland,137.0582
+2019-12-31,AU,Australia,114.8594
+2019-12-31,BE,Belgium,106.8041
+2019-12-31,BG,Bulgaria,109.4062
+2019-12-31,BR,Brazil,93.603
+2019-12-31,CA,Canada,153.6002
+2019-12-31,CH,Switzerland,137.0585
 2019-12-31,CL,Chile,187.0355
 2019-12-31,CN,China,108.7462
-2019-12-31,CO,Colombia,142.3261
+2019-12-31,CO,Colombia,140.1426
 2019-12-31,CY,Cyprus,76.2045
-2019-12-31,CZ,Czechia,130.9968
+2019-12-31,CZ,Czechia,131.0295
 2019-12-31,DE,Germany,137.1975
-2019-12-31,DK,Denmark,116.2524
+2019-12-31,DK,Denmark,116.2716
 2019-12-31,EE,Estonia,165.3539
-2019-12-31,ES,Spain,83.3549
+2019-12-31,ES,Spain,83.3553
 2019-12-31,FI,Finland,97.6029
-2019-12-31,FR,France,102.2275
-2019-12-31,GB,United Kingdom,112.4318
-2019-12-31,GR,Greece,68.382
+2019-12-31,FR,France,102.2358
+2019-12-31,GB,United Kingdom,112.4384
+2019-12-31,GR,Greece,68.3864
 2019-12-31,HK,Hong Kong SAR,185.5009
-2019-12-31,HR,Croatia,102.1941
+2019-12-31,HR,Croatia,102.2373
 2019-12-31,HU,Hungary,149.1813
 2019-12-31,ID,Indonesia,101.8454
-2019-12-31,IE,Ireland,119.6229
-2019-12-31,IL,Israel,147.9627
-2019-12-31,IN,India,172.2227
-2019-12-31,IS,Iceland,162.153
-2019-12-31,IT,Italy,75.4972
+2019-12-31,IE,Ireland,119.6039
+2019-12-31,IL,Israel,147.9625
+2019-12-31,IN,India,171.9146
+2019-12-31,IS,Iceland,162.1573
+2019-12-31,IT,Italy,75.4981
 2019-12-31,JP,Japan,106.2136
-2019-12-31,KR,Korea,105.8135
+2019-12-31,KR,Korea,105.7758
 2019-12-31,LT,Lithuania,133.2458
-2019-12-31,LU,Luxembourg,147.9439
-2019-12-31,LV,Latvia,153.5184
-2019-12-31,MA,Morocco,99.1088
-2019-12-31,MK,North Macedonia,87.0228
+2019-12-31,LU,Luxembourg,147.9224
+2019-12-31,LV,Latvia,153.55
+2019-12-31,MA,Morocco,96.0018
+2019-12-31,MK,North Macedonia,87.078
 2019-12-31,MT,Malta,125.5673
 2019-12-31,MX,Mexico,126.1846
 2019-12-31,MY,Malaysia,161.2281
-2019-12-31,NL,Netherlands,104.2775
-2019-12-31,NO,Norway,124.6364
+2019-12-31,NL,Netherlands,104.9487
+2019-12-31,NO,Norway,124.6355
 2019-12-31,NZ,New Zealand,159.0308
 2019-12-31,PE,Peru,129.7182
-2019-12-31,PH,Philippines,156.5284
+2019-12-31,PH,Philippines,154.2029
 2019-12-31,PL,Poland,104.1111
 2019-12-31,PT,Portugal,122.5313
 2019-12-31,RO,Romania,83.7585
-2019-12-31,RS,Serbia,97.1024
-2019-12-31,RU,Russia,54.2543
-2019-12-31,SE,Sweden,144.206
-2019-12-31,SG,Singapore,100.8302
-2019-12-31,SI,Slovenia,100.5263
-2019-12-31,SK,Slovak Republic,122.4881
-2019-12-31,TH,Thailand,128.9255
-2019-12-31,TR,Türkiye,103.2244
-2019-12-31,US,United States,132.3567
-2019-12-31,XM,Euro area,106.1709
-2019-12-31,XW,World,116.8447
-2019-12-31,ZA,South Africa,98.2351
-2020-03-31,4T,Emerging market economies (aggregate),114.333
-2020-03-31,5R,Advanced economies,121.3591
-2020-03-31,AE,United Arab Emirates,107.1961
+2019-12-31,RS,Serbia,100.0401
+2019-12-31,RU,Russia,54.2619
+2019-12-31,SE,Sweden,144.2116
+2019-12-31,SG,Singapore,100.8014
+2019-12-31,SI,Slovenia,100.5247
+2019-12-31,SK,Slovakia,122.2295
+2019-12-31,TH,Thailand,140.1918
+2019-12-31,TR,Türkiye,105.4017
+2019-12-31,US,United States,132.4036
+2019-12-31,XM,Euro area,106.047
+2019-12-31,XW,World,116.5113
+2019-12-31,ZA,South Africa,95.7649
+2020-03-31,4T,Emerging market economies (aggregate),113.7213
+2020-03-31,5R,Advanced economies,120.9691
 2020-03-31,AT,Austria,140.3019
-2020-03-31,AU,Australia,116.3274
-2020-03-31,BE,Belgium,106.4431
-2020-03-31,BG,Bulgaria,109.0631
-2020-03-31,BR,Brazil,94.1649
-2020-03-31,CA,Canada,156.8621
-2020-03-31,CH,Switzerland,136.2027
-2020-03-31,CL,Chile,188.524
+2020-03-31,AU,Australia,116.2681
+2020-03-31,BE,Belgium,106.5837
+2020-03-31,BG,Bulgaria,109.039
+2020-03-31,BR,Brazil,94.1266
+2020-03-31,CA,Canada,156.2749
+2020-03-31,CH,Switzerland,136.203
+2020-03-31,CL,Chile,188.3263
 2020-03-31,CN,China,107.1595
-2020-03-31,CO,Colombia,143.4781
+2020-03-31,CO,Colombia,141.049
 2020-03-31,CY,Cyprus,76.7185
-2020-03-31,CZ,Czechia,130.9246
+2020-03-31,CZ,Czechia,130.9984
 2020-03-31,DE,Germany,138.1141
-2020-03-31,DK,Denmark,118.021
+2020-03-31,DK,Denmark,118.0153
 2020-03-31,EE,Estonia,174.2705
-2020-03-31,ES,Spain,85.3385
+2020-03-31,ES,Spain,85.3388
 2020-03-31,FI,Finland,98.643
-2020-03-31,FR,France,103.4148
-2020-03-31,GB,United Kingdom,112.1205
+2020-03-31,FR,France,103.416
+2020-03-31,GB,United Kingdom,112.1297
 2020-03-31,GR,Greece,70.564
 2020-03-31,HK,Hong Kong SAR,184.6611
-2020-03-31,HR,Croatia,105.5566
-2020-03-31,HU,Hungary,152.9059
-2020-03-31,ID,Indonesia,101.3946
-2020-03-31,IE,Ireland,118.7804
-2020-03-31,IL,Israel,150.0776
-2020-03-31,IN,India,171.1444
-2020-03-31,IS,Iceland,165.0696
-2020-03-31,IT,Italy,76.0882
+2020-03-31,HR,Croatia,105.5702
+2020-03-31,HU,Hungary,152.906
+2020-03-31,ID,Indonesia,101.3679
+2020-03-31,IE,Ireland,118.7668
+2020-03-31,IL,Israel,150.0784
+2020-03-31,IN,India,170.8349
+2020-03-31,IS,Iceland,165.0769
+2020-03-31,IT,Italy,76.088
 2020-03-31,JP,Japan,108.3035
-2020-03-31,KR,Korea,106.5355
+2020-03-31,KR,Korea,106.5688
 2020-03-31,LT,Lithuania,135.92
-2020-03-31,LU,Luxembourg,153.744
-2020-03-31,LV,Latvia,154.1509
-2020-03-31,MA,Morocco,98.3951
-2020-03-31,MK,North Macedonia,87.1239
+2020-03-31,LU,Luxembourg,153.7249
+2020-03-31,LV,Latvia,154.203
+2020-03-31,MA,Morocco,95.1224
+2020-03-31,MK,North Macedonia,87.2229
 2020-03-31,MT,Malta,120.9609
 2020-03-31,MX,Mexico,126.5326
 2020-03-31,MY,Malaysia,162.268
-2020-03-31,NL,Netherlands,106.4238
-2020-03-31,NO,Norway,127.3131
+2020-03-31,NL,Netherlands,107.4667
+2020-03-31,NO,Norway,127.2266
 2020-03-31,NZ,New Zealand,162.8244
 2020-03-31,PE,Peru,130.6543
-2020-03-31,PH,Philippines,160.6992
+2020-03-31,PH,Philippines,153.5524
 2020-03-31,PL,Poland,105.7661
 2020-03-31,PT,Portugal,128.4041
 2020-03-31,RO,Romania,86.1575
-2020-03-31,RS,Serbia,97.8544
-2020-03-31,RU,Russia,55.9705
-2020-03-31,SE,Sweden,147.287
-2020-03-31,SG,Singapore,99.9163
-2020-03-31,SI,Slovenia,102.3492
-2020-03-31,SK,Slovak Republic,125.9027
-2020-03-31,TH,Thailand,132.1545
-2020-03-31,TR,Türkiye,106.3904
-2020-03-31,US,United States,133.673
-2020-03-31,XM,Euro area,108.0311
-2020-03-31,XW,World,117.4673
-2020-03-31,ZA,South Africa,96.406
-2020-06-30,4T,Emerging market economies (aggregate),116.1629
-2020-06-30,5R,Advanced economies,122.4533
-2020-06-30,AE,United Arab Emirates,105.1173
+2020-03-31,RS,Serbia,101.3453
+2020-03-31,RU,Russia,55.9796
+2020-03-31,SE,Sweden,147.2861
+2020-03-31,SG,Singapore,99.8851
+2020-03-31,SI,Slovenia,102.3512
+2020-03-31,SK,Slovakia,125.4768
+2020-03-31,TH,Thailand,141.8771
+2020-03-31,TR,Türkiye,109.118
+2020-03-31,US,United States,133.8113
+2020-03-31,XM,Euro area,107.916
+2020-03-31,XW,World,117.1483
+2020-03-31,ZA,South Africa,94.5002
+2020-06-30,4T,Emerging market economies (aggregate),115.324
+2020-06-30,5R,Advanced economies,122.1193
 2020-06-30,AT,Austria,144.5156
-2020-06-30,AU,Australia,116.4502
-2020-06-30,BE,Belgium,108.0128
-2020-06-30,BG,Bulgaria,109.3826
-2020-06-30,BR,Brazil,96.556
-2020-06-30,CA,Canada,161.0699
-2020-06-30,CH,Switzerland,138.3868
-2020-06-30,CL,Chile,189.7425
+2020-06-30,AU,Australia,116.4373
+2020-06-30,BE,Belgium,107.992
+2020-06-30,BG,Bulgaria,109.4203
+2020-06-30,BR,Brazil,96.4809
+2020-06-30,CA,Canada,160.4669
+2020-06-30,CH,Switzerland,138.3871
+2020-06-30,CL,Chile,189.7728
 2020-06-30,CN,China,109.9375
-2020-06-30,CO,Colombia,138.7745
+2020-06-30,CO,Colombia,136.9019
 2020-06-30,CY,Cyprus,78.6282
-2020-06-30,CZ,Czechia,132.7234
+2020-06-30,CZ,Czechia,132.8256
 2020-06-30,DE,Germany,140.0671
-2020-06-30,DK,Denmark,120.1697
+2020-06-30,DK,Denmark,120.1919
 2020-06-30,EE,Estonia,165.6087
-2020-06-30,ES,Spain,85.2464
+2020-06-30,ES,Spain,85.2462
 2020-06-30,FI,Finland,100.0054
-2020-06-30,FR,France,104.734
-2020-06-30,GB,United Kingdom,112.3283
+2020-06-30,FR,France,104.7395
+2020-06-30,GB,United Kingdom,112.3348
 2020-06-30,GR,Greece,70.9774
 2020-06-30,HK,Hong Kong SAR,186.5493
-2020-06-30,HR,Croatia,107.5188
+2020-06-30,HR,Croatia,107.6036
 2020-06-30,HU,Hungary,149.5233
-2020-06-30,ID,Indonesia,101.3299
-2020-06-30,IE,Ireland,118.8268
-2020-06-30,IL,Israel,150.2197
-2020-06-30,IN,India,170.8414
-2020-06-30,IS,Iceland,165.2115
-2020-06-30,IT,Italy,78.3593
+2020-06-30,ID,Indonesia,101.3277
+2020-06-30,IE,Ireland,118.8835
+2020-06-30,IL,Israel,150.2201
+2020-06-30,IN,India,170.5077
+2020-06-30,IS,Iceland,165.2172
+2020-06-30,IT,Italy,78.3595
 2020-06-30,JP,Japan,107.4278
-2020-06-30,KR,Korea,108.1911
+2020-06-30,KR,Korea,108.1684
 2020-06-30,LT,Lithuania,139.0751
-2020-06-30,LU,Luxembourg,160.2235
-2020-06-30,LV,Latvia,151.1813
-2020-06-30,MA,Morocco,97.9176
-2020-06-30,MK,North Macedonia,88.2726
+2020-06-30,LU,Luxembourg,160.2137
+2020-06-30,LV,Latvia,151.2184
+2020-06-30,MA,Morocco,90.6171
+2020-06-30,MK,North Macedonia,88.3534
 2020-06-30,MT,Malta,122.524
 2020-06-30,MX,Mexico,128.69
 2020-06-30,MY,Malaysia,167.934
-2020-06-30,NL,Netherlands,108.0791
-2020-06-30,NO,Norway,131.1821
+2020-06-30,NL,Netherlands,109.1406
+2020-06-30,NO,Norway,131.1751
 2020-06-30,NZ,New Zealand,161.8924
 2020-06-30,PE,Peru,131.3619
-2020-06-30,PH,Philippines,178.2187
+2020-06-30,PH,Philippines,160.9517
 2020-06-30,PL,Poland,107.5437
 2020-06-30,PT,Portugal,129.3041
 2020-06-30,RO,Romania,85.5352
-2020-06-30,RS,Serbia,99.7038
-2020-06-30,RU,Russia,55.8602
-2020-06-30,SE,Sweden,146.9059
-2020-06-30,SG,Singapore,101.0602
-2020-06-30,SI,Slovenia,104.5569
-2020-06-30,SK,Slovak Republic,126.317
-2020-06-30,TH,Thailand,135.8519
-2020-06-30,TR,Türkiye,115.2812
-2020-06-30,US,United States,135.4454
-2020-06-30,XM,Euro area,108.9727
-2020-06-30,XW,World,118.9775
-2020-06-30,ZA,South Africa,97.3691
-2020-09-30,4T,Emerging market economies (aggregate),116.1519
-2020-09-30,5R,Advanced economies,124.5527
-2020-09-30,AE,United Arab Emirates,103.8844
+2020-06-30,RS,Serbia,103.8598
+2020-06-30,RU,Russia,55.8535
+2020-06-30,SE,Sweden,146.9085
+2020-06-30,SG,Singapore,101.0241
+2020-06-30,SI,Slovenia,104.5548
+2020-06-30,SK,Slovakia,125.9768
+2020-06-30,TH,Thailand,146.2428
+2020-06-30,TR,Türkiye,112.4381
+2020-06-30,US,United States,135.664
+2020-06-30,XM,Euro area,108.8612
+2020-06-30,XW,World,118.539
+2020-06-30,ZA,South Africa,95.0281
+2020-09-30,4T,Emerging market economies (aggregate),115.4269
+2020-09-30,5R,Advanced economies,124.1449
 2020-09-30,AT,Austria,149.2834
-2020-09-30,AU,Australia,115.5269
-2020-09-30,BE,Belgium,110.2227
-2020-09-30,BG,Bulgaria,113.3508
-2020-09-30,BR,Brazil,98.068
-2020-09-30,CA,Canada,162.4343
-2020-09-30,CH,Switzerland,138.8478
-2020-09-30,CL,Chile,186.5749
+2020-09-30,AU,Australia,115.5427
+2020-09-30,BE,Belgium,110.0807
+2020-09-30,BG,Bulgaria,113.3418
+2020-09-30,BR,Brazil,97.947
+2020-09-30,CA,Canada,161.8262
+2020-09-30,CH,Switzerland,138.8481
+2020-09-30,CL,Chile,186.7171
 2020-09-30,CN,China,110.3074
-2020-09-30,CO,Colombia,142.5292
+2020-09-30,CO,Colombia,140.1745
 2020-09-30,CY,Cyprus,78.6593
-2020-09-30,CZ,Czechia,135.09
+2020-09-30,CZ,Czechia,135.1162
 2020-09-30,DE,Germany,145.3409
-2020-09-30,DK,Denmark,125.3108
+2020-09-30,DK,Denmark,125.3151
 2020-09-30,EE,Estonia,168.2167
-2020-09-30,ES,Spain,86.7542
+2020-09-30,ES,Spain,86.7537
 2020-09-30,FI,Finland,99.8686
-2020-09-30,FR,France,106.5583
-2020-09-30,GB,United Kingdom,115.2236
+2020-09-30,FR,France,106.5584
+2020-09-30,GB,United Kingdom,115.1981
 2020-09-30,GR,Greece,72.9046
 2020-09-30,HK,Hong Kong SAR,190.94
-2020-09-30,HR,Croatia,107.1042
+2020-09-30,HR,Croatia,107.1786
 2020-09-30,HU,Hungary,153.1086
-2020-09-30,ID,Indonesia,101.5372
-2020-09-30,IE,Ireland,119.5883
-2020-09-30,IL,Israel,151.6161
-2020-09-30,IN,India,165.0701
-2020-09-30,IS,Iceland,166.6398
+2020-09-30,ID,Indonesia,101.5166
+2020-09-30,IE,Ireland,119.7115
+2020-09-30,IL,Israel,151.6165
+2020-09-30,IN,India,164.7084
+2020-09-30,IS,Iceland,166.6441
 2020-09-30,IT,Italy,76.5432
 2020-09-30,JP,Japan,107.4995
-2020-09-30,KR,Korea,109.6581
-2020-09-30,LT,Lithuania,139.7961
-2020-09-30,LU,Luxembourg,164.3453
-2020-09-30,LV,Latvia,156.4186
-2020-09-30,MA,Morocco,98.248
-2020-09-30,MK,North Macedonia,86.7664
+2020-09-30,KR,Korea,109.6809
+2020-09-30,LT,Lithuania,139.7962
+2020-09-30,LU,Luxembourg,164.3285
+2020-09-30,LV,Latvia,156.4434
+2020-09-30,MA,Morocco,94.8135
+2020-09-30,MK,North Macedonia,86.864
 2020-09-30,MT,Malta,125.124
 2020-09-30,MX,Mexico,127.8991
 2020-09-30,MY,Malaysia,164.9565
-2020-09-30,NL,Netherlands,109.8338
-2020-09-30,NO,Norway,131.9893
+2020-09-30,NL,Netherlands,110.7603
+2020-09-30,NO,Norway,131.9218
 2020-09-30,NZ,New Zealand,168.9748
 2020-09-30,PE,Peru,131.4962
-2020-09-30,PH,Philippines,151.7608
+2020-09-30,PH,Philippines,156.9651
 2020-09-30,PL,Poland,109.6267
 2020-09-30,PT,Portugal,129.6169
 2020-09-30,RO,Romania,82.9095
-2020-09-30,RS,Serbia,101.3525
-2020-09-30,RU,Russia,57.3647
-2020-09-30,SE,Sweden,149.059
-2020-09-30,SG,Singapore,101.4694
-2020-09-30,SI,Slovenia,103.7354
-2020-09-30,SK,Slovak Republic,128.2103
-2020-09-30,TH,Thailand,133.534
-2020-09-30,TR,Türkiye,118.0268
-2020-09-30,US,United States,138.3297
-2020-09-30,XM,Euro area,111.0022
-2020-09-30,XW,World,119.8903
-2020-09-30,ZA,South Africa,98.1109
-2020-12-31,4T,Emerging market economies (aggregate),116.9652
-2020-12-31,5R,Advanced economies,127.6545
-2020-12-31,AE,United Arab Emirates,104.3755
+2020-09-30,RS,Serbia,106.2643
+2020-09-30,RU,Russia,57.3727
+2020-09-30,SE,Sweden,149.0622
+2020-09-30,SG,Singapore,101.4285
+2020-09-30,SI,Slovenia,103.7394
+2020-09-30,SK,Slovakia,127.7852
+2020-09-30,TH,Thailand,141.6167
+2020-09-30,TR,Türkiye,120.8968
+2020-09-30,US,United States,138.4346
+2020-09-30,XM,Euro area,110.8825
+2020-09-30,XW,World,119.5462
+2020-09-30,ZA,South Africa,95.2068
+2020-12-31,4T,Emerging market economies (aggregate),116.1906
+2020-12-31,5R,Advanced economies,127.1715
 2020-12-31,AT,Austria,150.1851
-2020-12-31,AU,Australia,118.0338
-2020-12-31,BE,Belgium,112.7716
-2020-12-31,BG,Bulgaria,114.7792
-2020-12-31,BR,Brazil,97.9906
-2020-12-31,CA,Canada,165.7664
-2020-12-31,CH,Switzerland,142.3285
-2020-12-31,CL,Chile,190.1125
+2020-12-31,AU,Australia,117.9981
+2020-12-31,BE,Belgium,112.4435
+2020-12-31,BG,Bulgaria,114.7807
+2020-12-31,BR,Brazil,97.8175
+2020-12-31,CA,Canada,165.1458
+2020-12-31,CH,Switzerland,142.3288
+2020-12-31,CL,Chile,189.9794
 2020-12-31,CN,China,111.2144
-2020-12-31,CO,Colombia,142.7693
+2020-12-31,CO,Colombia,140.3333
 2020-12-31,CY,Cyprus,77.4396
-2020-12-31,CZ,Czechia,139.0667
+2020-12-31,CZ,Czechia,139.0651
 2020-12-31,DE,Germany,149.3463
-2020-12-31,DK,Denmark,128.2559
+2020-12-31,DK,Denmark,128.2652
 2020-12-31,EE,Estonia,175.3265
-2020-12-31,ES,Spain,85.3705
+2020-12-31,ES,Spain,85.3706
 2020-12-31,FI,Finland,100.904
-2020-12-31,FR,France,108.1316
-2020-12-31,GB,United Kingdom,118.3866
-2020-12-31,GR,Greece,72.0313
+2020-12-31,FR,France,108.1313
+2020-12-31,GB,United Kingdom,118.3291
+2020-12-31,GR,Greece,72.0312
 2020-12-31,HK,Hong Kong SAR,186.4041
-2020-12-31,HR,Croatia,109.1748
+2020-12-31,HR,Croatia,109.1994
 2020-12-31,HU,Hungary,151.1723
-2020-12-31,ID,Indonesia,101.4265
-2020-12-31,IE,Ireland,121.8991
-2020-12-31,IL,Israel,154.4849
-2020-12-31,IN,India,165.4658
-2020-12-31,IS,Iceland,168.7444
-2020-12-31,IT,Italy,76.8214
+2020-12-31,ID,Indonesia,101.4023
+2020-12-31,IE,Ireland,121.8529
+2020-12-31,IL,Israel,154.4853
+2020-12-31,IN,India,165.2078
+2020-12-31,IS,Iceland,168.7502
+2020-12-31,IT,Italy,76.8251
 2020-12-31,JP,Japan,108.8926
-2020-12-31,KR,Korea,112.8528
+2020-12-31,KR,Korea,112.8457
 2020-12-31,LT,Lithuania,145.0123
-2020-12-31,LU,Luxembourg,171.7028
-2020-12-31,LV,Latvia,157.9013
-2020-12-31,MA,Morocco,99.928
-2020-12-31,MK,North Macedonia,86.7229
+2020-12-31,LU,Luxembourg,171.6775
+2020-12-31,LV,Latvia,157.9985
+2020-12-31,MA,Morocco,97.077
+2020-12-31,MK,North Macedonia,86.8202
 2020-12-31,MT,Malta,127.2461
 2020-12-31,MX,Mexico,128.4474
 2020-12-31,MY,Malaysia,165.7071
-2020-12-31,NL,Netherlands,112.265
-2020-12-31,NO,Norway,132.3382
+2020-12-31,NL,Netherlands,112.8903
+2020-12-31,NO,Norway,132.2949
 2020-12-31,NZ,New Zealand,181.9659
 2020-12-31,PE,Peru,132.1357
-2020-12-31,PH,Philippines,153.4142
+2020-12-31,PH,Philippines,155.7586
 2020-12-31,PL,Poland,110.3555
 2020-12-31,PT,Portugal,132.5093
 2020-12-31,RO,Romania,83.9652
-2020-12-31,RS,Serbia,103.6456
-2020-12-31,RU,Russia,59.2097
-2020-12-31,SE,Sweden,151.3285
-2020-12-31,SG,Singapore,103.1801
-2020-12-31,SI,Slovenia,106.4747
-2020-12-31,SK,Slovak Republic,129.3728
-2020-12-31,TH,Thailand,134.5123
-2020-12-31,TR,Türkiye,118.5725
-2020-12-31,US,United States,143.181
-2020-12-31,XM,Euro area,112.7823
-2020-12-31,XW,World,121.6966
-2020-12-31,ZA,South Africa,98.8587
-2021-03-31,4T,Emerging market economies (aggregate),117.1437
-2021-03-31,5R,Advanced economies,129.9945
-2021-03-31,AE,United Arab Emirates,105.2058
-2021-03-31,AT,Austria,155.5366
-2021-03-31,AU,Australia,123.6455
-2021-03-31,BE,Belgium,113.2106
-2021-03-31,BG,Bulgaria,117.2582
-2021-03-31,BR,Brazil,97.7875
-2021-03-31,CA,Canada,168.1633
-2021-03-31,CH,Switzerland,142.0723
-2021-03-31,CL,Chile,197.5719
+2020-12-31,RS,Serbia,109.2674
+2020-12-31,RU,Russia,59.2185
+2020-12-31,SE,Sweden,151.3301
+2020-12-31,SG,Singapore,103.1341
+2020-12-31,SI,Slovenia,106.476
+2020-12-31,SK,Slovakia,128.9483
+2020-12-31,TH,Thailand,142.317
+2020-12-31,TR,Türkiye,121.9683
+2020-12-31,US,United States,143.2557
+2020-12-31,XM,Euro area,112.6579
+2020-12-31,XW,World,121.3662
+2020-12-31,ZA,South Africa,96.6818
+2021-03-31,4T,Emerging market economies (aggregate),116.1965
+2021-03-31,5R,Advanced economies,129.488
+2021-03-31,AT,Austria,155.5367
+2021-03-31,AU,Australia,123.6324
+2021-03-31,BE,Belgium,112.6126
+2021-03-31,BG,Bulgaria,117.2827
+2021-03-31,BR,Brazil,97.5552
+2021-03-31,CA,Canada,167.5337
+2021-03-31,CH,Switzerland,142.0726
+2021-03-31,CL,Chile,197.9004
 2021-03-31,CN,China,110.5531
-2021-03-31,CO,Colombia,144.3237
+2021-03-31,CO,Colombia,141.9684
 2021-03-31,CY,Cyprus,78.5138
-2021-03-31,CZ,Czechia,145.2316
+2021-03-31,CZ,Czechia,145.3161
 2021-03-31,DE,Germany,148.7445
-2021-03-31,DK,Denmark,133.6192
+2021-03-31,DK,Denmark,133.6529
 2021-03-31,EE,Estonia,184.5691
-2021-03-31,ES,Spain,85.6374
+2021-03-31,ES,Spain,85.6376
 2021-03-31,FI,Finland,101.662
-2021-03-31,FR,France,108.3302
-2021-03-31,GB,United Kingdom,120.6621
+2021-03-31,FR,France,108.334
+2021-03-31,GB,United Kingdom,119.9913
 2021-03-31,GR,Greece,74.9826
 2021-03-31,HK,Hong Kong SAR,186.4898
-2021-03-31,HR,Croatia,109.9813
+2021-03-31,HR,Croatia,109.9931
 2021-03-31,HU,Hungary,162.5724
-2021-03-31,ID,Indonesia,100.9217
-2021-03-31,IE,Ireland,122.5917
-2021-03-31,IL,Israel,157.1338
-2021-03-31,IN,India,167.5383
-2021-03-31,IS,Iceland,171.8997
-2021-03-31,IT,Italy,76.9408
+2021-03-31,ID,Indonesia,100.8933
+2021-03-31,IE,Ireland,122.6536
+2021-03-31,IL,Israel,157.134
+2021-03-31,IN,India,167.2228
+2021-03-31,IS,Iceland,171.9056
+2021-03-31,IT,Italy,76.9429
 2021-03-31,JP,Japan,112.523
-2021-03-31,KR,Korea,115.8494
-2021-03-31,LT,Lithuania,150.9321
-2021-03-31,LU,Luxembourg,177.9091
-2021-03-31,LV,Latvia,158.7723
-2021-03-31,MA,Morocco,98.0944
-2021-03-31,MK,North Macedonia,88.102
+2021-03-31,KR,Korea,115.8442
+2021-03-31,LT,Lithuania,150.932
+2021-03-31,LU,Luxembourg,177.8882
+2021-03-31,LV,Latvia,158.7857
+2021-03-31,MA,Morocco,95.5117
+2021-03-31,MK,North Macedonia,88.0956
 2021-03-31,MT,Malta,126.092
 2021-03-31,MX,Mexico,129.6716
 2021-03-31,MY,Malaysia,162.6052
-2021-03-31,NL,Netherlands,116.3743
-2021-03-31,NO,Norway,137.4183
+2021-03-31,NL,Netherlands,116.5295
+2021-03-31,NO,Norway,137.4302
 2021-03-31,NZ,New Zealand,196.8574
 2021-03-31,PE,Peru,130.1122
-2021-03-31,PH,Philippines,147.9786
+2021-03-31,PH,Philippines,153.6671
 2021-03-31,PL,Poland,110.2567
 2021-03-31,PT,Portugal,136.3332
 2021-03-31,RO,Romania,84.2366
-2021-03-31,RS,Serbia,104.9115
-2021-03-31,RU,Russia,58.8966
-2021-03-31,SE,Sweden,155.5506
-2021-03-31,SG,Singapore,105.7492
-2021-03-31,SI,Slovenia,110.3742
-2021-03-31,SK,Slovak Republic,127.1161
-2021-03-31,TH,Thailand,133.3234
-2021-03-31,TR,Türkiye,121.4701
-2021-03-31,US,United States,146.1633
-2021-03-31,XM,Euro area,113.5473
-2021-03-31,XW,World,122.7947
-2021-03-31,ZA,South Africa,97.8953
-2021-06-30,4T,Emerging market economies (aggregate),118.3862
-2021-06-30,5R,Advanced economies,132.6067
-2021-06-30,AE,United Arab Emirates,107.8789
+2021-03-31,RS,Serbia,111.1511
+2021-03-31,RU,Russia,58.9033
+2021-03-31,SE,Sweden,155.5478
+2021-03-31,SG,Singapore,105.7039
+2021-03-31,SI,Slovenia,110.3768
+2021-03-31,SK,Slovakia,126.6944
+2021-03-31,TH,Thailand,144.022
+2021-03-31,TR,Türkiye,124.0829
+2021-03-31,US,United States,146.2052
+2021-03-31,XM,Euro area,113.3859
+2021-03-31,XW,World,122.4251
+2021-03-31,ZA,South Africa,97.4488
+2021-06-30,4T,Emerging market economies (aggregate),117.2676
+2021-06-30,5R,Advanced economies,132.0739
 2021-06-30,AT,Austria,157.55
-2021-06-30,AU,Australia,130.9311
-2021-06-30,BE,Belgium,114.3674
-2021-06-30,BG,Bulgaria,116.5457
-2021-06-30,BR,Brazil,97.6209
-2021-06-30,CA,Canada,176.8375
-2021-06-30,CH,Switzerland,144.1959
-2021-06-30,CL,Chile,201.7732
+2021-06-30,AU,Australia,130.957
+2021-06-30,BE,Belgium,113.9179
+2021-06-30,BG,Bulgaria,116.5109
+2021-06-30,BR,Brazil,97.3325
+2021-06-30,CA,Canada,176.1755
+2021-06-30,CH,Switzerland,144.1962
+2021-06-30,CL,Chile,202.1669
 2021-06-30,CN,China,112.6308
-2021-06-30,CO,Colombia,145.4983
+2021-06-30,CO,Colombia,142.7084
 2021-06-30,CY,Cyprus,76.9845
-2021-06-30,CZ,Czechia,151.2039
+2021-06-30,CZ,Czechia,151.2174
 2021-06-30,DE,Germany,152.7808
-2021-06-30,DK,Denmark,136.3869
+2021-06-30,DK,Denmark,136.4027
 2021-06-30,EE,Estonia,186.4331
-2021-06-30,ES,Spain,85.8483
+2021-06-30,ES,Spain,85.8482
 2021-06-30,FI,Finland,103.3056
-2021-06-30,FR,France,109.5674
-2021-06-30,GB,United Kingdom,121.2147
-2021-06-30,GR,Greece,75.634
+2021-06-30,FR,France,109.5723
+2021-06-30,GB,United Kingdom,120.442
+2021-06-30,GR,Greece,75.6339
 2021-06-30,HK,Hong Kong SAR,189.6816
-2021-06-30,HR,Croatia,112.0988
+2021-06-30,HR,Croatia,112.1243
 2021-06-30,HU,Hungary,166.1408
-2021-06-30,ID,Indonesia,100.8089
-2021-06-30,IE,Ireland,123.7242
-2021-06-30,IL,Israel,159.6311
-2021-06-30,IN,India,164.9822
-2021-06-30,IS,Iceland,178.1969
-2021-06-30,IT,Italy,77.7337
+2021-06-30,ID,Indonesia,100.8077
+2021-06-30,IE,Ireland,123.7376
+2021-06-30,IL,Israel,159.6321
+2021-06-30,IN,India,164.6467
+2021-06-30,IS,Iceland,178.2031
+2021-06-30,IT,Italy,77.733
 2021-06-30,JP,Japan,114.1395
-2021-06-30,KR,Korea,119.2947
+2021-06-30,KR,Korea,119.2727
 2021-06-30,LT,Lithuania,152.6017
-2021-06-30,LU,Luxembourg,177.7342
-2021-06-30,LV,Latvia,165.6265
-2021-06-30,MA,Morocco,92.1456
-2021-06-30,MK,North Macedonia,89.381
+2021-06-30,LU,Luxembourg,177.7199
+2021-06-30,LV,Latvia,165.6135
+2021-06-30,MA,Morocco,91.2457
+2021-06-30,MK,North Macedonia,89.5191
 2021-06-30,MT,Malta,127.5175
 2021-06-30,MX,Mexico,130.8693
 2021-06-30,MY,Malaysia,162.8951
-2021-06-30,NL,Netherlands,119.7394
-2021-06-30,NO,Norway,143.3745
+2021-06-30,NL,Netherlands,120.3924
+2021-06-30,NO,Norway,143.3648
 2021-06-30,NZ,New Zealand,201.3281
 2021-06-30,PE,Peru,129.7524
-2021-06-30,PH,Philippines,155.3172
+2021-06-30,PH,Philippines,158.4439
 2021-06-30,PL,Poland,111.5602
 2021-06-30,PT,Portugal,138.3465
 2021-06-30,RO,Romania,85.0666
-2021-06-30,RS,Serbia,105.5307
-2021-06-30,RU,Russia,60.2526
-2021-06-30,SE,Sweden,160.0747
-2021-06-30,SG,Singapore,105.8522
-2021-06-30,SI,Slovenia,112.9715
-2021-06-30,SK,Slovak Republic,129.476
-2021-06-30,TH,Thailand,133.3662
-2021-06-30,TR,Türkiye,127.2534
-2021-06-30,US,United States,149.706
-2021-06-30,XM,Euro area,114.8979
-2021-06-30,XW,World,124.6169
-2021-06-30,ZA,South Africa,97.3285
-2021-09-30,4T,Emerging market economies (aggregate),118.7435
-2021-09-30,5R,Advanced economies,135.8438
-2021-09-30,AE,United Arab Emirates,111.3549
+2021-06-30,RS,Serbia,112.3856
+2021-06-30,RU,Russia,60.2644
+2021-06-30,SE,Sweden,160.0786
+2021-06-30,SG,Singapore,105.8037
+2021-06-30,SI,Slovenia,112.9723
+2021-06-30,SK,Slovakia,129.0599
+2021-06-30,TH,Thailand,144.0713
+2021-06-30,TR,Türkiye,128.9773
+2021-06-30,US,United States,149.5856
+2021-06-30,XM,Euro area,114.7586
+2021-06-30,XW,World,124.1821
+2021-06-30,ZA,South Africa,97.6502
+2021-09-30,4T,Emerging market economies (aggregate),117.3086
+2021-09-30,5R,Advanced economies,135.2056
 2021-09-30,AT,Austria,159.8272
-2021-09-30,AU,Australia,136.4751
-2021-09-30,BE,Belgium,116.2082
-2021-09-30,BG,Bulgaria,118.6887
-2021-09-30,BR,Brazil,96.4719
-2021-09-30,CA,Canada,178.5126
-2021-09-30,CH,Switzerland,147.263
-2021-09-30,CL,Chile,201.6152
+2021-09-30,AU,Australia,136.3786
+2021-09-30,BE,Belgium,115.3707
+2021-09-30,BG,Bulgaria,118.7139
+2021-09-30,BR,Brazil,96.1439
+2021-09-30,CA,Canada,177.8443
+2021-09-30,CH,Switzerland,147.2633
+2021-09-30,CL,Chile,201.7403
 2021-09-30,CN,China,112.9908
-2021-09-30,CO,Colombia,146.0386
+2021-09-30,CO,Colombia,142.9478
 2021-09-30,CY,Cyprus,76.2411
-2021-09-30,CZ,Czechia,158.4602
+2021-09-30,CZ,Czechia,158.5331
 2021-09-30,DE,Germany,157.7869
-2021-09-30,DK,Denmark,136.816
+2021-09-30,DK,Denmark,136.8435
 2021-09-30,EE,Estonia,186.9596
 2021-09-30,ES,Spain,87.4019
 2021-09-30,FI,Finland,102.4113
-2021-09-30,FR,France,112.2212
-2021-09-30,GB,United Kingdom,122.3296
+2021-09-30,FR,France,112.2253
+2021-09-30,GB,United Kingdom,121.4089
 2021-09-30,GR,Greece,77.9059
 2021-09-30,HK,Hong Kong SAR,193.6996
-2021-09-30,HR,Croatia,113.24
-2021-09-30,HU,Hungary,170.1468
-2021-09-30,ID,Indonesia,100.9896
-2021-09-30,IE,Ireland,128.5703
-2021-09-30,IL,Israel,162.5963
-2021-09-30,IN,India,160.8375
-2021-09-30,IS,Iceland,183.1858
-2021-09-30,IT,Italy,77.9912
+2021-09-30,HR,Croatia,113.285
+2021-09-30,HU,Hungary,170.1469
+2021-09-30,ID,Indonesia,100.9689
+2021-09-30,IE,Ireland,128.5944
+2021-09-30,IL,Israel,162.5966
+2021-09-30,IN,India,160.5066
+2021-09-30,IS,Iceland,183.192
+2021-09-30,IT,Italy,77.9923
 2021-09-30,JP,Japan,116.449
-2021-09-30,KR,Korea,123.1131
+2021-09-30,KR,Korea,123.1007
 2021-09-30,LT,Lithuania,157.651
-2021-09-30,LU,Luxembourg,181.5434
-2021-09-30,LV,Latvia,169.3839
-2021-09-30,MA,Morocco,91.0593
-2021-09-30,MK,North Macedonia,88.6111
+2021-09-30,LU,Luxembourg,181.523
+2021-09-30,LV,Latvia,169.41
+2021-09-30,MA,Morocco,88.4018
+2021-09-30,MK,North Macedonia,88.6049
 2021-09-30,MT,Malta,129.8925
 2021-09-30,MX,Mexico,131.3621
 2021-09-30,MY,Malaysia,163.1997
-2021-09-30,NL,Netherlands,125.5218
-2021-09-30,NO,Norway,140.8519
+2021-09-30,NL,Netherlands,125.9581
+2021-09-30,NO,Norway,140.7633
 2021-09-30,NZ,New Zealand,207.1979
 2021-09-30,PE,Peru,124.7887
-2021-09-30,PH,Philippines,155.0056
+2021-09-30,PH,Philippines,158.3397
 2021-09-30,PL,Poland,113.2813
-2021-09-30,PT,Portugal,142.4167
+2021-09-30,PT,Portugal,142.4168
 2021-09-30,RO,Romania,83.5813
-2021-09-30,RS,Serbia,107.0592
-2021-09-30,RU,Russia,61.509
-2021-09-30,SE,Sweden,162.7346
-2021-09-30,SG,Singapore,106.4112
-2021-09-30,SI,Slovenia,114.6325
-2021-09-30,SK,Slovak Republic,133.2974
-2021-09-30,TH,Thailand,135.2625
-2021-09-30,TR,Türkiye,134.1761
-2021-09-30,US,United States,153.8053
-2021-09-30,XM,Euro area,117.9585
-2021-09-30,XW,World,126.1823
-2021-09-30,ZA,South Africa,97.0699
-2021-12-31,4T,Emerging market economies (aggregate),118.9414
-2021-12-31,5R,Advanced economies,137.3668
-2021-12-31,AE,United Arab Emirates,112.0104
+2021-09-30,RS,Serbia,114.7509
+2021-09-30,RU,Russia,61.5081
+2021-09-30,SE,Sweden,162.7373
+2021-09-30,SG,Singapore,106.3555
+2021-09-30,SI,Slovenia,114.6304
+2021-09-30,SK,Slovakia,132.8882
+2021-09-30,TH,Thailand,146.57
+2021-09-30,TR,Türkiye,135.1061
+2021-09-30,US,United States,153.4163
+2021-09-30,XM,Euro area,117.7698
+2021-09-30,XW,World,125.6109
+2021-09-30,ZA,South Africa,97.1341
+2021-12-31,4T,Emerging market economies (aggregate),116.9833
+2021-12-31,5R,Advanced economies,136.7595
 2021-12-31,AT,Austria,162.4088
-2021-12-31,AU,Australia,141.0406
-2021-12-31,BE,Belgium,113.7048
-2021-12-31,BG,Bulgaria,117.2925
-2021-12-31,BR,Brazil,94.3331
-2021-12-31,CA,Canada,180.343
-2021-12-31,CH,Switzerland,150.5775
-2021-12-31,CL,Chile,206.6326
+2021-12-31,AU,Australia,141.0273
+2021-12-31,BE,Belgium,113.2305
+2021-12-31,BG,Bulgaria,117.2995
+2021-12-31,BR,Brazil,93.9977
+2021-12-31,CA,Canada,179.6678
+2021-12-31,CH,Switzerland,150.5779
+2021-12-31,CL,Chile,205.669
 2021-12-31,CN,China,111.0876
-2021-12-31,CO,Colombia,145.3986
+2021-12-31,CO,Colombia,142.2227
 2021-12-31,CY,Cyprus,76.0699
-2021-12-31,CZ,Czechia,164.8007
+2021-12-31,CZ,Czechia,164.7857
 2021-12-31,DE,Germany,160.595
-2021-12-31,DK,Denmark,132.6232
+2021-12-31,DK,Denmark,132.6501
 2021-12-31,EE,Estonia,193.0393
-2021-12-31,ES,Spain,85.7609
+2021-12-31,ES,Spain,85.7608
 2021-12-31,FI,Finland,101.2586
-2021-12-31,FR,France,112.506
-2021-12-31,GB,United Kingdom,122.1418
+2021-12-31,FR,France,112.5061
+2021-12-31,GB,United Kingdom,121.0006
 2021-12-31,GR,Greece,75.8914
 2021-12-31,HK,Hong Kong SAR,189.3652
-2021-12-31,HR,Croatia,113.6753
+2021-12-31,HR,Croatia,113.7057
 2021-12-31,HU,Hungary,173.3456
-2021-12-31,ID,Indonesia,100.8524
-2021-12-31,IE,Ireland,131.7353
-2021-12-31,IL,Israel,168.4199
-2021-12-31,IN,India,162.4924
-2021-12-31,IS,Iceland,186.5015
-2021-12-31,IT,Italy,77.1591
+2021-12-31,ID,Indonesia,100.8287
+2021-12-31,IE,Ireland,131.7516
+2021-12-31,IL,Israel,168.4205
+2021-12-31,IN,India,162.1969
+2021-12-31,IS,Iceland,186.5079
+2021-12-31,IT,Italy,77.1593
 2021-12-31,JP,Japan,115.7422
-2021-12-31,KR,Korea,126.0981
-2021-12-31,LT,Lithuania,159.0404
-2021-12-31,LU,Luxembourg,184.935
-2021-12-31,LV,Latvia,171.1556
-2021-12-31,MA,Morocco,90.2428
-2021-12-31,MK,North Macedonia,92.3172
+2021-12-31,KR,Korea,126.145
+2021-12-31,LT,Lithuania,159.0405
+2021-12-31,LU,Luxembourg,184.9205
+2021-12-31,LV,Latvia,171.1651
+2021-12-31,MA,Morocco,87.9482
+2021-12-31,MK,North Macedonia,92.485
 2021-12-31,MT,Malta,129.8328
 2021-12-31,MX,Mexico,130.3188
 2021-12-31,MY,Malaysia,163.6655
-2021-12-31,NL,Netherlands,127.2204
-2021-12-31,NO,Norway,136.5696
+2021-12-31,NL,Netherlands,127.7308
+2021-12-31,NO,Norway,136.5252
 2021-12-31,NZ,New Zealand,216.2783
 2021-12-31,PE,Peru,120.9654
-2021-12-31,PH,Philippines,155.3913
+2021-12-31,PH,Philippines,159.9433
 2021-12-31,PL,Poland,114.6312
 2021-12-31,PT,Portugal,144.4167
 2021-12-31,RO,Romania,83.8378
-2021-12-31,RS,Serbia,108.0236
-2021-12-31,RU,Russia,62.8408
-2021-12-31,SE,Sweden,162.4365
-2021-12-31,SG,Singapore,110.0357
-2021-12-31,SI,Slovenia,118.3411
-2021-12-31,SK,Slovak Republic,135.7456
-2021-12-31,TH,Thailand,134.4897
-2021-12-31,TR,Türkiye,150.482
-2021-12-31,US,United States,157.5557
-2021-12-31,XM,Euro area,118.1383
-2021-12-31,XW,World,126.9299
-2021-12-31,ZA,South Africa,97.0147
-2022-03-31,4T,Emerging market economies (aggregate),118.9983
-2022-03-31,5R,Advanced economies,139.8619
-2022-03-31,AE,United Arab Emirates,113.4262
+2021-12-31,RS,Serbia,116.3704
+2021-12-31,RU,Russia,62.8475
+2021-12-31,SE,Sweden,162.4337
+2021-12-31,SG,Singapore,109.9756
+2021-12-31,SI,Slovenia,118.3465
+2021-12-31,SK,Slovakia,135.3433
+2021-12-31,TH,Thailand,143.1707
+2021-12-31,TR,Türkiye,144.593
+2021-12-31,US,United States,156.9861
+2021-12-31,XM,Euro area,117.94
+2021-12-31,XW,World,126.1182
+2021-12-31,ZA,South Africa,97.1429
+2022-03-31,4T,Emerging market economies (aggregate),117.0103
+2022-03-31,5R,Advanced economies,138.7453
 2022-03-31,AT,Austria,165.1219
-2022-03-31,AU,Australia,141.8813
-2022-03-31,BE,Belgium,111.6189
-2022-03-31,BG,Bulgaria,118.3005
-2022-03-31,BR,Brazil,92.4227
-2022-03-31,CA,Canada,199.4965
-2022-03-31,CH,Switzerland,148.9094
-2022-03-31,CL,Chile,196.9032
+2022-03-31,AU,Australia,141.8381
+2022-03-31,BE,Belgium,110.7734
+2022-03-31,BG,Bulgaria,118.3077
+2022-03-31,BR,Brazil,92.1329
+2022-03-31,CA,Canada,198.607
+2022-03-31,CH,Switzerland,148.9098
+2022-03-31,CL,Chile,196.2268
 2022-03-31,CN,China,109.3304
-2022-03-31,CO,Colombia,145.2642
+2022-03-31,CO,Colombia,142.2037
 2022-03-31,CY,Cyprus,76.1672
-2022-03-31,CZ,Czechia,162.5611
-2022-03-31,DE,Germany,158.4231
-2022-03-31,DK,Denmark,132.7398
+2022-03-31,CZ,Czechia,162.6418
+2022-03-31,DE,Germany,159.2513
+2022-03-31,DK,Denmark,132.7634
 2022-03-31,EE,Estonia,197.8654
-2022-03-31,ES,Spain,86.1696
-2022-03-31,FI,Finland,100.0867
-2022-03-31,FR,France,111.8103
-2022-03-31,GB,United Kingdom,123.6345
+2022-03-31,ES,Spain,86.17
+2022-03-31,FI,Finland,99.8191
+2022-03-31,FR,France,111.8132
+2022-03-31,GB,United Kingdom,122.2217
 2022-03-31,GR,Greece,76.7863
 2022-03-31,HK,Hong Kong SAR,183.5552
-2022-03-31,HR,Croatia,117.2538
+2022-03-31,HR,Croatia,117.2845
 2022-03-31,HU,Hungary,185.0115
-2022-03-31,ID,Indonesia,100.2188
-2022-03-31,IE,Ireland,133.2234
-2022-03-31,IL,Israel,175.1366
-2022-03-31,IN,India,160.3741
-2022-03-31,IS,Iceland,192.788
-2022-03-31,IT,Italy,76.1252
+2022-03-31,ID,Indonesia,100.1885
+2022-03-31,IE,Ireland,133.2734
+2022-03-31,IL,Israel,175.1374
+2022-03-31,IN,India,160.0698
+2022-03-31,IS,Iceland,192.7946
+2022-03-31,IT,Italy,76.1277
 2022-03-31,JP,Japan,121.6617
-2022-03-31,KR,Korea,125.6504
-2022-03-31,LT,Lithuania,157.5921
-2022-03-31,LU,Luxembourg,186.0116
-2022-03-31,LV,Latvia,170.6452
-2022-03-31,MA,Morocco,89.1715
-2022-03-31,MK,North Macedonia,91.9239
+2022-03-31,KR,Korea,125.5399
+2022-03-31,LT,Lithuania,157.5922
+2022-03-31,LU,Luxembourg,185.9956
+2022-03-31,LV,Latvia,170.691
+2022-03-31,MA,Morocco,86.9851
+2022-03-31,MK,North Macedonia,91.9744
 2022-03-31,MT,Malta,129.2717
 2022-03-31,MX,Mexico,130.2439
 2022-03-31,MY,Malaysia,162.8527
-2022-03-31,NL,Netherlands,129.2216
-2022-03-31,NO,Norway,141.8917
+2022-03-31,NL,Netherlands,129.0916
+2022-03-31,NO,Norway,141.854
 2022-03-31,NZ,New Zealand,209.1248
 2022-03-31,PE,Peru,119.9112
-2022-03-31,PH,Philippines,151.4093
+2022-03-31,PH,Philippines,162.2014
 2022-03-31,PL,Poland,114.1316
-2022-03-31,PT,Portugal,147.6513
+2022-03-31,PT,Portugal,147.6512
 2022-03-31,RO,Romania,82.5809
-2022-03-31,RS,Serbia,109.4674
-2022-03-31,RU,Russia,69.9618
-2022-03-31,SE,Sweden,163.9687
-2022-03-31,SG,Singapore,108.9783
-2022-03-31,SI,Slovenia,121.8437
-2022-03-31,SK,Slovak Republic,132.7873
-2022-03-31,TH,Thailand,132.595
-2022-03-31,TR,Türkiye,164.8572
-2022-03-31,US,United States,161.305
-2022-03-31,XM,Euro area,117.5069
-2022-03-31,XW,World,127.9859
-2022-03-31,ZA,South Africa,96.2654
-2022-06-30,4T,Emerging market economies (aggregate),118.1466
-2022-06-30,5R,Advanced economies,138.867
-2022-06-30,AE,United Arab Emirates,112.1795
+2022-03-31,RS,Serbia,118.3328
+2022-03-31,RU,Russia,69.9602
+2022-03-31,SE,Sweden,163.9677
+2022-03-31,SG,Singapore,108.9188
+2022-03-31,SI,Slovenia,121.8498
+2022-03-31,SK,Slovakia,132.4013
+2022-03-31,TH,Thailand,141.3756
+2022-03-31,TR,Türkiye,154.1157
+2022-03-31,US,United States,159.9398
+2022-03-31,XM,Euro area,117.4907
+2022-03-31,XW,World,127.0037
+2022-03-31,ZA,South Africa,96.9232
+2022-06-30,4T,Emerging market economies (aggregate),116.0445
+2022-06-30,5R,Advanced economies,137.661
 2022-06-30,AT,Austria,165.2386
-2022-06-30,AU,Australia,139.8042
-2022-06-30,BE,Belgium,111.1754
-2022-06-30,BG,Bulgaria,115.5281
-2022-06-30,BR,Brazil,89.893
-2022-06-30,CA,Canada,189.5877
-2022-06-30,CH,Switzerland,150.53
-2022-06-30,CL,Chile,196.6078
+2022-06-30,AU,Australia,139.772
+2022-06-30,BE,Belgium,110.7344
+2022-06-30,BG,Bulgaria,115.5325
+2022-06-30,BR,Brazil,89.7296
+2022-06-30,CA,Canada,187.6682
+2022-06-30,CH,Switzerland,150.5303
+2022-06-30,CL,Chile,194.2804
 2022-06-30,CN,China,107.8288
-2022-06-30,CO,Colombia,142.9431
+2022-06-30,CO,Colombia,139.6218
 2022-06-30,CY,Cyprus,73.8005
-2022-06-30,CZ,Czechia,159.7212
-2022-06-30,DE,Germany,157.0124
-2022-06-30,DK,Denmark,130.2348
+2022-06-30,CZ,Czechia,159.8639
+2022-06-30,DE,Germany,157.8981
+2022-06-30,DK,Denmark,130.2532
 2022-06-30,EE,Estonia,197.4212
-2022-06-30,ES,Spain,85.0242
-2022-06-30,FI,Finland,98.9588
-2022-06-30,FR,France,111.1144
-2022-06-30,GB,United Kingdom,121.6522
-2022-06-30,GR,Greece,75.4158
+2022-06-30,ES,Spain,85.0245
+2022-06-30,FI,Finland,98.698
+2022-06-30,FR,France,111.1164
+2022-06-30,GB,United Kingdom,120.1854
+2022-06-30,GR,Greece,75.4159
 2022-06-30,HK,Hong Kong SAR,182.7035
-2022-06-30,HR,Croatia,114.9515
+2022-06-30,HR,Croatia,114.9772
 2022-06-30,HU,Hungary,187.5193
-2022-06-30,ID,Indonesia,98.7305
-2022-06-30,IE,Ireland,130.9444
-2022-06-30,IL,Israel,180.0222
-2022-06-30,IN,India,158.9494
-2022-06-30,IS,Iceland,202.9584
-2022-06-30,IT,Italy,76.4551
+2022-06-30,ID,Indonesia,98.7306
+2022-06-30,IE,Ireland,130.9449
+2022-06-30,IL,Israel,180.0225
+2022-06-30,IN,India,158.6761
+2022-06-30,IS,Iceland,202.9654
+2022-06-30,IT,Italy,76.4556
 2022-06-30,JP,Japan,121.7397
-2022-06-30,KR,Korea,123.7842
-2022-06-30,LT,Lithuania,156.6324
-2022-06-30,LU,Luxembourg,185.4006
-2022-06-30,LV,Latvia,165.5111
-2022-06-30,MA,Morocco,86.3669
-2022-06-30,MK,North Macedonia,92.7305
+2022-06-30,KR,Korea,123.8105
+2022-06-30,LT,Lithuania,156.6323
+2022-06-30,LU,Luxembourg,185.376
+2022-06-30,LV,Latvia,165.5877
+2022-06-30,MA,Morocco,84.1735
+2022-06-30,MK,North Macedonia,92.8842
 2022-06-30,MT,Malta,129.4702
 2022-06-30,MX,Mexico,131.1043
 2022-06-30,MY,Malaysia,162.5384
-2022-06-30,NL,Netherlands,129.8612
-2022-06-30,NO,Norway,144.0894
+2022-06-30,NL,Netherlands,129.841
+2022-06-30,NO,Norway,144.0209
 2022-06-30,NZ,New Zealand,197.2147
 2022-06-30,PE,Peru,117.8188
-2022-06-30,PH,Philippines,151.1119
+2022-06-30,PH,Philippines,164.7229
 2022-06-30,PL,Poland,109.9889
 2022-06-30,PT,Portugal,144.9951
 2022-06-30,RO,Romania,80.4358
-2022-06-30,RS,Serbia,109.416
-2022-06-30,RU,Russia,66.7025
+2022-06-30,RS,Serbia,118.3274
+2022-06-30,RU,Russia,66.7007
 2022-06-30,SE,Sweden,159.5052
-2022-06-30,SG,Singapore,110.5894
-2022-06-30,SI,Slovenia,120.3181
-2022-06-30,SK,Slovak Republic,134.2133
-2022-06-30,TH,Thailand,131.8344
-2022-06-30,TR,Türkiye,190.567
-2022-06-30,US,United States,161.3458
-2022-06-30,XM,Euro area,116.1592
-2022-06-30,XW,World,127.0724
-2022-06-30,ZA,South Africa,94.7553
-2022-09-30,4T,Emerging market economies (aggregate),117.9278
-2022-09-30,5R,Advanced economies,136.5866
-2022-09-30,AE,United Arab Emirates,112.4027
+2022-06-30,SG,Singapore,110.5248
+2022-06-30,SI,Slovenia,120.3165
+2022-06-30,SK,Slovakia,133.7697
+2022-06-30,TH,Thailand,140.1493
+2022-06-30,TR,Türkiye,180.2502
+2022-06-30,US,United States,159.6711
+2022-06-30,XM,Euro area,116.2265
+2022-06-30,XW,World,125.9819
+2022-06-30,ZA,South Africa,95.7073
+2022-09-30,4T,Emerging market economies (aggregate),116.3875
+2022-09-30,5R,Advanced economies,135.6172
 2022-09-30,AT,Austria,161.2757
-2022-09-30,AU,Australia,132.5326
-2022-09-30,BE,Belgium,111.0095
-2022-09-30,BG,Bulgaria,116.3716
-2022-09-30,BR,Brazil,90.3566
-2022-09-30,CA,Canada,171.2987
-2022-09-30,CH,Switzerland,151.444
-2022-09-30,CL,Chile,191.3788
+2022-09-30,AU,Australia,132.5022
+2022-09-30,BE,Belgium,110.2697
+2022-09-30,BG,Bulgaria,116.3476
+2022-09-30,BR,Brazil,90.4373
+2022-09-30,CA,Canada,169.2519
+2022-09-30,CH,Switzerland,151.4443
+2022-09-30,CL,Chile,191.918
 2022-09-30,CN,China,106.4509
-2022-09-30,CO,Colombia,141.5968
+2022-09-30,CO,Colombia,137.8117
 2022-09-30,CY,Cyprus,74.0046
-2022-09-30,CZ,Czechia,155.7877
-2022-09-30,DE,Germany,153.4093
-2022-09-30,DK,Denmark,122.6887
+2022-09-30,CZ,Czechia,155.8373
+2022-09-30,DE,Germany,154.3602
+2022-09-30,DK,Denmark,122.7242
 2022-09-30,EE,Estonia,187.5923
 2022-09-30,ES,Spain,85.4797
-2022-09-30,FI,Finland,96.2873
-2022-09-30,FR,France,112.8255
-2022-09-30,GB,United Kingdom,123.7211
-2022-09-30,GR,Greece,78.5657
+2022-09-30,FI,Finland,96.1159
+2022-09-30,FR,France,112.8278
+2022-09-30,GB,United Kingdom,122.4408
+2022-09-30,GR,Greece,78.5656
 2022-09-30,HK,Hong Kong SAR,174.6389
-2022-09-30,HR,Croatia,115.6313
+2022-09-30,HR,Croatia,115.6638
 2022-09-30,HU,Hungary,181.3082
-2022-09-30,ID,Indonesia,97.863
-2022-09-30,IE,Ireland,132.3538
-2022-09-30,IL,Israel,185.5321
-2022-09-30,IN,India,157.0842
-2022-09-30,IS,Iceland,204.8306
-2022-09-30,IT,Italy,74.0326
+2022-09-30,ID,Indonesia,97.8429
+2022-09-30,IE,Ireland,132.3715
+2022-09-30,IL,Israel,185.5328
+2022-09-30,IN,India,159.9862
+2022-09-30,IS,Iceland,204.8376
+2022-09-30,IT,Italy,74.0357
 2022-09-30,JP,Japan,122.0932
-2022-09-30,KR,Korea,122.3957
+2022-09-30,KR,Korea,122.4332
 2022-09-30,LT,Lithuania,153.2297
-2022-09-30,LU,Luxembourg,188.7292
-2022-09-30,LV,Latvia,158.0525
-2022-09-30,MA,Morocco,85.2507
-2022-09-30,MK,North Macedonia,91.7146
+2022-09-30,LU,Luxembourg,188.7039
+2022-09-30,LV,Latvia,158.1311
+2022-09-30,MA,Morocco,83.093
+2022-09-30,MK,North Macedonia,91.7883
 2022-09-30,MT,Malta,128.9473
 2022-09-30,MX,Mexico,132.4609
 2022-09-30,MY,Malaysia,164.1916
-2022-09-30,NL,Netherlands,125.3944
-2022-09-30,NO,Norway,138.3371
+2022-09-30,NL,Netherlands,125.7396
+2022-09-30,NO,Norway,138.3226
 2022-09-30,NZ,New Zealand,186.1785
 2022-09-30,PE,Peru,115.0823
-2022-09-30,PH,Philippines,154.9895
+2022-09-30,PH,Philippines,169.3081
 2022-09-30,PL,Poland,109.1493
 2022-09-30,PT,Portugal,147.7046
 2022-09-30,RO,Romania,77.2984
-2022-09-30,RS,Serbia,109.0229
-2022-09-30,RU,Russia,68.2358
-2022-09-30,SE,Sweden,150.0202
-2022-09-30,SG,Singapore,112.6366
-2022-09-30,SI,Slovenia,119.308
-2022-09-30,SK,Slovak Republic,134.0061
-2022-09-30,TH,Thailand,130.6039
-2022-09-30,TR,Türkiye,214.1822
-2022-09-30,US,United States,157.9778
-2022-09-30,XM,Euro area,115.1937
-2022-09-30,XW,World,126.0162
-2022-09-30,ZA,South Africa,93.1363
-2022-12-31,4T,Emerging market economies (aggregate),117.3853
-2022-12-31,5R,Advanced economies,133.5423
-2022-12-31,AE,United Arab Emirates,115.2842
+2022-09-30,RS,Serbia,117.9761
+2022-09-30,RU,Russia,68.2436
+2022-09-30,SE,Sweden,150.0183
+2022-09-30,SG,Singapore,112.5732
+2022-09-30,SI,Slovenia,119.3097
+2022-09-30,SK,Slovakia,133.647
+2022-09-30,TH,Thailand,138.4935
+2022-09-30,TR,Türkiye,209.2756
+2022-09-30,US,United States,156.7072
+2022-09-30,XM,Euro area,115.2578
+2022-09-30,XW,World,125.2885
+2022-09-30,ZA,South Africa,93.9465
+2022-12-31,4T,Emerging market economies (aggregate),115.8347
+2022-12-31,5R,Advanced economies,132.7287
 2022-12-31,AT,Austria,154.5522
-2022-12-31,AU,Australia,126.7409
-2022-12-31,BE,Belgium,107.2464
-2022-12-31,BG,Bulgaria,113.5471
-2022-12-31,BR,Brazil,89.7527
-2022-12-31,CA,Canada,162.596
-2022-12-31,CH,Switzerland,153.3211
-2022-12-31,CL,Chile,191.4374
+2022-12-31,AU,Australia,126.7314
+2022-12-31,BE,Belgium,106.6383
+2022-12-31,BG,Bulgaria,113.5231
+2022-12-31,BR,Brazil,90.2402
+2022-12-31,CA,Canada,160.5654
+2022-12-31,CH,Switzerland,153.3214
+2022-12-31,CL,Chile,190.9661
 2022-12-31,CN,China,105.0432
-2022-12-31,CO,Colombia,136.7684
+2022-12-31,CO,Colombia,133.1677
 2022-12-31,CY,Cyprus,74.7536
-2022-12-31,CZ,Czechia,152.3084
-2022-12-31,DE,Germany,142.6217
-2022-12-31,DK,Denmark,113.5574
+2022-12-31,CZ,Czechia,152.3569
+2022-12-31,DE,Germany,144.253
+2022-12-31,DK,Denmark,113.5591
 2022-12-31,EE,Estonia,187.3057
-2022-12-31,ES,Spain,84.8562
+2022-12-31,ES,Spain,84.8561
 2022-12-31,FI,Finland,90.8526
-2022-12-31,FR,France,111.0625
-2022-12-31,GB,United Kingdom,120.3173
-2022-12-31,GR,Greece,79.8881
+2022-12-31,FR,France,111.0659
+2022-12-31,GB,United Kingdom,119.1114
+2022-12-31,GR,Greece,80.0765
 2022-12-31,HK,Hong Kong SAR,160.7623
-2022-12-31,HR,Croatia,117.733
-2022-12-31,HU,Hungary,165.5063
-2022-12-31,ID,Indonesia,97.4703
-2022-12-31,IE,Ireland,131.487
-2022-12-31,IL,Israel,186.8648
-2022-12-31,IN,India,157.4219
-2022-12-31,IS,Iceland,204.9629
-2022-12-31,IT,Italy,70.9075
+2022-12-31,HR,Croatia,117.8111
+2022-12-31,HU,Hungary,165.9559
+2022-12-31,ID,Indonesia,97.4461
+2022-12-31,IE,Ireland,131.5078
+2022-12-31,IL,Israel,186.8654
+2022-12-31,IN,India,159.7076
+2022-12-31,IS,Iceland,204.97
+2022-12-31,IT,Italy,70.9097
 2022-12-31,JP,Japan,119.8312
-2022-12-31,KR,Korea,119.7316
-2022-12-31,LT,Lithuania,150.36
-2022-12-31,LU,Luxembourg,183.9971
-2022-12-31,LV,Latvia,153.0569
-2022-12-31,MA,Morocco,83.4374
-2022-12-31,MK,North Macedonia,93.2216
+2022-12-31,KR,Korea,119.7853
+2022-12-31,LT,Lithuania,150.3601
+2022-12-31,LU,Luxembourg,183.969
+2022-12-31,LV,Latvia,153.1002
+2022-12-31,MA,Morocco,82.0849
+2022-12-31,MK,North Macedonia,93.321
 2022-12-31,MT,Malta,128.12
 2022-12-31,MX,Mexico,133.2171
 2022-12-31,MY,Malaysia,163.6338
-2022-12-31,NL,Netherlands,120.4763
-2022-12-31,NO,Norway,131.4201
+2022-12-31,NL,Netherlands,121.3061
+2022-12-31,NO,Norway,131.3603
 2022-12-31,NZ,New Zealand,179.9556
 2022-12-31,PE,Peru,113.3167
-2022-12-31,PH,Philippines,155.141
+2022-12-31,PH,Philippines,167.4026
 2022-12-31,PL,Poland,106.7396
 2022-12-31,PT,Portugal,146.3205
 2022-12-31,RO,Romania,76.8874
-2022-12-31,RS,Serbia,107.9781
-2022-12-31,RU,Russia,68.9297
-2022-12-31,SE,Sweden,140.2261
-2022-12-31,SG,Singapore,112.0944
-2022-12-31,SI,Slovenia,120.0008
-2022-12-31,SK,Slovak Republic,129.2961
-2022-12-31,TH,Thailand,133.1587
-2022-12-31,TR,Türkiye,227.2557
-2022-12-31,US,United States,157.4611
-2022-12-31,XM,Euro area,110.5908
-2022-12-31,XW,World,124.4482
-2022-12-31,ZA,South Africa,93.1713
-2023-03-31,4T,Emerging market economies (aggregate),116.8961
-2023-03-31,5R,Advanced economies,133.0387
-2023-03-31,AE,United Arab Emirates,122.3506
+2022-12-31,RS,Serbia,116.7632
+2022-12-31,RU,Russia,68.9329
+2022-12-31,SE,Sweden,140.2313
+2022-12-31,SG,Singapore,112.0231
+2022-12-31,SI,Slovenia,120.0031
+2022-12-31,SK,Slovakia,128.877
+2022-12-31,TH,Thailand,141.0859
+2022-12-31,TR,Türkiye,220.4896
+2022-12-31,US,United States,156.6899
+2022-12-31,XM,Euro area,110.7033
+2022-12-31,XW,World,123.7082
+2022-12-31,ZA,South Africa,93.6511
+2023-03-31,4T,Emerging market economies (aggregate),115.0048
+2023-03-31,5R,Advanced economies,131.8949
 2023-03-31,AT,Austria,151.1036
-2023-03-31,AU,Australia,124.4049
-2023-03-31,BE,Belgium,108.7538
-2023-03-31,BG,Bulgaria,112.0866
-2023-03-31,BR,Brazil,88.1793
-2023-03-31,CA,Canada,161.8289
-2023-03-31,CH,Switzerland,149.9552
-2023-03-31,CL,Chile,190.3931
+2023-03-31,AU,Australia,124.4225
+2023-03-31,BE,Belgium,107.4156
+2023-03-31,BG,Bulgaria,112.084
+2023-03-31,BR,Brazil,89.265
+2023-03-31,CA,Canada,159.7024
+2023-03-31,CH,Switzerland,149.9556
+2023-03-31,CL,Chile,190.1624
 2023-03-31,CN,China,104.3427
-2023-03-31,CO,Colombia,139.6091
+2023-03-31,CO,Colombia,135.3757
 2023-03-31,CY,Cyprus,76.9943
-2023-03-31,CZ,Czechia,140.6765
-2023-03-31,DE,Germany,136.4207
-2023-03-31,DK,Denmark,113.9054
+2023-03-31,CZ,Czechia,140.706
+2023-03-31,DE,Germany,137.7979
+2023-03-31,DK,Denmark,118.8363
 2023-03-31,EE,Estonia,184.4707
 2023-03-31,ES,Spain,84.9326
-2023-03-31,FI,Finland,87.6533
-2023-03-31,FR,France,108.5265
-2023-03-31,GB,United Kingdom,116.4446
-2023-03-31,GR,Greece,83.6631
+2023-03-31,FI,Finland,87.0771
+2023-03-31,FR,France,108.5261
+2023-03-31,GB,United Kingdom,115.3541
+2023-03-31,GR,Greece,83.8519
 2023-03-31,HK,Hong Kong SAR,161.6107
-2023-03-31,HR,Croatia,119.5665
-2023-03-31,HU,Hungary,162.8533
-2023-03-31,ID,Indonesia,96.937
-2023-03-31,IE,Ireland,129.6905
-2023-03-31,IL,Israel,185.2239
-2023-03-31,IN,India,157.9188
-2023-03-31,IS,Iceland,198.6946
-2023-03-31,IT,Italy,70.6296
+2023-03-31,HR,Croatia,119.6202
+2023-03-31,HU,Hungary,164.2588
+2023-03-31,ID,Indonesia,96.9761
+2023-03-31,IE,Ireland,129.75
+2023-03-31,IL,Israel,185.2248
+2023-03-31,IN,India,157.2766
+2023-03-31,IS,Iceland,198.7015
+2023-03-31,IT,Italy,70.6321
 2023-03-31,JP,Japan,122.96
-2023-03-31,KR,Korea,114.7712
+2023-03-31,KR,Korea,114.8288
 2023-03-31,LT,Lithuania,150.5466
-2023-03-31,LU,Luxembourg,175.4444
-2023-03-31,LV,Latvia,151.0141
-2023-03-31,MA,Morocco,82.0578
-2023-03-31,MK,North Macedonia,94.057
-2023-03-31,MT,Malta,128.7652
+2023-03-31,LU,Luxembourg,175.4182
+2023-03-31,LV,Latvia,150.9831
+2023-03-31,MA,Morocco,80.2765
+2023-03-31,MK,North Macedonia,94.2664
+2023-03-31,MT,Malta,129.63
 2023-03-31,MX,Mexico,135.3621
 2023-03-31,MY,Malaysia,164.7625
-2023-03-31,NL,Netherlands,121.0197
-2023-03-31,NO,Norway,132.9915
+2023-03-31,NL,Netherlands,121.1682
+2023-03-31,NO,Norway,132.9734
 2023-03-31,NZ,New Zealand,173.1862
 2023-03-31,PE,Peru,111.2452
-2023-03-31,PH,Philippines,154.1009
+2023-03-31,PH,Philippines,164.9183
 2023-03-31,PL,Poland,102.5538
 2023-03-31,PT,Portugal,148.6117
 2023-03-31,RO,Romania,74.8627
-2023-03-31,RS,Serbia,106.943
-2023-03-31,RU,Russia,65.1469
-2023-03-31,SE,Sweden,136.9924
-2023-03-31,SG,Singapore,114.4145
-2023-03-31,SI,Slovenia,120.5968
-2023-03-31,SK,Slovak Republic,124.1564
-2023-03-31,TH,Thailand,133.7783
-2023-03-31,TR,Türkiye,248.7175
-2023-03-31,US,United States,157.685
-2023-03-31,XM,Euro area,109.27
-2023-03-31,XW,World,123.9511
-2023-03-31,ZA,South Africa,92.3362
-2023-06-30,4T,Emerging market economies (aggregate),117.6303
-2023-06-30,5R,Advanced economies,132.32
-2023-06-30,AE,United Arab Emirates,126.6636
+2023-03-31,RS,Serbia,115.8904
+2023-03-31,RU,Russia,65.1438
+2023-03-31,SE,Sweden,137.2798
+2023-03-31,SG,Singapore,114.3399
+2023-03-31,SI,Slovenia,120.8003
+2023-03-31,SK,Slovakia,123.5528
+2023-03-31,TH,Thailand,142.5475
+2023-03-31,TR,Türkiye,242.3274
+2023-03-31,US,United States,156.7183
+2023-03-31,XM,Euro area,109.3075
+2023-03-31,XW,World,122.8728
+2023-03-31,ZA,South Africa,92.9408
+2023-06-30,4T,Emerging market economies (aggregate),115.7231
+2023-06-30,5R,Advanced economies,131.0922
 2023-06-30,AT,Austria,148.3815
-2023-06-30,AU,Australia,126.7623
-2023-06-30,BE,Belgium,107.7369
-2023-06-30,BG,Bulgaria,116.0901
-2023-06-30,BR,Brazil,86.9812
-2023-06-30,CA,Canada,167.3866
-2023-06-30,CH,Switzerland,150.8982
-2023-06-30,CL,Chile,195.0304
-2023-06-30,CN,China,104.8412
-2023-06-30,CO,Colombia,136.1855
+2023-06-30,AU,Australia,126.8132
+2023-06-30,BE,Belgium,107.3712
+2023-06-30,BG,Bulgaria,116.0981
+2023-06-30,BR,Brazil,88.8829
+2023-06-30,CA,Canada,165.2839
+2023-06-30,CH,Switzerland,150.8986
+2023-06-30,CL,Chile,193.0589
+2023-06-30,CN,China,104.8471
+2023-06-30,CO,Colombia,131.6168
 2023-06-30,CY,Cyprus,77.0818
-2023-06-30,CZ,Czechia,139.8057
-2023-06-30,DE,Germany,133.1571
-2023-06-30,DK,Denmark,117.4733
+2023-06-30,CZ,Czechia,139.7841
+2023-06-30,DE,Germany,134.2151
+2023-06-30,DK,Denmark,119.7811
 2023-06-30,EE,Estonia,186.2542
-2023-06-30,ES,Spain,85.5698
-2023-06-30,FI,Finland,87.3743
-2023-06-30,FR,France,106.3616
-2023-06-30,GB,United Kingdom,113.1013
-2023-06-30,GR,Greece,84.2031
+2023-06-30,ES,Spain,85.57
+2023-06-30,FI,Finland,86.6428
+2023-06-30,FR,France,106.3737
+2023-06-30,GB,United Kingdom,111.8532
+2023-06-30,GR,Greece,84.4807
 2023-06-30,HK,Hong Kong SAR,163.5059
-2023-06-30,HR,Croatia,120.9647
-2023-06-30,HU,Hungary,161.5118
-2023-06-30,ID,Indonesia,96.8122
-2023-06-30,IE,Ireland,126.126
-2023-06-30,IL,Israel,180.8096
-2023-06-30,IN,India,159.7416
-2023-06-30,IS,Iceland,200.1438
-2023-06-30,IT,Italy,71.6514
+2023-06-30,HR,Croatia,120.97
+2023-06-30,HU,Hungary,163.7433
+2023-06-30,ID,Indonesia,96.774
+2023-06-30,IE,Ireland,126.1487
+2023-06-30,IL,Israel,180.8108
+2023-06-30,IN,India,157.3215
+2023-06-30,IS,Iceland,200.1506
+2023-06-30,IT,Italy,71.6522
 2023-06-30,JP,Japan,121.5823
-2023-06-30,KR,Korea,111.7374
+2023-06-30,KR,Korea,111.7513
 2023-06-30,LT,Lithuania,153.3518
-2023-06-30,LU,Luxembourg,168.5827
-2023-06-30,LV,Latvia,156.2158
-2023-06-30,MA,Morocco,80.4927
-2023-06-30,MK,North Macedonia,94.2244
-2023-06-30,MT,Malta,128.0931
+2023-06-30,LU,Luxembourg,168.5618
+2023-06-30,LV,Latvia,156.2434
+2023-06-30,MA,Morocco,79.1117
+2023-06-30,MK,North Macedonia,94.4105
+2023-06-30,MT,Malta,129.0256
 2023-06-30,MX,Mexico,138.3224
 2023-06-30,MY,Malaysia,164.9327
-2023-06-30,NL,Netherlands,117.5907
-2023-06-30,NO,Norway,135.1249
+2023-06-30,NL,Netherlands,117.9282
+2023-06-30,NO,Norway,135.1144
 2023-06-30,NZ,New Zealand,169.4542
 2023-06-30,PE,Peru,110.8112
-2023-06-30,PH,Philippines,162.6479
+2023-06-30,PH,Philippines,171.6491
 2023-06-30,PL,Poland,103.9653
 2023-06-30,PT,Portugal,151.0659
 2023-06-30,RO,Romania,72.6614
-2023-06-30,RS,Serbia,105.8246
-2023-06-30,RU,Russia,65.4701
-2023-06-30,SE,Sweden,135.3819
-2023-06-30,SG,Singapore,113.0757
-2023-06-30,SI,Slovenia,119.3804
-2023-06-30,SK,Slovak Republic,117.3589
-2023-06-30,TH,Thailand,134.7092
-2023-06-30,TR,Türkiye,265.9259
-2023-06-30,US,United States,157.6985
-2023-06-30,XM,Euro area,107.71
-2023-06-30,XW,World,124.0972
-2023-06-30,ZA,South Africa,91.0168
-2023-09-30,4T,Emerging market economies (aggregate),
-2023-09-30,5R,Advanced economies,132.9029
-2023-09-30,AE,United Arab Emirates,131.2541
+2023-06-30,RS,Serbia,115.1257
+2023-06-30,RU,Russia,65.4736
+2023-06-30,SE,Sweden,135.4458
+2023-06-30,SG,Singapore,113.0007
+2023-06-30,SI,Slovenia,119.5536
+2023-06-30,SK,Slovakia,116.6997
+2023-06-30,TH,Thailand,142.569
+2023-06-30,TR,Türkiye,263.6878
+2023-06-30,US,United States,156.9492
+2023-06-30,XM,Euro area,107.7616
+2023-06-30,XW,World,122.9332
+2023-06-30,ZA,South Africa,91.6115
+2023-09-30,4T,Emerging market economies (aggregate),114.8068
+2023-09-30,5R,Advanced economies,131.262
 2023-09-30,AT,Austria,146.6119
-2023-09-30,AU,Australia,128.4883
-2023-09-30,BE,Belgium,108.4652
-2023-09-30,BG,Bulgaria,118.2167
-2023-09-30,BR,Brazil,86.7565
-2023-09-30,CA,Canada,165.1556
-2023-09-30,CH,Switzerland,151.003
-2023-09-30,CL,Chile,
-2023-09-30,CN,China,103.1507
-2023-09-30,CO,Colombia,136.0388
+2023-09-30,AU,Australia,128.8138
+2023-09-30,BE,Belgium,107.5736
+2023-09-30,BG,Bulgaria,118.1975
+2023-09-30,BR,Brazil,89.7138
+2023-09-30,CA,Canada,162.7144
+2023-09-30,CH,Switzerland,151.0033
+2023-09-30,CL,Chile,196.1229
+2023-09-30,CN,China,103.1349
+2023-09-30,CO,Colombia,134.0014
 2023-09-30,CY,Cyprus,77.5011
-2023-09-30,CZ,Czechia,139.128
-2023-09-30,DE,Germany,130.4116
-2023-09-30,DK,Denmark,119.7717
+2023-09-30,CZ,Czechia,139.1716
+2023-09-30,DE,Germany,131.237
+2023-09-30,DK,Denmark,120.6558
 2023-09-30,EE,Estonia,185.4199
-2023-09-30,ES,Spain,86.9031
-2023-09-30,FI,Finland,
-2023-09-30,FR,France,106.1747
-2023-09-30,GB,United Kingdom,115.4043
-2023-09-30,GR,Greece,85.9812
-2023-09-30,HK,Hong Kong SAR,156.7415
-2023-09-30,HR,Croatia,119.5504
-2023-09-30,HU,Hungary,159.5183
-2023-09-30,ID,Indonesia,96.9912
-2023-09-30,IE,Ireland,126.36
-2023-09-30,IL,Israel,178.3917
-2023-09-30,IN,India,
-2023-09-30,IS,Iceland,194.3497
-2023-09-30,IT,Italy,71.3728
-2023-09-30,JP,Japan,120.8431
-2023-09-30,KR,Korea,109.9962
-2023-09-30,LT,Lithuania,157.5566
-2023-09-30,LU,Luxembourg,156.7248
-2023-09-30,LV,Latvia,155.224
-2023-09-30,MA,Morocco,81.0996
-2023-09-30,MK,North Macedonia,94.4692
-2023-09-30,MT,Malta,129.4027
+2023-09-30,ES,Spain,86.903
+2023-09-30,FI,Finland,83.7292
+2023-09-30,FR,France,106.0969
+2023-09-30,GB,United Kingdom,113.4931
+2023-09-30,GR,Greece,86.629
+2023-09-30,HK,Hong Kong SAR,156.7105
+2023-09-30,HR,Croatia,119.5562
+2023-09-30,HU,Hungary,162.9251
+2023-09-30,ID,Indonesia,96.9029
+2023-09-30,IE,Ireland,126.3512
+2023-09-30,IL,Israel,178.467
+2023-09-30,IN,India,154.2193
+2023-09-30,IS,Iceland,194.3564
+2023-09-30,IT,Italy,71.3085
+2023-09-30,JP,Japan,120.9028
+2023-09-30,KR,Korea,110.0125
+2023-09-30,LT,Lithuania,157.5565
+2023-09-30,LU,Luxembourg,156.1483
+2023-09-30,LV,Latvia,155.0654
+2023-09-30,MA,Morocco,79.2676
+2023-09-30,MK,North Macedonia,94.717
+2023-09-30,MT,Malta,130.7226
 2023-09-30,MX,Mexico,139.7483
-2023-09-30,MY,Malaysia,161.1599
-2023-09-30,NL,Netherlands,117.6458
-2023-09-30,NO,Norway,130.6869
-2023-09-30,NZ,New Zealand,168.6544
-2023-09-30,PE,Peru,110.9476
-2023-09-30,PH,Philippines,166.013
+2023-09-30,MY,Malaysia,166.3146
+2023-09-30,NL,Netherlands,118.0294
+2023-09-30,NO,Norway,130.6589
+2023-09-30,NZ,New Zealand,169.0654
+2023-09-30,PE,Peru,110.2764
+2023-09-30,PH,Philippines,172.5017
 2023-09-30,PL,Poland,109.0124
-2023-09-30,PT,Portugal,
-2023-09-30,RO,Romania,
-2023-09-30,RS,Serbia,105.89
-2023-09-30,RU,Russia,
-2023-09-30,SE,Sweden,133.3813
-2023-09-30,SG,Singapore,112.9369
-2023-09-30,SI,Slovenia,118.3616
-2023-09-30,SK,Slovak Republic,118.3797
-2023-09-30,TH,Thailand,134.607
-2023-09-30,TR,Türkiye,259.4377
-2023-09-30,US,United States,159.5899
-2023-09-30,XM,Euro area,107.4444
-2023-09-30,XW,World,
-2023-09-30,ZA,South Africa,89.4377
+2023-09-30,PT,Portugal,153.5731
+2023-09-30,RO,Romania,74.2307
+2023-09-30,RS,Serbia,115.4951
+2023-09-30,RU,Russia,66.034
+2023-09-30,SE,Sweden,133.463
+2023-09-30,SG,Singapore,112.8568
+2023-09-30,SI,Slovenia,118.2713
+2023-09-30,SK,Slovakia,117.7202
+2023-09-30,TH,Thailand,142.1841
+2023-09-30,TR,Türkiye,259.6306
+2023-09-30,US,United States,158.4461
+2023-09-30,XM,Euro area,107.3829
+2023-09-30,XW,World,122.4883
+2023-09-30,ZA,South Africa,90.2794
+2023-12-31,4T,Emerging market economies (aggregate),114.36
+2023-12-31,5R,Advanced economies,130.8474
+2023-12-31,AT,Austria,143.1445
+2023-12-31,AU,Australia,130.6211
+2023-12-31,BE,Belgium,108.6997
+2023-12-31,BG,Bulgaria,118.696
+2023-12-31,BR,Brazil,90.2901
+2023-12-31,CA,Canada,156.2966
+2023-12-31,CH,Switzerland,152.7646
+2023-12-31,CL,Chile,196.5245
+2023-12-31,CN,China,101.4751
+2023-12-31,CO,Colombia,127.0036
+2023-12-31,CY,Cyprus,79.1852
+2023-12-31,CZ,Czechia,140.2002
+2023-12-31,DE,Germany,128.6493
+2023-12-31,DK,Denmark,123.2446
+2023-12-31,EE,Estonia,189.929
+2023-12-31,ES,Spain,85.6999
+2023-12-31,FI,Finland,82.6107
+2023-12-31,FR,France,103.2317
+2023-12-31,GB,United Kingdom,111.5411
+2023-12-31,GR,Greece,87.1808
+2023-12-31,HK,Hong Kong SAR,145.3754
+2023-12-31,HR,Croatia,122.7415
+2023-12-31,HU,Hungary,165.3738
+2023-12-31,ID,Indonesia,96.4337
+2023-12-31,IE,Ireland,129.7843
+2023-12-31,IL,Israel,177.8873
+2023-12-31,IN,India,156.0796
+2023-12-31,IS,Iceland,198.0411
+2023-12-31,IT,Italy,71.4691
+2023-12-31,JP,Japan,118.7967
+2023-12-31,KR,Korea,109.3419
+2023-12-31,LT,Lithuania,159.684
+2023-12-31,LU,Luxembourg,152.4357
+2023-12-31,LV,Latvia,152.5029
+2023-12-31,MA,Morocco,78.881
+2023-12-31,MK,North Macedonia,96.4474
+2023-12-31,MT,Malta,131.949
+2023-12-31,MX,Mexico,140.4219
+2023-12-31,MY,Malaysia,167.2524
+2023-12-31,NL,Netherlands,120.5153
+2023-12-31,NO,Norway,124.8077
+2023-12-31,NZ,New Zealand,170.8937
+2023-12-31,PE,Peru,112.4389
+2023-12-31,PH,Philippines,165.6145
+2023-12-31,PL,Poland,113.7153
+2023-12-31,PT,Portugal,155.1652
+2023-12-31,RO,Romania,74.2131
+2023-12-31,RS,Serbia,115.8099
+2023-12-31,RU,Russia,66.3919
+2023-12-31,SE,Sweden,129.0579
+2023-12-31,SG,Singapore,115.0516
+2023-12-31,SI,Slovenia,121.8442
+2023-12-31,SK,Slovakia,119.4283
+2023-12-31,TH,Thailand,145.4207
+2023-12-31,TR,Türkiye,253.7424
+2023-12-31,US,United States,160.1054
+2023-12-31,XM,Euro area,106.3985
+2023-12-31,XW,World,122.0535
+2023-12-31,ZA,South Africa,89.5077
+2024-03-31,4T,Emerging market economies (aggregate),114.3537
+2024-03-31,5R,Advanced economies,130.9978
+2024-03-31,AT,Austria,141.153
+2024-03-31,AU,Australia,131.5506
+2024-03-31,BE,Belgium,107.9284
+2024-03-31,BG,Bulgaria,125.763
+2024-03-31,BR,Brazil,90.3743
+2024-03-31,CA,Canada,156.4211
+2024-03-31,CH,Switzerland,150.4214
+2024-03-31,CL,Chile,196.6378
+2024-03-31,CN,China,98.9629
+2024-03-31,CO,Colombia,135.539
+2024-03-31,CY,Cyprus,81.713
+2024-03-31,CZ,Czechia,139.4734
+2024-03-31,DE,Germany,127.4733
+2024-03-31,DK,Denmark,119.0739
+2024-03-31,EE,Estonia,190.7585
+2024-03-31,ES,Spain,87.6102
+2024-03-31,FI,Finland,81.2806
+2024-03-31,FR,France,100.5522
+2024-03-31,GB,United Kingdom,109.9391
+2024-03-31,GR,Greece,90.1308
+2024-03-31,HK,Hong Kong SAR,140.2602
+2024-03-31,HR,Croatia,125.3328
+2024-03-31,HU,Hungary,177.3863
+2024-03-31,ID,Indonesia,96.1178
+2024-03-31,IE,Ireland,133.3316
+2024-03-31,IL,Israel,182.4518
+2024-03-31,IN,India,160.0363
+2024-03-31,IS,Iceland,199.212
+2024-03-31,IT,Italy,71.0974
+2024-03-31,JP,Japan,122.9175
+2024-03-31,KR,Korea,108.3503
+2024-03-31,LT,Lithuania,164.631
+2024-03-31,LU,Luxembourg,150.876
+2024-03-31,LV,Latvia,155.3558
+2024-03-31,MA,Morocco,78.8963
+2024-03-31,MK,North Macedonia,95.327
+2024-03-31,MT,Malta,135.039
+2024-03-31,MX,Mexico,141.9676
+2024-03-31,MY,Malaysia,167.7633
+2024-03-31,NL,Netherlands,121.9622
+2024-03-31,NO,Norway,128.8927
+2024-03-31,NZ,New Zealand,169.9534
+2024-03-31,PE,Peru,109.5304
+2024-03-31,PH,Philippines,171.4876
+2024-03-31,PL,Poland,117.5165
+2024-03-31,PT,Portugal,155.5623
+2024-03-31,RO,Romania,73.7418
+2024-03-31,RS,Serbia,116.1127
+2024-03-31,RU,Russia,72.0088
+2024-03-31,SE,Sweden,129.0693
+2024-03-31,SG,Singapore,116.1574
+2024-03-31,SI,Slovenia,125.4281
+2024-03-31,SK,Slovakia,116.2024
+2024-03-31,TH,Thailand,144.5306
+2024-03-31,TR,Türkiye,237.2708
+2024-03-31,US,United States,159.9693
+2024-03-31,XM,Euro area,106.2782
+2024-03-31,XW,World,122.1144
+2024-03-31,ZA,South Africa,89.0311
+2024-06-30,4T,Emerging market economies (aggregate),113.4145
+2024-06-30,5R,Advanced economies,130.9224
+2024-06-30,AT,Austria,140.1204
+2024-06-30,AU,Australia,132.9694
+2024-06-30,BE,Belgium,107.1467
+2024-06-30,BG,Bulgaria,130.5049
+2024-06-30,BR,Brazil,90.7557
+2024-06-30,CA,Canada,156.3798
+2024-06-30,CH,Switzerland,150.9198
+2024-06-30,CL,Chile,198.6178
+2024-06-30,CN,China,96.8513
+2024-06-30,CO,Colombia,132.3252
+2024-06-30,CY,Cyprus,81.0656
+2024-06-30,CZ,Czechia,142.0417
+2024-06-30,DE,Germany,127.9643
+2024-06-30,DK,Denmark,122.4564
+2024-06-30,EE,Estonia,193.422
+2024-06-30,ES,Spain,89.2716
+2024-06-30,FI,Finland,81.5653
+2024-06-30,FR,France,99.3364
+2024-06-30,GB,United Kingdom,109.9853
+2024-06-30,GR,Greece,90.3971
+2024-06-30,HK,Hong Kong SAR,140.8883
+2024-06-30,HR,Croatia,128.9732
+2024-06-30,HU,Hungary,178.1427
+2024-06-30,ID,Indonesia,95.8124
+2024-06-30,IE,Ireland,133.4938
+2024-06-30,IL,Israel,183.781
+2024-06-30,IN,India,161.3394
+2024-06-30,IS,Iceland,200.6489
+2024-06-30,IT,Italy,73.1693
+2024-06-30,JP,Japan,121.633
+2024-06-30,KR,Korea,107.7932
+2024-06-30,LT,Lithuania,168.4797
+2024-06-30,LU,Luxembourg,150.7772
+2024-06-30,LV,Latvia,156.0591
+2024-06-30,MA,Morocco,78.2686
+2024-06-30,MK,North Macedonia,101.1901
+2024-06-30,MT,Malta,135.9287
+2024-06-30,MX,Mexico,144.3732
+2024-06-30,MY,Malaysia,168.4264
+2024-06-30,NL,Netherlands,123.3785
+2024-06-30,NO,Norway,133.0581
+2024-06-30,NZ,New Zealand,165.9624
+2024-06-30,PE,Peru,108.8665
+2024-06-30,PH,Philippines,178.4146
+2024-06-30,PL,Poland,119.2149
+2024-06-30,PT,Portugal,158.609
+2024-06-30,RO,Romania,73.7483
+2024-06-30,RS,Serbia,116.1119
+2024-06-30,RU,Russia,72.1296
+2024-06-30,SE,Sweden,129.9998
+2024-06-30,SG,Singapore,116.5867
+2024-06-30,SI,Slovenia,124.9511
+2024-06-30,SK,Slovakia,118.8672
+2024-06-30,TH,Thailand,143.238
+2024-06-30,TR,Türkiye,229.1177
+2024-06-30,US,United States,159.3691
+2024-06-30,XM,Euro area,106.6218
+2024-06-30,XW,World,121.5401
+2024-06-30,ZA,South Africa,87.6516
+2024-09-30,4T,Emerging market economies (aggregate),111.5155
+2024-09-30,5R,Advanced economies,131.7218
+2024-09-30,AT,Austria,140.0215
+2024-09-30,AU,Australia,134.5531
+2024-09-30,BE,Belgium,107.9619
+2024-09-30,BG,Bulgaria,135.1532
+2024-09-30,BR,Brazil,91.3523
+2024-09-30,CA,Canada,153.045
+2024-09-30,CH,Switzerland,152.0226
+2024-09-30,CL,Chile,200.4528
+2024-09-30,CN,China,93.823
+2024-09-30,CO,Colombia,135.4288
+2024-09-30,CY,Cyprus,81.3793
+2024-09-30,CZ,Czechia,144.3525
+2024-09-30,DE,Germany,128.5318
+2024-09-30,DK,Denmark,125.3582
+2024-09-30,EE,Estonia,191.2007
+2024-09-30,ES,Spain,92.0855
+2024-09-30,FI,Finland,81.2961
+2024-09-30,FR,France,100.6522
+2024-09-30,GB,United Kingdom,112.2059
+2024-09-30,GR,Greece,91.4131
+2024-09-30,HK,Hong Kong SAR,132.9822
+2024-09-30,HR,Croatia,131.7687
+2024-09-30,HU,Hungary,178.9085
+2024-09-30,ID,Indonesia,96.3599
+2024-09-30,IE,Ireland,136.7761
+2024-09-30,IL,Israel,183.2201
+2024-09-30,IN,India,158.2476
+2024-09-30,IS,Iceland,205.3442
+2024-09-30,IT,Italy,73.2473
+2024-09-30,JP,Japan,121.4486
+2024-09-30,KR,Korea,107.4475
+2024-09-30,LT,Lithuania,170.3627
+2024-09-30,LU,Luxembourg,150.7056
+2024-09-30,LV,Latvia,161.6351
+2024-09-30,MA,Morocco,78.0516
+2024-09-30,MK,North Macedonia,99.6666
+2024-09-30,MT,Malta,137.94
+2024-09-30,MX,Mexico,145.2581
+2024-09-30,MY,Malaysia,170.2585
+2024-09-30,NL,Netherlands,125.793
+2024-09-30,NO,Norway,131.2112
+2024-09-30,NZ,New Zealand,163.8554
+2024-09-30,PE,Peru,108.2194
+2024-09-30,PH,Philippines,179.8116
+2024-09-30,PL,Poland,119.1505
+2024-09-30,PT,Portugal,165.0546
+2024-09-30,RO,Romania,73.4929
+2024-09-30,RS,Serbia,116.5936
+2024-09-30,RU,Russia,71.3483
+2024-09-30,SE,Sweden,131.0829
+2024-09-30,SG,Singapore,115.3568
+2024-09-30,SI,Slovenia,126.7193
+2024-09-30,SK,Slovakia,121.7268
+2024-09-30,TH,Thailand,145.6368
+2024-09-30,TR,Türkiye,224.5494
+2024-09-30,US,United States,160.1804
+2024-09-30,XM,Euro area,108.043
+2024-09-30,XW,World,120.7815
+2024-09-30,ZA,South Africa,87.1358
+2024-12-31,4T,Emerging market economies (aggregate),110.857
+2024-12-31,5R,Advanced economies,131.8692
+2024-12-31,AT,Austria,138.9332
+2024-12-31,AU,Australia,134.9086
+2024-12-31,BE,Belgium,108.3145
+2024-12-31,BG,Bulgaria,137.6134
+2024-12-31,BR,Brazil,91.3895
+2024-12-31,CA,Canada,150.5615
+2024-12-31,CH,Switzerland,155.3577
+2024-12-31,CL,Chile,202.1224
+2024-12-31,CN,China,92.5967
+2024-12-31,CO,Colombia,132.9616
+2024-12-31,CY,Cyprus,81.518
+2024-12-31,CZ,Czechia,147.7854
+2024-12-31,DE,Germany,128.1794
+2024-12-31,DK,Denmark,125.6667
+2024-12-31,EE,Estonia,189.332
+2024-12-31,ES,Spain,93.2412
+2024-12-31,FI,Finland,80.3255
+2024-12-31,FR,France,100.0356
+2024-12-31,GB,United Kingdom,111.4854
+2024-12-31,GR,Greece,91.409
+2024-12-31,HK,Hong Kong SAR,131.7367
+2024-12-31,HR,Croatia,131.5031
+2024-12-31,HU,Hungary,184.9809
+2024-12-31,ID,Indonesia,96.2241
+2024-12-31,IE,Ireland,140.4857
+2024-12-31,IL,Israel,184.9994
+2024-12-31,IN,India,157.8825
+2024-12-31,IS,Iceland,205.3033
+2024-12-31,IT,Italy,73.7615
+2024-12-31,JP,Japan,118.6312
+2024-12-31,KR,Korea,107.4756
+2024-12-31,LT,Lithuania,173.1851
+2024-12-31,LU,Luxembourg,153.176
+2024-12-31,LV,Latvia,159.5542
+2024-12-31,MA,Morocco,79.6522
+2024-12-31,MK,North Macedonia,102.508
+2024-12-31,MT,Malta,138.4019
+2024-12-31,MX,Mexico,146.0747
+2024-12-31,MY,Malaysia,171.5628
+2024-12-31,NL,Netherlands,128.5809
+2024-12-31,NO,Norway,127.7271
+2024-12-31,NZ,New Zealand,164.5161
+2024-12-31,PE,Peru,108.4975
+2024-12-31,PH,Philippines,177.2592
+2024-12-31,PL,Poland,119.6379
+2024-12-31,PT,Portugal,168.7043
+2024-12-31,RO,Romania,73.4884
+2024-12-31,RS,Serbia,116.9976
+2024-12-31,RU,Russia,71.3369
+2024-12-31,SE,Sweden,130.0841
+2024-12-31,SG,Singapore,117.8917
+2024-12-31,SI,Slovenia,129.5742
+2024-12-31,SK,Slovakia,125.1272
+2024-12-31,TH,Thailand,147.6933
+2024-12-31,TR,Türkiye,222.4299
+2024-12-31,US,United States,161.22
+2024-12-31,XM,Euro area,108.4047
+2024-12-31,XW,World,120.4582
+2024-12-31,ZA,South Africa,87.9349
+2025-03-31,4T,Emerging market economies (aggregate),111.3444
+2025-03-31,5R,Advanced economies,132.2766
+2025-03-31,AT,Austria,137.3711
+2025-03-31,AU,Australia,134.2057
+2025-03-31,BE,Belgium,107.0495
+2025-03-31,BG,Bulgaria,139.2356
+2025-03-31,BR,Brazil,90.9267
+2025-03-31,CA,Canada,150.6479
+2025-03-31,CH,Switzerland,156.0774
+2025-03-31,CL,Chile,200.5176
+2025-03-31,CN,China,91.6149
+2025-03-31,CO,Colombia,134.2041
+2025-03-31,CY,Cyprus,83.9893
+2025-03-31,CZ,Czechia,149.2739
+2025-03-31,DE,Germany,129.0376
+2025-03-31,DK,Denmark,127.37
+2025-03-31,EE,Estonia,190.9288
+2025-03-31,ES,Spain,95.7693
+2025-03-31,FI,Finland,79.3157
+2025-03-31,FR,France,99.8815
+2025-03-31,GB,United Kingdom,111.4309
+2025-03-31,GR,Greece,94.4405
+2025-03-31,HK,Hong Kong SAR,129.0244
+2025-03-31,HR,Croatia,136.7535
+2025-03-31,HU,Hungary,197.2589
+2025-03-31,ID,Indonesia,96.6061
+2025-03-31,IE,Ireland,141.2135
+2025-03-31,IL,Israel,186.6793
+2025-03-31,IN,India,160.2325
+2025-03-31,IS,Iceland,204.559
+2025-03-31,IT,Italy,73.0279
+2025-03-31,JP,Japan,124.0035
+2025-03-31,KR,Korea,105.9526
+2025-03-31,LT,Lithuania,172.6669
+2025-03-31,LU,Luxembourg,149.9026
+2025-03-31,LV,Latvia,158.4813
+2025-03-31,MA,Morocco,77.6398
+2025-03-31,MK,North Macedonia,109.2784
+2025-03-31,MT,Malta,140.3992
+2025-03-31,MX,Mexico,148.0345
+2025-03-31,MY,Malaysia,171.0588
+2025-03-31,NL,Netherlands,130.487
+2025-03-31,NO,Norway,133.5101
+2025-03-31,NZ,New Zealand,162.6095
+2025-03-31,PE,Peru,108.6773
+2025-03-31,PH,Philippines,180.4258
+2025-03-31,PL,Poland,118.8149
+2025-03-31,PT,Portugal,176.9055
+2025-03-31,RO,Romania,73.9179
+2025-03-31,RS,Serbia,117.296
+2025-03-31,RU,Russia,76.5422
+2025-03-31,SE,Sweden,130.6167
+2025-03-31,SG,Singapore,118.8421
+2025-03-31,SI,Slovenia,127.0404
+2025-03-31,SK,Slovakia,126.6184
+2025-03-31,TH,Thailand,147.9787
+2025-03-31,TR,Türkiye,223.9131
+2025-03-31,US,United States,159.8592
+2025-03-31,XM,Euro area,109.3739
+2025-03-31,XW,World,120.9164
+2025-03-31,ZA,South Africa,87.9561
+2025-06-30,4T,Emerging market economies (aggregate),111.1457
+2025-06-30,5R,Advanced economies,131.6861
+2025-06-30,AT,Austria,135.9142
+2025-06-30,AU,Australia,135.5363
+2025-06-30,BE,Belgium,107.8057
+2025-06-30,BG,Bulgaria,145.1545
+2025-06-30,BR,Brazil,90.5587
+2025-06-30,CA,Canada,149.181
+2025-06-30,CH,Switzerland,158.3911
+2025-06-30,CL,Chile,202.6553
+2025-06-30,CN,China,90.6763
+2025-06-30,CO,Colombia,138.5494
+2025-06-30,CY,Cyprus,84.9783
+2025-06-30,CZ,Czechia,153.2942
+2025-06-30,DE,Germany,129.2809
+2025-06-30,DK,Denmark,129.3279
+2025-06-30,EE,Estonia,194.9588
+2025-06-30,ES,Spain,98.5509
+2025-06-30,FI,Finland,80.1258
+2025-06-30,FR,France,99.1566
+2025-06-30,GB,United Kingdom,108.5338
+2025-06-30,GR,Greece,95.332
+2025-06-30,HK,Hong Kong SAR,129.6833
+2025-06-30,HR,Croatia,141.1936
+2025-06-30,HU,Hungary,194.3144
+2025-06-30,ID,Indonesia,94.9583
+2025-06-30,IE,Ireland,141.1978
+2025-06-30,IL,Israel,182.6278
+2025-06-30,IN,India,162.5237
+2025-06-30,IS,Iceland,204.1409
+2025-06-30,IT,Italy,74.7634
+2025-06-30,JP,Japan,121.9416
+2025-06-30,KR,Korea,105.7423
+2025-06-30,LT,Lithuania,176.659
+2025-06-30,LU,Luxembourg,154.5414
+2025-06-30,LV,Latvia,160.1363
+2025-06-30,MA,Morocco,78.0952
+2025-06-30,MK,North Macedonia,117.2595
+2025-06-30,MT,Malta,140.1291
+2025-06-30,MX,Mexico,150.5931
+2025-06-30,MY,Malaysia,171.3492
+2025-06-30,NL,Netherlands,130.7001
+2025-06-30,NO,Norway,135.238
+2025-06-30,NZ,New Zealand,159.8576
+2025-06-30,PE,Peru,109.4643
+2025-06-30,PH,Philippines,189.3172
+2025-06-30,PL,Poland,119.5238
+2025-06-30,PT,Portugal,181.8636
+2025-06-30,RO,Romania,73.1876
+2025-06-30,RS,Serbia,117.8373
+2025-06-30,RU,Russia,76.3463
+2025-06-30,SE,Sweden,130.2343
+2025-06-30,SG,Singapore,119.6363
+2025-06-30,SI,Slovenia,129.186
+2025-06-30,SK,Slovakia,127.1347
+2025-06-30,TH,Thailand,147.8057
+2025-06-30,TR,Türkiye,223.3435
+2025-06-30,US,United States,158.492
+2025-06-30,XM,Euro area,109.8977
+2025-06-30,XW,World,120.5538
+2025-06-30,ZA,South Africa,88.0077
+2025-09-30,4T,Emerging market economies (aggregate),110.1446
+2025-09-30,5R,Advanced economies,132.0787
+2025-09-30,AT,Austria,136.7489
+2025-09-30,AU,Australia,136.8992
+2025-09-30,BE,Belgium,109.7328
+2025-09-30,BG,Bulgaria,148.0171
+2025-09-30,BR,Brazil,90.9509
+2025-09-30,CA,Canada,145.2817
+2025-09-30,CH,Switzerland,159.6454
+2025-09-30,CL,Chile,206.0254
+2025-09-30,CN,China,88.8506
+2025-09-30,CO,Colombia,139.6693
+2025-09-30,CY,Cyprus,86.1816
+2025-09-30,CZ,Czechia,156.0891
+2025-09-30,DE,Germany,129.6554
+2025-09-30,DK,Denmark,130.4982
+2025-09-30,EE,Estonia,190.4304
+2025-09-30,ES,Spain,101.0733
+2025-09-30,FI,Finland,78.4186
+2025-09-30,FR,France,100.3502
+2025-09-30,GB,United Kingdom,110.7652
+2025-09-30,GR,Greece,96.4274
+2025-09-30,HK,Hong Kong SAR,130.4794
+2025-09-30,HR,Croatia,144.0758
+2025-09-30,HU,Hungary,207.4944
+2025-09-30,ID,Indonesia,94.8529
+2025-09-30,IE,Ireland,143.9676
+2025-09-30,IL,Israel,179.4153
+2025-09-30,IN,India,161.1433
+2025-09-30,IS,Iceland,203.1107
+2025-09-30,IT,Italy,74.7822
+2025-09-30,JP,Japan,123.1591
+2025-09-30,KR,Korea,105.7606
+2025-09-30,LT,Lithuania,181.6905
+2025-09-30,LU,Luxembourg,148.3479
+2025-09-30,LV,Latvia,167.7571
+2025-09-30,MA,Morocco,79.2823
+2025-09-30,MK,North Macedonia,119.4232
+2025-09-30,MT,Malta,142.167
+2025-09-30,MX,Mexico,152.6182
+2025-09-30,MY,Malaysia,171.9199
+2025-09-30,NL,Netherlands,131.5963
+2025-09-30,NO,Norway,133.2081
+2025-09-30,NZ,New Zealand,158.1678
+2025-09-30,PE,Peru,111.0809
+2025-09-30,PH,Philippines,180.6855
+2025-09-30,PL,Poland,120.1896
+2025-09-30,PT,Portugal,189.3081
+2025-09-30,RO,Romania,71.6183
+2025-09-30,RS,Serbia,118.3768
+2025-09-30,RU,Russia,76.4252
+2025-09-30,SE,Sweden,130.2869
+2025-09-30,SG,Singapore,120.4756
+2025-09-30,SI,Slovenia,126.5818
+2025-09-30,SK,Slovakia,132.3586
+2025-09-30,TH,Thailand,147.3073
+2025-09-30,TR,Türkiye,222.6568
+2025-09-30,US,United States,157.6917
+2025-09-30,XM,Euro area,111.1583
+2025-09-30,XW,World,120.1228
+2025-09-30,ZA,South Africa,88.3881
+2025-12-31,5R,Advanced economies,132.3509
+2025-12-31,AT,Austria,136.512
+2025-12-31,AU,Australia,140.3706
+2025-12-31,BE,Belgium,109.7031
+2025-12-31,BG,Bulgaria,147.2992
+2025-12-31,BR,Brazil,91.3082
+2025-12-31,CA,Canada,142.2693
+2025-12-31,CH,Switzerland,161.3827
+2025-12-31,CN,China,86.7897
+2025-12-31,CO,Colombia,142.5357
+2025-12-31,CY,Cyprus,87.6905
+2025-12-31,CZ,Czechia,159.5508
+2025-12-31,DE,Germany,129.2697
+2025-12-31,DK,Denmark,132.5439
+2025-12-31,EE,Estonia,191.2155
+2025-12-31,ES,Spain,102.1633
+2025-12-31,FR,France,100.1856
+2025-12-31,GB,United Kingdom,110.5025
+2025-12-31,GR,Greece,96.1333
+2025-12-31,HK,Hong Kong SAR,133.2756
+2025-12-31,HR,Croatia,147.297
+2025-12-31,HU,Hungary,216.1053
+2025-12-31,IE,Ireland,145.9828
+2025-12-31,IL,Israel,180.1966
+2025-12-31,IN,India,162.6139
+2025-12-31,IS,Iceland,204.2836
+2025-12-31,IT,Italy,75.8755
+2025-12-31,JP,Japan,121.3699
+2025-12-31,KR,Korea,105.7143
+2025-12-31,LT,Lithuania,184.9508
+2025-12-31,LU,Luxembourg,148.8765
+2025-12-31,LV,Latvia,170.5865
+2025-12-31,MA,Morocco,80.0068
+2025-12-31,MK,North Macedonia,122.9718
+2025-12-31,MX,Mexico,153.4535
+2025-12-31,MY,Malaysia,171.685
+2025-12-31,NO,Norway,131.2946
+2025-12-31,NZ,New Zealand,157.5408
+2025-12-31,PE,Peru,113.5186
+2025-12-31,PH,Philippines,177.1109
+2025-12-31,PL,Poland,121.7738
+2025-12-31,PT,Portugal,196.1766
+2025-12-31,RO,Romania,71.6306
+2025-12-31,RS,Serbia,120.3412
+2025-12-31,RU,Russia,76.4414
+2025-12-31,SE,Sweden,130.9817
+2025-12-31,SG,Singapore,120.3952
+2025-12-31,SI,Slovenia,133.4399
+2025-12-31,SK,Slovakia,135.9443
+2025-12-31,TH,Thailand,149.3848
+2025-12-31,TR,Türkiye,220.7611
+2025-12-31,US,United States,158.3615
+2025-12-31,XM,Euro area,111.6702
+2025-12-31,ZA,South Africa,89.4681

--- a/data/real_year.csv
+++ b/data/real_year.csv
@@ -1,20942 +1,5088 @@
 date,country_code,country,price
-1927-03-31,4T,Emerging market economies (aggregate),
-1927-03-31,5R,Advanced economies,
-1927-03-31,AE,United Arab Emirates,
-1927-03-31,AT,Austria,
-1927-03-31,AU,Australia,
-1927-03-31,BE,Belgium,
-1927-03-31,BG,Bulgaria,
-1927-03-31,BR,Brazil,
-1927-03-31,CA,Canada,
-1927-03-31,CH,Switzerland,
-1927-03-31,CL,Chile,
-1927-03-31,CN,China,
-1927-03-31,CO,Colombia,
-1927-03-31,CY,Cyprus,
-1927-03-31,CZ,Czechia,
-1927-03-31,DE,Germany,
-1927-03-31,DK,Denmark,
-1927-03-31,EE,Estonia,
-1927-03-31,ES,Spain,
-1927-03-31,FI,Finland,
-1927-03-31,FR,France,
-1927-03-31,GB,United Kingdom,
-1927-03-31,GR,Greece,
-1927-03-31,HK,Hong Kong SAR,
-1927-03-31,HR,Croatia,
-1927-03-31,HU,Hungary,
-1927-03-31,ID,Indonesia,
-1927-03-31,IE,Ireland,
-1927-03-31,IL,Israel,
-1927-03-31,IN,India,
-1927-03-31,IS,Iceland,
-1927-03-31,IT,Italy,
-1927-03-31,JP,Japan,
-1927-03-31,KR,Korea,
-1927-03-31,LT,Lithuania,
-1927-03-31,LU,Luxembourg,
-1927-03-31,LV,Latvia,
-1927-03-31,MA,Morocco,
-1927-03-31,MK,North Macedonia,
-1927-03-31,MT,Malta,
-1927-03-31,MX,Mexico,
-1927-03-31,MY,Malaysia,
-1927-03-31,NL,Netherlands,
-1927-03-31,NO,Norway,
-1927-03-31,NZ,New Zealand,
-1927-03-31,PE,Peru,
-1927-03-31,PH,Philippines,
-1927-03-31,PL,Poland,
-1927-03-31,PT,Portugal,
-1927-03-31,RO,Romania,
-1927-03-31,RS,Serbia,
-1927-03-31,RU,Russia,
-1927-03-31,SE,Sweden,
-1927-03-31,SG,Singapore,
-1927-03-31,SI,Slovenia,
-1927-03-31,SK,Slovak Republic,
-1927-03-31,TH,Thailand,
-1927-03-31,TR,Türkiye,
-1927-03-31,US,United States,
-1927-03-31,XM,Euro area,
-1927-03-31,XW,World,
-1927-03-31,ZA,South Africa,
-1927-06-30,4T,Emerging market economies (aggregate),
-1927-06-30,5R,Advanced economies,
-1927-06-30,AE,United Arab Emirates,
-1927-06-30,AT,Austria,
-1927-06-30,AU,Australia,
-1927-06-30,BE,Belgium,
-1927-06-30,BG,Bulgaria,
-1927-06-30,BR,Brazil,
-1927-06-30,CA,Canada,
-1927-06-30,CH,Switzerland,
-1927-06-30,CL,Chile,
-1927-06-30,CN,China,
-1927-06-30,CO,Colombia,
-1927-06-30,CY,Cyprus,
-1927-06-30,CZ,Czechia,
-1927-06-30,DE,Germany,
-1927-06-30,DK,Denmark,
-1927-06-30,EE,Estonia,
-1927-06-30,ES,Spain,
-1927-06-30,FI,Finland,
-1927-06-30,FR,France,
-1927-06-30,GB,United Kingdom,
-1927-06-30,GR,Greece,
-1927-06-30,HK,Hong Kong SAR,
-1927-06-30,HR,Croatia,
-1927-06-30,HU,Hungary,
-1927-06-30,ID,Indonesia,
-1927-06-30,IE,Ireland,
-1927-06-30,IL,Israel,
-1927-06-30,IN,India,
-1927-06-30,IS,Iceland,
-1927-06-30,IT,Italy,
-1927-06-30,JP,Japan,
-1927-06-30,KR,Korea,
-1927-06-30,LT,Lithuania,
-1927-06-30,LU,Luxembourg,
-1927-06-30,LV,Latvia,
-1927-06-30,MA,Morocco,
-1927-06-30,MK,North Macedonia,
-1927-06-30,MT,Malta,
-1927-06-30,MX,Mexico,
-1927-06-30,MY,Malaysia,
-1927-06-30,NL,Netherlands,
-1927-06-30,NO,Norway,
-1927-06-30,NZ,New Zealand,
-1927-06-30,PE,Peru,
-1927-06-30,PH,Philippines,
-1927-06-30,PL,Poland,
-1927-06-30,PT,Portugal,
-1927-06-30,RO,Romania,
-1927-06-30,RS,Serbia,
-1927-06-30,RU,Russia,
-1927-06-30,SE,Sweden,
-1927-06-30,SG,Singapore,
-1927-06-30,SI,Slovenia,
-1927-06-30,SK,Slovak Republic,
-1927-06-30,TH,Thailand,
-1927-06-30,TR,Türkiye,
-1927-06-30,US,United States,
-1927-06-30,XM,Euro area,
-1927-06-30,XW,World,
-1927-06-30,ZA,South Africa,
-1927-09-30,4T,Emerging market economies (aggregate),
-1927-09-30,5R,Advanced economies,
-1927-09-30,AE,United Arab Emirates,
-1927-09-30,AT,Austria,
-1927-09-30,AU,Australia,
-1927-09-30,BE,Belgium,
-1927-09-30,BG,Bulgaria,
-1927-09-30,BR,Brazil,
-1927-09-30,CA,Canada,
-1927-09-30,CH,Switzerland,
-1927-09-30,CL,Chile,
-1927-09-30,CN,China,
-1927-09-30,CO,Colombia,
-1927-09-30,CY,Cyprus,
-1927-09-30,CZ,Czechia,
-1927-09-30,DE,Germany,
-1927-09-30,DK,Denmark,
-1927-09-30,EE,Estonia,
-1927-09-30,ES,Spain,
-1927-09-30,FI,Finland,
-1927-09-30,FR,France,
-1927-09-30,GB,United Kingdom,
-1927-09-30,GR,Greece,
-1927-09-30,HK,Hong Kong SAR,
-1927-09-30,HR,Croatia,
-1927-09-30,HU,Hungary,
-1927-09-30,ID,Indonesia,
-1927-09-30,IE,Ireland,
-1927-09-30,IL,Israel,
-1927-09-30,IN,India,
-1927-09-30,IS,Iceland,
-1927-09-30,IT,Italy,
-1927-09-30,JP,Japan,
-1927-09-30,KR,Korea,
-1927-09-30,LT,Lithuania,
-1927-09-30,LU,Luxembourg,
-1927-09-30,LV,Latvia,
-1927-09-30,MA,Morocco,
-1927-09-30,MK,North Macedonia,
-1927-09-30,MT,Malta,
-1927-09-30,MX,Mexico,
-1927-09-30,MY,Malaysia,
-1927-09-30,NL,Netherlands,
-1927-09-30,NO,Norway,
-1927-09-30,NZ,New Zealand,
-1927-09-30,PE,Peru,
-1927-09-30,PH,Philippines,
-1927-09-30,PL,Poland,
-1927-09-30,PT,Portugal,
-1927-09-30,RO,Romania,
-1927-09-30,RS,Serbia,
-1927-09-30,RU,Russia,
-1927-09-30,SE,Sweden,
-1927-09-30,SG,Singapore,
-1927-09-30,SI,Slovenia,
-1927-09-30,SK,Slovak Republic,
-1927-09-30,TH,Thailand,
-1927-09-30,TR,Türkiye,
-1927-09-30,US,United States,
-1927-09-30,XM,Euro area,
-1927-09-30,XW,World,
-1927-09-30,ZA,South Africa,
-1927-12-31,4T,Emerging market economies (aggregate),
-1927-12-31,5R,Advanced economies,
-1927-12-31,AE,United Arab Emirates,
-1927-12-31,AT,Austria,
-1927-12-31,AU,Australia,
-1927-12-31,BE,Belgium,
-1927-12-31,BG,Bulgaria,
-1927-12-31,BR,Brazil,
-1927-12-31,CA,Canada,
-1927-12-31,CH,Switzerland,
-1927-12-31,CL,Chile,
-1927-12-31,CN,China,
-1927-12-31,CO,Colombia,
-1927-12-31,CY,Cyprus,
-1927-12-31,CZ,Czechia,
-1927-12-31,DE,Germany,
-1927-12-31,DK,Denmark,
-1927-12-31,EE,Estonia,
-1927-12-31,ES,Spain,
-1927-12-31,FI,Finland,
-1927-12-31,FR,France,
-1927-12-31,GB,United Kingdom,
-1927-12-31,GR,Greece,
-1927-12-31,HK,Hong Kong SAR,
-1927-12-31,HR,Croatia,
-1927-12-31,HU,Hungary,
-1927-12-31,ID,Indonesia,
-1927-12-31,IE,Ireland,
-1927-12-31,IL,Israel,
-1927-12-31,IN,India,
-1927-12-31,IS,Iceland,
-1927-12-31,IT,Italy,
-1927-12-31,JP,Japan,
-1927-12-31,KR,Korea,
-1927-12-31,LT,Lithuania,
-1927-12-31,LU,Luxembourg,
-1927-12-31,LV,Latvia,
-1927-12-31,MA,Morocco,
-1927-12-31,MK,North Macedonia,
-1927-12-31,MT,Malta,
-1927-12-31,MX,Mexico,
-1927-12-31,MY,Malaysia,
-1927-12-31,NL,Netherlands,
-1927-12-31,NO,Norway,
-1927-12-31,NZ,New Zealand,
-1927-12-31,PE,Peru,
-1927-12-31,PH,Philippines,
-1927-12-31,PL,Poland,
-1927-12-31,PT,Portugal,
-1927-12-31,RO,Romania,
-1927-12-31,RS,Serbia,
-1927-12-31,RU,Russia,
-1927-12-31,SE,Sweden,
-1927-12-31,SG,Singapore,
-1927-12-31,SI,Slovenia,
-1927-12-31,SK,Slovak Republic,
-1927-12-31,TH,Thailand,
-1927-12-31,TR,Türkiye,
-1927-12-31,US,United States,
-1927-12-31,XM,Euro area,
-1927-12-31,XW,World,
-1927-12-31,ZA,South Africa,
-1928-03-31,4T,Emerging market economies (aggregate),
-1928-03-31,5R,Advanced economies,
-1928-03-31,AE,United Arab Emirates,
-1928-03-31,AT,Austria,
-1928-03-31,AU,Australia,
-1928-03-31,BE,Belgium,
-1928-03-31,BG,Bulgaria,
-1928-03-31,BR,Brazil,
-1928-03-31,CA,Canada,
-1928-03-31,CH,Switzerland,
-1928-03-31,CL,Chile,
-1928-03-31,CN,China,
-1928-03-31,CO,Colombia,
-1928-03-31,CY,Cyprus,
-1928-03-31,CZ,Czechia,
-1928-03-31,DE,Germany,
-1928-03-31,DK,Denmark,
-1928-03-31,EE,Estonia,
-1928-03-31,ES,Spain,
-1928-03-31,FI,Finland,
-1928-03-31,FR,France,
-1928-03-31,GB,United Kingdom,
-1928-03-31,GR,Greece,
-1928-03-31,HK,Hong Kong SAR,
-1928-03-31,HR,Croatia,
-1928-03-31,HU,Hungary,
-1928-03-31,ID,Indonesia,
-1928-03-31,IE,Ireland,
-1928-03-31,IL,Israel,
-1928-03-31,IN,India,
-1928-03-31,IS,Iceland,
-1928-03-31,IT,Italy,
-1928-03-31,JP,Japan,
-1928-03-31,KR,Korea,
-1928-03-31,LT,Lithuania,
-1928-03-31,LU,Luxembourg,
-1928-03-31,LV,Latvia,
-1928-03-31,MA,Morocco,
-1928-03-31,MK,North Macedonia,
-1928-03-31,MT,Malta,
-1928-03-31,MX,Mexico,
-1928-03-31,MY,Malaysia,
-1928-03-31,NL,Netherlands,
-1928-03-31,NO,Norway,
-1928-03-31,NZ,New Zealand,
-1928-03-31,PE,Peru,
-1928-03-31,PH,Philippines,
-1928-03-31,PL,Poland,
-1928-03-31,PT,Portugal,
-1928-03-31,RO,Romania,
-1928-03-31,RS,Serbia,
-1928-03-31,RU,Russia,
-1928-03-31,SE,Sweden,
-1928-03-31,SG,Singapore,
-1928-03-31,SI,Slovenia,
-1928-03-31,SK,Slovak Republic,
-1928-03-31,TH,Thailand,
-1928-03-31,TR,Türkiye,
-1928-03-31,US,United States,
-1928-03-31,XM,Euro area,
-1928-03-31,XW,World,
-1928-03-31,ZA,South Africa,
-1928-06-30,4T,Emerging market economies (aggregate),
-1928-06-30,5R,Advanced economies,
-1928-06-30,AE,United Arab Emirates,
-1928-06-30,AT,Austria,
-1928-06-30,AU,Australia,
-1928-06-30,BE,Belgium,
-1928-06-30,BG,Bulgaria,
-1928-06-30,BR,Brazil,
-1928-06-30,CA,Canada,
-1928-06-30,CH,Switzerland,
-1928-06-30,CL,Chile,
-1928-06-30,CN,China,
-1928-06-30,CO,Colombia,
-1928-06-30,CY,Cyprus,
-1928-06-30,CZ,Czechia,
-1928-06-30,DE,Germany,
-1928-06-30,DK,Denmark,
-1928-06-30,EE,Estonia,
-1928-06-30,ES,Spain,
-1928-06-30,FI,Finland,
-1928-06-30,FR,France,
-1928-06-30,GB,United Kingdom,
-1928-06-30,GR,Greece,
-1928-06-30,HK,Hong Kong SAR,
-1928-06-30,HR,Croatia,
-1928-06-30,HU,Hungary,
-1928-06-30,ID,Indonesia,
-1928-06-30,IE,Ireland,
-1928-06-30,IL,Israel,
-1928-06-30,IN,India,
-1928-06-30,IS,Iceland,
-1928-06-30,IT,Italy,
-1928-06-30,JP,Japan,
-1928-06-30,KR,Korea,
-1928-06-30,LT,Lithuania,
-1928-06-30,LU,Luxembourg,
-1928-06-30,LV,Latvia,
-1928-06-30,MA,Morocco,
-1928-06-30,MK,North Macedonia,
-1928-06-30,MT,Malta,
-1928-06-30,MX,Mexico,
-1928-06-30,MY,Malaysia,
-1928-06-30,NL,Netherlands,
-1928-06-30,NO,Norway,
-1928-06-30,NZ,New Zealand,
-1928-06-30,PE,Peru,
-1928-06-30,PH,Philippines,
-1928-06-30,PL,Poland,
-1928-06-30,PT,Portugal,
-1928-06-30,RO,Romania,
-1928-06-30,RS,Serbia,
-1928-06-30,RU,Russia,
-1928-06-30,SE,Sweden,
-1928-06-30,SG,Singapore,
-1928-06-30,SI,Slovenia,
-1928-06-30,SK,Slovak Republic,
-1928-06-30,TH,Thailand,
-1928-06-30,TR,Türkiye,
-1928-06-30,US,United States,
-1928-06-30,XM,Euro area,
-1928-06-30,XW,World,
-1928-06-30,ZA,South Africa,
-1928-09-30,4T,Emerging market economies (aggregate),
-1928-09-30,5R,Advanced economies,
-1928-09-30,AE,United Arab Emirates,
-1928-09-30,AT,Austria,
-1928-09-30,AU,Australia,
-1928-09-30,BE,Belgium,
-1928-09-30,BG,Bulgaria,
-1928-09-30,BR,Brazil,
-1928-09-30,CA,Canada,
-1928-09-30,CH,Switzerland,
-1928-09-30,CL,Chile,
-1928-09-30,CN,China,
-1928-09-30,CO,Colombia,
-1928-09-30,CY,Cyprus,
-1928-09-30,CZ,Czechia,
-1928-09-30,DE,Germany,
-1928-09-30,DK,Denmark,
-1928-09-30,EE,Estonia,
-1928-09-30,ES,Spain,
-1928-09-30,FI,Finland,
-1928-09-30,FR,France,
-1928-09-30,GB,United Kingdom,
-1928-09-30,GR,Greece,
-1928-09-30,HK,Hong Kong SAR,
-1928-09-30,HR,Croatia,
-1928-09-30,HU,Hungary,
-1928-09-30,ID,Indonesia,
-1928-09-30,IE,Ireland,
-1928-09-30,IL,Israel,
-1928-09-30,IN,India,
-1928-09-30,IS,Iceland,
-1928-09-30,IT,Italy,
-1928-09-30,JP,Japan,
-1928-09-30,KR,Korea,
-1928-09-30,LT,Lithuania,
-1928-09-30,LU,Luxembourg,
-1928-09-30,LV,Latvia,
-1928-09-30,MA,Morocco,
-1928-09-30,MK,North Macedonia,
-1928-09-30,MT,Malta,
-1928-09-30,MX,Mexico,
-1928-09-30,MY,Malaysia,
-1928-09-30,NL,Netherlands,
-1928-09-30,NO,Norway,
-1928-09-30,NZ,New Zealand,
-1928-09-30,PE,Peru,
-1928-09-30,PH,Philippines,
-1928-09-30,PL,Poland,
-1928-09-30,PT,Portugal,
-1928-09-30,RO,Romania,
-1928-09-30,RS,Serbia,
-1928-09-30,RU,Russia,
-1928-09-30,SE,Sweden,
-1928-09-30,SG,Singapore,
-1928-09-30,SI,Slovenia,
-1928-09-30,SK,Slovak Republic,
-1928-09-30,TH,Thailand,
-1928-09-30,TR,Türkiye,
-1928-09-30,US,United States,
-1928-09-30,XM,Euro area,
-1928-09-30,XW,World,
-1928-09-30,ZA,South Africa,
-1928-12-31,4T,Emerging market economies (aggregate),
-1928-12-31,5R,Advanced economies,
-1928-12-31,AE,United Arab Emirates,
-1928-12-31,AT,Austria,
-1928-12-31,AU,Australia,
-1928-12-31,BE,Belgium,
-1928-12-31,BG,Bulgaria,
-1928-12-31,BR,Brazil,
-1928-12-31,CA,Canada,
-1928-12-31,CH,Switzerland,
-1928-12-31,CL,Chile,
-1928-12-31,CN,China,
-1928-12-31,CO,Colombia,
-1928-12-31,CY,Cyprus,
-1928-12-31,CZ,Czechia,
-1928-12-31,DE,Germany,
-1928-12-31,DK,Denmark,
-1928-12-31,EE,Estonia,
-1928-12-31,ES,Spain,
-1928-12-31,FI,Finland,
-1928-12-31,FR,France,
-1928-12-31,GB,United Kingdom,
-1928-12-31,GR,Greece,
-1928-12-31,HK,Hong Kong SAR,
-1928-12-31,HR,Croatia,
-1928-12-31,HU,Hungary,
-1928-12-31,ID,Indonesia,
-1928-12-31,IE,Ireland,
-1928-12-31,IL,Israel,
-1928-12-31,IN,India,
-1928-12-31,IS,Iceland,
-1928-12-31,IT,Italy,
-1928-12-31,JP,Japan,
-1928-12-31,KR,Korea,
-1928-12-31,LT,Lithuania,
-1928-12-31,LU,Luxembourg,
-1928-12-31,LV,Latvia,
-1928-12-31,MA,Morocco,
-1928-12-31,MK,North Macedonia,
-1928-12-31,MT,Malta,
-1928-12-31,MX,Mexico,
-1928-12-31,MY,Malaysia,
-1928-12-31,NL,Netherlands,
-1928-12-31,NO,Norway,
-1928-12-31,NZ,New Zealand,
-1928-12-31,PE,Peru,
-1928-12-31,PH,Philippines,
-1928-12-31,PL,Poland,
-1928-12-31,PT,Portugal,
-1928-12-31,RO,Romania,
-1928-12-31,RS,Serbia,
-1928-12-31,RU,Russia,
-1928-12-31,SE,Sweden,
-1928-12-31,SG,Singapore,
-1928-12-31,SI,Slovenia,
-1928-12-31,SK,Slovak Republic,
-1928-12-31,TH,Thailand,
-1928-12-31,TR,Türkiye,
-1928-12-31,US,United States,
-1928-12-31,XM,Euro area,
-1928-12-31,XW,World,
-1928-12-31,ZA,South Africa,
-1929-03-31,4T,Emerging market economies (aggregate),
-1929-03-31,5R,Advanced economies,
-1929-03-31,AE,United Arab Emirates,
-1929-03-31,AT,Austria,
-1929-03-31,AU,Australia,
-1929-03-31,BE,Belgium,
-1929-03-31,BG,Bulgaria,
-1929-03-31,BR,Brazil,
-1929-03-31,CA,Canada,
-1929-03-31,CH,Switzerland,
-1929-03-31,CL,Chile,
-1929-03-31,CN,China,
-1929-03-31,CO,Colombia,
-1929-03-31,CY,Cyprus,
-1929-03-31,CZ,Czechia,
-1929-03-31,DE,Germany,
-1929-03-31,DK,Denmark,
-1929-03-31,EE,Estonia,
-1929-03-31,ES,Spain,
-1929-03-31,FI,Finland,
-1929-03-31,FR,France,
-1929-03-31,GB,United Kingdom,
-1929-03-31,GR,Greece,
-1929-03-31,HK,Hong Kong SAR,
-1929-03-31,HR,Croatia,
-1929-03-31,HU,Hungary,
-1929-03-31,ID,Indonesia,
-1929-03-31,IE,Ireland,
-1929-03-31,IL,Israel,
-1929-03-31,IN,India,
-1929-03-31,IS,Iceland,
-1929-03-31,IT,Italy,
-1929-03-31,JP,Japan,
-1929-03-31,KR,Korea,
-1929-03-31,LT,Lithuania,
-1929-03-31,LU,Luxembourg,
-1929-03-31,LV,Latvia,
-1929-03-31,MA,Morocco,
-1929-03-31,MK,North Macedonia,
-1929-03-31,MT,Malta,
-1929-03-31,MX,Mexico,
-1929-03-31,MY,Malaysia,
-1929-03-31,NL,Netherlands,
-1929-03-31,NO,Norway,
-1929-03-31,NZ,New Zealand,
-1929-03-31,PE,Peru,
-1929-03-31,PH,Philippines,
-1929-03-31,PL,Poland,
-1929-03-31,PT,Portugal,
-1929-03-31,RO,Romania,
-1929-03-31,RS,Serbia,
-1929-03-31,RU,Russia,
-1929-03-31,SE,Sweden,
-1929-03-31,SG,Singapore,
-1929-03-31,SI,Slovenia,
-1929-03-31,SK,Slovak Republic,
-1929-03-31,TH,Thailand,
-1929-03-31,TR,Türkiye,
-1929-03-31,US,United States,
-1929-03-31,XM,Euro area,
-1929-03-31,XW,World,
-1929-03-31,ZA,South Africa,
-1929-06-30,4T,Emerging market economies (aggregate),
-1929-06-30,5R,Advanced economies,
-1929-06-30,AE,United Arab Emirates,
-1929-06-30,AT,Austria,
-1929-06-30,AU,Australia,
-1929-06-30,BE,Belgium,
-1929-06-30,BG,Bulgaria,
-1929-06-30,BR,Brazil,
-1929-06-30,CA,Canada,
-1929-06-30,CH,Switzerland,
-1929-06-30,CL,Chile,
-1929-06-30,CN,China,
-1929-06-30,CO,Colombia,
-1929-06-30,CY,Cyprus,
-1929-06-30,CZ,Czechia,
-1929-06-30,DE,Germany,
-1929-06-30,DK,Denmark,
-1929-06-30,EE,Estonia,
-1929-06-30,ES,Spain,
-1929-06-30,FI,Finland,
-1929-06-30,FR,France,
-1929-06-30,GB,United Kingdom,
-1929-06-30,GR,Greece,
-1929-06-30,HK,Hong Kong SAR,
-1929-06-30,HR,Croatia,
-1929-06-30,HU,Hungary,
-1929-06-30,ID,Indonesia,
-1929-06-30,IE,Ireland,
-1929-06-30,IL,Israel,
-1929-06-30,IN,India,
-1929-06-30,IS,Iceland,
-1929-06-30,IT,Italy,
-1929-06-30,JP,Japan,
-1929-06-30,KR,Korea,
-1929-06-30,LT,Lithuania,
-1929-06-30,LU,Luxembourg,
-1929-06-30,LV,Latvia,
-1929-06-30,MA,Morocco,
-1929-06-30,MK,North Macedonia,
-1929-06-30,MT,Malta,
-1929-06-30,MX,Mexico,
-1929-06-30,MY,Malaysia,
-1929-06-30,NL,Netherlands,
-1929-06-30,NO,Norway,
-1929-06-30,NZ,New Zealand,
-1929-06-30,PE,Peru,
-1929-06-30,PH,Philippines,
-1929-06-30,PL,Poland,
-1929-06-30,PT,Portugal,
-1929-06-30,RO,Romania,
-1929-06-30,RS,Serbia,
-1929-06-30,RU,Russia,
-1929-06-30,SE,Sweden,
-1929-06-30,SG,Singapore,
-1929-06-30,SI,Slovenia,
-1929-06-30,SK,Slovak Republic,
-1929-06-30,TH,Thailand,
-1929-06-30,TR,Türkiye,
-1929-06-30,US,United States,
-1929-06-30,XM,Euro area,
-1929-06-30,XW,World,
-1929-06-30,ZA,South Africa,
-1929-09-30,4T,Emerging market economies (aggregate),
-1929-09-30,5R,Advanced economies,
-1929-09-30,AE,United Arab Emirates,
-1929-09-30,AT,Austria,
-1929-09-30,AU,Australia,
-1929-09-30,BE,Belgium,
-1929-09-30,BG,Bulgaria,
-1929-09-30,BR,Brazil,
-1929-09-30,CA,Canada,
-1929-09-30,CH,Switzerland,
-1929-09-30,CL,Chile,
-1929-09-30,CN,China,
-1929-09-30,CO,Colombia,
-1929-09-30,CY,Cyprus,
-1929-09-30,CZ,Czechia,
-1929-09-30,DE,Germany,
-1929-09-30,DK,Denmark,
-1929-09-30,EE,Estonia,
-1929-09-30,ES,Spain,
-1929-09-30,FI,Finland,
-1929-09-30,FR,France,
-1929-09-30,GB,United Kingdom,
-1929-09-30,GR,Greece,
-1929-09-30,HK,Hong Kong SAR,
-1929-09-30,HR,Croatia,
-1929-09-30,HU,Hungary,
-1929-09-30,ID,Indonesia,
-1929-09-30,IE,Ireland,
-1929-09-30,IL,Israel,
-1929-09-30,IN,India,
-1929-09-30,IS,Iceland,
-1929-09-30,IT,Italy,
-1929-09-30,JP,Japan,
-1929-09-30,KR,Korea,
-1929-09-30,LT,Lithuania,
-1929-09-30,LU,Luxembourg,
-1929-09-30,LV,Latvia,
-1929-09-30,MA,Morocco,
-1929-09-30,MK,North Macedonia,
-1929-09-30,MT,Malta,
-1929-09-30,MX,Mexico,
-1929-09-30,MY,Malaysia,
-1929-09-30,NL,Netherlands,
-1929-09-30,NO,Norway,
-1929-09-30,NZ,New Zealand,
-1929-09-30,PE,Peru,
-1929-09-30,PH,Philippines,
-1929-09-30,PL,Poland,
-1929-09-30,PT,Portugal,
-1929-09-30,RO,Romania,
-1929-09-30,RS,Serbia,
-1929-09-30,RU,Russia,
-1929-09-30,SE,Sweden,
-1929-09-30,SG,Singapore,
-1929-09-30,SI,Slovenia,
-1929-09-30,SK,Slovak Republic,
-1929-09-30,TH,Thailand,
-1929-09-30,TR,Türkiye,
-1929-09-30,US,United States,
-1929-09-30,XM,Euro area,
-1929-09-30,XW,World,
-1929-09-30,ZA,South Africa,
-1929-12-31,4T,Emerging market economies (aggregate),
-1929-12-31,5R,Advanced economies,
-1929-12-31,AE,United Arab Emirates,
-1929-12-31,AT,Austria,
-1929-12-31,AU,Australia,
-1929-12-31,BE,Belgium,
-1929-12-31,BG,Bulgaria,
-1929-12-31,BR,Brazil,
-1929-12-31,CA,Canada,
-1929-12-31,CH,Switzerland,
-1929-12-31,CL,Chile,
-1929-12-31,CN,China,
-1929-12-31,CO,Colombia,
-1929-12-31,CY,Cyprus,
-1929-12-31,CZ,Czechia,
-1929-12-31,DE,Germany,
-1929-12-31,DK,Denmark,
-1929-12-31,EE,Estonia,
-1929-12-31,ES,Spain,
-1929-12-31,FI,Finland,
-1929-12-31,FR,France,
-1929-12-31,GB,United Kingdom,
-1929-12-31,GR,Greece,
-1929-12-31,HK,Hong Kong SAR,
-1929-12-31,HR,Croatia,
-1929-12-31,HU,Hungary,
-1929-12-31,ID,Indonesia,
-1929-12-31,IE,Ireland,
-1929-12-31,IL,Israel,
-1929-12-31,IN,India,
-1929-12-31,IS,Iceland,
-1929-12-31,IT,Italy,
-1929-12-31,JP,Japan,
-1929-12-31,KR,Korea,
-1929-12-31,LT,Lithuania,
-1929-12-31,LU,Luxembourg,
-1929-12-31,LV,Latvia,
-1929-12-31,MA,Morocco,
-1929-12-31,MK,North Macedonia,
-1929-12-31,MT,Malta,
-1929-12-31,MX,Mexico,
-1929-12-31,MY,Malaysia,
-1929-12-31,NL,Netherlands,
-1929-12-31,NO,Norway,
-1929-12-31,NZ,New Zealand,
-1929-12-31,PE,Peru,
-1929-12-31,PH,Philippines,
-1929-12-31,PL,Poland,
-1929-12-31,PT,Portugal,
-1929-12-31,RO,Romania,
-1929-12-31,RS,Serbia,
-1929-12-31,RU,Russia,
-1929-12-31,SE,Sweden,
-1929-12-31,SG,Singapore,
-1929-12-31,SI,Slovenia,
-1929-12-31,SK,Slovak Republic,
-1929-12-31,TH,Thailand,
-1929-12-31,TR,Türkiye,
-1929-12-31,US,United States,
-1929-12-31,XM,Euro area,
-1929-12-31,XW,World,
-1929-12-31,ZA,South Africa,
-1930-03-31,4T,Emerging market economies (aggregate),
-1930-03-31,5R,Advanced economies,
-1930-03-31,AE,United Arab Emirates,
-1930-03-31,AT,Austria,
-1930-03-31,AU,Australia,
-1930-03-31,BE,Belgium,
-1930-03-31,BG,Bulgaria,
-1930-03-31,BR,Brazil,
-1930-03-31,CA,Canada,
-1930-03-31,CH,Switzerland,
-1930-03-31,CL,Chile,
-1930-03-31,CN,China,
-1930-03-31,CO,Colombia,
-1930-03-31,CY,Cyprus,
-1930-03-31,CZ,Czechia,
-1930-03-31,DE,Germany,
-1930-03-31,DK,Denmark,
-1930-03-31,EE,Estonia,
-1930-03-31,ES,Spain,
-1930-03-31,FI,Finland,
-1930-03-31,FR,France,
-1930-03-31,GB,United Kingdom,
-1930-03-31,GR,Greece,
-1930-03-31,HK,Hong Kong SAR,
-1930-03-31,HR,Croatia,
-1930-03-31,HU,Hungary,
-1930-03-31,ID,Indonesia,
-1930-03-31,IE,Ireland,
-1930-03-31,IL,Israel,
-1930-03-31,IN,India,
-1930-03-31,IS,Iceland,
-1930-03-31,IT,Italy,
-1930-03-31,JP,Japan,
-1930-03-31,KR,Korea,
-1930-03-31,LT,Lithuania,
-1930-03-31,LU,Luxembourg,
-1930-03-31,LV,Latvia,
-1930-03-31,MA,Morocco,
-1930-03-31,MK,North Macedonia,
-1930-03-31,MT,Malta,
-1930-03-31,MX,Mexico,
-1930-03-31,MY,Malaysia,
-1930-03-31,NL,Netherlands,
-1930-03-31,NO,Norway,
-1930-03-31,NZ,New Zealand,
-1930-03-31,PE,Peru,
-1930-03-31,PH,Philippines,
-1930-03-31,PL,Poland,
-1930-03-31,PT,Portugal,
-1930-03-31,RO,Romania,
-1930-03-31,RS,Serbia,
-1930-03-31,RU,Russia,
-1930-03-31,SE,Sweden,
-1930-03-31,SG,Singapore,
-1930-03-31,SI,Slovenia,
-1930-03-31,SK,Slovak Republic,
-1930-03-31,TH,Thailand,
-1930-03-31,TR,Türkiye,
-1930-03-31,US,United States,
-1930-03-31,XM,Euro area,
-1930-03-31,XW,World,
-1930-03-31,ZA,South Africa,
-1930-06-30,4T,Emerging market economies (aggregate),
-1930-06-30,5R,Advanced economies,
-1930-06-30,AE,United Arab Emirates,
-1930-06-30,AT,Austria,
-1930-06-30,AU,Australia,
-1930-06-30,BE,Belgium,
-1930-06-30,BG,Bulgaria,
-1930-06-30,BR,Brazil,
-1930-06-30,CA,Canada,
-1930-06-30,CH,Switzerland,
-1930-06-30,CL,Chile,
-1930-06-30,CN,China,
-1930-06-30,CO,Colombia,
-1930-06-30,CY,Cyprus,
-1930-06-30,CZ,Czechia,
-1930-06-30,DE,Germany,
-1930-06-30,DK,Denmark,
-1930-06-30,EE,Estonia,
-1930-06-30,ES,Spain,
-1930-06-30,FI,Finland,
-1930-06-30,FR,France,
-1930-06-30,GB,United Kingdom,
-1930-06-30,GR,Greece,
-1930-06-30,HK,Hong Kong SAR,
-1930-06-30,HR,Croatia,
-1930-06-30,HU,Hungary,
-1930-06-30,ID,Indonesia,
-1930-06-30,IE,Ireland,
-1930-06-30,IL,Israel,
-1930-06-30,IN,India,
-1930-06-30,IS,Iceland,
-1930-06-30,IT,Italy,
-1930-06-30,JP,Japan,
-1930-06-30,KR,Korea,
-1930-06-30,LT,Lithuania,
-1930-06-30,LU,Luxembourg,
-1930-06-30,LV,Latvia,
-1930-06-30,MA,Morocco,
-1930-06-30,MK,North Macedonia,
-1930-06-30,MT,Malta,
-1930-06-30,MX,Mexico,
-1930-06-30,MY,Malaysia,
-1930-06-30,NL,Netherlands,
-1930-06-30,NO,Norway,
-1930-06-30,NZ,New Zealand,
-1930-06-30,PE,Peru,
-1930-06-30,PH,Philippines,
-1930-06-30,PL,Poland,
-1930-06-30,PT,Portugal,
-1930-06-30,RO,Romania,
-1930-06-30,RS,Serbia,
-1930-06-30,RU,Russia,
-1930-06-30,SE,Sweden,
-1930-06-30,SG,Singapore,
-1930-06-30,SI,Slovenia,
-1930-06-30,SK,Slovak Republic,
-1930-06-30,TH,Thailand,
-1930-06-30,TR,Türkiye,
-1930-06-30,US,United States,
-1930-06-30,XM,Euro area,
-1930-06-30,XW,World,
-1930-06-30,ZA,South Africa,
-1930-09-30,4T,Emerging market economies (aggregate),
-1930-09-30,5R,Advanced economies,
-1930-09-30,AE,United Arab Emirates,
-1930-09-30,AT,Austria,
-1930-09-30,AU,Australia,
-1930-09-30,BE,Belgium,
-1930-09-30,BG,Bulgaria,
-1930-09-30,BR,Brazil,
-1930-09-30,CA,Canada,
-1930-09-30,CH,Switzerland,
-1930-09-30,CL,Chile,
-1930-09-30,CN,China,
-1930-09-30,CO,Colombia,
-1930-09-30,CY,Cyprus,
-1930-09-30,CZ,Czechia,
-1930-09-30,DE,Germany,
-1930-09-30,DK,Denmark,
-1930-09-30,EE,Estonia,
-1930-09-30,ES,Spain,
-1930-09-30,FI,Finland,
-1930-09-30,FR,France,
-1930-09-30,GB,United Kingdom,
-1930-09-30,GR,Greece,
-1930-09-30,HK,Hong Kong SAR,
-1930-09-30,HR,Croatia,
-1930-09-30,HU,Hungary,
-1930-09-30,ID,Indonesia,
-1930-09-30,IE,Ireland,
-1930-09-30,IL,Israel,
-1930-09-30,IN,India,
-1930-09-30,IS,Iceland,
-1930-09-30,IT,Italy,
-1930-09-30,JP,Japan,
-1930-09-30,KR,Korea,
-1930-09-30,LT,Lithuania,
-1930-09-30,LU,Luxembourg,
-1930-09-30,LV,Latvia,
-1930-09-30,MA,Morocco,
-1930-09-30,MK,North Macedonia,
-1930-09-30,MT,Malta,
-1930-09-30,MX,Mexico,
-1930-09-30,MY,Malaysia,
-1930-09-30,NL,Netherlands,
-1930-09-30,NO,Norway,
-1930-09-30,NZ,New Zealand,
-1930-09-30,PE,Peru,
-1930-09-30,PH,Philippines,
-1930-09-30,PL,Poland,
-1930-09-30,PT,Portugal,
-1930-09-30,RO,Romania,
-1930-09-30,RS,Serbia,
-1930-09-30,RU,Russia,
-1930-09-30,SE,Sweden,
-1930-09-30,SG,Singapore,
-1930-09-30,SI,Slovenia,
-1930-09-30,SK,Slovak Republic,
-1930-09-30,TH,Thailand,
-1930-09-30,TR,Türkiye,
-1930-09-30,US,United States,
-1930-09-30,XM,Euro area,
-1930-09-30,XW,World,
-1930-09-30,ZA,South Africa,
-1930-12-31,4T,Emerging market economies (aggregate),
-1930-12-31,5R,Advanced economies,
-1930-12-31,AE,United Arab Emirates,
-1930-12-31,AT,Austria,
-1930-12-31,AU,Australia,
-1930-12-31,BE,Belgium,
-1930-12-31,BG,Bulgaria,
-1930-12-31,BR,Brazil,
-1930-12-31,CA,Canada,
-1930-12-31,CH,Switzerland,
-1930-12-31,CL,Chile,
-1930-12-31,CN,China,
-1930-12-31,CO,Colombia,
-1930-12-31,CY,Cyprus,
-1930-12-31,CZ,Czechia,
-1930-12-31,DE,Germany,
-1930-12-31,DK,Denmark,
-1930-12-31,EE,Estonia,
-1930-12-31,ES,Spain,
-1930-12-31,FI,Finland,
-1930-12-31,FR,France,
-1930-12-31,GB,United Kingdom,
-1930-12-31,GR,Greece,
-1930-12-31,HK,Hong Kong SAR,
-1930-12-31,HR,Croatia,
-1930-12-31,HU,Hungary,
-1930-12-31,ID,Indonesia,
-1930-12-31,IE,Ireland,
-1930-12-31,IL,Israel,
-1930-12-31,IN,India,
-1930-12-31,IS,Iceland,
-1930-12-31,IT,Italy,
-1930-12-31,JP,Japan,
-1930-12-31,KR,Korea,
-1930-12-31,LT,Lithuania,
-1930-12-31,LU,Luxembourg,
-1930-12-31,LV,Latvia,
-1930-12-31,MA,Morocco,
-1930-12-31,MK,North Macedonia,
-1930-12-31,MT,Malta,
-1930-12-31,MX,Mexico,
-1930-12-31,MY,Malaysia,
-1930-12-31,NL,Netherlands,
-1930-12-31,NO,Norway,
-1930-12-31,NZ,New Zealand,
-1930-12-31,PE,Peru,
-1930-12-31,PH,Philippines,
-1930-12-31,PL,Poland,
-1930-12-31,PT,Portugal,
-1930-12-31,RO,Romania,
-1930-12-31,RS,Serbia,
-1930-12-31,RU,Russia,
-1930-12-31,SE,Sweden,
-1930-12-31,SG,Singapore,
-1930-12-31,SI,Slovenia,
-1930-12-31,SK,Slovak Republic,
-1930-12-31,TH,Thailand,
-1930-12-31,TR,Türkiye,
-1930-12-31,US,United States,
-1930-12-31,XM,Euro area,
-1930-12-31,XW,World,
-1930-12-31,ZA,South Africa,
-1931-03-31,4T,Emerging market economies (aggregate),
-1931-03-31,5R,Advanced economies,
-1931-03-31,AE,United Arab Emirates,
-1931-03-31,AT,Austria,
-1931-03-31,AU,Australia,
-1931-03-31,BE,Belgium,
-1931-03-31,BG,Bulgaria,
-1931-03-31,BR,Brazil,
-1931-03-31,CA,Canada,
-1931-03-31,CH,Switzerland,
-1931-03-31,CL,Chile,
-1931-03-31,CN,China,
-1931-03-31,CO,Colombia,
-1931-03-31,CY,Cyprus,
-1931-03-31,CZ,Czechia,
-1931-03-31,DE,Germany,
-1931-03-31,DK,Denmark,
-1931-03-31,EE,Estonia,
-1931-03-31,ES,Spain,
-1931-03-31,FI,Finland,
-1931-03-31,FR,France,
-1931-03-31,GB,United Kingdom,
-1931-03-31,GR,Greece,
-1931-03-31,HK,Hong Kong SAR,
-1931-03-31,HR,Croatia,
-1931-03-31,HU,Hungary,
-1931-03-31,ID,Indonesia,
-1931-03-31,IE,Ireland,
-1931-03-31,IL,Israel,
-1931-03-31,IN,India,
-1931-03-31,IS,Iceland,
-1931-03-31,IT,Italy,
-1931-03-31,JP,Japan,
-1931-03-31,KR,Korea,
-1931-03-31,LT,Lithuania,
-1931-03-31,LU,Luxembourg,
-1931-03-31,LV,Latvia,
-1931-03-31,MA,Morocco,
-1931-03-31,MK,North Macedonia,
-1931-03-31,MT,Malta,
-1931-03-31,MX,Mexico,
-1931-03-31,MY,Malaysia,
-1931-03-31,NL,Netherlands,
-1931-03-31,NO,Norway,
-1931-03-31,NZ,New Zealand,
-1931-03-31,PE,Peru,
-1931-03-31,PH,Philippines,
-1931-03-31,PL,Poland,
-1931-03-31,PT,Portugal,
-1931-03-31,RO,Romania,
-1931-03-31,RS,Serbia,
-1931-03-31,RU,Russia,
-1931-03-31,SE,Sweden,
-1931-03-31,SG,Singapore,
-1931-03-31,SI,Slovenia,
-1931-03-31,SK,Slovak Republic,
-1931-03-31,TH,Thailand,
-1931-03-31,TR,Türkiye,
-1931-03-31,US,United States,
-1931-03-31,XM,Euro area,
-1931-03-31,XW,World,
-1931-03-31,ZA,South Africa,
-1931-06-30,4T,Emerging market economies (aggregate),
-1931-06-30,5R,Advanced economies,
-1931-06-30,AE,United Arab Emirates,
-1931-06-30,AT,Austria,
-1931-06-30,AU,Australia,
-1931-06-30,BE,Belgium,
-1931-06-30,BG,Bulgaria,
-1931-06-30,BR,Brazil,
-1931-06-30,CA,Canada,
-1931-06-30,CH,Switzerland,
-1931-06-30,CL,Chile,
-1931-06-30,CN,China,
-1931-06-30,CO,Colombia,
-1931-06-30,CY,Cyprus,
-1931-06-30,CZ,Czechia,
-1931-06-30,DE,Germany,
-1931-06-30,DK,Denmark,
-1931-06-30,EE,Estonia,
-1931-06-30,ES,Spain,
-1931-06-30,FI,Finland,
-1931-06-30,FR,France,
-1931-06-30,GB,United Kingdom,
-1931-06-30,GR,Greece,
-1931-06-30,HK,Hong Kong SAR,
-1931-06-30,HR,Croatia,
-1931-06-30,HU,Hungary,
-1931-06-30,ID,Indonesia,
-1931-06-30,IE,Ireland,
-1931-06-30,IL,Israel,
-1931-06-30,IN,India,
-1931-06-30,IS,Iceland,
-1931-06-30,IT,Italy,
-1931-06-30,JP,Japan,
-1931-06-30,KR,Korea,
-1931-06-30,LT,Lithuania,
-1931-06-30,LU,Luxembourg,
-1931-06-30,LV,Latvia,
-1931-06-30,MA,Morocco,
-1931-06-30,MK,North Macedonia,
-1931-06-30,MT,Malta,
-1931-06-30,MX,Mexico,
-1931-06-30,MY,Malaysia,
-1931-06-30,NL,Netherlands,
-1931-06-30,NO,Norway,
-1931-06-30,NZ,New Zealand,
-1931-06-30,PE,Peru,
-1931-06-30,PH,Philippines,
-1931-06-30,PL,Poland,
-1931-06-30,PT,Portugal,
-1931-06-30,RO,Romania,
-1931-06-30,RS,Serbia,
-1931-06-30,RU,Russia,
-1931-06-30,SE,Sweden,
-1931-06-30,SG,Singapore,
-1931-06-30,SI,Slovenia,
-1931-06-30,SK,Slovak Republic,
-1931-06-30,TH,Thailand,
-1931-06-30,TR,Türkiye,
-1931-06-30,US,United States,
-1931-06-30,XM,Euro area,
-1931-06-30,XW,World,
-1931-06-30,ZA,South Africa,
-1931-09-30,4T,Emerging market economies (aggregate),
-1931-09-30,5R,Advanced economies,
-1931-09-30,AE,United Arab Emirates,
-1931-09-30,AT,Austria,
-1931-09-30,AU,Australia,
-1931-09-30,BE,Belgium,
-1931-09-30,BG,Bulgaria,
-1931-09-30,BR,Brazil,
-1931-09-30,CA,Canada,
-1931-09-30,CH,Switzerland,
-1931-09-30,CL,Chile,
-1931-09-30,CN,China,
-1931-09-30,CO,Colombia,
-1931-09-30,CY,Cyprus,
-1931-09-30,CZ,Czechia,
-1931-09-30,DE,Germany,
-1931-09-30,DK,Denmark,
-1931-09-30,EE,Estonia,
-1931-09-30,ES,Spain,
-1931-09-30,FI,Finland,
-1931-09-30,FR,France,
-1931-09-30,GB,United Kingdom,
-1931-09-30,GR,Greece,
-1931-09-30,HK,Hong Kong SAR,
-1931-09-30,HR,Croatia,
-1931-09-30,HU,Hungary,
-1931-09-30,ID,Indonesia,
-1931-09-30,IE,Ireland,
-1931-09-30,IL,Israel,
-1931-09-30,IN,India,
-1931-09-30,IS,Iceland,
-1931-09-30,IT,Italy,
-1931-09-30,JP,Japan,
-1931-09-30,KR,Korea,
-1931-09-30,LT,Lithuania,
-1931-09-30,LU,Luxembourg,
-1931-09-30,LV,Latvia,
-1931-09-30,MA,Morocco,
-1931-09-30,MK,North Macedonia,
-1931-09-30,MT,Malta,
-1931-09-30,MX,Mexico,
-1931-09-30,MY,Malaysia,
-1931-09-30,NL,Netherlands,
-1931-09-30,NO,Norway,
-1931-09-30,NZ,New Zealand,
-1931-09-30,PE,Peru,
-1931-09-30,PH,Philippines,
-1931-09-30,PL,Poland,
-1931-09-30,PT,Portugal,
-1931-09-30,RO,Romania,
-1931-09-30,RS,Serbia,
-1931-09-30,RU,Russia,
-1931-09-30,SE,Sweden,
-1931-09-30,SG,Singapore,
-1931-09-30,SI,Slovenia,
-1931-09-30,SK,Slovak Republic,
-1931-09-30,TH,Thailand,
-1931-09-30,TR,Türkiye,
-1931-09-30,US,United States,
-1931-09-30,XM,Euro area,
-1931-09-30,XW,World,
-1931-09-30,ZA,South Africa,
-1931-12-31,4T,Emerging market economies (aggregate),
-1931-12-31,5R,Advanced economies,
-1931-12-31,AE,United Arab Emirates,
-1931-12-31,AT,Austria,
-1931-12-31,AU,Australia,
-1931-12-31,BE,Belgium,
-1931-12-31,BG,Bulgaria,
-1931-12-31,BR,Brazil,
-1931-12-31,CA,Canada,
-1931-12-31,CH,Switzerland,
-1931-12-31,CL,Chile,
-1931-12-31,CN,China,
-1931-12-31,CO,Colombia,
-1931-12-31,CY,Cyprus,
-1931-12-31,CZ,Czechia,
-1931-12-31,DE,Germany,
-1931-12-31,DK,Denmark,
-1931-12-31,EE,Estonia,
-1931-12-31,ES,Spain,
-1931-12-31,FI,Finland,
-1931-12-31,FR,France,
-1931-12-31,GB,United Kingdom,
-1931-12-31,GR,Greece,
-1931-12-31,HK,Hong Kong SAR,
-1931-12-31,HR,Croatia,
-1931-12-31,HU,Hungary,
-1931-12-31,ID,Indonesia,
-1931-12-31,IE,Ireland,
-1931-12-31,IL,Israel,
-1931-12-31,IN,India,
-1931-12-31,IS,Iceland,
-1931-12-31,IT,Italy,
-1931-12-31,JP,Japan,
-1931-12-31,KR,Korea,
-1931-12-31,LT,Lithuania,
-1931-12-31,LU,Luxembourg,
-1931-12-31,LV,Latvia,
-1931-12-31,MA,Morocco,
-1931-12-31,MK,North Macedonia,
-1931-12-31,MT,Malta,
-1931-12-31,MX,Mexico,
-1931-12-31,MY,Malaysia,
-1931-12-31,NL,Netherlands,
-1931-12-31,NO,Norway,
-1931-12-31,NZ,New Zealand,
-1931-12-31,PE,Peru,
-1931-12-31,PH,Philippines,
-1931-12-31,PL,Poland,
-1931-12-31,PT,Portugal,
-1931-12-31,RO,Romania,
-1931-12-31,RS,Serbia,
-1931-12-31,RU,Russia,
-1931-12-31,SE,Sweden,
-1931-12-31,SG,Singapore,
-1931-12-31,SI,Slovenia,
-1931-12-31,SK,Slovak Republic,
-1931-12-31,TH,Thailand,
-1931-12-31,TR,Türkiye,
-1931-12-31,US,United States,
-1931-12-31,XM,Euro area,
-1931-12-31,XW,World,
-1931-12-31,ZA,South Africa,
-1932-03-31,4T,Emerging market economies (aggregate),
-1932-03-31,5R,Advanced economies,
-1932-03-31,AE,United Arab Emirates,
-1932-03-31,AT,Austria,
-1932-03-31,AU,Australia,
-1932-03-31,BE,Belgium,
-1932-03-31,BG,Bulgaria,
-1932-03-31,BR,Brazil,
-1932-03-31,CA,Canada,
-1932-03-31,CH,Switzerland,
-1932-03-31,CL,Chile,
-1932-03-31,CN,China,
-1932-03-31,CO,Colombia,
-1932-03-31,CY,Cyprus,
-1932-03-31,CZ,Czechia,
-1932-03-31,DE,Germany,
-1932-03-31,DK,Denmark,
-1932-03-31,EE,Estonia,
-1932-03-31,ES,Spain,
-1932-03-31,FI,Finland,
-1932-03-31,FR,France,
-1932-03-31,GB,United Kingdom,
-1932-03-31,GR,Greece,
-1932-03-31,HK,Hong Kong SAR,
-1932-03-31,HR,Croatia,
-1932-03-31,HU,Hungary,
-1932-03-31,ID,Indonesia,
-1932-03-31,IE,Ireland,
-1932-03-31,IL,Israel,
-1932-03-31,IN,India,
-1932-03-31,IS,Iceland,
-1932-03-31,IT,Italy,
-1932-03-31,JP,Japan,
-1932-03-31,KR,Korea,
-1932-03-31,LT,Lithuania,
-1932-03-31,LU,Luxembourg,
-1932-03-31,LV,Latvia,
-1932-03-31,MA,Morocco,
-1932-03-31,MK,North Macedonia,
-1932-03-31,MT,Malta,
-1932-03-31,MX,Mexico,
-1932-03-31,MY,Malaysia,
-1932-03-31,NL,Netherlands,
-1932-03-31,NO,Norway,
-1932-03-31,NZ,New Zealand,
-1932-03-31,PE,Peru,
-1932-03-31,PH,Philippines,
-1932-03-31,PL,Poland,
-1932-03-31,PT,Portugal,
-1932-03-31,RO,Romania,
-1932-03-31,RS,Serbia,
-1932-03-31,RU,Russia,
-1932-03-31,SE,Sweden,
-1932-03-31,SG,Singapore,
-1932-03-31,SI,Slovenia,
-1932-03-31,SK,Slovak Republic,
-1932-03-31,TH,Thailand,
-1932-03-31,TR,Türkiye,
-1932-03-31,US,United States,
-1932-03-31,XM,Euro area,
-1932-03-31,XW,World,
-1932-03-31,ZA,South Africa,
-1932-06-30,4T,Emerging market economies (aggregate),
-1932-06-30,5R,Advanced economies,
-1932-06-30,AE,United Arab Emirates,
-1932-06-30,AT,Austria,
-1932-06-30,AU,Australia,
-1932-06-30,BE,Belgium,
-1932-06-30,BG,Bulgaria,
-1932-06-30,BR,Brazil,
-1932-06-30,CA,Canada,
-1932-06-30,CH,Switzerland,
-1932-06-30,CL,Chile,
-1932-06-30,CN,China,
-1932-06-30,CO,Colombia,
-1932-06-30,CY,Cyprus,
-1932-06-30,CZ,Czechia,
-1932-06-30,DE,Germany,
-1932-06-30,DK,Denmark,
-1932-06-30,EE,Estonia,
-1932-06-30,ES,Spain,
-1932-06-30,FI,Finland,
-1932-06-30,FR,France,
-1932-06-30,GB,United Kingdom,
-1932-06-30,GR,Greece,
-1932-06-30,HK,Hong Kong SAR,
-1932-06-30,HR,Croatia,
-1932-06-30,HU,Hungary,
-1932-06-30,ID,Indonesia,
-1932-06-30,IE,Ireland,
-1932-06-30,IL,Israel,
-1932-06-30,IN,India,
-1932-06-30,IS,Iceland,
-1932-06-30,IT,Italy,
-1932-06-30,JP,Japan,
-1932-06-30,KR,Korea,
-1932-06-30,LT,Lithuania,
-1932-06-30,LU,Luxembourg,
-1932-06-30,LV,Latvia,
-1932-06-30,MA,Morocco,
-1932-06-30,MK,North Macedonia,
-1932-06-30,MT,Malta,
-1932-06-30,MX,Mexico,
-1932-06-30,MY,Malaysia,
-1932-06-30,NL,Netherlands,
-1932-06-30,NO,Norway,
-1932-06-30,NZ,New Zealand,
-1932-06-30,PE,Peru,
-1932-06-30,PH,Philippines,
-1932-06-30,PL,Poland,
-1932-06-30,PT,Portugal,
-1932-06-30,RO,Romania,
-1932-06-30,RS,Serbia,
-1932-06-30,RU,Russia,
-1932-06-30,SE,Sweden,
-1932-06-30,SG,Singapore,
-1932-06-30,SI,Slovenia,
-1932-06-30,SK,Slovak Republic,
-1932-06-30,TH,Thailand,
-1932-06-30,TR,Türkiye,
-1932-06-30,US,United States,
-1932-06-30,XM,Euro area,
-1932-06-30,XW,World,
-1932-06-30,ZA,South Africa,
-1932-09-30,4T,Emerging market economies (aggregate),
-1932-09-30,5R,Advanced economies,
-1932-09-30,AE,United Arab Emirates,
-1932-09-30,AT,Austria,
-1932-09-30,AU,Australia,
-1932-09-30,BE,Belgium,
-1932-09-30,BG,Bulgaria,
-1932-09-30,BR,Brazil,
-1932-09-30,CA,Canada,
-1932-09-30,CH,Switzerland,
-1932-09-30,CL,Chile,
-1932-09-30,CN,China,
-1932-09-30,CO,Colombia,
-1932-09-30,CY,Cyprus,
-1932-09-30,CZ,Czechia,
-1932-09-30,DE,Germany,
-1932-09-30,DK,Denmark,
-1932-09-30,EE,Estonia,
-1932-09-30,ES,Spain,
-1932-09-30,FI,Finland,
-1932-09-30,FR,France,
-1932-09-30,GB,United Kingdom,
-1932-09-30,GR,Greece,
-1932-09-30,HK,Hong Kong SAR,
-1932-09-30,HR,Croatia,
-1932-09-30,HU,Hungary,
-1932-09-30,ID,Indonesia,
-1932-09-30,IE,Ireland,
-1932-09-30,IL,Israel,
-1932-09-30,IN,India,
-1932-09-30,IS,Iceland,
-1932-09-30,IT,Italy,
-1932-09-30,JP,Japan,
-1932-09-30,KR,Korea,
-1932-09-30,LT,Lithuania,
-1932-09-30,LU,Luxembourg,
-1932-09-30,LV,Latvia,
-1932-09-30,MA,Morocco,
-1932-09-30,MK,North Macedonia,
-1932-09-30,MT,Malta,
-1932-09-30,MX,Mexico,
-1932-09-30,MY,Malaysia,
-1932-09-30,NL,Netherlands,
-1932-09-30,NO,Norway,
-1932-09-30,NZ,New Zealand,
-1932-09-30,PE,Peru,
-1932-09-30,PH,Philippines,
-1932-09-30,PL,Poland,
-1932-09-30,PT,Portugal,
-1932-09-30,RO,Romania,
-1932-09-30,RS,Serbia,
-1932-09-30,RU,Russia,
-1932-09-30,SE,Sweden,
-1932-09-30,SG,Singapore,
-1932-09-30,SI,Slovenia,
-1932-09-30,SK,Slovak Republic,
-1932-09-30,TH,Thailand,
-1932-09-30,TR,Türkiye,
-1932-09-30,US,United States,
-1932-09-30,XM,Euro area,
-1932-09-30,XW,World,
-1932-09-30,ZA,South Africa,
-1932-12-31,4T,Emerging market economies (aggregate),
-1932-12-31,5R,Advanced economies,
-1932-12-31,AE,United Arab Emirates,
-1932-12-31,AT,Austria,
-1932-12-31,AU,Australia,
-1932-12-31,BE,Belgium,
-1932-12-31,BG,Bulgaria,
-1932-12-31,BR,Brazil,
-1932-12-31,CA,Canada,
-1932-12-31,CH,Switzerland,
-1932-12-31,CL,Chile,
-1932-12-31,CN,China,
-1932-12-31,CO,Colombia,
-1932-12-31,CY,Cyprus,
-1932-12-31,CZ,Czechia,
-1932-12-31,DE,Germany,
-1932-12-31,DK,Denmark,
-1932-12-31,EE,Estonia,
-1932-12-31,ES,Spain,
-1932-12-31,FI,Finland,
-1932-12-31,FR,France,
-1932-12-31,GB,United Kingdom,
-1932-12-31,GR,Greece,
-1932-12-31,HK,Hong Kong SAR,
-1932-12-31,HR,Croatia,
-1932-12-31,HU,Hungary,
-1932-12-31,ID,Indonesia,
-1932-12-31,IE,Ireland,
-1932-12-31,IL,Israel,
-1932-12-31,IN,India,
-1932-12-31,IS,Iceland,
-1932-12-31,IT,Italy,
-1932-12-31,JP,Japan,
-1932-12-31,KR,Korea,
-1932-12-31,LT,Lithuania,
-1932-12-31,LU,Luxembourg,
-1932-12-31,LV,Latvia,
-1932-12-31,MA,Morocco,
-1932-12-31,MK,North Macedonia,
-1932-12-31,MT,Malta,
-1932-12-31,MX,Mexico,
-1932-12-31,MY,Malaysia,
-1932-12-31,NL,Netherlands,
-1932-12-31,NO,Norway,
-1932-12-31,NZ,New Zealand,
-1932-12-31,PE,Peru,
-1932-12-31,PH,Philippines,
-1932-12-31,PL,Poland,
-1932-12-31,PT,Portugal,
-1932-12-31,RO,Romania,
-1932-12-31,RS,Serbia,
-1932-12-31,RU,Russia,
-1932-12-31,SE,Sweden,
-1932-12-31,SG,Singapore,
-1932-12-31,SI,Slovenia,
-1932-12-31,SK,Slovak Republic,
-1932-12-31,TH,Thailand,
-1932-12-31,TR,Türkiye,
-1932-12-31,US,United States,
-1932-12-31,XM,Euro area,
-1932-12-31,XW,World,
-1932-12-31,ZA,South Africa,
-1933-03-31,4T,Emerging market economies (aggregate),
-1933-03-31,5R,Advanced economies,
-1933-03-31,AE,United Arab Emirates,
-1933-03-31,AT,Austria,
-1933-03-31,AU,Australia,
-1933-03-31,BE,Belgium,
-1933-03-31,BG,Bulgaria,
-1933-03-31,BR,Brazil,
-1933-03-31,CA,Canada,
-1933-03-31,CH,Switzerland,
-1933-03-31,CL,Chile,
-1933-03-31,CN,China,
-1933-03-31,CO,Colombia,
-1933-03-31,CY,Cyprus,
-1933-03-31,CZ,Czechia,
-1933-03-31,DE,Germany,
-1933-03-31,DK,Denmark,
-1933-03-31,EE,Estonia,
-1933-03-31,ES,Spain,
-1933-03-31,FI,Finland,
-1933-03-31,FR,France,
-1933-03-31,GB,United Kingdom,
-1933-03-31,GR,Greece,
-1933-03-31,HK,Hong Kong SAR,
-1933-03-31,HR,Croatia,
-1933-03-31,HU,Hungary,
-1933-03-31,ID,Indonesia,
-1933-03-31,IE,Ireland,
-1933-03-31,IL,Israel,
-1933-03-31,IN,India,
-1933-03-31,IS,Iceland,
-1933-03-31,IT,Italy,
-1933-03-31,JP,Japan,
-1933-03-31,KR,Korea,
-1933-03-31,LT,Lithuania,
-1933-03-31,LU,Luxembourg,
-1933-03-31,LV,Latvia,
-1933-03-31,MA,Morocco,
-1933-03-31,MK,North Macedonia,
-1933-03-31,MT,Malta,
-1933-03-31,MX,Mexico,
-1933-03-31,MY,Malaysia,
-1933-03-31,NL,Netherlands,
-1933-03-31,NO,Norway,
-1933-03-31,NZ,New Zealand,
-1933-03-31,PE,Peru,
-1933-03-31,PH,Philippines,
-1933-03-31,PL,Poland,
-1933-03-31,PT,Portugal,
-1933-03-31,RO,Romania,
-1933-03-31,RS,Serbia,
-1933-03-31,RU,Russia,
-1933-03-31,SE,Sweden,
-1933-03-31,SG,Singapore,
-1933-03-31,SI,Slovenia,
-1933-03-31,SK,Slovak Republic,
-1933-03-31,TH,Thailand,
-1933-03-31,TR,Türkiye,
-1933-03-31,US,United States,
-1933-03-31,XM,Euro area,
-1933-03-31,XW,World,
-1933-03-31,ZA,South Africa,
-1933-06-30,4T,Emerging market economies (aggregate),
-1933-06-30,5R,Advanced economies,
-1933-06-30,AE,United Arab Emirates,
-1933-06-30,AT,Austria,
-1933-06-30,AU,Australia,
-1933-06-30,BE,Belgium,
-1933-06-30,BG,Bulgaria,
-1933-06-30,BR,Brazil,
-1933-06-30,CA,Canada,
-1933-06-30,CH,Switzerland,
-1933-06-30,CL,Chile,
-1933-06-30,CN,China,
-1933-06-30,CO,Colombia,
-1933-06-30,CY,Cyprus,
-1933-06-30,CZ,Czechia,
-1933-06-30,DE,Germany,
-1933-06-30,DK,Denmark,
-1933-06-30,EE,Estonia,
-1933-06-30,ES,Spain,
-1933-06-30,FI,Finland,
-1933-06-30,FR,France,
-1933-06-30,GB,United Kingdom,
-1933-06-30,GR,Greece,
-1933-06-30,HK,Hong Kong SAR,
-1933-06-30,HR,Croatia,
-1933-06-30,HU,Hungary,
-1933-06-30,ID,Indonesia,
-1933-06-30,IE,Ireland,
-1933-06-30,IL,Israel,
-1933-06-30,IN,India,
-1933-06-30,IS,Iceland,
-1933-06-30,IT,Italy,
-1933-06-30,JP,Japan,
-1933-06-30,KR,Korea,
-1933-06-30,LT,Lithuania,
-1933-06-30,LU,Luxembourg,
-1933-06-30,LV,Latvia,
-1933-06-30,MA,Morocco,
-1933-06-30,MK,North Macedonia,
-1933-06-30,MT,Malta,
-1933-06-30,MX,Mexico,
-1933-06-30,MY,Malaysia,
-1933-06-30,NL,Netherlands,
-1933-06-30,NO,Norway,
-1933-06-30,NZ,New Zealand,
-1933-06-30,PE,Peru,
-1933-06-30,PH,Philippines,
-1933-06-30,PL,Poland,
-1933-06-30,PT,Portugal,
-1933-06-30,RO,Romania,
-1933-06-30,RS,Serbia,
-1933-06-30,RU,Russia,
-1933-06-30,SE,Sweden,
-1933-06-30,SG,Singapore,
-1933-06-30,SI,Slovenia,
-1933-06-30,SK,Slovak Republic,
-1933-06-30,TH,Thailand,
-1933-06-30,TR,Türkiye,
-1933-06-30,US,United States,
-1933-06-30,XM,Euro area,
-1933-06-30,XW,World,
-1933-06-30,ZA,South Africa,
-1933-09-30,4T,Emerging market economies (aggregate),
-1933-09-30,5R,Advanced economies,
-1933-09-30,AE,United Arab Emirates,
-1933-09-30,AT,Austria,
-1933-09-30,AU,Australia,
-1933-09-30,BE,Belgium,
-1933-09-30,BG,Bulgaria,
-1933-09-30,BR,Brazil,
-1933-09-30,CA,Canada,
-1933-09-30,CH,Switzerland,
-1933-09-30,CL,Chile,
-1933-09-30,CN,China,
-1933-09-30,CO,Colombia,
-1933-09-30,CY,Cyprus,
-1933-09-30,CZ,Czechia,
-1933-09-30,DE,Germany,
-1933-09-30,DK,Denmark,
-1933-09-30,EE,Estonia,
-1933-09-30,ES,Spain,
-1933-09-30,FI,Finland,
-1933-09-30,FR,France,
-1933-09-30,GB,United Kingdom,
-1933-09-30,GR,Greece,
-1933-09-30,HK,Hong Kong SAR,
-1933-09-30,HR,Croatia,
-1933-09-30,HU,Hungary,
-1933-09-30,ID,Indonesia,
-1933-09-30,IE,Ireland,
-1933-09-30,IL,Israel,
-1933-09-30,IN,India,
-1933-09-30,IS,Iceland,
-1933-09-30,IT,Italy,
-1933-09-30,JP,Japan,
-1933-09-30,KR,Korea,
-1933-09-30,LT,Lithuania,
-1933-09-30,LU,Luxembourg,
-1933-09-30,LV,Latvia,
-1933-09-30,MA,Morocco,
-1933-09-30,MK,North Macedonia,
-1933-09-30,MT,Malta,
-1933-09-30,MX,Mexico,
-1933-09-30,MY,Malaysia,
-1933-09-30,NL,Netherlands,
-1933-09-30,NO,Norway,
-1933-09-30,NZ,New Zealand,
-1933-09-30,PE,Peru,
-1933-09-30,PH,Philippines,
-1933-09-30,PL,Poland,
-1933-09-30,PT,Portugal,
-1933-09-30,RO,Romania,
-1933-09-30,RS,Serbia,
-1933-09-30,RU,Russia,
-1933-09-30,SE,Sweden,
-1933-09-30,SG,Singapore,
-1933-09-30,SI,Slovenia,
-1933-09-30,SK,Slovak Republic,
-1933-09-30,TH,Thailand,
-1933-09-30,TR,Türkiye,
-1933-09-30,US,United States,
-1933-09-30,XM,Euro area,
-1933-09-30,XW,World,
-1933-09-30,ZA,South Africa,
-1933-12-31,4T,Emerging market economies (aggregate),
-1933-12-31,5R,Advanced economies,
-1933-12-31,AE,United Arab Emirates,
-1933-12-31,AT,Austria,
-1933-12-31,AU,Australia,
-1933-12-31,BE,Belgium,
-1933-12-31,BG,Bulgaria,
-1933-12-31,BR,Brazil,
-1933-12-31,CA,Canada,
-1933-12-31,CH,Switzerland,
-1933-12-31,CL,Chile,
-1933-12-31,CN,China,
-1933-12-31,CO,Colombia,
-1933-12-31,CY,Cyprus,
-1933-12-31,CZ,Czechia,
-1933-12-31,DE,Germany,
-1933-12-31,DK,Denmark,
-1933-12-31,EE,Estonia,
-1933-12-31,ES,Spain,
-1933-12-31,FI,Finland,
-1933-12-31,FR,France,
-1933-12-31,GB,United Kingdom,
-1933-12-31,GR,Greece,
-1933-12-31,HK,Hong Kong SAR,
-1933-12-31,HR,Croatia,
-1933-12-31,HU,Hungary,
-1933-12-31,ID,Indonesia,
-1933-12-31,IE,Ireland,
-1933-12-31,IL,Israel,
-1933-12-31,IN,India,
-1933-12-31,IS,Iceland,
-1933-12-31,IT,Italy,
-1933-12-31,JP,Japan,
-1933-12-31,KR,Korea,
-1933-12-31,LT,Lithuania,
-1933-12-31,LU,Luxembourg,
-1933-12-31,LV,Latvia,
-1933-12-31,MA,Morocco,
-1933-12-31,MK,North Macedonia,
-1933-12-31,MT,Malta,
-1933-12-31,MX,Mexico,
-1933-12-31,MY,Malaysia,
-1933-12-31,NL,Netherlands,
-1933-12-31,NO,Norway,
-1933-12-31,NZ,New Zealand,
-1933-12-31,PE,Peru,
-1933-12-31,PH,Philippines,
-1933-12-31,PL,Poland,
-1933-12-31,PT,Portugal,
-1933-12-31,RO,Romania,
-1933-12-31,RS,Serbia,
-1933-12-31,RU,Russia,
-1933-12-31,SE,Sweden,
-1933-12-31,SG,Singapore,
-1933-12-31,SI,Slovenia,
-1933-12-31,SK,Slovak Republic,
-1933-12-31,TH,Thailand,
-1933-12-31,TR,Türkiye,
-1933-12-31,US,United States,
-1933-12-31,XM,Euro area,
-1933-12-31,XW,World,
-1933-12-31,ZA,South Africa,
-1934-03-31,4T,Emerging market economies (aggregate),
-1934-03-31,5R,Advanced economies,
-1934-03-31,AE,United Arab Emirates,
-1934-03-31,AT,Austria,
-1934-03-31,AU,Australia,
-1934-03-31,BE,Belgium,
-1934-03-31,BG,Bulgaria,
-1934-03-31,BR,Brazil,
-1934-03-31,CA,Canada,
-1934-03-31,CH,Switzerland,
-1934-03-31,CL,Chile,
-1934-03-31,CN,China,
-1934-03-31,CO,Colombia,
-1934-03-31,CY,Cyprus,
-1934-03-31,CZ,Czechia,
-1934-03-31,DE,Germany,
-1934-03-31,DK,Denmark,
-1934-03-31,EE,Estonia,
-1934-03-31,ES,Spain,
-1934-03-31,FI,Finland,
-1934-03-31,FR,France,
-1934-03-31,GB,United Kingdom,
-1934-03-31,GR,Greece,
-1934-03-31,HK,Hong Kong SAR,
-1934-03-31,HR,Croatia,
-1934-03-31,HU,Hungary,
-1934-03-31,ID,Indonesia,
-1934-03-31,IE,Ireland,
-1934-03-31,IL,Israel,
-1934-03-31,IN,India,
-1934-03-31,IS,Iceland,
-1934-03-31,IT,Italy,
-1934-03-31,JP,Japan,
-1934-03-31,KR,Korea,
-1934-03-31,LT,Lithuania,
-1934-03-31,LU,Luxembourg,
-1934-03-31,LV,Latvia,
-1934-03-31,MA,Morocco,
-1934-03-31,MK,North Macedonia,
-1934-03-31,MT,Malta,
-1934-03-31,MX,Mexico,
-1934-03-31,MY,Malaysia,
-1934-03-31,NL,Netherlands,
-1934-03-31,NO,Norway,
-1934-03-31,NZ,New Zealand,
-1934-03-31,PE,Peru,
-1934-03-31,PH,Philippines,
-1934-03-31,PL,Poland,
-1934-03-31,PT,Portugal,
-1934-03-31,RO,Romania,
-1934-03-31,RS,Serbia,
-1934-03-31,RU,Russia,
-1934-03-31,SE,Sweden,
-1934-03-31,SG,Singapore,
-1934-03-31,SI,Slovenia,
-1934-03-31,SK,Slovak Republic,
-1934-03-31,TH,Thailand,
-1934-03-31,TR,Türkiye,
-1934-03-31,US,United States,
-1934-03-31,XM,Euro area,
-1934-03-31,XW,World,
-1934-03-31,ZA,South Africa,
-1934-06-30,4T,Emerging market economies (aggregate),
-1934-06-30,5R,Advanced economies,
-1934-06-30,AE,United Arab Emirates,
-1934-06-30,AT,Austria,
-1934-06-30,AU,Australia,
-1934-06-30,BE,Belgium,
-1934-06-30,BG,Bulgaria,
-1934-06-30,BR,Brazil,
-1934-06-30,CA,Canada,
-1934-06-30,CH,Switzerland,
-1934-06-30,CL,Chile,
-1934-06-30,CN,China,
-1934-06-30,CO,Colombia,
-1934-06-30,CY,Cyprus,
-1934-06-30,CZ,Czechia,
-1934-06-30,DE,Germany,
-1934-06-30,DK,Denmark,
-1934-06-30,EE,Estonia,
-1934-06-30,ES,Spain,
-1934-06-30,FI,Finland,
-1934-06-30,FR,France,
-1934-06-30,GB,United Kingdom,
-1934-06-30,GR,Greece,
-1934-06-30,HK,Hong Kong SAR,
-1934-06-30,HR,Croatia,
-1934-06-30,HU,Hungary,
-1934-06-30,ID,Indonesia,
-1934-06-30,IE,Ireland,
-1934-06-30,IL,Israel,
-1934-06-30,IN,India,
-1934-06-30,IS,Iceland,
-1934-06-30,IT,Italy,
-1934-06-30,JP,Japan,
-1934-06-30,KR,Korea,
-1934-06-30,LT,Lithuania,
-1934-06-30,LU,Luxembourg,
-1934-06-30,LV,Latvia,
-1934-06-30,MA,Morocco,
-1934-06-30,MK,North Macedonia,
-1934-06-30,MT,Malta,
-1934-06-30,MX,Mexico,
-1934-06-30,MY,Malaysia,
-1934-06-30,NL,Netherlands,
-1934-06-30,NO,Norway,
-1934-06-30,NZ,New Zealand,
-1934-06-30,PE,Peru,
-1934-06-30,PH,Philippines,
-1934-06-30,PL,Poland,
-1934-06-30,PT,Portugal,
-1934-06-30,RO,Romania,
-1934-06-30,RS,Serbia,
-1934-06-30,RU,Russia,
-1934-06-30,SE,Sweden,
-1934-06-30,SG,Singapore,
-1934-06-30,SI,Slovenia,
-1934-06-30,SK,Slovak Republic,
-1934-06-30,TH,Thailand,
-1934-06-30,TR,Türkiye,
-1934-06-30,US,United States,
-1934-06-30,XM,Euro area,
-1934-06-30,XW,World,
-1934-06-30,ZA,South Africa,
-1934-09-30,4T,Emerging market economies (aggregate),
-1934-09-30,5R,Advanced economies,
-1934-09-30,AE,United Arab Emirates,
-1934-09-30,AT,Austria,
-1934-09-30,AU,Australia,
-1934-09-30,BE,Belgium,
-1934-09-30,BG,Bulgaria,
-1934-09-30,BR,Brazil,
-1934-09-30,CA,Canada,
-1934-09-30,CH,Switzerland,
-1934-09-30,CL,Chile,
-1934-09-30,CN,China,
-1934-09-30,CO,Colombia,
-1934-09-30,CY,Cyprus,
-1934-09-30,CZ,Czechia,
-1934-09-30,DE,Germany,
-1934-09-30,DK,Denmark,
-1934-09-30,EE,Estonia,
-1934-09-30,ES,Spain,
-1934-09-30,FI,Finland,
-1934-09-30,FR,France,
-1934-09-30,GB,United Kingdom,
-1934-09-30,GR,Greece,
-1934-09-30,HK,Hong Kong SAR,
-1934-09-30,HR,Croatia,
-1934-09-30,HU,Hungary,
-1934-09-30,ID,Indonesia,
-1934-09-30,IE,Ireland,
-1934-09-30,IL,Israel,
-1934-09-30,IN,India,
-1934-09-30,IS,Iceland,
-1934-09-30,IT,Italy,
-1934-09-30,JP,Japan,
-1934-09-30,KR,Korea,
-1934-09-30,LT,Lithuania,
-1934-09-30,LU,Luxembourg,
-1934-09-30,LV,Latvia,
-1934-09-30,MA,Morocco,
-1934-09-30,MK,North Macedonia,
-1934-09-30,MT,Malta,
-1934-09-30,MX,Mexico,
-1934-09-30,MY,Malaysia,
-1934-09-30,NL,Netherlands,
-1934-09-30,NO,Norway,
-1934-09-30,NZ,New Zealand,
-1934-09-30,PE,Peru,
-1934-09-30,PH,Philippines,
-1934-09-30,PL,Poland,
-1934-09-30,PT,Portugal,
-1934-09-30,RO,Romania,
-1934-09-30,RS,Serbia,
-1934-09-30,RU,Russia,
-1934-09-30,SE,Sweden,
-1934-09-30,SG,Singapore,
-1934-09-30,SI,Slovenia,
-1934-09-30,SK,Slovak Republic,
-1934-09-30,TH,Thailand,
-1934-09-30,TR,Türkiye,
-1934-09-30,US,United States,
-1934-09-30,XM,Euro area,
-1934-09-30,XW,World,
-1934-09-30,ZA,South Africa,
-1934-12-31,4T,Emerging market economies (aggregate),
-1934-12-31,5R,Advanced economies,
-1934-12-31,AE,United Arab Emirates,
-1934-12-31,AT,Austria,
-1934-12-31,AU,Australia,
-1934-12-31,BE,Belgium,
-1934-12-31,BG,Bulgaria,
-1934-12-31,BR,Brazil,
-1934-12-31,CA,Canada,
-1934-12-31,CH,Switzerland,
-1934-12-31,CL,Chile,
-1934-12-31,CN,China,
-1934-12-31,CO,Colombia,
-1934-12-31,CY,Cyprus,
-1934-12-31,CZ,Czechia,
-1934-12-31,DE,Germany,
-1934-12-31,DK,Denmark,
-1934-12-31,EE,Estonia,
-1934-12-31,ES,Spain,
-1934-12-31,FI,Finland,
-1934-12-31,FR,France,
-1934-12-31,GB,United Kingdom,
-1934-12-31,GR,Greece,
-1934-12-31,HK,Hong Kong SAR,
-1934-12-31,HR,Croatia,
-1934-12-31,HU,Hungary,
-1934-12-31,ID,Indonesia,
-1934-12-31,IE,Ireland,
-1934-12-31,IL,Israel,
-1934-12-31,IN,India,
-1934-12-31,IS,Iceland,
-1934-12-31,IT,Italy,
-1934-12-31,JP,Japan,
-1934-12-31,KR,Korea,
-1934-12-31,LT,Lithuania,
-1934-12-31,LU,Luxembourg,
-1934-12-31,LV,Latvia,
-1934-12-31,MA,Morocco,
-1934-12-31,MK,North Macedonia,
-1934-12-31,MT,Malta,
-1934-12-31,MX,Mexico,
-1934-12-31,MY,Malaysia,
-1934-12-31,NL,Netherlands,
-1934-12-31,NO,Norway,
-1934-12-31,NZ,New Zealand,
-1934-12-31,PE,Peru,
-1934-12-31,PH,Philippines,
-1934-12-31,PL,Poland,
-1934-12-31,PT,Portugal,
-1934-12-31,RO,Romania,
-1934-12-31,RS,Serbia,
-1934-12-31,RU,Russia,
-1934-12-31,SE,Sweden,
-1934-12-31,SG,Singapore,
-1934-12-31,SI,Slovenia,
-1934-12-31,SK,Slovak Republic,
-1934-12-31,TH,Thailand,
-1934-12-31,TR,Türkiye,
-1934-12-31,US,United States,
-1934-12-31,XM,Euro area,
-1934-12-31,XW,World,
-1934-12-31,ZA,South Africa,
-1935-03-31,4T,Emerging market economies (aggregate),
-1935-03-31,5R,Advanced economies,
-1935-03-31,AE,United Arab Emirates,
-1935-03-31,AT,Austria,
-1935-03-31,AU,Australia,
-1935-03-31,BE,Belgium,
-1935-03-31,BG,Bulgaria,
-1935-03-31,BR,Brazil,
-1935-03-31,CA,Canada,
-1935-03-31,CH,Switzerland,
-1935-03-31,CL,Chile,
-1935-03-31,CN,China,
-1935-03-31,CO,Colombia,
-1935-03-31,CY,Cyprus,
-1935-03-31,CZ,Czechia,
-1935-03-31,DE,Germany,
-1935-03-31,DK,Denmark,
-1935-03-31,EE,Estonia,
-1935-03-31,ES,Spain,
-1935-03-31,FI,Finland,
-1935-03-31,FR,France,
-1935-03-31,GB,United Kingdom,
-1935-03-31,GR,Greece,
-1935-03-31,HK,Hong Kong SAR,
-1935-03-31,HR,Croatia,
-1935-03-31,HU,Hungary,
-1935-03-31,ID,Indonesia,
-1935-03-31,IE,Ireland,
-1935-03-31,IL,Israel,
-1935-03-31,IN,India,
-1935-03-31,IS,Iceland,
-1935-03-31,IT,Italy,
-1935-03-31,JP,Japan,
-1935-03-31,KR,Korea,
-1935-03-31,LT,Lithuania,
-1935-03-31,LU,Luxembourg,
-1935-03-31,LV,Latvia,
-1935-03-31,MA,Morocco,
-1935-03-31,MK,North Macedonia,
-1935-03-31,MT,Malta,
-1935-03-31,MX,Mexico,
-1935-03-31,MY,Malaysia,
-1935-03-31,NL,Netherlands,
-1935-03-31,NO,Norway,
-1935-03-31,NZ,New Zealand,
-1935-03-31,PE,Peru,
-1935-03-31,PH,Philippines,
-1935-03-31,PL,Poland,
-1935-03-31,PT,Portugal,
-1935-03-31,RO,Romania,
-1935-03-31,RS,Serbia,
-1935-03-31,RU,Russia,
-1935-03-31,SE,Sweden,
-1935-03-31,SG,Singapore,
-1935-03-31,SI,Slovenia,
-1935-03-31,SK,Slovak Republic,
-1935-03-31,TH,Thailand,
-1935-03-31,TR,Türkiye,
-1935-03-31,US,United States,
-1935-03-31,XM,Euro area,
-1935-03-31,XW,World,
-1935-03-31,ZA,South Africa,
-1935-06-30,4T,Emerging market economies (aggregate),
-1935-06-30,5R,Advanced economies,
-1935-06-30,AE,United Arab Emirates,
-1935-06-30,AT,Austria,
-1935-06-30,AU,Australia,
-1935-06-30,BE,Belgium,
-1935-06-30,BG,Bulgaria,
-1935-06-30,BR,Brazil,
-1935-06-30,CA,Canada,
-1935-06-30,CH,Switzerland,
-1935-06-30,CL,Chile,
-1935-06-30,CN,China,
-1935-06-30,CO,Colombia,
-1935-06-30,CY,Cyprus,
-1935-06-30,CZ,Czechia,
-1935-06-30,DE,Germany,
-1935-06-30,DK,Denmark,
-1935-06-30,EE,Estonia,
-1935-06-30,ES,Spain,
-1935-06-30,FI,Finland,
-1935-06-30,FR,France,
-1935-06-30,GB,United Kingdom,
-1935-06-30,GR,Greece,
-1935-06-30,HK,Hong Kong SAR,
-1935-06-30,HR,Croatia,
-1935-06-30,HU,Hungary,
-1935-06-30,ID,Indonesia,
-1935-06-30,IE,Ireland,
-1935-06-30,IL,Israel,
-1935-06-30,IN,India,
-1935-06-30,IS,Iceland,
-1935-06-30,IT,Italy,
-1935-06-30,JP,Japan,
-1935-06-30,KR,Korea,
-1935-06-30,LT,Lithuania,
-1935-06-30,LU,Luxembourg,
-1935-06-30,LV,Latvia,
-1935-06-30,MA,Morocco,
-1935-06-30,MK,North Macedonia,
-1935-06-30,MT,Malta,
-1935-06-30,MX,Mexico,
-1935-06-30,MY,Malaysia,
-1935-06-30,NL,Netherlands,
-1935-06-30,NO,Norway,
-1935-06-30,NZ,New Zealand,
-1935-06-30,PE,Peru,
-1935-06-30,PH,Philippines,
-1935-06-30,PL,Poland,
-1935-06-30,PT,Portugal,
-1935-06-30,RO,Romania,
-1935-06-30,RS,Serbia,
-1935-06-30,RU,Russia,
-1935-06-30,SE,Sweden,
-1935-06-30,SG,Singapore,
-1935-06-30,SI,Slovenia,
-1935-06-30,SK,Slovak Republic,
-1935-06-30,TH,Thailand,
-1935-06-30,TR,Türkiye,
-1935-06-30,US,United States,
-1935-06-30,XM,Euro area,
-1935-06-30,XW,World,
-1935-06-30,ZA,South Africa,
-1935-09-30,4T,Emerging market economies (aggregate),
-1935-09-30,5R,Advanced economies,
-1935-09-30,AE,United Arab Emirates,
-1935-09-30,AT,Austria,
-1935-09-30,AU,Australia,
-1935-09-30,BE,Belgium,
-1935-09-30,BG,Bulgaria,
-1935-09-30,BR,Brazil,
-1935-09-30,CA,Canada,
-1935-09-30,CH,Switzerland,
-1935-09-30,CL,Chile,
-1935-09-30,CN,China,
-1935-09-30,CO,Colombia,
-1935-09-30,CY,Cyprus,
-1935-09-30,CZ,Czechia,
-1935-09-30,DE,Germany,
-1935-09-30,DK,Denmark,
-1935-09-30,EE,Estonia,
-1935-09-30,ES,Spain,
-1935-09-30,FI,Finland,
-1935-09-30,FR,France,
-1935-09-30,GB,United Kingdom,
-1935-09-30,GR,Greece,
-1935-09-30,HK,Hong Kong SAR,
-1935-09-30,HR,Croatia,
-1935-09-30,HU,Hungary,
-1935-09-30,ID,Indonesia,
-1935-09-30,IE,Ireland,
-1935-09-30,IL,Israel,
-1935-09-30,IN,India,
-1935-09-30,IS,Iceland,
-1935-09-30,IT,Italy,
-1935-09-30,JP,Japan,
-1935-09-30,KR,Korea,
-1935-09-30,LT,Lithuania,
-1935-09-30,LU,Luxembourg,
-1935-09-30,LV,Latvia,
-1935-09-30,MA,Morocco,
-1935-09-30,MK,North Macedonia,
-1935-09-30,MT,Malta,
-1935-09-30,MX,Mexico,
-1935-09-30,MY,Malaysia,
-1935-09-30,NL,Netherlands,
-1935-09-30,NO,Norway,
-1935-09-30,NZ,New Zealand,
-1935-09-30,PE,Peru,
-1935-09-30,PH,Philippines,
-1935-09-30,PL,Poland,
-1935-09-30,PT,Portugal,
-1935-09-30,RO,Romania,
-1935-09-30,RS,Serbia,
-1935-09-30,RU,Russia,
-1935-09-30,SE,Sweden,
-1935-09-30,SG,Singapore,
-1935-09-30,SI,Slovenia,
-1935-09-30,SK,Slovak Republic,
-1935-09-30,TH,Thailand,
-1935-09-30,TR,Türkiye,
-1935-09-30,US,United States,
-1935-09-30,XM,Euro area,
-1935-09-30,XW,World,
-1935-09-30,ZA,South Africa,
-1935-12-31,4T,Emerging market economies (aggregate),
-1935-12-31,5R,Advanced economies,
-1935-12-31,AE,United Arab Emirates,
-1935-12-31,AT,Austria,
-1935-12-31,AU,Australia,
-1935-12-31,BE,Belgium,
-1935-12-31,BG,Bulgaria,
-1935-12-31,BR,Brazil,
-1935-12-31,CA,Canada,
-1935-12-31,CH,Switzerland,
-1935-12-31,CL,Chile,
-1935-12-31,CN,China,
-1935-12-31,CO,Colombia,
-1935-12-31,CY,Cyprus,
-1935-12-31,CZ,Czechia,
-1935-12-31,DE,Germany,
-1935-12-31,DK,Denmark,
-1935-12-31,EE,Estonia,
-1935-12-31,ES,Spain,
-1935-12-31,FI,Finland,
-1935-12-31,FR,France,
-1935-12-31,GB,United Kingdom,
-1935-12-31,GR,Greece,
-1935-12-31,HK,Hong Kong SAR,
-1935-12-31,HR,Croatia,
-1935-12-31,HU,Hungary,
-1935-12-31,ID,Indonesia,
-1935-12-31,IE,Ireland,
-1935-12-31,IL,Israel,
-1935-12-31,IN,India,
-1935-12-31,IS,Iceland,
-1935-12-31,IT,Italy,
-1935-12-31,JP,Japan,
-1935-12-31,KR,Korea,
-1935-12-31,LT,Lithuania,
-1935-12-31,LU,Luxembourg,
-1935-12-31,LV,Latvia,
-1935-12-31,MA,Morocco,
-1935-12-31,MK,North Macedonia,
-1935-12-31,MT,Malta,
-1935-12-31,MX,Mexico,
-1935-12-31,MY,Malaysia,
-1935-12-31,NL,Netherlands,
-1935-12-31,NO,Norway,
-1935-12-31,NZ,New Zealand,
-1935-12-31,PE,Peru,
-1935-12-31,PH,Philippines,
-1935-12-31,PL,Poland,
-1935-12-31,PT,Portugal,
-1935-12-31,RO,Romania,
-1935-12-31,RS,Serbia,
-1935-12-31,RU,Russia,
-1935-12-31,SE,Sweden,
-1935-12-31,SG,Singapore,
-1935-12-31,SI,Slovenia,
-1935-12-31,SK,Slovak Republic,
-1935-12-31,TH,Thailand,
-1935-12-31,TR,Türkiye,
-1935-12-31,US,United States,
-1935-12-31,XM,Euro area,
-1935-12-31,XW,World,
-1935-12-31,ZA,South Africa,
-1936-03-31,4T,Emerging market economies (aggregate),
-1936-03-31,5R,Advanced economies,
-1936-03-31,AE,United Arab Emirates,
-1936-03-31,AT,Austria,
-1936-03-31,AU,Australia,
-1936-03-31,BE,Belgium,
-1936-03-31,BG,Bulgaria,
-1936-03-31,BR,Brazil,
-1936-03-31,CA,Canada,
-1936-03-31,CH,Switzerland,
-1936-03-31,CL,Chile,
-1936-03-31,CN,China,
-1936-03-31,CO,Colombia,
-1936-03-31,CY,Cyprus,
-1936-03-31,CZ,Czechia,
-1936-03-31,DE,Germany,
-1936-03-31,DK,Denmark,
-1936-03-31,EE,Estonia,
-1936-03-31,ES,Spain,
-1936-03-31,FI,Finland,
-1936-03-31,FR,France,
-1936-03-31,GB,United Kingdom,
-1936-03-31,GR,Greece,
-1936-03-31,HK,Hong Kong SAR,
-1936-03-31,HR,Croatia,
-1936-03-31,HU,Hungary,
-1936-03-31,ID,Indonesia,
-1936-03-31,IE,Ireland,
-1936-03-31,IL,Israel,
-1936-03-31,IN,India,
-1936-03-31,IS,Iceland,
-1936-03-31,IT,Italy,
-1936-03-31,JP,Japan,
-1936-03-31,KR,Korea,
-1936-03-31,LT,Lithuania,
-1936-03-31,LU,Luxembourg,
-1936-03-31,LV,Latvia,
-1936-03-31,MA,Morocco,
-1936-03-31,MK,North Macedonia,
-1936-03-31,MT,Malta,
-1936-03-31,MX,Mexico,
-1936-03-31,MY,Malaysia,
-1936-03-31,NL,Netherlands,
-1936-03-31,NO,Norway,
-1936-03-31,NZ,New Zealand,
-1936-03-31,PE,Peru,
-1936-03-31,PH,Philippines,
-1936-03-31,PL,Poland,
-1936-03-31,PT,Portugal,
-1936-03-31,RO,Romania,
-1936-03-31,RS,Serbia,
-1936-03-31,RU,Russia,
-1936-03-31,SE,Sweden,
-1936-03-31,SG,Singapore,
-1936-03-31,SI,Slovenia,
-1936-03-31,SK,Slovak Republic,
-1936-03-31,TH,Thailand,
-1936-03-31,TR,Türkiye,
-1936-03-31,US,United States,
-1936-03-31,XM,Euro area,
-1936-03-31,XW,World,
-1936-03-31,ZA,South Africa,
-1936-06-30,4T,Emerging market economies (aggregate),
-1936-06-30,5R,Advanced economies,
-1936-06-30,AE,United Arab Emirates,
-1936-06-30,AT,Austria,
-1936-06-30,AU,Australia,
-1936-06-30,BE,Belgium,
-1936-06-30,BG,Bulgaria,
-1936-06-30,BR,Brazil,
-1936-06-30,CA,Canada,
-1936-06-30,CH,Switzerland,
-1936-06-30,CL,Chile,
-1936-06-30,CN,China,
-1936-06-30,CO,Colombia,
-1936-06-30,CY,Cyprus,
-1936-06-30,CZ,Czechia,
-1936-06-30,DE,Germany,
-1936-06-30,DK,Denmark,
-1936-06-30,EE,Estonia,
-1936-06-30,ES,Spain,
-1936-06-30,FI,Finland,
-1936-06-30,FR,France,
-1936-06-30,GB,United Kingdom,
-1936-06-30,GR,Greece,
-1936-06-30,HK,Hong Kong SAR,
-1936-06-30,HR,Croatia,
-1936-06-30,HU,Hungary,
-1936-06-30,ID,Indonesia,
-1936-06-30,IE,Ireland,
-1936-06-30,IL,Israel,
-1936-06-30,IN,India,
-1936-06-30,IS,Iceland,
-1936-06-30,IT,Italy,
-1936-06-30,JP,Japan,
-1936-06-30,KR,Korea,
-1936-06-30,LT,Lithuania,
-1936-06-30,LU,Luxembourg,
-1936-06-30,LV,Latvia,
-1936-06-30,MA,Morocco,
-1936-06-30,MK,North Macedonia,
-1936-06-30,MT,Malta,
-1936-06-30,MX,Mexico,
-1936-06-30,MY,Malaysia,
-1936-06-30,NL,Netherlands,
-1936-06-30,NO,Norway,
-1936-06-30,NZ,New Zealand,
-1936-06-30,PE,Peru,
-1936-06-30,PH,Philippines,
-1936-06-30,PL,Poland,
-1936-06-30,PT,Portugal,
-1936-06-30,RO,Romania,
-1936-06-30,RS,Serbia,
-1936-06-30,RU,Russia,
-1936-06-30,SE,Sweden,
-1936-06-30,SG,Singapore,
-1936-06-30,SI,Slovenia,
-1936-06-30,SK,Slovak Republic,
-1936-06-30,TH,Thailand,
-1936-06-30,TR,Türkiye,
-1936-06-30,US,United States,
-1936-06-30,XM,Euro area,
-1936-06-30,XW,World,
-1936-06-30,ZA,South Africa,
-1936-09-30,4T,Emerging market economies (aggregate),
-1936-09-30,5R,Advanced economies,
-1936-09-30,AE,United Arab Emirates,
-1936-09-30,AT,Austria,
-1936-09-30,AU,Australia,
-1936-09-30,BE,Belgium,
-1936-09-30,BG,Bulgaria,
-1936-09-30,BR,Brazil,
-1936-09-30,CA,Canada,
-1936-09-30,CH,Switzerland,
-1936-09-30,CL,Chile,
-1936-09-30,CN,China,
-1936-09-30,CO,Colombia,
-1936-09-30,CY,Cyprus,
-1936-09-30,CZ,Czechia,
-1936-09-30,DE,Germany,
-1936-09-30,DK,Denmark,
-1936-09-30,EE,Estonia,
-1936-09-30,ES,Spain,
-1936-09-30,FI,Finland,
-1936-09-30,FR,France,
-1936-09-30,GB,United Kingdom,
-1936-09-30,GR,Greece,
-1936-09-30,HK,Hong Kong SAR,
-1936-09-30,HR,Croatia,
-1936-09-30,HU,Hungary,
-1936-09-30,ID,Indonesia,
-1936-09-30,IE,Ireland,
-1936-09-30,IL,Israel,
-1936-09-30,IN,India,
-1936-09-30,IS,Iceland,
-1936-09-30,IT,Italy,
-1936-09-30,JP,Japan,
-1936-09-30,KR,Korea,
-1936-09-30,LT,Lithuania,
-1936-09-30,LU,Luxembourg,
-1936-09-30,LV,Latvia,
-1936-09-30,MA,Morocco,
-1936-09-30,MK,North Macedonia,
-1936-09-30,MT,Malta,
-1936-09-30,MX,Mexico,
-1936-09-30,MY,Malaysia,
-1936-09-30,NL,Netherlands,
-1936-09-30,NO,Norway,
-1936-09-30,NZ,New Zealand,
-1936-09-30,PE,Peru,
-1936-09-30,PH,Philippines,
-1936-09-30,PL,Poland,
-1936-09-30,PT,Portugal,
-1936-09-30,RO,Romania,
-1936-09-30,RS,Serbia,
-1936-09-30,RU,Russia,
-1936-09-30,SE,Sweden,
-1936-09-30,SG,Singapore,
-1936-09-30,SI,Slovenia,
-1936-09-30,SK,Slovak Republic,
-1936-09-30,TH,Thailand,
-1936-09-30,TR,Türkiye,
-1936-09-30,US,United States,
-1936-09-30,XM,Euro area,
-1936-09-30,XW,World,
-1936-09-30,ZA,South Africa,
-1936-12-31,4T,Emerging market economies (aggregate),
-1936-12-31,5R,Advanced economies,
-1936-12-31,AE,United Arab Emirates,
-1936-12-31,AT,Austria,
-1936-12-31,AU,Australia,
-1936-12-31,BE,Belgium,
-1936-12-31,BG,Bulgaria,
-1936-12-31,BR,Brazil,
-1936-12-31,CA,Canada,
-1936-12-31,CH,Switzerland,
-1936-12-31,CL,Chile,
-1936-12-31,CN,China,
-1936-12-31,CO,Colombia,
-1936-12-31,CY,Cyprus,
-1936-12-31,CZ,Czechia,
-1936-12-31,DE,Germany,
-1936-12-31,DK,Denmark,
-1936-12-31,EE,Estonia,
-1936-12-31,ES,Spain,
-1936-12-31,FI,Finland,
-1936-12-31,FR,France,
-1936-12-31,GB,United Kingdom,
-1936-12-31,GR,Greece,
-1936-12-31,HK,Hong Kong SAR,
-1936-12-31,HR,Croatia,
-1936-12-31,HU,Hungary,
-1936-12-31,ID,Indonesia,
-1936-12-31,IE,Ireland,
-1936-12-31,IL,Israel,
-1936-12-31,IN,India,
-1936-12-31,IS,Iceland,
-1936-12-31,IT,Italy,
-1936-12-31,JP,Japan,
-1936-12-31,KR,Korea,
-1936-12-31,LT,Lithuania,
-1936-12-31,LU,Luxembourg,
-1936-12-31,LV,Latvia,
-1936-12-31,MA,Morocco,
-1936-12-31,MK,North Macedonia,
-1936-12-31,MT,Malta,
-1936-12-31,MX,Mexico,
-1936-12-31,MY,Malaysia,
-1936-12-31,NL,Netherlands,
-1936-12-31,NO,Norway,
-1936-12-31,NZ,New Zealand,
-1936-12-31,PE,Peru,
-1936-12-31,PH,Philippines,
-1936-12-31,PL,Poland,
-1936-12-31,PT,Portugal,
-1936-12-31,RO,Romania,
-1936-12-31,RS,Serbia,
-1936-12-31,RU,Russia,
-1936-12-31,SE,Sweden,
-1936-12-31,SG,Singapore,
-1936-12-31,SI,Slovenia,
-1936-12-31,SK,Slovak Republic,
-1936-12-31,TH,Thailand,
-1936-12-31,TR,Türkiye,
-1936-12-31,US,United States,
-1936-12-31,XM,Euro area,
-1936-12-31,XW,World,
-1936-12-31,ZA,South Africa,
-1937-03-31,4T,Emerging market economies (aggregate),
-1937-03-31,5R,Advanced economies,
-1937-03-31,AE,United Arab Emirates,
-1937-03-31,AT,Austria,
-1937-03-31,AU,Australia,
-1937-03-31,BE,Belgium,
-1937-03-31,BG,Bulgaria,
-1937-03-31,BR,Brazil,
-1937-03-31,CA,Canada,
-1937-03-31,CH,Switzerland,
-1937-03-31,CL,Chile,
-1937-03-31,CN,China,
-1937-03-31,CO,Colombia,
-1937-03-31,CY,Cyprus,
-1937-03-31,CZ,Czechia,
-1937-03-31,DE,Germany,
-1937-03-31,DK,Denmark,
-1937-03-31,EE,Estonia,
-1937-03-31,ES,Spain,
-1937-03-31,FI,Finland,
-1937-03-31,FR,France,
-1937-03-31,GB,United Kingdom,
-1937-03-31,GR,Greece,
-1937-03-31,HK,Hong Kong SAR,
-1937-03-31,HR,Croatia,
-1937-03-31,HU,Hungary,
-1937-03-31,ID,Indonesia,
-1937-03-31,IE,Ireland,
-1937-03-31,IL,Israel,
-1937-03-31,IN,India,
-1937-03-31,IS,Iceland,
-1937-03-31,IT,Italy,
-1937-03-31,JP,Japan,
-1937-03-31,KR,Korea,
-1937-03-31,LT,Lithuania,
-1937-03-31,LU,Luxembourg,
-1937-03-31,LV,Latvia,
-1937-03-31,MA,Morocco,
-1937-03-31,MK,North Macedonia,
-1937-03-31,MT,Malta,
-1937-03-31,MX,Mexico,
-1937-03-31,MY,Malaysia,
-1937-03-31,NL,Netherlands,
-1937-03-31,NO,Norway,
-1937-03-31,NZ,New Zealand,
-1937-03-31,PE,Peru,
-1937-03-31,PH,Philippines,
-1937-03-31,PL,Poland,
-1937-03-31,PT,Portugal,
-1937-03-31,RO,Romania,
-1937-03-31,RS,Serbia,
-1937-03-31,RU,Russia,
-1937-03-31,SE,Sweden,
-1937-03-31,SG,Singapore,
-1937-03-31,SI,Slovenia,
-1937-03-31,SK,Slovak Republic,
-1937-03-31,TH,Thailand,
-1937-03-31,TR,Türkiye,
-1937-03-31,US,United States,
-1937-03-31,XM,Euro area,
-1937-03-31,XW,World,
-1937-03-31,ZA,South Africa,
-1937-06-30,4T,Emerging market economies (aggregate),
-1937-06-30,5R,Advanced economies,
-1937-06-30,AE,United Arab Emirates,
-1937-06-30,AT,Austria,
-1937-06-30,AU,Australia,
-1937-06-30,BE,Belgium,
-1937-06-30,BG,Bulgaria,
-1937-06-30,BR,Brazil,
-1937-06-30,CA,Canada,
-1937-06-30,CH,Switzerland,
-1937-06-30,CL,Chile,
-1937-06-30,CN,China,
-1937-06-30,CO,Colombia,
-1937-06-30,CY,Cyprus,
-1937-06-30,CZ,Czechia,
-1937-06-30,DE,Germany,
-1937-06-30,DK,Denmark,
-1937-06-30,EE,Estonia,
-1937-06-30,ES,Spain,
-1937-06-30,FI,Finland,
-1937-06-30,FR,France,
-1937-06-30,GB,United Kingdom,
-1937-06-30,GR,Greece,
-1937-06-30,HK,Hong Kong SAR,
-1937-06-30,HR,Croatia,
-1937-06-30,HU,Hungary,
-1937-06-30,ID,Indonesia,
-1937-06-30,IE,Ireland,
-1937-06-30,IL,Israel,
-1937-06-30,IN,India,
-1937-06-30,IS,Iceland,
-1937-06-30,IT,Italy,
-1937-06-30,JP,Japan,
-1937-06-30,KR,Korea,
-1937-06-30,LT,Lithuania,
-1937-06-30,LU,Luxembourg,
-1937-06-30,LV,Latvia,
-1937-06-30,MA,Morocco,
-1937-06-30,MK,North Macedonia,
-1937-06-30,MT,Malta,
-1937-06-30,MX,Mexico,
-1937-06-30,MY,Malaysia,
-1937-06-30,NL,Netherlands,
-1937-06-30,NO,Norway,
-1937-06-30,NZ,New Zealand,
-1937-06-30,PE,Peru,
-1937-06-30,PH,Philippines,
-1937-06-30,PL,Poland,
-1937-06-30,PT,Portugal,
-1937-06-30,RO,Romania,
-1937-06-30,RS,Serbia,
-1937-06-30,RU,Russia,
-1937-06-30,SE,Sweden,
-1937-06-30,SG,Singapore,
-1937-06-30,SI,Slovenia,
-1937-06-30,SK,Slovak Republic,
-1937-06-30,TH,Thailand,
-1937-06-30,TR,Türkiye,
-1937-06-30,US,United States,
-1937-06-30,XM,Euro area,
-1937-06-30,XW,World,
-1937-06-30,ZA,South Africa,
-1937-09-30,4T,Emerging market economies (aggregate),
-1937-09-30,5R,Advanced economies,
-1937-09-30,AE,United Arab Emirates,
-1937-09-30,AT,Austria,
-1937-09-30,AU,Australia,
-1937-09-30,BE,Belgium,
-1937-09-30,BG,Bulgaria,
-1937-09-30,BR,Brazil,
-1937-09-30,CA,Canada,
-1937-09-30,CH,Switzerland,
-1937-09-30,CL,Chile,
-1937-09-30,CN,China,
-1937-09-30,CO,Colombia,
-1937-09-30,CY,Cyprus,
-1937-09-30,CZ,Czechia,
-1937-09-30,DE,Germany,
-1937-09-30,DK,Denmark,
-1937-09-30,EE,Estonia,
-1937-09-30,ES,Spain,
-1937-09-30,FI,Finland,
-1937-09-30,FR,France,
-1937-09-30,GB,United Kingdom,
-1937-09-30,GR,Greece,
-1937-09-30,HK,Hong Kong SAR,
-1937-09-30,HR,Croatia,
-1937-09-30,HU,Hungary,
-1937-09-30,ID,Indonesia,
-1937-09-30,IE,Ireland,
-1937-09-30,IL,Israel,
-1937-09-30,IN,India,
-1937-09-30,IS,Iceland,
-1937-09-30,IT,Italy,
-1937-09-30,JP,Japan,
-1937-09-30,KR,Korea,
-1937-09-30,LT,Lithuania,
-1937-09-30,LU,Luxembourg,
-1937-09-30,LV,Latvia,
-1937-09-30,MA,Morocco,
-1937-09-30,MK,North Macedonia,
-1937-09-30,MT,Malta,
-1937-09-30,MX,Mexico,
-1937-09-30,MY,Malaysia,
-1937-09-30,NL,Netherlands,
-1937-09-30,NO,Norway,
-1937-09-30,NZ,New Zealand,
-1937-09-30,PE,Peru,
-1937-09-30,PH,Philippines,
-1937-09-30,PL,Poland,
-1937-09-30,PT,Portugal,
-1937-09-30,RO,Romania,
-1937-09-30,RS,Serbia,
-1937-09-30,RU,Russia,
-1937-09-30,SE,Sweden,
-1937-09-30,SG,Singapore,
-1937-09-30,SI,Slovenia,
-1937-09-30,SK,Slovak Republic,
-1937-09-30,TH,Thailand,
-1937-09-30,TR,Türkiye,
-1937-09-30,US,United States,
-1937-09-30,XM,Euro area,
-1937-09-30,XW,World,
-1937-09-30,ZA,South Africa,
-1937-12-31,4T,Emerging market economies (aggregate),
-1937-12-31,5R,Advanced economies,
-1937-12-31,AE,United Arab Emirates,
-1937-12-31,AT,Austria,
-1937-12-31,AU,Australia,
-1937-12-31,BE,Belgium,
-1937-12-31,BG,Bulgaria,
-1937-12-31,BR,Brazil,
-1937-12-31,CA,Canada,
-1937-12-31,CH,Switzerland,
-1937-12-31,CL,Chile,
-1937-12-31,CN,China,
-1937-12-31,CO,Colombia,
-1937-12-31,CY,Cyprus,
-1937-12-31,CZ,Czechia,
-1937-12-31,DE,Germany,
-1937-12-31,DK,Denmark,
-1937-12-31,EE,Estonia,
-1937-12-31,ES,Spain,
-1937-12-31,FI,Finland,
-1937-12-31,FR,France,
-1937-12-31,GB,United Kingdom,
-1937-12-31,GR,Greece,
-1937-12-31,HK,Hong Kong SAR,
-1937-12-31,HR,Croatia,
-1937-12-31,HU,Hungary,
-1937-12-31,ID,Indonesia,
-1937-12-31,IE,Ireland,
-1937-12-31,IL,Israel,
-1937-12-31,IN,India,
-1937-12-31,IS,Iceland,
-1937-12-31,IT,Italy,
-1937-12-31,JP,Japan,
-1937-12-31,KR,Korea,
-1937-12-31,LT,Lithuania,
-1937-12-31,LU,Luxembourg,
-1937-12-31,LV,Latvia,
-1937-12-31,MA,Morocco,
-1937-12-31,MK,North Macedonia,
-1937-12-31,MT,Malta,
-1937-12-31,MX,Mexico,
-1937-12-31,MY,Malaysia,
-1937-12-31,NL,Netherlands,
-1937-12-31,NO,Norway,
-1937-12-31,NZ,New Zealand,
-1937-12-31,PE,Peru,
-1937-12-31,PH,Philippines,
-1937-12-31,PL,Poland,
-1937-12-31,PT,Portugal,
-1937-12-31,RO,Romania,
-1937-12-31,RS,Serbia,
-1937-12-31,RU,Russia,
-1937-12-31,SE,Sweden,
-1937-12-31,SG,Singapore,
-1937-12-31,SI,Slovenia,
-1937-12-31,SK,Slovak Republic,
-1937-12-31,TH,Thailand,
-1937-12-31,TR,Türkiye,
-1937-12-31,US,United States,
-1937-12-31,XM,Euro area,
-1937-12-31,XW,World,
-1937-12-31,ZA,South Africa,
-1938-03-31,4T,Emerging market economies (aggregate),
-1938-03-31,5R,Advanced economies,
-1938-03-31,AE,United Arab Emirates,
-1938-03-31,AT,Austria,
-1938-03-31,AU,Australia,
-1938-03-31,BE,Belgium,
-1938-03-31,BG,Bulgaria,
-1938-03-31,BR,Brazil,
-1938-03-31,CA,Canada,
-1938-03-31,CH,Switzerland,
-1938-03-31,CL,Chile,
-1938-03-31,CN,China,
-1938-03-31,CO,Colombia,
-1938-03-31,CY,Cyprus,
-1938-03-31,CZ,Czechia,
-1938-03-31,DE,Germany,
-1938-03-31,DK,Denmark,
-1938-03-31,EE,Estonia,
-1938-03-31,ES,Spain,
-1938-03-31,FI,Finland,
-1938-03-31,FR,France,
-1938-03-31,GB,United Kingdom,
-1938-03-31,GR,Greece,
-1938-03-31,HK,Hong Kong SAR,
-1938-03-31,HR,Croatia,
-1938-03-31,HU,Hungary,
-1938-03-31,ID,Indonesia,
-1938-03-31,IE,Ireland,
-1938-03-31,IL,Israel,
-1938-03-31,IN,India,
-1938-03-31,IS,Iceland,
-1938-03-31,IT,Italy,
-1938-03-31,JP,Japan,
-1938-03-31,KR,Korea,
-1938-03-31,LT,Lithuania,
-1938-03-31,LU,Luxembourg,
-1938-03-31,LV,Latvia,
-1938-03-31,MA,Morocco,
-1938-03-31,MK,North Macedonia,
-1938-03-31,MT,Malta,
-1938-03-31,MX,Mexico,
-1938-03-31,MY,Malaysia,
-1938-03-31,NL,Netherlands,
-1938-03-31,NO,Norway,
-1938-03-31,NZ,New Zealand,
-1938-03-31,PE,Peru,
-1938-03-31,PH,Philippines,
-1938-03-31,PL,Poland,
-1938-03-31,PT,Portugal,
-1938-03-31,RO,Romania,
-1938-03-31,RS,Serbia,
-1938-03-31,RU,Russia,
-1938-03-31,SE,Sweden,
-1938-03-31,SG,Singapore,
-1938-03-31,SI,Slovenia,
-1938-03-31,SK,Slovak Republic,
-1938-03-31,TH,Thailand,
-1938-03-31,TR,Türkiye,
-1938-03-31,US,United States,
-1938-03-31,XM,Euro area,
-1938-03-31,XW,World,
-1938-03-31,ZA,South Africa,
-1938-06-30,4T,Emerging market economies (aggregate),
-1938-06-30,5R,Advanced economies,
-1938-06-30,AE,United Arab Emirates,
-1938-06-30,AT,Austria,
-1938-06-30,AU,Australia,
-1938-06-30,BE,Belgium,
-1938-06-30,BG,Bulgaria,
-1938-06-30,BR,Brazil,
-1938-06-30,CA,Canada,
-1938-06-30,CH,Switzerland,
-1938-06-30,CL,Chile,
-1938-06-30,CN,China,
-1938-06-30,CO,Colombia,
-1938-06-30,CY,Cyprus,
-1938-06-30,CZ,Czechia,
-1938-06-30,DE,Germany,
-1938-06-30,DK,Denmark,
-1938-06-30,EE,Estonia,
-1938-06-30,ES,Spain,
-1938-06-30,FI,Finland,
-1938-06-30,FR,France,
-1938-06-30,GB,United Kingdom,
-1938-06-30,GR,Greece,
-1938-06-30,HK,Hong Kong SAR,
-1938-06-30,HR,Croatia,
-1938-06-30,HU,Hungary,
-1938-06-30,ID,Indonesia,
-1938-06-30,IE,Ireland,
-1938-06-30,IL,Israel,
-1938-06-30,IN,India,
-1938-06-30,IS,Iceland,
-1938-06-30,IT,Italy,
-1938-06-30,JP,Japan,
-1938-06-30,KR,Korea,
-1938-06-30,LT,Lithuania,
-1938-06-30,LU,Luxembourg,
-1938-06-30,LV,Latvia,
-1938-06-30,MA,Morocco,
-1938-06-30,MK,North Macedonia,
-1938-06-30,MT,Malta,
-1938-06-30,MX,Mexico,
-1938-06-30,MY,Malaysia,
-1938-06-30,NL,Netherlands,
-1938-06-30,NO,Norway,
-1938-06-30,NZ,New Zealand,
-1938-06-30,PE,Peru,
-1938-06-30,PH,Philippines,
-1938-06-30,PL,Poland,
-1938-06-30,PT,Portugal,
-1938-06-30,RO,Romania,
-1938-06-30,RS,Serbia,
-1938-06-30,RU,Russia,
-1938-06-30,SE,Sweden,
-1938-06-30,SG,Singapore,
-1938-06-30,SI,Slovenia,
-1938-06-30,SK,Slovak Republic,
-1938-06-30,TH,Thailand,
-1938-06-30,TR,Türkiye,
-1938-06-30,US,United States,
-1938-06-30,XM,Euro area,
-1938-06-30,XW,World,
-1938-06-30,ZA,South Africa,
-1938-09-30,4T,Emerging market economies (aggregate),
-1938-09-30,5R,Advanced economies,
-1938-09-30,AE,United Arab Emirates,
-1938-09-30,AT,Austria,
-1938-09-30,AU,Australia,
-1938-09-30,BE,Belgium,
-1938-09-30,BG,Bulgaria,
-1938-09-30,BR,Brazil,
-1938-09-30,CA,Canada,
-1938-09-30,CH,Switzerland,
-1938-09-30,CL,Chile,
-1938-09-30,CN,China,
-1938-09-30,CO,Colombia,
-1938-09-30,CY,Cyprus,
-1938-09-30,CZ,Czechia,
-1938-09-30,DE,Germany,
-1938-09-30,DK,Denmark,
-1938-09-30,EE,Estonia,
-1938-09-30,ES,Spain,
-1938-09-30,FI,Finland,
-1938-09-30,FR,France,
-1938-09-30,GB,United Kingdom,
-1938-09-30,GR,Greece,
-1938-09-30,HK,Hong Kong SAR,
-1938-09-30,HR,Croatia,
-1938-09-30,HU,Hungary,
-1938-09-30,ID,Indonesia,
-1938-09-30,IE,Ireland,
-1938-09-30,IL,Israel,
-1938-09-30,IN,India,
-1938-09-30,IS,Iceland,
-1938-09-30,IT,Italy,
-1938-09-30,JP,Japan,
-1938-09-30,KR,Korea,
-1938-09-30,LT,Lithuania,
-1938-09-30,LU,Luxembourg,
-1938-09-30,LV,Latvia,
-1938-09-30,MA,Morocco,
-1938-09-30,MK,North Macedonia,
-1938-09-30,MT,Malta,
-1938-09-30,MX,Mexico,
-1938-09-30,MY,Malaysia,
-1938-09-30,NL,Netherlands,
-1938-09-30,NO,Norway,
-1938-09-30,NZ,New Zealand,
-1938-09-30,PE,Peru,
-1938-09-30,PH,Philippines,
-1938-09-30,PL,Poland,
-1938-09-30,PT,Portugal,
-1938-09-30,RO,Romania,
-1938-09-30,RS,Serbia,
-1938-09-30,RU,Russia,
-1938-09-30,SE,Sweden,
-1938-09-30,SG,Singapore,
-1938-09-30,SI,Slovenia,
-1938-09-30,SK,Slovak Republic,
-1938-09-30,TH,Thailand,
-1938-09-30,TR,Türkiye,
-1938-09-30,US,United States,
-1938-09-30,XM,Euro area,
-1938-09-30,XW,World,
-1938-09-30,ZA,South Africa,
-1938-12-31,4T,Emerging market economies (aggregate),
-1938-12-31,5R,Advanced economies,
-1938-12-31,AE,United Arab Emirates,
-1938-12-31,AT,Austria,
-1938-12-31,AU,Australia,
-1938-12-31,BE,Belgium,
-1938-12-31,BG,Bulgaria,
-1938-12-31,BR,Brazil,
-1938-12-31,CA,Canada,
-1938-12-31,CH,Switzerland,
-1938-12-31,CL,Chile,
-1938-12-31,CN,China,
-1938-12-31,CO,Colombia,
-1938-12-31,CY,Cyprus,
-1938-12-31,CZ,Czechia,
-1938-12-31,DE,Germany,
-1938-12-31,DK,Denmark,
-1938-12-31,EE,Estonia,
-1938-12-31,ES,Spain,
-1938-12-31,FI,Finland,
-1938-12-31,FR,France,
-1938-12-31,GB,United Kingdom,
-1938-12-31,GR,Greece,
-1938-12-31,HK,Hong Kong SAR,
-1938-12-31,HR,Croatia,
-1938-12-31,HU,Hungary,
-1938-12-31,ID,Indonesia,
-1938-12-31,IE,Ireland,
-1938-12-31,IL,Israel,
-1938-12-31,IN,India,
-1938-12-31,IS,Iceland,
-1938-12-31,IT,Italy,
-1938-12-31,JP,Japan,
-1938-12-31,KR,Korea,
-1938-12-31,LT,Lithuania,
-1938-12-31,LU,Luxembourg,
-1938-12-31,LV,Latvia,
-1938-12-31,MA,Morocco,
-1938-12-31,MK,North Macedonia,
-1938-12-31,MT,Malta,
-1938-12-31,MX,Mexico,
-1938-12-31,MY,Malaysia,
-1938-12-31,NL,Netherlands,
-1938-12-31,NO,Norway,
-1938-12-31,NZ,New Zealand,
-1938-12-31,PE,Peru,
-1938-12-31,PH,Philippines,
-1938-12-31,PL,Poland,
-1938-12-31,PT,Portugal,
-1938-12-31,RO,Romania,
-1938-12-31,RS,Serbia,
-1938-12-31,RU,Russia,
-1938-12-31,SE,Sweden,
-1938-12-31,SG,Singapore,
-1938-12-31,SI,Slovenia,
-1938-12-31,SK,Slovak Republic,
-1938-12-31,TH,Thailand,
-1938-12-31,TR,Türkiye,
-1938-12-31,US,United States,
-1938-12-31,XM,Euro area,
-1938-12-31,XW,World,
-1938-12-31,ZA,South Africa,
-1939-03-31,4T,Emerging market economies (aggregate),
-1939-03-31,5R,Advanced economies,
-1939-03-31,AE,United Arab Emirates,
-1939-03-31,AT,Austria,
-1939-03-31,AU,Australia,
-1939-03-31,BE,Belgium,
-1939-03-31,BG,Bulgaria,
-1939-03-31,BR,Brazil,
-1939-03-31,CA,Canada,
-1939-03-31,CH,Switzerland,
-1939-03-31,CL,Chile,
-1939-03-31,CN,China,
-1939-03-31,CO,Colombia,
-1939-03-31,CY,Cyprus,
-1939-03-31,CZ,Czechia,
-1939-03-31,DE,Germany,
-1939-03-31,DK,Denmark,
-1939-03-31,EE,Estonia,
-1939-03-31,ES,Spain,
-1939-03-31,FI,Finland,
-1939-03-31,FR,France,
-1939-03-31,GB,United Kingdom,
-1939-03-31,GR,Greece,
-1939-03-31,HK,Hong Kong SAR,
-1939-03-31,HR,Croatia,
-1939-03-31,HU,Hungary,
-1939-03-31,ID,Indonesia,
-1939-03-31,IE,Ireland,
-1939-03-31,IL,Israel,
-1939-03-31,IN,India,
-1939-03-31,IS,Iceland,
-1939-03-31,IT,Italy,
-1939-03-31,JP,Japan,
-1939-03-31,KR,Korea,
-1939-03-31,LT,Lithuania,
-1939-03-31,LU,Luxembourg,
-1939-03-31,LV,Latvia,
-1939-03-31,MA,Morocco,
-1939-03-31,MK,North Macedonia,
-1939-03-31,MT,Malta,
-1939-03-31,MX,Mexico,
-1939-03-31,MY,Malaysia,
-1939-03-31,NL,Netherlands,
-1939-03-31,NO,Norway,
-1939-03-31,NZ,New Zealand,
-1939-03-31,PE,Peru,
-1939-03-31,PH,Philippines,
-1939-03-31,PL,Poland,
-1939-03-31,PT,Portugal,
-1939-03-31,RO,Romania,
-1939-03-31,RS,Serbia,
-1939-03-31,RU,Russia,
-1939-03-31,SE,Sweden,
-1939-03-31,SG,Singapore,
-1939-03-31,SI,Slovenia,
-1939-03-31,SK,Slovak Republic,
-1939-03-31,TH,Thailand,
-1939-03-31,TR,Türkiye,
-1939-03-31,US,United States,
-1939-03-31,XM,Euro area,
-1939-03-31,XW,World,
-1939-03-31,ZA,South Africa,
-1939-06-30,4T,Emerging market economies (aggregate),
-1939-06-30,5R,Advanced economies,
-1939-06-30,AE,United Arab Emirates,
-1939-06-30,AT,Austria,
-1939-06-30,AU,Australia,
-1939-06-30,BE,Belgium,
-1939-06-30,BG,Bulgaria,
-1939-06-30,BR,Brazil,
-1939-06-30,CA,Canada,
-1939-06-30,CH,Switzerland,
-1939-06-30,CL,Chile,
-1939-06-30,CN,China,
-1939-06-30,CO,Colombia,
-1939-06-30,CY,Cyprus,
-1939-06-30,CZ,Czechia,
-1939-06-30,DE,Germany,
-1939-06-30,DK,Denmark,
-1939-06-30,EE,Estonia,
-1939-06-30,ES,Spain,
-1939-06-30,FI,Finland,
-1939-06-30,FR,France,
-1939-06-30,GB,United Kingdom,
-1939-06-30,GR,Greece,
-1939-06-30,HK,Hong Kong SAR,
-1939-06-30,HR,Croatia,
-1939-06-30,HU,Hungary,
-1939-06-30,ID,Indonesia,
-1939-06-30,IE,Ireland,
-1939-06-30,IL,Israel,
-1939-06-30,IN,India,
-1939-06-30,IS,Iceland,
-1939-06-30,IT,Italy,
-1939-06-30,JP,Japan,
-1939-06-30,KR,Korea,
-1939-06-30,LT,Lithuania,
-1939-06-30,LU,Luxembourg,
-1939-06-30,LV,Latvia,
-1939-06-30,MA,Morocco,
-1939-06-30,MK,North Macedonia,
-1939-06-30,MT,Malta,
-1939-06-30,MX,Mexico,
-1939-06-30,MY,Malaysia,
-1939-06-30,NL,Netherlands,
-1939-06-30,NO,Norway,
-1939-06-30,NZ,New Zealand,
-1939-06-30,PE,Peru,
-1939-06-30,PH,Philippines,
-1939-06-30,PL,Poland,
-1939-06-30,PT,Portugal,
-1939-06-30,RO,Romania,
-1939-06-30,RS,Serbia,
-1939-06-30,RU,Russia,
-1939-06-30,SE,Sweden,
-1939-06-30,SG,Singapore,
-1939-06-30,SI,Slovenia,
-1939-06-30,SK,Slovak Republic,
-1939-06-30,TH,Thailand,
-1939-06-30,TR,Türkiye,
-1939-06-30,US,United States,
-1939-06-30,XM,Euro area,
-1939-06-30,XW,World,
-1939-06-30,ZA,South Africa,
-1939-09-30,4T,Emerging market economies (aggregate),
-1939-09-30,5R,Advanced economies,
-1939-09-30,AE,United Arab Emirates,
-1939-09-30,AT,Austria,
-1939-09-30,AU,Australia,
-1939-09-30,BE,Belgium,
-1939-09-30,BG,Bulgaria,
-1939-09-30,BR,Brazil,
-1939-09-30,CA,Canada,
-1939-09-30,CH,Switzerland,
-1939-09-30,CL,Chile,
-1939-09-30,CN,China,
-1939-09-30,CO,Colombia,
-1939-09-30,CY,Cyprus,
-1939-09-30,CZ,Czechia,
-1939-09-30,DE,Germany,
-1939-09-30,DK,Denmark,
-1939-09-30,EE,Estonia,
-1939-09-30,ES,Spain,
-1939-09-30,FI,Finland,
-1939-09-30,FR,France,
-1939-09-30,GB,United Kingdom,
-1939-09-30,GR,Greece,
-1939-09-30,HK,Hong Kong SAR,
-1939-09-30,HR,Croatia,
-1939-09-30,HU,Hungary,
-1939-09-30,ID,Indonesia,
-1939-09-30,IE,Ireland,
-1939-09-30,IL,Israel,
-1939-09-30,IN,India,
-1939-09-30,IS,Iceland,
-1939-09-30,IT,Italy,
-1939-09-30,JP,Japan,
-1939-09-30,KR,Korea,
-1939-09-30,LT,Lithuania,
-1939-09-30,LU,Luxembourg,
-1939-09-30,LV,Latvia,
-1939-09-30,MA,Morocco,
-1939-09-30,MK,North Macedonia,
-1939-09-30,MT,Malta,
-1939-09-30,MX,Mexico,
-1939-09-30,MY,Malaysia,
-1939-09-30,NL,Netherlands,
-1939-09-30,NO,Norway,
-1939-09-30,NZ,New Zealand,
-1939-09-30,PE,Peru,
-1939-09-30,PH,Philippines,
-1939-09-30,PL,Poland,
-1939-09-30,PT,Portugal,
-1939-09-30,RO,Romania,
-1939-09-30,RS,Serbia,
-1939-09-30,RU,Russia,
-1939-09-30,SE,Sweden,
-1939-09-30,SG,Singapore,
-1939-09-30,SI,Slovenia,
-1939-09-30,SK,Slovak Republic,
-1939-09-30,TH,Thailand,
-1939-09-30,TR,Türkiye,
-1939-09-30,US,United States,
-1939-09-30,XM,Euro area,
-1939-09-30,XW,World,
-1939-09-30,ZA,South Africa,
-1939-12-31,4T,Emerging market economies (aggregate),
-1939-12-31,5R,Advanced economies,
-1939-12-31,AE,United Arab Emirates,
-1939-12-31,AT,Austria,
-1939-12-31,AU,Australia,
-1939-12-31,BE,Belgium,
-1939-12-31,BG,Bulgaria,
-1939-12-31,BR,Brazil,
-1939-12-31,CA,Canada,
-1939-12-31,CH,Switzerland,
-1939-12-31,CL,Chile,
-1939-12-31,CN,China,
-1939-12-31,CO,Colombia,
-1939-12-31,CY,Cyprus,
-1939-12-31,CZ,Czechia,
-1939-12-31,DE,Germany,
-1939-12-31,DK,Denmark,
-1939-12-31,EE,Estonia,
-1939-12-31,ES,Spain,
-1939-12-31,FI,Finland,
-1939-12-31,FR,France,
-1939-12-31,GB,United Kingdom,
-1939-12-31,GR,Greece,
-1939-12-31,HK,Hong Kong SAR,
-1939-12-31,HR,Croatia,
-1939-12-31,HU,Hungary,
-1939-12-31,ID,Indonesia,
-1939-12-31,IE,Ireland,
-1939-12-31,IL,Israel,
-1939-12-31,IN,India,
-1939-12-31,IS,Iceland,
-1939-12-31,IT,Italy,
-1939-12-31,JP,Japan,
-1939-12-31,KR,Korea,
-1939-12-31,LT,Lithuania,
-1939-12-31,LU,Luxembourg,
-1939-12-31,LV,Latvia,
-1939-12-31,MA,Morocco,
-1939-12-31,MK,North Macedonia,
-1939-12-31,MT,Malta,
-1939-12-31,MX,Mexico,
-1939-12-31,MY,Malaysia,
-1939-12-31,NL,Netherlands,
-1939-12-31,NO,Norway,
-1939-12-31,NZ,New Zealand,
-1939-12-31,PE,Peru,
-1939-12-31,PH,Philippines,
-1939-12-31,PL,Poland,
-1939-12-31,PT,Portugal,
-1939-12-31,RO,Romania,
-1939-12-31,RS,Serbia,
-1939-12-31,RU,Russia,
-1939-12-31,SE,Sweden,
-1939-12-31,SG,Singapore,
-1939-12-31,SI,Slovenia,
-1939-12-31,SK,Slovak Republic,
-1939-12-31,TH,Thailand,
-1939-12-31,TR,Türkiye,
-1939-12-31,US,United States,
-1939-12-31,XM,Euro area,
-1939-12-31,XW,World,
-1939-12-31,ZA,South Africa,
-1940-03-31,4T,Emerging market economies (aggregate),
-1940-03-31,5R,Advanced economies,
-1940-03-31,AE,United Arab Emirates,
-1940-03-31,AT,Austria,
-1940-03-31,AU,Australia,
-1940-03-31,BE,Belgium,
-1940-03-31,BG,Bulgaria,
-1940-03-31,BR,Brazil,
-1940-03-31,CA,Canada,
-1940-03-31,CH,Switzerland,
-1940-03-31,CL,Chile,
-1940-03-31,CN,China,
-1940-03-31,CO,Colombia,
-1940-03-31,CY,Cyprus,
-1940-03-31,CZ,Czechia,
-1940-03-31,DE,Germany,
-1940-03-31,DK,Denmark,
-1940-03-31,EE,Estonia,
-1940-03-31,ES,Spain,
-1940-03-31,FI,Finland,
-1940-03-31,FR,France,
-1940-03-31,GB,United Kingdom,
-1940-03-31,GR,Greece,
-1940-03-31,HK,Hong Kong SAR,
-1940-03-31,HR,Croatia,
-1940-03-31,HU,Hungary,
-1940-03-31,ID,Indonesia,
-1940-03-31,IE,Ireland,
-1940-03-31,IL,Israel,
-1940-03-31,IN,India,
-1940-03-31,IS,Iceland,
-1940-03-31,IT,Italy,
-1940-03-31,JP,Japan,
-1940-03-31,KR,Korea,
-1940-03-31,LT,Lithuania,
-1940-03-31,LU,Luxembourg,
-1940-03-31,LV,Latvia,
-1940-03-31,MA,Morocco,
-1940-03-31,MK,North Macedonia,
-1940-03-31,MT,Malta,
-1940-03-31,MX,Mexico,
-1940-03-31,MY,Malaysia,
-1940-03-31,NL,Netherlands,
-1940-03-31,NO,Norway,
-1940-03-31,NZ,New Zealand,
-1940-03-31,PE,Peru,
-1940-03-31,PH,Philippines,
-1940-03-31,PL,Poland,
-1940-03-31,PT,Portugal,
-1940-03-31,RO,Romania,
-1940-03-31,RS,Serbia,
-1940-03-31,RU,Russia,
-1940-03-31,SE,Sweden,
-1940-03-31,SG,Singapore,
-1940-03-31,SI,Slovenia,
-1940-03-31,SK,Slovak Republic,
-1940-03-31,TH,Thailand,
-1940-03-31,TR,Türkiye,
-1940-03-31,US,United States,
-1940-03-31,XM,Euro area,
-1940-03-31,XW,World,
-1940-03-31,ZA,South Africa,
-1940-06-30,4T,Emerging market economies (aggregate),
-1940-06-30,5R,Advanced economies,
-1940-06-30,AE,United Arab Emirates,
-1940-06-30,AT,Austria,
-1940-06-30,AU,Australia,
-1940-06-30,BE,Belgium,
-1940-06-30,BG,Bulgaria,
-1940-06-30,BR,Brazil,
-1940-06-30,CA,Canada,
-1940-06-30,CH,Switzerland,
-1940-06-30,CL,Chile,
-1940-06-30,CN,China,
-1940-06-30,CO,Colombia,
-1940-06-30,CY,Cyprus,
-1940-06-30,CZ,Czechia,
-1940-06-30,DE,Germany,
-1940-06-30,DK,Denmark,
-1940-06-30,EE,Estonia,
-1940-06-30,ES,Spain,
-1940-06-30,FI,Finland,
-1940-06-30,FR,France,
-1940-06-30,GB,United Kingdom,
-1940-06-30,GR,Greece,
-1940-06-30,HK,Hong Kong SAR,
-1940-06-30,HR,Croatia,
-1940-06-30,HU,Hungary,
-1940-06-30,ID,Indonesia,
-1940-06-30,IE,Ireland,
-1940-06-30,IL,Israel,
-1940-06-30,IN,India,
-1940-06-30,IS,Iceland,
-1940-06-30,IT,Italy,
-1940-06-30,JP,Japan,
-1940-06-30,KR,Korea,
-1940-06-30,LT,Lithuania,
-1940-06-30,LU,Luxembourg,
-1940-06-30,LV,Latvia,
-1940-06-30,MA,Morocco,
-1940-06-30,MK,North Macedonia,
-1940-06-30,MT,Malta,
-1940-06-30,MX,Mexico,
-1940-06-30,MY,Malaysia,
-1940-06-30,NL,Netherlands,
-1940-06-30,NO,Norway,
-1940-06-30,NZ,New Zealand,
-1940-06-30,PE,Peru,
-1940-06-30,PH,Philippines,
-1940-06-30,PL,Poland,
-1940-06-30,PT,Portugal,
-1940-06-30,RO,Romania,
-1940-06-30,RS,Serbia,
-1940-06-30,RU,Russia,
-1940-06-30,SE,Sweden,
-1940-06-30,SG,Singapore,
-1940-06-30,SI,Slovenia,
-1940-06-30,SK,Slovak Republic,
-1940-06-30,TH,Thailand,
-1940-06-30,TR,Türkiye,
-1940-06-30,US,United States,
-1940-06-30,XM,Euro area,
-1940-06-30,XW,World,
-1940-06-30,ZA,South Africa,
-1940-09-30,4T,Emerging market economies (aggregate),
-1940-09-30,5R,Advanced economies,
-1940-09-30,AE,United Arab Emirates,
-1940-09-30,AT,Austria,
-1940-09-30,AU,Australia,
-1940-09-30,BE,Belgium,
-1940-09-30,BG,Bulgaria,
-1940-09-30,BR,Brazil,
-1940-09-30,CA,Canada,
-1940-09-30,CH,Switzerland,
-1940-09-30,CL,Chile,
-1940-09-30,CN,China,
-1940-09-30,CO,Colombia,
-1940-09-30,CY,Cyprus,
-1940-09-30,CZ,Czechia,
-1940-09-30,DE,Germany,
-1940-09-30,DK,Denmark,
-1940-09-30,EE,Estonia,
-1940-09-30,ES,Spain,
-1940-09-30,FI,Finland,
-1940-09-30,FR,France,
-1940-09-30,GB,United Kingdom,
-1940-09-30,GR,Greece,
-1940-09-30,HK,Hong Kong SAR,
-1940-09-30,HR,Croatia,
-1940-09-30,HU,Hungary,
-1940-09-30,ID,Indonesia,
-1940-09-30,IE,Ireland,
-1940-09-30,IL,Israel,
-1940-09-30,IN,India,
-1940-09-30,IS,Iceland,
-1940-09-30,IT,Italy,
-1940-09-30,JP,Japan,
-1940-09-30,KR,Korea,
-1940-09-30,LT,Lithuania,
-1940-09-30,LU,Luxembourg,
-1940-09-30,LV,Latvia,
-1940-09-30,MA,Morocco,
-1940-09-30,MK,North Macedonia,
-1940-09-30,MT,Malta,
-1940-09-30,MX,Mexico,
-1940-09-30,MY,Malaysia,
-1940-09-30,NL,Netherlands,
-1940-09-30,NO,Norway,
-1940-09-30,NZ,New Zealand,
-1940-09-30,PE,Peru,
-1940-09-30,PH,Philippines,
-1940-09-30,PL,Poland,
-1940-09-30,PT,Portugal,
-1940-09-30,RO,Romania,
-1940-09-30,RS,Serbia,
-1940-09-30,RU,Russia,
-1940-09-30,SE,Sweden,
-1940-09-30,SG,Singapore,
-1940-09-30,SI,Slovenia,
-1940-09-30,SK,Slovak Republic,
-1940-09-30,TH,Thailand,
-1940-09-30,TR,Türkiye,
-1940-09-30,US,United States,
-1940-09-30,XM,Euro area,
-1940-09-30,XW,World,
-1940-09-30,ZA,South Africa,
-1940-12-31,4T,Emerging market economies (aggregate),
-1940-12-31,5R,Advanced economies,
-1940-12-31,AE,United Arab Emirates,
-1940-12-31,AT,Austria,
-1940-12-31,AU,Australia,
-1940-12-31,BE,Belgium,
-1940-12-31,BG,Bulgaria,
-1940-12-31,BR,Brazil,
-1940-12-31,CA,Canada,
-1940-12-31,CH,Switzerland,
-1940-12-31,CL,Chile,
-1940-12-31,CN,China,
-1940-12-31,CO,Colombia,
-1940-12-31,CY,Cyprus,
-1940-12-31,CZ,Czechia,
-1940-12-31,DE,Germany,
-1940-12-31,DK,Denmark,
-1940-12-31,EE,Estonia,
-1940-12-31,ES,Spain,
-1940-12-31,FI,Finland,
-1940-12-31,FR,France,
-1940-12-31,GB,United Kingdom,
-1940-12-31,GR,Greece,
-1940-12-31,HK,Hong Kong SAR,
-1940-12-31,HR,Croatia,
-1940-12-31,HU,Hungary,
-1940-12-31,ID,Indonesia,
-1940-12-31,IE,Ireland,
-1940-12-31,IL,Israel,
-1940-12-31,IN,India,
-1940-12-31,IS,Iceland,
-1940-12-31,IT,Italy,
-1940-12-31,JP,Japan,
-1940-12-31,KR,Korea,
-1940-12-31,LT,Lithuania,
-1940-12-31,LU,Luxembourg,
-1940-12-31,LV,Latvia,
-1940-12-31,MA,Morocco,
-1940-12-31,MK,North Macedonia,
-1940-12-31,MT,Malta,
-1940-12-31,MX,Mexico,
-1940-12-31,MY,Malaysia,
-1940-12-31,NL,Netherlands,
-1940-12-31,NO,Norway,
-1940-12-31,NZ,New Zealand,
-1940-12-31,PE,Peru,
-1940-12-31,PH,Philippines,
-1940-12-31,PL,Poland,
-1940-12-31,PT,Portugal,
-1940-12-31,RO,Romania,
-1940-12-31,RS,Serbia,
-1940-12-31,RU,Russia,
-1940-12-31,SE,Sweden,
-1940-12-31,SG,Singapore,
-1940-12-31,SI,Slovenia,
-1940-12-31,SK,Slovak Republic,
-1940-12-31,TH,Thailand,
-1940-12-31,TR,Türkiye,
-1940-12-31,US,United States,
-1940-12-31,XM,Euro area,
-1940-12-31,XW,World,
-1940-12-31,ZA,South Africa,
-1941-03-31,4T,Emerging market economies (aggregate),
-1941-03-31,5R,Advanced economies,
-1941-03-31,AE,United Arab Emirates,
-1941-03-31,AT,Austria,
-1941-03-31,AU,Australia,
-1941-03-31,BE,Belgium,
-1941-03-31,BG,Bulgaria,
-1941-03-31,BR,Brazil,
-1941-03-31,CA,Canada,
-1941-03-31,CH,Switzerland,
-1941-03-31,CL,Chile,
-1941-03-31,CN,China,
-1941-03-31,CO,Colombia,
-1941-03-31,CY,Cyprus,
-1941-03-31,CZ,Czechia,
-1941-03-31,DE,Germany,
-1941-03-31,DK,Denmark,
-1941-03-31,EE,Estonia,
-1941-03-31,ES,Spain,
-1941-03-31,FI,Finland,
-1941-03-31,FR,France,
-1941-03-31,GB,United Kingdom,
-1941-03-31,GR,Greece,
-1941-03-31,HK,Hong Kong SAR,
-1941-03-31,HR,Croatia,
-1941-03-31,HU,Hungary,
-1941-03-31,ID,Indonesia,
-1941-03-31,IE,Ireland,
-1941-03-31,IL,Israel,
-1941-03-31,IN,India,
-1941-03-31,IS,Iceland,
-1941-03-31,IT,Italy,
-1941-03-31,JP,Japan,
-1941-03-31,KR,Korea,
-1941-03-31,LT,Lithuania,
-1941-03-31,LU,Luxembourg,
-1941-03-31,LV,Latvia,
-1941-03-31,MA,Morocco,
-1941-03-31,MK,North Macedonia,
-1941-03-31,MT,Malta,
-1941-03-31,MX,Mexico,
-1941-03-31,MY,Malaysia,
-1941-03-31,NL,Netherlands,
-1941-03-31,NO,Norway,
-1941-03-31,NZ,New Zealand,
-1941-03-31,PE,Peru,
-1941-03-31,PH,Philippines,
-1941-03-31,PL,Poland,
-1941-03-31,PT,Portugal,
-1941-03-31,RO,Romania,
-1941-03-31,RS,Serbia,
-1941-03-31,RU,Russia,
-1941-03-31,SE,Sweden,
-1941-03-31,SG,Singapore,
-1941-03-31,SI,Slovenia,
-1941-03-31,SK,Slovak Republic,
-1941-03-31,TH,Thailand,
-1941-03-31,TR,Türkiye,
-1941-03-31,US,United States,
-1941-03-31,XM,Euro area,
-1941-03-31,XW,World,
-1941-03-31,ZA,South Africa,
-1941-06-30,4T,Emerging market economies (aggregate),
-1941-06-30,5R,Advanced economies,
-1941-06-30,AE,United Arab Emirates,
-1941-06-30,AT,Austria,
-1941-06-30,AU,Australia,
-1941-06-30,BE,Belgium,
-1941-06-30,BG,Bulgaria,
-1941-06-30,BR,Brazil,
-1941-06-30,CA,Canada,
-1941-06-30,CH,Switzerland,
-1941-06-30,CL,Chile,
-1941-06-30,CN,China,
-1941-06-30,CO,Colombia,
-1941-06-30,CY,Cyprus,
-1941-06-30,CZ,Czechia,
-1941-06-30,DE,Germany,
-1941-06-30,DK,Denmark,
-1941-06-30,EE,Estonia,
-1941-06-30,ES,Spain,
-1941-06-30,FI,Finland,
-1941-06-30,FR,France,
-1941-06-30,GB,United Kingdom,
-1941-06-30,GR,Greece,
-1941-06-30,HK,Hong Kong SAR,
-1941-06-30,HR,Croatia,
-1941-06-30,HU,Hungary,
-1941-06-30,ID,Indonesia,
-1941-06-30,IE,Ireland,
-1941-06-30,IL,Israel,
-1941-06-30,IN,India,
-1941-06-30,IS,Iceland,
-1941-06-30,IT,Italy,
-1941-06-30,JP,Japan,
-1941-06-30,KR,Korea,
-1941-06-30,LT,Lithuania,
-1941-06-30,LU,Luxembourg,
-1941-06-30,LV,Latvia,
-1941-06-30,MA,Morocco,
-1941-06-30,MK,North Macedonia,
-1941-06-30,MT,Malta,
-1941-06-30,MX,Mexico,
-1941-06-30,MY,Malaysia,
-1941-06-30,NL,Netherlands,
-1941-06-30,NO,Norway,
-1941-06-30,NZ,New Zealand,
-1941-06-30,PE,Peru,
-1941-06-30,PH,Philippines,
-1941-06-30,PL,Poland,
-1941-06-30,PT,Portugal,
-1941-06-30,RO,Romania,
-1941-06-30,RS,Serbia,
-1941-06-30,RU,Russia,
-1941-06-30,SE,Sweden,
-1941-06-30,SG,Singapore,
-1941-06-30,SI,Slovenia,
-1941-06-30,SK,Slovak Republic,
-1941-06-30,TH,Thailand,
-1941-06-30,TR,Türkiye,
-1941-06-30,US,United States,
-1941-06-30,XM,Euro area,
-1941-06-30,XW,World,
-1941-06-30,ZA,South Africa,
-1941-09-30,4T,Emerging market economies (aggregate),
-1941-09-30,5R,Advanced economies,
-1941-09-30,AE,United Arab Emirates,
-1941-09-30,AT,Austria,
-1941-09-30,AU,Australia,
-1941-09-30,BE,Belgium,
-1941-09-30,BG,Bulgaria,
-1941-09-30,BR,Brazil,
-1941-09-30,CA,Canada,
-1941-09-30,CH,Switzerland,
-1941-09-30,CL,Chile,
-1941-09-30,CN,China,
-1941-09-30,CO,Colombia,
-1941-09-30,CY,Cyprus,
-1941-09-30,CZ,Czechia,
-1941-09-30,DE,Germany,
-1941-09-30,DK,Denmark,
-1941-09-30,EE,Estonia,
-1941-09-30,ES,Spain,
-1941-09-30,FI,Finland,
-1941-09-30,FR,France,
-1941-09-30,GB,United Kingdom,
-1941-09-30,GR,Greece,
-1941-09-30,HK,Hong Kong SAR,
-1941-09-30,HR,Croatia,
-1941-09-30,HU,Hungary,
-1941-09-30,ID,Indonesia,
-1941-09-30,IE,Ireland,
-1941-09-30,IL,Israel,
-1941-09-30,IN,India,
-1941-09-30,IS,Iceland,
-1941-09-30,IT,Italy,
-1941-09-30,JP,Japan,
-1941-09-30,KR,Korea,
-1941-09-30,LT,Lithuania,
-1941-09-30,LU,Luxembourg,
-1941-09-30,LV,Latvia,
-1941-09-30,MA,Morocco,
-1941-09-30,MK,North Macedonia,
-1941-09-30,MT,Malta,
-1941-09-30,MX,Mexico,
-1941-09-30,MY,Malaysia,
-1941-09-30,NL,Netherlands,
-1941-09-30,NO,Norway,
-1941-09-30,NZ,New Zealand,
-1941-09-30,PE,Peru,
-1941-09-30,PH,Philippines,
-1941-09-30,PL,Poland,
-1941-09-30,PT,Portugal,
-1941-09-30,RO,Romania,
-1941-09-30,RS,Serbia,
-1941-09-30,RU,Russia,
-1941-09-30,SE,Sweden,
-1941-09-30,SG,Singapore,
-1941-09-30,SI,Slovenia,
-1941-09-30,SK,Slovak Republic,
-1941-09-30,TH,Thailand,
-1941-09-30,TR,Türkiye,
-1941-09-30,US,United States,
-1941-09-30,XM,Euro area,
-1941-09-30,XW,World,
-1941-09-30,ZA,South Africa,
-1941-12-31,4T,Emerging market economies (aggregate),
-1941-12-31,5R,Advanced economies,
-1941-12-31,AE,United Arab Emirates,
-1941-12-31,AT,Austria,
-1941-12-31,AU,Australia,
-1941-12-31,BE,Belgium,
-1941-12-31,BG,Bulgaria,
-1941-12-31,BR,Brazil,
-1941-12-31,CA,Canada,
-1941-12-31,CH,Switzerland,
-1941-12-31,CL,Chile,
-1941-12-31,CN,China,
-1941-12-31,CO,Colombia,
-1941-12-31,CY,Cyprus,
-1941-12-31,CZ,Czechia,
-1941-12-31,DE,Germany,
-1941-12-31,DK,Denmark,
-1941-12-31,EE,Estonia,
-1941-12-31,ES,Spain,
-1941-12-31,FI,Finland,
-1941-12-31,FR,France,
-1941-12-31,GB,United Kingdom,
-1941-12-31,GR,Greece,
-1941-12-31,HK,Hong Kong SAR,
-1941-12-31,HR,Croatia,
-1941-12-31,HU,Hungary,
-1941-12-31,ID,Indonesia,
-1941-12-31,IE,Ireland,
-1941-12-31,IL,Israel,
-1941-12-31,IN,India,
-1941-12-31,IS,Iceland,
-1941-12-31,IT,Italy,
-1941-12-31,JP,Japan,
-1941-12-31,KR,Korea,
-1941-12-31,LT,Lithuania,
-1941-12-31,LU,Luxembourg,
-1941-12-31,LV,Latvia,
-1941-12-31,MA,Morocco,
-1941-12-31,MK,North Macedonia,
-1941-12-31,MT,Malta,
-1941-12-31,MX,Mexico,
-1941-12-31,MY,Malaysia,
-1941-12-31,NL,Netherlands,
-1941-12-31,NO,Norway,
-1941-12-31,NZ,New Zealand,
-1941-12-31,PE,Peru,
-1941-12-31,PH,Philippines,
-1941-12-31,PL,Poland,
-1941-12-31,PT,Portugal,
-1941-12-31,RO,Romania,
-1941-12-31,RS,Serbia,
-1941-12-31,RU,Russia,
-1941-12-31,SE,Sweden,
-1941-12-31,SG,Singapore,
-1941-12-31,SI,Slovenia,
-1941-12-31,SK,Slovak Republic,
-1941-12-31,TH,Thailand,
-1941-12-31,TR,Türkiye,
-1941-12-31,US,United States,
-1941-12-31,XM,Euro area,
-1941-12-31,XW,World,
-1941-12-31,ZA,South Africa,
-1942-03-31,4T,Emerging market economies (aggregate),
-1942-03-31,5R,Advanced economies,
-1942-03-31,AE,United Arab Emirates,
-1942-03-31,AT,Austria,
-1942-03-31,AU,Australia,
-1942-03-31,BE,Belgium,
-1942-03-31,BG,Bulgaria,
-1942-03-31,BR,Brazil,
-1942-03-31,CA,Canada,
-1942-03-31,CH,Switzerland,
-1942-03-31,CL,Chile,
-1942-03-31,CN,China,
-1942-03-31,CO,Colombia,
-1942-03-31,CY,Cyprus,
-1942-03-31,CZ,Czechia,
-1942-03-31,DE,Germany,
-1942-03-31,DK,Denmark,
-1942-03-31,EE,Estonia,
-1942-03-31,ES,Spain,
-1942-03-31,FI,Finland,
-1942-03-31,FR,France,
-1942-03-31,GB,United Kingdom,
-1942-03-31,GR,Greece,
-1942-03-31,HK,Hong Kong SAR,
-1942-03-31,HR,Croatia,
-1942-03-31,HU,Hungary,
-1942-03-31,ID,Indonesia,
-1942-03-31,IE,Ireland,
-1942-03-31,IL,Israel,
-1942-03-31,IN,India,
-1942-03-31,IS,Iceland,
-1942-03-31,IT,Italy,
-1942-03-31,JP,Japan,
-1942-03-31,KR,Korea,
-1942-03-31,LT,Lithuania,
-1942-03-31,LU,Luxembourg,
-1942-03-31,LV,Latvia,
-1942-03-31,MA,Morocco,
-1942-03-31,MK,North Macedonia,
-1942-03-31,MT,Malta,
-1942-03-31,MX,Mexico,
-1942-03-31,MY,Malaysia,
-1942-03-31,NL,Netherlands,
-1942-03-31,NO,Norway,
-1942-03-31,NZ,New Zealand,
-1942-03-31,PE,Peru,
-1942-03-31,PH,Philippines,
-1942-03-31,PL,Poland,
-1942-03-31,PT,Portugal,
-1942-03-31,RO,Romania,
-1942-03-31,RS,Serbia,
-1942-03-31,RU,Russia,
-1942-03-31,SE,Sweden,
-1942-03-31,SG,Singapore,
-1942-03-31,SI,Slovenia,
-1942-03-31,SK,Slovak Republic,
-1942-03-31,TH,Thailand,
-1942-03-31,TR,Türkiye,
-1942-03-31,US,United States,
-1942-03-31,XM,Euro area,
-1942-03-31,XW,World,
-1942-03-31,ZA,South Africa,
-1942-06-30,4T,Emerging market economies (aggregate),
-1942-06-30,5R,Advanced economies,
-1942-06-30,AE,United Arab Emirates,
-1942-06-30,AT,Austria,
-1942-06-30,AU,Australia,
-1942-06-30,BE,Belgium,
-1942-06-30,BG,Bulgaria,
-1942-06-30,BR,Brazil,
-1942-06-30,CA,Canada,
-1942-06-30,CH,Switzerland,
-1942-06-30,CL,Chile,
-1942-06-30,CN,China,
-1942-06-30,CO,Colombia,
-1942-06-30,CY,Cyprus,
-1942-06-30,CZ,Czechia,
-1942-06-30,DE,Germany,
-1942-06-30,DK,Denmark,
-1942-06-30,EE,Estonia,
-1942-06-30,ES,Spain,
-1942-06-30,FI,Finland,
-1942-06-30,FR,France,
-1942-06-30,GB,United Kingdom,
-1942-06-30,GR,Greece,
-1942-06-30,HK,Hong Kong SAR,
-1942-06-30,HR,Croatia,
-1942-06-30,HU,Hungary,
-1942-06-30,ID,Indonesia,
-1942-06-30,IE,Ireland,
-1942-06-30,IL,Israel,
-1942-06-30,IN,India,
-1942-06-30,IS,Iceland,
-1942-06-30,IT,Italy,
-1942-06-30,JP,Japan,
-1942-06-30,KR,Korea,
-1942-06-30,LT,Lithuania,
-1942-06-30,LU,Luxembourg,
-1942-06-30,LV,Latvia,
-1942-06-30,MA,Morocco,
-1942-06-30,MK,North Macedonia,
-1942-06-30,MT,Malta,
-1942-06-30,MX,Mexico,
-1942-06-30,MY,Malaysia,
-1942-06-30,NL,Netherlands,
-1942-06-30,NO,Norway,
-1942-06-30,NZ,New Zealand,
-1942-06-30,PE,Peru,
-1942-06-30,PH,Philippines,
-1942-06-30,PL,Poland,
-1942-06-30,PT,Portugal,
-1942-06-30,RO,Romania,
-1942-06-30,RS,Serbia,
-1942-06-30,RU,Russia,
-1942-06-30,SE,Sweden,
-1942-06-30,SG,Singapore,
-1942-06-30,SI,Slovenia,
-1942-06-30,SK,Slovak Republic,
-1942-06-30,TH,Thailand,
-1942-06-30,TR,Türkiye,
-1942-06-30,US,United States,
-1942-06-30,XM,Euro area,
-1942-06-30,XW,World,
-1942-06-30,ZA,South Africa,
-1942-09-30,4T,Emerging market economies (aggregate),
-1942-09-30,5R,Advanced economies,
-1942-09-30,AE,United Arab Emirates,
-1942-09-30,AT,Austria,
-1942-09-30,AU,Australia,
-1942-09-30,BE,Belgium,
-1942-09-30,BG,Bulgaria,
-1942-09-30,BR,Brazil,
-1942-09-30,CA,Canada,
-1942-09-30,CH,Switzerland,
-1942-09-30,CL,Chile,
-1942-09-30,CN,China,
-1942-09-30,CO,Colombia,
-1942-09-30,CY,Cyprus,
-1942-09-30,CZ,Czechia,
-1942-09-30,DE,Germany,
-1942-09-30,DK,Denmark,
-1942-09-30,EE,Estonia,
-1942-09-30,ES,Spain,
-1942-09-30,FI,Finland,
-1942-09-30,FR,France,
-1942-09-30,GB,United Kingdom,
-1942-09-30,GR,Greece,
-1942-09-30,HK,Hong Kong SAR,
-1942-09-30,HR,Croatia,
-1942-09-30,HU,Hungary,
-1942-09-30,ID,Indonesia,
-1942-09-30,IE,Ireland,
-1942-09-30,IL,Israel,
-1942-09-30,IN,India,
-1942-09-30,IS,Iceland,
-1942-09-30,IT,Italy,
-1942-09-30,JP,Japan,
-1942-09-30,KR,Korea,
-1942-09-30,LT,Lithuania,
-1942-09-30,LU,Luxembourg,
-1942-09-30,LV,Latvia,
-1942-09-30,MA,Morocco,
-1942-09-30,MK,North Macedonia,
-1942-09-30,MT,Malta,
-1942-09-30,MX,Mexico,
-1942-09-30,MY,Malaysia,
-1942-09-30,NL,Netherlands,
-1942-09-30,NO,Norway,
-1942-09-30,NZ,New Zealand,
-1942-09-30,PE,Peru,
-1942-09-30,PH,Philippines,
-1942-09-30,PL,Poland,
-1942-09-30,PT,Portugal,
-1942-09-30,RO,Romania,
-1942-09-30,RS,Serbia,
-1942-09-30,RU,Russia,
-1942-09-30,SE,Sweden,
-1942-09-30,SG,Singapore,
-1942-09-30,SI,Slovenia,
-1942-09-30,SK,Slovak Republic,
-1942-09-30,TH,Thailand,
-1942-09-30,TR,Türkiye,
-1942-09-30,US,United States,
-1942-09-30,XM,Euro area,
-1942-09-30,XW,World,
-1942-09-30,ZA,South Africa,
-1942-12-31,4T,Emerging market economies (aggregate),
-1942-12-31,5R,Advanced economies,
-1942-12-31,AE,United Arab Emirates,
-1942-12-31,AT,Austria,
-1942-12-31,AU,Australia,
-1942-12-31,BE,Belgium,
-1942-12-31,BG,Bulgaria,
-1942-12-31,BR,Brazil,
-1942-12-31,CA,Canada,
-1942-12-31,CH,Switzerland,
-1942-12-31,CL,Chile,
-1942-12-31,CN,China,
-1942-12-31,CO,Colombia,
-1942-12-31,CY,Cyprus,
-1942-12-31,CZ,Czechia,
-1942-12-31,DE,Germany,
-1942-12-31,DK,Denmark,
-1942-12-31,EE,Estonia,
-1942-12-31,ES,Spain,
-1942-12-31,FI,Finland,
-1942-12-31,FR,France,
-1942-12-31,GB,United Kingdom,
-1942-12-31,GR,Greece,
-1942-12-31,HK,Hong Kong SAR,
-1942-12-31,HR,Croatia,
-1942-12-31,HU,Hungary,
-1942-12-31,ID,Indonesia,
-1942-12-31,IE,Ireland,
-1942-12-31,IL,Israel,
-1942-12-31,IN,India,
-1942-12-31,IS,Iceland,
-1942-12-31,IT,Italy,
-1942-12-31,JP,Japan,
-1942-12-31,KR,Korea,
-1942-12-31,LT,Lithuania,
-1942-12-31,LU,Luxembourg,
-1942-12-31,LV,Latvia,
-1942-12-31,MA,Morocco,
-1942-12-31,MK,North Macedonia,
-1942-12-31,MT,Malta,
-1942-12-31,MX,Mexico,
-1942-12-31,MY,Malaysia,
-1942-12-31,NL,Netherlands,
-1942-12-31,NO,Norway,
-1942-12-31,NZ,New Zealand,
-1942-12-31,PE,Peru,
-1942-12-31,PH,Philippines,
-1942-12-31,PL,Poland,
-1942-12-31,PT,Portugal,
-1942-12-31,RO,Romania,
-1942-12-31,RS,Serbia,
-1942-12-31,RU,Russia,
-1942-12-31,SE,Sweden,
-1942-12-31,SG,Singapore,
-1942-12-31,SI,Slovenia,
-1942-12-31,SK,Slovak Republic,
-1942-12-31,TH,Thailand,
-1942-12-31,TR,Türkiye,
-1942-12-31,US,United States,
-1942-12-31,XM,Euro area,
-1942-12-31,XW,World,
-1942-12-31,ZA,South Africa,
-1943-03-31,4T,Emerging market economies (aggregate),
-1943-03-31,5R,Advanced economies,
-1943-03-31,AE,United Arab Emirates,
-1943-03-31,AT,Austria,
-1943-03-31,AU,Australia,
-1943-03-31,BE,Belgium,
-1943-03-31,BG,Bulgaria,
-1943-03-31,BR,Brazil,
-1943-03-31,CA,Canada,
-1943-03-31,CH,Switzerland,
-1943-03-31,CL,Chile,
-1943-03-31,CN,China,
-1943-03-31,CO,Colombia,
-1943-03-31,CY,Cyprus,
-1943-03-31,CZ,Czechia,
-1943-03-31,DE,Germany,
-1943-03-31,DK,Denmark,
-1943-03-31,EE,Estonia,
-1943-03-31,ES,Spain,
-1943-03-31,FI,Finland,
-1943-03-31,FR,France,
-1943-03-31,GB,United Kingdom,
-1943-03-31,GR,Greece,
-1943-03-31,HK,Hong Kong SAR,
-1943-03-31,HR,Croatia,
-1943-03-31,HU,Hungary,
-1943-03-31,ID,Indonesia,
-1943-03-31,IE,Ireland,
-1943-03-31,IL,Israel,
-1943-03-31,IN,India,
-1943-03-31,IS,Iceland,
-1943-03-31,IT,Italy,
-1943-03-31,JP,Japan,
-1943-03-31,KR,Korea,
-1943-03-31,LT,Lithuania,
-1943-03-31,LU,Luxembourg,
-1943-03-31,LV,Latvia,
-1943-03-31,MA,Morocco,
-1943-03-31,MK,North Macedonia,
-1943-03-31,MT,Malta,
-1943-03-31,MX,Mexico,
-1943-03-31,MY,Malaysia,
-1943-03-31,NL,Netherlands,
-1943-03-31,NO,Norway,
-1943-03-31,NZ,New Zealand,
-1943-03-31,PE,Peru,
-1943-03-31,PH,Philippines,
-1943-03-31,PL,Poland,
-1943-03-31,PT,Portugal,
-1943-03-31,RO,Romania,
-1943-03-31,RS,Serbia,
-1943-03-31,RU,Russia,
-1943-03-31,SE,Sweden,
-1943-03-31,SG,Singapore,
-1943-03-31,SI,Slovenia,
-1943-03-31,SK,Slovak Republic,
-1943-03-31,TH,Thailand,
-1943-03-31,TR,Türkiye,
-1943-03-31,US,United States,
-1943-03-31,XM,Euro area,
-1943-03-31,XW,World,
-1943-03-31,ZA,South Africa,
-1943-06-30,4T,Emerging market economies (aggregate),
-1943-06-30,5R,Advanced economies,
-1943-06-30,AE,United Arab Emirates,
-1943-06-30,AT,Austria,
-1943-06-30,AU,Australia,
-1943-06-30,BE,Belgium,
-1943-06-30,BG,Bulgaria,
-1943-06-30,BR,Brazil,
-1943-06-30,CA,Canada,
-1943-06-30,CH,Switzerland,
-1943-06-30,CL,Chile,
-1943-06-30,CN,China,
-1943-06-30,CO,Colombia,
-1943-06-30,CY,Cyprus,
-1943-06-30,CZ,Czechia,
-1943-06-30,DE,Germany,
-1943-06-30,DK,Denmark,
-1943-06-30,EE,Estonia,
-1943-06-30,ES,Spain,
-1943-06-30,FI,Finland,
-1943-06-30,FR,France,
-1943-06-30,GB,United Kingdom,
-1943-06-30,GR,Greece,
-1943-06-30,HK,Hong Kong SAR,
-1943-06-30,HR,Croatia,
-1943-06-30,HU,Hungary,
-1943-06-30,ID,Indonesia,
-1943-06-30,IE,Ireland,
-1943-06-30,IL,Israel,
-1943-06-30,IN,India,
-1943-06-30,IS,Iceland,
-1943-06-30,IT,Italy,
-1943-06-30,JP,Japan,
-1943-06-30,KR,Korea,
-1943-06-30,LT,Lithuania,
-1943-06-30,LU,Luxembourg,
-1943-06-30,LV,Latvia,
-1943-06-30,MA,Morocco,
-1943-06-30,MK,North Macedonia,
-1943-06-30,MT,Malta,
-1943-06-30,MX,Mexico,
-1943-06-30,MY,Malaysia,
-1943-06-30,NL,Netherlands,
-1943-06-30,NO,Norway,
-1943-06-30,NZ,New Zealand,
-1943-06-30,PE,Peru,
-1943-06-30,PH,Philippines,
-1943-06-30,PL,Poland,
-1943-06-30,PT,Portugal,
-1943-06-30,RO,Romania,
-1943-06-30,RS,Serbia,
-1943-06-30,RU,Russia,
-1943-06-30,SE,Sweden,
-1943-06-30,SG,Singapore,
-1943-06-30,SI,Slovenia,
-1943-06-30,SK,Slovak Republic,
-1943-06-30,TH,Thailand,
-1943-06-30,TR,Türkiye,
-1943-06-30,US,United States,
-1943-06-30,XM,Euro area,
-1943-06-30,XW,World,
-1943-06-30,ZA,South Africa,
-1943-09-30,4T,Emerging market economies (aggregate),
-1943-09-30,5R,Advanced economies,
-1943-09-30,AE,United Arab Emirates,
-1943-09-30,AT,Austria,
-1943-09-30,AU,Australia,
-1943-09-30,BE,Belgium,
-1943-09-30,BG,Bulgaria,
-1943-09-30,BR,Brazil,
-1943-09-30,CA,Canada,
-1943-09-30,CH,Switzerland,
-1943-09-30,CL,Chile,
-1943-09-30,CN,China,
-1943-09-30,CO,Colombia,
-1943-09-30,CY,Cyprus,
-1943-09-30,CZ,Czechia,
-1943-09-30,DE,Germany,
-1943-09-30,DK,Denmark,
-1943-09-30,EE,Estonia,
-1943-09-30,ES,Spain,
-1943-09-30,FI,Finland,
-1943-09-30,FR,France,
-1943-09-30,GB,United Kingdom,
-1943-09-30,GR,Greece,
-1943-09-30,HK,Hong Kong SAR,
-1943-09-30,HR,Croatia,
-1943-09-30,HU,Hungary,
-1943-09-30,ID,Indonesia,
-1943-09-30,IE,Ireland,
-1943-09-30,IL,Israel,
-1943-09-30,IN,India,
-1943-09-30,IS,Iceland,
-1943-09-30,IT,Italy,
-1943-09-30,JP,Japan,
-1943-09-30,KR,Korea,
-1943-09-30,LT,Lithuania,
-1943-09-30,LU,Luxembourg,
-1943-09-30,LV,Latvia,
-1943-09-30,MA,Morocco,
-1943-09-30,MK,North Macedonia,
-1943-09-30,MT,Malta,
-1943-09-30,MX,Mexico,
-1943-09-30,MY,Malaysia,
-1943-09-30,NL,Netherlands,
-1943-09-30,NO,Norway,
-1943-09-30,NZ,New Zealand,
-1943-09-30,PE,Peru,
-1943-09-30,PH,Philippines,
-1943-09-30,PL,Poland,
-1943-09-30,PT,Portugal,
-1943-09-30,RO,Romania,
-1943-09-30,RS,Serbia,
-1943-09-30,RU,Russia,
-1943-09-30,SE,Sweden,
-1943-09-30,SG,Singapore,
-1943-09-30,SI,Slovenia,
-1943-09-30,SK,Slovak Republic,
-1943-09-30,TH,Thailand,
-1943-09-30,TR,Türkiye,
-1943-09-30,US,United States,
-1943-09-30,XM,Euro area,
-1943-09-30,XW,World,
-1943-09-30,ZA,South Africa,
-1943-12-31,4T,Emerging market economies (aggregate),
-1943-12-31,5R,Advanced economies,
-1943-12-31,AE,United Arab Emirates,
-1943-12-31,AT,Austria,
-1943-12-31,AU,Australia,
-1943-12-31,BE,Belgium,
-1943-12-31,BG,Bulgaria,
-1943-12-31,BR,Brazil,
-1943-12-31,CA,Canada,
-1943-12-31,CH,Switzerland,
-1943-12-31,CL,Chile,
-1943-12-31,CN,China,
-1943-12-31,CO,Colombia,
-1943-12-31,CY,Cyprus,
-1943-12-31,CZ,Czechia,
-1943-12-31,DE,Germany,
-1943-12-31,DK,Denmark,
-1943-12-31,EE,Estonia,
-1943-12-31,ES,Spain,
-1943-12-31,FI,Finland,
-1943-12-31,FR,France,
-1943-12-31,GB,United Kingdom,
-1943-12-31,GR,Greece,
-1943-12-31,HK,Hong Kong SAR,
-1943-12-31,HR,Croatia,
-1943-12-31,HU,Hungary,
-1943-12-31,ID,Indonesia,
-1943-12-31,IE,Ireland,
-1943-12-31,IL,Israel,
-1943-12-31,IN,India,
-1943-12-31,IS,Iceland,
-1943-12-31,IT,Italy,
-1943-12-31,JP,Japan,
-1943-12-31,KR,Korea,
-1943-12-31,LT,Lithuania,
-1943-12-31,LU,Luxembourg,
-1943-12-31,LV,Latvia,
-1943-12-31,MA,Morocco,
-1943-12-31,MK,North Macedonia,
-1943-12-31,MT,Malta,
-1943-12-31,MX,Mexico,
-1943-12-31,MY,Malaysia,
-1943-12-31,NL,Netherlands,
-1943-12-31,NO,Norway,
-1943-12-31,NZ,New Zealand,
-1943-12-31,PE,Peru,
-1943-12-31,PH,Philippines,
-1943-12-31,PL,Poland,
-1943-12-31,PT,Portugal,
-1943-12-31,RO,Romania,
-1943-12-31,RS,Serbia,
-1943-12-31,RU,Russia,
-1943-12-31,SE,Sweden,
-1943-12-31,SG,Singapore,
-1943-12-31,SI,Slovenia,
-1943-12-31,SK,Slovak Republic,
-1943-12-31,TH,Thailand,
-1943-12-31,TR,Türkiye,
-1943-12-31,US,United States,
-1943-12-31,XM,Euro area,
-1943-12-31,XW,World,
-1943-12-31,ZA,South Africa,
-1944-03-31,4T,Emerging market economies (aggregate),
-1944-03-31,5R,Advanced economies,
-1944-03-31,AE,United Arab Emirates,
-1944-03-31,AT,Austria,
-1944-03-31,AU,Australia,
-1944-03-31,BE,Belgium,
-1944-03-31,BG,Bulgaria,
-1944-03-31,BR,Brazil,
-1944-03-31,CA,Canada,
-1944-03-31,CH,Switzerland,
-1944-03-31,CL,Chile,
-1944-03-31,CN,China,
-1944-03-31,CO,Colombia,
-1944-03-31,CY,Cyprus,
-1944-03-31,CZ,Czechia,
-1944-03-31,DE,Germany,
-1944-03-31,DK,Denmark,
-1944-03-31,EE,Estonia,
-1944-03-31,ES,Spain,
-1944-03-31,FI,Finland,
-1944-03-31,FR,France,
-1944-03-31,GB,United Kingdom,
-1944-03-31,GR,Greece,
-1944-03-31,HK,Hong Kong SAR,
-1944-03-31,HR,Croatia,
-1944-03-31,HU,Hungary,
-1944-03-31,ID,Indonesia,
-1944-03-31,IE,Ireland,
-1944-03-31,IL,Israel,
-1944-03-31,IN,India,
-1944-03-31,IS,Iceland,
-1944-03-31,IT,Italy,
-1944-03-31,JP,Japan,
-1944-03-31,KR,Korea,
-1944-03-31,LT,Lithuania,
-1944-03-31,LU,Luxembourg,
-1944-03-31,LV,Latvia,
-1944-03-31,MA,Morocco,
-1944-03-31,MK,North Macedonia,
-1944-03-31,MT,Malta,
-1944-03-31,MX,Mexico,
-1944-03-31,MY,Malaysia,
-1944-03-31,NL,Netherlands,
-1944-03-31,NO,Norway,
-1944-03-31,NZ,New Zealand,
-1944-03-31,PE,Peru,
-1944-03-31,PH,Philippines,
-1944-03-31,PL,Poland,
-1944-03-31,PT,Portugal,
-1944-03-31,RO,Romania,
-1944-03-31,RS,Serbia,
-1944-03-31,RU,Russia,
-1944-03-31,SE,Sweden,
-1944-03-31,SG,Singapore,
-1944-03-31,SI,Slovenia,
-1944-03-31,SK,Slovak Republic,
-1944-03-31,TH,Thailand,
-1944-03-31,TR,Türkiye,
-1944-03-31,US,United States,
-1944-03-31,XM,Euro area,
-1944-03-31,XW,World,
-1944-03-31,ZA,South Africa,
-1944-06-30,4T,Emerging market economies (aggregate),
-1944-06-30,5R,Advanced economies,
-1944-06-30,AE,United Arab Emirates,
-1944-06-30,AT,Austria,
-1944-06-30,AU,Australia,
-1944-06-30,BE,Belgium,
-1944-06-30,BG,Bulgaria,
-1944-06-30,BR,Brazil,
-1944-06-30,CA,Canada,
-1944-06-30,CH,Switzerland,
-1944-06-30,CL,Chile,
-1944-06-30,CN,China,
-1944-06-30,CO,Colombia,
-1944-06-30,CY,Cyprus,
-1944-06-30,CZ,Czechia,
-1944-06-30,DE,Germany,
-1944-06-30,DK,Denmark,
-1944-06-30,EE,Estonia,
-1944-06-30,ES,Spain,
-1944-06-30,FI,Finland,
-1944-06-30,FR,France,
-1944-06-30,GB,United Kingdom,
-1944-06-30,GR,Greece,
-1944-06-30,HK,Hong Kong SAR,
-1944-06-30,HR,Croatia,
-1944-06-30,HU,Hungary,
-1944-06-30,ID,Indonesia,
-1944-06-30,IE,Ireland,
-1944-06-30,IL,Israel,
-1944-06-30,IN,India,
-1944-06-30,IS,Iceland,
-1944-06-30,IT,Italy,
-1944-06-30,JP,Japan,
-1944-06-30,KR,Korea,
-1944-06-30,LT,Lithuania,
-1944-06-30,LU,Luxembourg,
-1944-06-30,LV,Latvia,
-1944-06-30,MA,Morocco,
-1944-06-30,MK,North Macedonia,
-1944-06-30,MT,Malta,
-1944-06-30,MX,Mexico,
-1944-06-30,MY,Malaysia,
-1944-06-30,NL,Netherlands,
-1944-06-30,NO,Norway,
-1944-06-30,NZ,New Zealand,
-1944-06-30,PE,Peru,
-1944-06-30,PH,Philippines,
-1944-06-30,PL,Poland,
-1944-06-30,PT,Portugal,
-1944-06-30,RO,Romania,
-1944-06-30,RS,Serbia,
-1944-06-30,RU,Russia,
-1944-06-30,SE,Sweden,
-1944-06-30,SG,Singapore,
-1944-06-30,SI,Slovenia,
-1944-06-30,SK,Slovak Republic,
-1944-06-30,TH,Thailand,
-1944-06-30,TR,Türkiye,
-1944-06-30,US,United States,
-1944-06-30,XM,Euro area,
-1944-06-30,XW,World,
-1944-06-30,ZA,South Africa,
-1944-09-30,4T,Emerging market economies (aggregate),
-1944-09-30,5R,Advanced economies,
-1944-09-30,AE,United Arab Emirates,
-1944-09-30,AT,Austria,
-1944-09-30,AU,Australia,
-1944-09-30,BE,Belgium,
-1944-09-30,BG,Bulgaria,
-1944-09-30,BR,Brazil,
-1944-09-30,CA,Canada,
-1944-09-30,CH,Switzerland,
-1944-09-30,CL,Chile,
-1944-09-30,CN,China,
-1944-09-30,CO,Colombia,
-1944-09-30,CY,Cyprus,
-1944-09-30,CZ,Czechia,
-1944-09-30,DE,Germany,
-1944-09-30,DK,Denmark,
-1944-09-30,EE,Estonia,
-1944-09-30,ES,Spain,
-1944-09-30,FI,Finland,
-1944-09-30,FR,France,
-1944-09-30,GB,United Kingdom,
-1944-09-30,GR,Greece,
-1944-09-30,HK,Hong Kong SAR,
-1944-09-30,HR,Croatia,
-1944-09-30,HU,Hungary,
-1944-09-30,ID,Indonesia,
-1944-09-30,IE,Ireland,
-1944-09-30,IL,Israel,
-1944-09-30,IN,India,
-1944-09-30,IS,Iceland,
-1944-09-30,IT,Italy,
-1944-09-30,JP,Japan,
-1944-09-30,KR,Korea,
-1944-09-30,LT,Lithuania,
-1944-09-30,LU,Luxembourg,
-1944-09-30,LV,Latvia,
-1944-09-30,MA,Morocco,
-1944-09-30,MK,North Macedonia,
-1944-09-30,MT,Malta,
-1944-09-30,MX,Mexico,
-1944-09-30,MY,Malaysia,
-1944-09-30,NL,Netherlands,
-1944-09-30,NO,Norway,
-1944-09-30,NZ,New Zealand,
-1944-09-30,PE,Peru,
-1944-09-30,PH,Philippines,
-1944-09-30,PL,Poland,
-1944-09-30,PT,Portugal,
-1944-09-30,RO,Romania,
-1944-09-30,RS,Serbia,
-1944-09-30,RU,Russia,
-1944-09-30,SE,Sweden,
-1944-09-30,SG,Singapore,
-1944-09-30,SI,Slovenia,
-1944-09-30,SK,Slovak Republic,
-1944-09-30,TH,Thailand,
-1944-09-30,TR,Türkiye,
-1944-09-30,US,United States,
-1944-09-30,XM,Euro area,
-1944-09-30,XW,World,
-1944-09-30,ZA,South Africa,
-1944-12-31,4T,Emerging market economies (aggregate),
-1944-12-31,5R,Advanced economies,
-1944-12-31,AE,United Arab Emirates,
-1944-12-31,AT,Austria,
-1944-12-31,AU,Australia,
-1944-12-31,BE,Belgium,
-1944-12-31,BG,Bulgaria,
-1944-12-31,BR,Brazil,
-1944-12-31,CA,Canada,
-1944-12-31,CH,Switzerland,
-1944-12-31,CL,Chile,
-1944-12-31,CN,China,
-1944-12-31,CO,Colombia,
-1944-12-31,CY,Cyprus,
-1944-12-31,CZ,Czechia,
-1944-12-31,DE,Germany,
-1944-12-31,DK,Denmark,
-1944-12-31,EE,Estonia,
-1944-12-31,ES,Spain,
-1944-12-31,FI,Finland,
-1944-12-31,FR,France,
-1944-12-31,GB,United Kingdom,
-1944-12-31,GR,Greece,
-1944-12-31,HK,Hong Kong SAR,
-1944-12-31,HR,Croatia,
-1944-12-31,HU,Hungary,
-1944-12-31,ID,Indonesia,
-1944-12-31,IE,Ireland,
-1944-12-31,IL,Israel,
-1944-12-31,IN,India,
-1944-12-31,IS,Iceland,
-1944-12-31,IT,Italy,
-1944-12-31,JP,Japan,
-1944-12-31,KR,Korea,
-1944-12-31,LT,Lithuania,
-1944-12-31,LU,Luxembourg,
-1944-12-31,LV,Latvia,
-1944-12-31,MA,Morocco,
-1944-12-31,MK,North Macedonia,
-1944-12-31,MT,Malta,
-1944-12-31,MX,Mexico,
-1944-12-31,MY,Malaysia,
-1944-12-31,NL,Netherlands,
-1944-12-31,NO,Norway,
-1944-12-31,NZ,New Zealand,
-1944-12-31,PE,Peru,
-1944-12-31,PH,Philippines,
-1944-12-31,PL,Poland,
-1944-12-31,PT,Portugal,
-1944-12-31,RO,Romania,
-1944-12-31,RS,Serbia,
-1944-12-31,RU,Russia,
-1944-12-31,SE,Sweden,
-1944-12-31,SG,Singapore,
-1944-12-31,SI,Slovenia,
-1944-12-31,SK,Slovak Republic,
-1944-12-31,TH,Thailand,
-1944-12-31,TR,Türkiye,
-1944-12-31,US,United States,
-1944-12-31,XM,Euro area,
-1944-12-31,XW,World,
-1944-12-31,ZA,South Africa,
-1945-03-31,4T,Emerging market economies (aggregate),
-1945-03-31,5R,Advanced economies,
-1945-03-31,AE,United Arab Emirates,
-1945-03-31,AT,Austria,
-1945-03-31,AU,Australia,
-1945-03-31,BE,Belgium,
-1945-03-31,BG,Bulgaria,
-1945-03-31,BR,Brazil,
-1945-03-31,CA,Canada,
-1945-03-31,CH,Switzerland,
-1945-03-31,CL,Chile,
-1945-03-31,CN,China,
-1945-03-31,CO,Colombia,
-1945-03-31,CY,Cyprus,
-1945-03-31,CZ,Czechia,
-1945-03-31,DE,Germany,
-1945-03-31,DK,Denmark,
-1945-03-31,EE,Estonia,
-1945-03-31,ES,Spain,
-1945-03-31,FI,Finland,
-1945-03-31,FR,France,
-1945-03-31,GB,United Kingdom,
-1945-03-31,GR,Greece,
-1945-03-31,HK,Hong Kong SAR,
-1945-03-31,HR,Croatia,
-1945-03-31,HU,Hungary,
-1945-03-31,ID,Indonesia,
-1945-03-31,IE,Ireland,
-1945-03-31,IL,Israel,
-1945-03-31,IN,India,
-1945-03-31,IS,Iceland,
-1945-03-31,IT,Italy,
-1945-03-31,JP,Japan,
-1945-03-31,KR,Korea,
-1945-03-31,LT,Lithuania,
-1945-03-31,LU,Luxembourg,
-1945-03-31,LV,Latvia,
-1945-03-31,MA,Morocco,
-1945-03-31,MK,North Macedonia,
-1945-03-31,MT,Malta,
-1945-03-31,MX,Mexico,
-1945-03-31,MY,Malaysia,
-1945-03-31,NL,Netherlands,
-1945-03-31,NO,Norway,
-1945-03-31,NZ,New Zealand,
-1945-03-31,PE,Peru,
-1945-03-31,PH,Philippines,
-1945-03-31,PL,Poland,
-1945-03-31,PT,Portugal,
-1945-03-31,RO,Romania,
-1945-03-31,RS,Serbia,
-1945-03-31,RU,Russia,
-1945-03-31,SE,Sweden,
-1945-03-31,SG,Singapore,
-1945-03-31,SI,Slovenia,
-1945-03-31,SK,Slovak Republic,
-1945-03-31,TH,Thailand,
-1945-03-31,TR,Türkiye,
-1945-03-31,US,United States,
-1945-03-31,XM,Euro area,
-1945-03-31,XW,World,
-1945-03-31,ZA,South Africa,
-1945-06-30,4T,Emerging market economies (aggregate),
-1945-06-30,5R,Advanced economies,
-1945-06-30,AE,United Arab Emirates,
-1945-06-30,AT,Austria,
-1945-06-30,AU,Australia,
-1945-06-30,BE,Belgium,
-1945-06-30,BG,Bulgaria,
-1945-06-30,BR,Brazil,
-1945-06-30,CA,Canada,
-1945-06-30,CH,Switzerland,
-1945-06-30,CL,Chile,
-1945-06-30,CN,China,
-1945-06-30,CO,Colombia,
-1945-06-30,CY,Cyprus,
-1945-06-30,CZ,Czechia,
-1945-06-30,DE,Germany,
-1945-06-30,DK,Denmark,
-1945-06-30,EE,Estonia,
-1945-06-30,ES,Spain,
-1945-06-30,FI,Finland,
-1945-06-30,FR,France,
-1945-06-30,GB,United Kingdom,
-1945-06-30,GR,Greece,
-1945-06-30,HK,Hong Kong SAR,
-1945-06-30,HR,Croatia,
-1945-06-30,HU,Hungary,
-1945-06-30,ID,Indonesia,
-1945-06-30,IE,Ireland,
-1945-06-30,IL,Israel,
-1945-06-30,IN,India,
-1945-06-30,IS,Iceland,
-1945-06-30,IT,Italy,
-1945-06-30,JP,Japan,
-1945-06-30,KR,Korea,
-1945-06-30,LT,Lithuania,
-1945-06-30,LU,Luxembourg,
-1945-06-30,LV,Latvia,
-1945-06-30,MA,Morocco,
-1945-06-30,MK,North Macedonia,
-1945-06-30,MT,Malta,
-1945-06-30,MX,Mexico,
-1945-06-30,MY,Malaysia,
-1945-06-30,NL,Netherlands,
-1945-06-30,NO,Norway,
-1945-06-30,NZ,New Zealand,
-1945-06-30,PE,Peru,
-1945-06-30,PH,Philippines,
-1945-06-30,PL,Poland,
-1945-06-30,PT,Portugal,
-1945-06-30,RO,Romania,
-1945-06-30,RS,Serbia,
-1945-06-30,RU,Russia,
-1945-06-30,SE,Sweden,
-1945-06-30,SG,Singapore,
-1945-06-30,SI,Slovenia,
-1945-06-30,SK,Slovak Republic,
-1945-06-30,TH,Thailand,
-1945-06-30,TR,Türkiye,
-1945-06-30,US,United States,
-1945-06-30,XM,Euro area,
-1945-06-30,XW,World,
-1945-06-30,ZA,South Africa,
-1945-09-30,4T,Emerging market economies (aggregate),
-1945-09-30,5R,Advanced economies,
-1945-09-30,AE,United Arab Emirates,
-1945-09-30,AT,Austria,
-1945-09-30,AU,Australia,
-1945-09-30,BE,Belgium,
-1945-09-30,BG,Bulgaria,
-1945-09-30,BR,Brazil,
-1945-09-30,CA,Canada,
-1945-09-30,CH,Switzerland,
-1945-09-30,CL,Chile,
-1945-09-30,CN,China,
-1945-09-30,CO,Colombia,
-1945-09-30,CY,Cyprus,
-1945-09-30,CZ,Czechia,
-1945-09-30,DE,Germany,
-1945-09-30,DK,Denmark,
-1945-09-30,EE,Estonia,
-1945-09-30,ES,Spain,
-1945-09-30,FI,Finland,
-1945-09-30,FR,France,
-1945-09-30,GB,United Kingdom,
-1945-09-30,GR,Greece,
-1945-09-30,HK,Hong Kong SAR,
-1945-09-30,HR,Croatia,
-1945-09-30,HU,Hungary,
-1945-09-30,ID,Indonesia,
-1945-09-30,IE,Ireland,
-1945-09-30,IL,Israel,
-1945-09-30,IN,India,
-1945-09-30,IS,Iceland,
-1945-09-30,IT,Italy,
-1945-09-30,JP,Japan,
-1945-09-30,KR,Korea,
-1945-09-30,LT,Lithuania,
-1945-09-30,LU,Luxembourg,
-1945-09-30,LV,Latvia,
-1945-09-30,MA,Morocco,
-1945-09-30,MK,North Macedonia,
-1945-09-30,MT,Malta,
-1945-09-30,MX,Mexico,
-1945-09-30,MY,Malaysia,
-1945-09-30,NL,Netherlands,
-1945-09-30,NO,Norway,
-1945-09-30,NZ,New Zealand,
-1945-09-30,PE,Peru,
-1945-09-30,PH,Philippines,
-1945-09-30,PL,Poland,
-1945-09-30,PT,Portugal,
-1945-09-30,RO,Romania,
-1945-09-30,RS,Serbia,
-1945-09-30,RU,Russia,
-1945-09-30,SE,Sweden,
-1945-09-30,SG,Singapore,
-1945-09-30,SI,Slovenia,
-1945-09-30,SK,Slovak Republic,
-1945-09-30,TH,Thailand,
-1945-09-30,TR,Türkiye,
-1945-09-30,US,United States,
-1945-09-30,XM,Euro area,
-1945-09-30,XW,World,
-1945-09-30,ZA,South Africa,
-1945-12-31,4T,Emerging market economies (aggregate),
-1945-12-31,5R,Advanced economies,
-1945-12-31,AE,United Arab Emirates,
-1945-12-31,AT,Austria,
-1945-12-31,AU,Australia,
-1945-12-31,BE,Belgium,
-1945-12-31,BG,Bulgaria,
-1945-12-31,BR,Brazil,
-1945-12-31,CA,Canada,
-1945-12-31,CH,Switzerland,
-1945-12-31,CL,Chile,
-1945-12-31,CN,China,
-1945-12-31,CO,Colombia,
-1945-12-31,CY,Cyprus,
-1945-12-31,CZ,Czechia,
-1945-12-31,DE,Germany,
-1945-12-31,DK,Denmark,
-1945-12-31,EE,Estonia,
-1945-12-31,ES,Spain,
-1945-12-31,FI,Finland,
-1945-12-31,FR,France,
-1945-12-31,GB,United Kingdom,
-1945-12-31,GR,Greece,
-1945-12-31,HK,Hong Kong SAR,
-1945-12-31,HR,Croatia,
-1945-12-31,HU,Hungary,
-1945-12-31,ID,Indonesia,
-1945-12-31,IE,Ireland,
-1945-12-31,IL,Israel,
-1945-12-31,IN,India,
-1945-12-31,IS,Iceland,
-1945-12-31,IT,Italy,
-1945-12-31,JP,Japan,
-1945-12-31,KR,Korea,
-1945-12-31,LT,Lithuania,
-1945-12-31,LU,Luxembourg,
-1945-12-31,LV,Latvia,
-1945-12-31,MA,Morocco,
-1945-12-31,MK,North Macedonia,
-1945-12-31,MT,Malta,
-1945-12-31,MX,Mexico,
-1945-12-31,MY,Malaysia,
-1945-12-31,NL,Netherlands,
-1945-12-31,NO,Norway,
-1945-12-31,NZ,New Zealand,
-1945-12-31,PE,Peru,
-1945-12-31,PH,Philippines,
-1945-12-31,PL,Poland,
-1945-12-31,PT,Portugal,
-1945-12-31,RO,Romania,
-1945-12-31,RS,Serbia,
-1945-12-31,RU,Russia,
-1945-12-31,SE,Sweden,
-1945-12-31,SG,Singapore,
-1945-12-31,SI,Slovenia,
-1945-12-31,SK,Slovak Republic,
-1945-12-31,TH,Thailand,
-1945-12-31,TR,Türkiye,
-1945-12-31,US,United States,
-1945-12-31,XM,Euro area,
-1945-12-31,XW,World,
-1945-12-31,ZA,South Africa,
-1946-03-31,4T,Emerging market economies (aggregate),
-1946-03-31,5R,Advanced economies,
-1946-03-31,AE,United Arab Emirates,
-1946-03-31,AT,Austria,
-1946-03-31,AU,Australia,
-1946-03-31,BE,Belgium,
-1946-03-31,BG,Bulgaria,
-1946-03-31,BR,Brazil,
-1946-03-31,CA,Canada,
-1946-03-31,CH,Switzerland,
-1946-03-31,CL,Chile,
-1946-03-31,CN,China,
-1946-03-31,CO,Colombia,
-1946-03-31,CY,Cyprus,
-1946-03-31,CZ,Czechia,
-1946-03-31,DE,Germany,
-1946-03-31,DK,Denmark,
-1946-03-31,EE,Estonia,
-1946-03-31,ES,Spain,
-1946-03-31,FI,Finland,
-1946-03-31,FR,France,
-1946-03-31,GB,United Kingdom,
-1946-03-31,GR,Greece,
-1946-03-31,HK,Hong Kong SAR,
-1946-03-31,HR,Croatia,
-1946-03-31,HU,Hungary,
-1946-03-31,ID,Indonesia,
-1946-03-31,IE,Ireland,
-1946-03-31,IL,Israel,
-1946-03-31,IN,India,
-1946-03-31,IS,Iceland,
-1946-03-31,IT,Italy,
-1946-03-31,JP,Japan,
-1946-03-31,KR,Korea,
-1946-03-31,LT,Lithuania,
-1946-03-31,LU,Luxembourg,
-1946-03-31,LV,Latvia,
-1946-03-31,MA,Morocco,
-1946-03-31,MK,North Macedonia,
-1946-03-31,MT,Malta,
-1946-03-31,MX,Mexico,
-1946-03-31,MY,Malaysia,
-1946-03-31,NL,Netherlands,
-1946-03-31,NO,Norway,
-1946-03-31,NZ,New Zealand,
-1946-03-31,PE,Peru,
-1946-03-31,PH,Philippines,
-1946-03-31,PL,Poland,
-1946-03-31,PT,Portugal,
-1946-03-31,RO,Romania,
-1946-03-31,RS,Serbia,
-1946-03-31,RU,Russia,
-1946-03-31,SE,Sweden,
-1946-03-31,SG,Singapore,
-1946-03-31,SI,Slovenia,
-1946-03-31,SK,Slovak Republic,
-1946-03-31,TH,Thailand,
-1946-03-31,TR,Türkiye,
-1946-03-31,US,United States,
-1946-03-31,XM,Euro area,
-1946-03-31,XW,World,
-1946-03-31,ZA,South Africa,
-1946-06-30,4T,Emerging market economies (aggregate),
-1946-06-30,5R,Advanced economies,
-1946-06-30,AE,United Arab Emirates,
-1946-06-30,AT,Austria,
-1946-06-30,AU,Australia,
-1946-06-30,BE,Belgium,
-1946-06-30,BG,Bulgaria,
-1946-06-30,BR,Brazil,
-1946-06-30,CA,Canada,
-1946-06-30,CH,Switzerland,
-1946-06-30,CL,Chile,
-1946-06-30,CN,China,
-1946-06-30,CO,Colombia,
-1946-06-30,CY,Cyprus,
-1946-06-30,CZ,Czechia,
-1946-06-30,DE,Germany,
-1946-06-30,DK,Denmark,
-1946-06-30,EE,Estonia,
-1946-06-30,ES,Spain,
-1946-06-30,FI,Finland,
-1946-06-30,FR,France,
-1946-06-30,GB,United Kingdom,
-1946-06-30,GR,Greece,
-1946-06-30,HK,Hong Kong SAR,
-1946-06-30,HR,Croatia,
-1946-06-30,HU,Hungary,
-1946-06-30,ID,Indonesia,
-1946-06-30,IE,Ireland,
-1946-06-30,IL,Israel,
-1946-06-30,IN,India,
-1946-06-30,IS,Iceland,
-1946-06-30,IT,Italy,
-1946-06-30,JP,Japan,
-1946-06-30,KR,Korea,
-1946-06-30,LT,Lithuania,
-1946-06-30,LU,Luxembourg,
-1946-06-30,LV,Latvia,
-1946-06-30,MA,Morocco,
-1946-06-30,MK,North Macedonia,
-1946-06-30,MT,Malta,
-1946-06-30,MX,Mexico,
-1946-06-30,MY,Malaysia,
-1946-06-30,NL,Netherlands,
-1946-06-30,NO,Norway,
-1946-06-30,NZ,New Zealand,
-1946-06-30,PE,Peru,
-1946-06-30,PH,Philippines,
-1946-06-30,PL,Poland,
-1946-06-30,PT,Portugal,
-1946-06-30,RO,Romania,
-1946-06-30,RS,Serbia,
-1946-06-30,RU,Russia,
-1946-06-30,SE,Sweden,
-1946-06-30,SG,Singapore,
-1946-06-30,SI,Slovenia,
-1946-06-30,SK,Slovak Republic,
-1946-06-30,TH,Thailand,
-1946-06-30,TR,Türkiye,
-1946-06-30,US,United States,
-1946-06-30,XM,Euro area,
-1946-06-30,XW,World,
-1946-06-30,ZA,South Africa,
-1946-09-30,4T,Emerging market economies (aggregate),
-1946-09-30,5R,Advanced economies,
-1946-09-30,AE,United Arab Emirates,
-1946-09-30,AT,Austria,
-1946-09-30,AU,Australia,
-1946-09-30,BE,Belgium,
-1946-09-30,BG,Bulgaria,
-1946-09-30,BR,Brazil,
-1946-09-30,CA,Canada,
-1946-09-30,CH,Switzerland,
-1946-09-30,CL,Chile,
-1946-09-30,CN,China,
-1946-09-30,CO,Colombia,
-1946-09-30,CY,Cyprus,
-1946-09-30,CZ,Czechia,
-1946-09-30,DE,Germany,
-1946-09-30,DK,Denmark,
-1946-09-30,EE,Estonia,
-1946-09-30,ES,Spain,
-1946-09-30,FI,Finland,
-1946-09-30,FR,France,
-1946-09-30,GB,United Kingdom,
-1946-09-30,GR,Greece,
-1946-09-30,HK,Hong Kong SAR,
-1946-09-30,HR,Croatia,
-1946-09-30,HU,Hungary,
-1946-09-30,ID,Indonesia,
-1946-09-30,IE,Ireland,
-1946-09-30,IL,Israel,
-1946-09-30,IN,India,
-1946-09-30,IS,Iceland,
-1946-09-30,IT,Italy,
-1946-09-30,JP,Japan,
-1946-09-30,KR,Korea,
-1946-09-30,LT,Lithuania,
-1946-09-30,LU,Luxembourg,
-1946-09-30,LV,Latvia,
-1946-09-30,MA,Morocco,
-1946-09-30,MK,North Macedonia,
-1946-09-30,MT,Malta,
-1946-09-30,MX,Mexico,
-1946-09-30,MY,Malaysia,
-1946-09-30,NL,Netherlands,
-1946-09-30,NO,Norway,
-1946-09-30,NZ,New Zealand,
-1946-09-30,PE,Peru,
-1946-09-30,PH,Philippines,
-1946-09-30,PL,Poland,
-1946-09-30,PT,Portugal,
-1946-09-30,RO,Romania,
-1946-09-30,RS,Serbia,
-1946-09-30,RU,Russia,
-1946-09-30,SE,Sweden,
-1946-09-30,SG,Singapore,
-1946-09-30,SI,Slovenia,
-1946-09-30,SK,Slovak Republic,
-1946-09-30,TH,Thailand,
-1946-09-30,TR,Türkiye,
-1946-09-30,US,United States,
-1946-09-30,XM,Euro area,
-1946-09-30,XW,World,
-1946-09-30,ZA,South Africa,
-1946-12-31,4T,Emerging market economies (aggregate),
-1946-12-31,5R,Advanced economies,
-1946-12-31,AE,United Arab Emirates,
-1946-12-31,AT,Austria,
-1946-12-31,AU,Australia,
-1946-12-31,BE,Belgium,
-1946-12-31,BG,Bulgaria,
-1946-12-31,BR,Brazil,
-1946-12-31,CA,Canada,
-1946-12-31,CH,Switzerland,
-1946-12-31,CL,Chile,
-1946-12-31,CN,China,
-1946-12-31,CO,Colombia,
-1946-12-31,CY,Cyprus,
-1946-12-31,CZ,Czechia,
-1946-12-31,DE,Germany,
-1946-12-31,DK,Denmark,
-1946-12-31,EE,Estonia,
-1946-12-31,ES,Spain,
-1946-12-31,FI,Finland,
-1946-12-31,FR,France,
-1946-12-31,GB,United Kingdom,
-1946-12-31,GR,Greece,
-1946-12-31,HK,Hong Kong SAR,
-1946-12-31,HR,Croatia,
-1946-12-31,HU,Hungary,
-1946-12-31,ID,Indonesia,
-1946-12-31,IE,Ireland,
-1946-12-31,IL,Israel,
-1946-12-31,IN,India,
-1946-12-31,IS,Iceland,
-1946-12-31,IT,Italy,
-1946-12-31,JP,Japan,
-1946-12-31,KR,Korea,
-1946-12-31,LT,Lithuania,
-1946-12-31,LU,Luxembourg,
-1946-12-31,LV,Latvia,
-1946-12-31,MA,Morocco,
-1946-12-31,MK,North Macedonia,
-1946-12-31,MT,Malta,
-1946-12-31,MX,Mexico,
-1946-12-31,MY,Malaysia,
-1946-12-31,NL,Netherlands,
-1946-12-31,NO,Norway,
-1946-12-31,NZ,New Zealand,
-1946-12-31,PE,Peru,
-1946-12-31,PH,Philippines,
-1946-12-31,PL,Poland,
-1946-12-31,PT,Portugal,
-1946-12-31,RO,Romania,
-1946-12-31,RS,Serbia,
-1946-12-31,RU,Russia,
-1946-12-31,SE,Sweden,
-1946-12-31,SG,Singapore,
-1946-12-31,SI,Slovenia,
-1946-12-31,SK,Slovak Republic,
-1946-12-31,TH,Thailand,
-1946-12-31,TR,Türkiye,
-1946-12-31,US,United States,
-1946-12-31,XM,Euro area,
-1946-12-31,XW,World,
-1946-12-31,ZA,South Africa,
-1947-03-31,4T,Emerging market economies (aggregate),
-1947-03-31,5R,Advanced economies,
-1947-03-31,AE,United Arab Emirates,
-1947-03-31,AT,Austria,
-1947-03-31,AU,Australia,
-1947-03-31,BE,Belgium,
-1947-03-31,BG,Bulgaria,
-1947-03-31,BR,Brazil,
-1947-03-31,CA,Canada,
-1947-03-31,CH,Switzerland,
-1947-03-31,CL,Chile,
-1947-03-31,CN,China,
-1947-03-31,CO,Colombia,
-1947-03-31,CY,Cyprus,
-1947-03-31,CZ,Czechia,
-1947-03-31,DE,Germany,
-1947-03-31,DK,Denmark,
-1947-03-31,EE,Estonia,
-1947-03-31,ES,Spain,
-1947-03-31,FI,Finland,
-1947-03-31,FR,France,
-1947-03-31,GB,United Kingdom,
-1947-03-31,GR,Greece,
-1947-03-31,HK,Hong Kong SAR,
-1947-03-31,HR,Croatia,
-1947-03-31,HU,Hungary,
-1947-03-31,ID,Indonesia,
-1947-03-31,IE,Ireland,
-1947-03-31,IL,Israel,
-1947-03-31,IN,India,
-1947-03-31,IS,Iceland,
-1947-03-31,IT,Italy,
-1947-03-31,JP,Japan,
-1947-03-31,KR,Korea,
-1947-03-31,LT,Lithuania,
-1947-03-31,LU,Luxembourg,
-1947-03-31,LV,Latvia,
-1947-03-31,MA,Morocco,
-1947-03-31,MK,North Macedonia,
-1947-03-31,MT,Malta,
-1947-03-31,MX,Mexico,
-1947-03-31,MY,Malaysia,
-1947-03-31,NL,Netherlands,
-1947-03-31,NO,Norway,
-1947-03-31,NZ,New Zealand,
-1947-03-31,PE,Peru,
-1947-03-31,PH,Philippines,
-1947-03-31,PL,Poland,
-1947-03-31,PT,Portugal,
-1947-03-31,RO,Romania,
-1947-03-31,RS,Serbia,
-1947-03-31,RU,Russia,
-1947-03-31,SE,Sweden,
-1947-03-31,SG,Singapore,
-1947-03-31,SI,Slovenia,
-1947-03-31,SK,Slovak Republic,
-1947-03-31,TH,Thailand,
-1947-03-31,TR,Türkiye,
-1947-03-31,US,United States,
-1947-03-31,XM,Euro area,
-1947-03-31,XW,World,
-1947-03-31,ZA,South Africa,
-1947-06-30,4T,Emerging market economies (aggregate),
-1947-06-30,5R,Advanced economies,
-1947-06-30,AE,United Arab Emirates,
-1947-06-30,AT,Austria,
-1947-06-30,AU,Australia,
-1947-06-30,BE,Belgium,
-1947-06-30,BG,Bulgaria,
-1947-06-30,BR,Brazil,
-1947-06-30,CA,Canada,
-1947-06-30,CH,Switzerland,
-1947-06-30,CL,Chile,
-1947-06-30,CN,China,
-1947-06-30,CO,Colombia,
-1947-06-30,CY,Cyprus,
-1947-06-30,CZ,Czechia,
-1947-06-30,DE,Germany,
-1947-06-30,DK,Denmark,
-1947-06-30,EE,Estonia,
-1947-06-30,ES,Spain,
-1947-06-30,FI,Finland,
-1947-06-30,FR,France,
-1947-06-30,GB,United Kingdom,
-1947-06-30,GR,Greece,
-1947-06-30,HK,Hong Kong SAR,
-1947-06-30,HR,Croatia,
-1947-06-30,HU,Hungary,
-1947-06-30,ID,Indonesia,
-1947-06-30,IE,Ireland,
-1947-06-30,IL,Israel,
-1947-06-30,IN,India,
-1947-06-30,IS,Iceland,
-1947-06-30,IT,Italy,
-1947-06-30,JP,Japan,
-1947-06-30,KR,Korea,
-1947-06-30,LT,Lithuania,
-1947-06-30,LU,Luxembourg,
-1947-06-30,LV,Latvia,
-1947-06-30,MA,Morocco,
-1947-06-30,MK,North Macedonia,
-1947-06-30,MT,Malta,
-1947-06-30,MX,Mexico,
-1947-06-30,MY,Malaysia,
-1947-06-30,NL,Netherlands,
-1947-06-30,NO,Norway,
-1947-06-30,NZ,New Zealand,
-1947-06-30,PE,Peru,
-1947-06-30,PH,Philippines,
-1947-06-30,PL,Poland,
-1947-06-30,PT,Portugal,
-1947-06-30,RO,Romania,
-1947-06-30,RS,Serbia,
-1947-06-30,RU,Russia,
-1947-06-30,SE,Sweden,
-1947-06-30,SG,Singapore,
-1947-06-30,SI,Slovenia,
-1947-06-30,SK,Slovak Republic,
-1947-06-30,TH,Thailand,
-1947-06-30,TR,Türkiye,
-1947-06-30,US,United States,
-1947-06-30,XM,Euro area,
-1947-06-30,XW,World,
-1947-06-30,ZA,South Africa,
-1947-09-30,4T,Emerging market economies (aggregate),
-1947-09-30,5R,Advanced economies,
-1947-09-30,AE,United Arab Emirates,
-1947-09-30,AT,Austria,
-1947-09-30,AU,Australia,
-1947-09-30,BE,Belgium,
-1947-09-30,BG,Bulgaria,
-1947-09-30,BR,Brazil,
-1947-09-30,CA,Canada,
-1947-09-30,CH,Switzerland,
-1947-09-30,CL,Chile,
-1947-09-30,CN,China,
-1947-09-30,CO,Colombia,
-1947-09-30,CY,Cyprus,
-1947-09-30,CZ,Czechia,
-1947-09-30,DE,Germany,
-1947-09-30,DK,Denmark,
-1947-09-30,EE,Estonia,
-1947-09-30,ES,Spain,
-1947-09-30,FI,Finland,
-1947-09-30,FR,France,
-1947-09-30,GB,United Kingdom,
-1947-09-30,GR,Greece,
-1947-09-30,HK,Hong Kong SAR,
-1947-09-30,HR,Croatia,
-1947-09-30,HU,Hungary,
-1947-09-30,ID,Indonesia,
-1947-09-30,IE,Ireland,
-1947-09-30,IL,Israel,
-1947-09-30,IN,India,
-1947-09-30,IS,Iceland,
-1947-09-30,IT,Italy,
-1947-09-30,JP,Japan,
-1947-09-30,KR,Korea,
-1947-09-30,LT,Lithuania,
-1947-09-30,LU,Luxembourg,
-1947-09-30,LV,Latvia,
-1947-09-30,MA,Morocco,
-1947-09-30,MK,North Macedonia,
-1947-09-30,MT,Malta,
-1947-09-30,MX,Mexico,
-1947-09-30,MY,Malaysia,
-1947-09-30,NL,Netherlands,
-1947-09-30,NO,Norway,
-1947-09-30,NZ,New Zealand,
-1947-09-30,PE,Peru,
-1947-09-30,PH,Philippines,
-1947-09-30,PL,Poland,
-1947-09-30,PT,Portugal,
-1947-09-30,RO,Romania,
-1947-09-30,RS,Serbia,
-1947-09-30,RU,Russia,
-1947-09-30,SE,Sweden,
-1947-09-30,SG,Singapore,
-1947-09-30,SI,Slovenia,
-1947-09-30,SK,Slovak Republic,
-1947-09-30,TH,Thailand,
-1947-09-30,TR,Türkiye,
-1947-09-30,US,United States,
-1947-09-30,XM,Euro area,
-1947-09-30,XW,World,
-1947-09-30,ZA,South Africa,
-1947-12-31,4T,Emerging market economies (aggregate),
-1947-12-31,5R,Advanced economies,
-1947-12-31,AE,United Arab Emirates,
-1947-12-31,AT,Austria,
-1947-12-31,AU,Australia,
-1947-12-31,BE,Belgium,
-1947-12-31,BG,Bulgaria,
-1947-12-31,BR,Brazil,
-1947-12-31,CA,Canada,
-1947-12-31,CH,Switzerland,
-1947-12-31,CL,Chile,
-1947-12-31,CN,China,
-1947-12-31,CO,Colombia,
-1947-12-31,CY,Cyprus,
-1947-12-31,CZ,Czechia,
-1947-12-31,DE,Germany,
-1947-12-31,DK,Denmark,
-1947-12-31,EE,Estonia,
-1947-12-31,ES,Spain,
-1947-12-31,FI,Finland,
-1947-12-31,FR,France,
-1947-12-31,GB,United Kingdom,
-1947-12-31,GR,Greece,
-1947-12-31,HK,Hong Kong SAR,
-1947-12-31,HR,Croatia,
-1947-12-31,HU,Hungary,
-1947-12-31,ID,Indonesia,
-1947-12-31,IE,Ireland,
-1947-12-31,IL,Israel,
-1947-12-31,IN,India,
-1947-12-31,IS,Iceland,
-1947-12-31,IT,Italy,
-1947-12-31,JP,Japan,
-1947-12-31,KR,Korea,
-1947-12-31,LT,Lithuania,
-1947-12-31,LU,Luxembourg,
-1947-12-31,LV,Latvia,
-1947-12-31,MA,Morocco,
-1947-12-31,MK,North Macedonia,
-1947-12-31,MT,Malta,
-1947-12-31,MX,Mexico,
-1947-12-31,MY,Malaysia,
-1947-12-31,NL,Netherlands,
-1947-12-31,NO,Norway,
-1947-12-31,NZ,New Zealand,
-1947-12-31,PE,Peru,
-1947-12-31,PH,Philippines,
-1947-12-31,PL,Poland,
-1947-12-31,PT,Portugal,
-1947-12-31,RO,Romania,
-1947-12-31,RS,Serbia,
-1947-12-31,RU,Russia,
-1947-12-31,SE,Sweden,
-1947-12-31,SG,Singapore,
-1947-12-31,SI,Slovenia,
-1947-12-31,SK,Slovak Republic,
-1947-12-31,TH,Thailand,
-1947-12-31,TR,Türkiye,
-1947-12-31,US,United States,
-1947-12-31,XM,Euro area,
-1947-12-31,XW,World,
-1947-12-31,ZA,South Africa,
-1948-03-31,4T,Emerging market economies (aggregate),
-1948-03-31,5R,Advanced economies,
-1948-03-31,AE,United Arab Emirates,
-1948-03-31,AT,Austria,
-1948-03-31,AU,Australia,
-1948-03-31,BE,Belgium,
-1948-03-31,BG,Bulgaria,
-1948-03-31,BR,Brazil,
-1948-03-31,CA,Canada,
-1948-03-31,CH,Switzerland,
-1948-03-31,CL,Chile,
-1948-03-31,CN,China,
-1948-03-31,CO,Colombia,
-1948-03-31,CY,Cyprus,
-1948-03-31,CZ,Czechia,
-1948-03-31,DE,Germany,
-1948-03-31,DK,Denmark,
-1948-03-31,EE,Estonia,
-1948-03-31,ES,Spain,
-1948-03-31,FI,Finland,
-1948-03-31,FR,France,
-1948-03-31,GB,United Kingdom,
-1948-03-31,GR,Greece,
-1948-03-31,HK,Hong Kong SAR,
-1948-03-31,HR,Croatia,
-1948-03-31,HU,Hungary,
-1948-03-31,ID,Indonesia,
-1948-03-31,IE,Ireland,
-1948-03-31,IL,Israel,
-1948-03-31,IN,India,
-1948-03-31,IS,Iceland,
-1948-03-31,IT,Italy,5.1995
-1948-03-31,JP,Japan,
-1948-03-31,KR,Korea,
-1948-03-31,LT,Lithuania,
-1948-03-31,LU,Luxembourg,
-1948-03-31,LV,Latvia,
-1948-03-31,MA,Morocco,
-1948-03-31,MK,North Macedonia,
-1948-03-31,MT,Malta,
-1948-03-31,MX,Mexico,
-1948-03-31,MY,Malaysia,
-1948-03-31,NL,Netherlands,
-1948-03-31,NO,Norway,
-1948-03-31,NZ,New Zealand,
-1948-03-31,PE,Peru,
-1948-03-31,PH,Philippines,
-1948-03-31,PL,Poland,
-1948-03-31,PT,Portugal,
-1948-03-31,RO,Romania,
-1948-03-31,RS,Serbia,
-1948-03-31,RU,Russia,
-1948-03-31,SE,Sweden,
-1948-03-31,SG,Singapore,
-1948-03-31,SI,Slovenia,
-1948-03-31,SK,Slovak Republic,
-1948-03-31,TH,Thailand,
-1948-03-31,TR,Türkiye,
-1948-03-31,US,United States,
-1948-03-31,XM,Euro area,
-1948-03-31,XW,World,
-1948-03-31,ZA,South Africa,
-1948-06-30,4T,Emerging market economies (aggregate),
-1948-06-30,5R,Advanced economies,
-1948-06-30,AE,United Arab Emirates,
-1948-06-30,AT,Austria,
-1948-06-30,AU,Australia,
-1948-06-30,BE,Belgium,
-1948-06-30,BG,Bulgaria,
-1948-06-30,BR,Brazil,
-1948-06-30,CA,Canada,
-1948-06-30,CH,Switzerland,
-1948-06-30,CL,Chile,
-1948-06-30,CN,China,
-1948-06-30,CO,Colombia,
-1948-06-30,CY,Cyprus,
-1948-06-30,CZ,Czechia,
-1948-06-30,DE,Germany,
-1948-06-30,DK,Denmark,
-1948-06-30,EE,Estonia,
-1948-06-30,ES,Spain,
-1948-06-30,FI,Finland,
-1948-06-30,FR,France,
-1948-06-30,GB,United Kingdom,
-1948-06-30,GR,Greece,
-1948-06-30,HK,Hong Kong SAR,
-1948-06-30,HR,Croatia,
-1948-06-30,HU,Hungary,
-1948-06-30,ID,Indonesia,
-1948-06-30,IE,Ireland,
-1948-06-30,IL,Israel,
-1948-06-30,IN,India,
-1948-06-30,IS,Iceland,
-1948-06-30,IT,Italy,15.0592
-1948-06-30,JP,Japan,
-1948-06-30,KR,Korea,
-1948-06-30,LT,Lithuania,
-1948-06-30,LU,Luxembourg,
-1948-06-30,LV,Latvia,
-1948-06-30,MA,Morocco,
-1948-06-30,MK,North Macedonia,
-1948-06-30,MT,Malta,
-1948-06-30,MX,Mexico,
-1948-06-30,MY,Malaysia,
-1948-06-30,NL,Netherlands,
-1948-06-30,NO,Norway,
-1948-06-30,NZ,New Zealand,
-1948-06-30,PE,Peru,
-1948-06-30,PH,Philippines,
-1948-06-30,PL,Poland,
-1948-06-30,PT,Portugal,
-1948-06-30,RO,Romania,
-1948-06-30,RS,Serbia,
-1948-06-30,RU,Russia,
-1948-06-30,SE,Sweden,
-1948-06-30,SG,Singapore,
-1948-06-30,SI,Slovenia,
-1948-06-30,SK,Slovak Republic,
-1948-06-30,TH,Thailand,
-1948-06-30,TR,Türkiye,
-1948-06-30,US,United States,
-1948-06-30,XM,Euro area,
-1948-06-30,XW,World,
-1948-06-30,ZA,South Africa,
-1948-09-30,4T,Emerging market economies (aggregate),
-1948-09-30,5R,Advanced economies,
-1948-09-30,AE,United Arab Emirates,
-1948-09-30,AT,Austria,
-1948-09-30,AU,Australia,
-1948-09-30,BE,Belgium,
-1948-09-30,BG,Bulgaria,
-1948-09-30,BR,Brazil,
-1948-09-30,CA,Canada,
-1948-09-30,CH,Switzerland,
-1948-09-30,CL,Chile,
-1948-09-30,CN,China,
-1948-09-30,CO,Colombia,
-1948-09-30,CY,Cyprus,
-1948-09-30,CZ,Czechia,
-1948-09-30,DE,Germany,
-1948-09-30,DK,Denmark,
-1948-09-30,EE,Estonia,
-1948-09-30,ES,Spain,
-1948-09-30,FI,Finland,
-1948-09-30,FR,France,
-1948-09-30,GB,United Kingdom,
-1948-09-30,GR,Greece,
-1948-09-30,HK,Hong Kong SAR,
-1948-09-30,HR,Croatia,
-1948-09-30,HU,Hungary,
-1948-09-30,ID,Indonesia,
-1948-09-30,IE,Ireland,
-1948-09-30,IL,Israel,
-1948-09-30,IN,India,
-1948-09-30,IS,Iceland,
-1948-09-30,IT,Italy,17.1932
-1948-09-30,JP,Japan,
-1948-09-30,KR,Korea,
-1948-09-30,LT,Lithuania,
-1948-09-30,LU,Luxembourg,
-1948-09-30,LV,Latvia,
-1948-09-30,MA,Morocco,
-1948-09-30,MK,North Macedonia,
-1948-09-30,MT,Malta,
-1948-09-30,MX,Mexico,
-1948-09-30,MY,Malaysia,
-1948-09-30,NL,Netherlands,
-1948-09-30,NO,Norway,
-1948-09-30,NZ,New Zealand,
-1948-09-30,PE,Peru,
-1948-09-30,PH,Philippines,
-1948-09-30,PL,Poland,
-1948-09-30,PT,Portugal,
-1948-09-30,RO,Romania,
-1948-09-30,RS,Serbia,
-1948-09-30,RU,Russia,
-1948-09-30,SE,Sweden,
-1948-09-30,SG,Singapore,
-1948-09-30,SI,Slovenia,
-1948-09-30,SK,Slovak Republic,
-1948-09-30,TH,Thailand,
-1948-09-30,TR,Türkiye,
-1948-09-30,US,United States,
-1948-09-30,XM,Euro area,
-1948-09-30,XW,World,
-1948-09-30,ZA,South Africa,
-1948-12-31,4T,Emerging market economies (aggregate),
-1948-12-31,5R,Advanced economies,
-1948-12-31,AE,United Arab Emirates,
-1948-12-31,AT,Austria,
-1948-12-31,AU,Australia,
-1948-12-31,BE,Belgium,
-1948-12-31,BG,Bulgaria,
-1948-12-31,BR,Brazil,
-1948-12-31,CA,Canada,
-1948-12-31,CH,Switzerland,
-1948-12-31,CL,Chile,
-1948-12-31,CN,China,
-1948-12-31,CO,Colombia,
-1948-12-31,CY,Cyprus,
-1948-12-31,CZ,Czechia,
-1948-12-31,DE,Germany,
-1948-12-31,DK,Denmark,
-1948-12-31,EE,Estonia,
-1948-12-31,ES,Spain,
-1948-12-31,FI,Finland,
-1948-12-31,FR,France,
-1948-12-31,GB,United Kingdom,
-1948-12-31,GR,Greece,
-1948-12-31,HK,Hong Kong SAR,
-1948-12-31,HR,Croatia,
-1948-12-31,HU,Hungary,
-1948-12-31,ID,Indonesia,
-1948-12-31,IE,Ireland,
-1948-12-31,IL,Israel,
-1948-12-31,IN,India,
-1948-12-31,IS,Iceland,
-1948-12-31,IT,Italy,13.1009
-1948-12-31,JP,Japan,
-1948-12-31,KR,Korea,
-1948-12-31,LT,Lithuania,
-1948-12-31,LU,Luxembourg,
-1948-12-31,LV,Latvia,
-1948-12-31,MA,Morocco,
-1948-12-31,MK,North Macedonia,
-1948-12-31,MT,Malta,
-1948-12-31,MX,Mexico,
-1948-12-31,MY,Malaysia,
-1948-12-31,NL,Netherlands,
-1948-12-31,NO,Norway,
-1948-12-31,NZ,New Zealand,
-1948-12-31,PE,Peru,
-1948-12-31,PH,Philippines,
-1948-12-31,PL,Poland,
-1948-12-31,PT,Portugal,
-1948-12-31,RO,Romania,
-1948-12-31,RS,Serbia,
-1948-12-31,RU,Russia,
-1948-12-31,SE,Sweden,
-1948-12-31,SG,Singapore,
-1948-12-31,SI,Slovenia,
-1948-12-31,SK,Slovak Republic,
-1948-12-31,TH,Thailand,
-1948-12-31,TR,Türkiye,
-1948-12-31,US,United States,
-1948-12-31,XM,Euro area,
-1948-12-31,XW,World,
-1948-12-31,ZA,South Africa,
-1949-03-31,4T,Emerging market economies (aggregate),
-1949-03-31,5R,Advanced economies,
-1949-03-31,AE,United Arab Emirates,
-1949-03-31,AT,Austria,
-1949-03-31,AU,Australia,
-1949-03-31,BE,Belgium,
-1949-03-31,BG,Bulgaria,
-1949-03-31,BR,Brazil,
-1949-03-31,CA,Canada,
-1949-03-31,CH,Switzerland,
-1949-03-31,CL,Chile,
-1949-03-31,CN,China,
-1949-03-31,CO,Colombia,
-1949-03-31,CY,Cyprus,
-1949-03-31,CZ,Czechia,
-1949-03-31,DE,Germany,
-1949-03-31,DK,Denmark,
-1949-03-31,EE,Estonia,
-1949-03-31,ES,Spain,
-1949-03-31,FI,Finland,
-1949-03-31,FR,France,
-1949-03-31,GB,United Kingdom,
-1949-03-31,GR,Greece,
-1949-03-31,HK,Hong Kong SAR,
-1949-03-31,HR,Croatia,
-1949-03-31,HU,Hungary,
-1949-03-31,ID,Indonesia,
-1949-03-31,IE,Ireland,
-1949-03-31,IL,Israel,
-1949-03-31,IN,India,
-1949-03-31,IS,Iceland,
-1949-03-31,IT,Italy,-1.8206
-1949-03-31,JP,Japan,
-1949-03-31,KR,Korea,
-1949-03-31,LT,Lithuania,
-1949-03-31,LU,Luxembourg,
-1949-03-31,LV,Latvia,
-1949-03-31,MA,Morocco,
-1949-03-31,MK,North Macedonia,
-1949-03-31,MT,Malta,
-1949-03-31,MX,Mexico,
-1949-03-31,MY,Malaysia,
-1949-03-31,NL,Netherlands,
-1949-03-31,NO,Norway,
-1949-03-31,NZ,New Zealand,
-1949-03-31,PE,Peru,
-1949-03-31,PH,Philippines,
-1949-03-31,PL,Poland,
-1949-03-31,PT,Portugal,
-1949-03-31,RO,Romania,
-1949-03-31,RS,Serbia,
-1949-03-31,RU,Russia,
-1949-03-31,SE,Sweden,
-1949-03-31,SG,Singapore,
-1949-03-31,SI,Slovenia,
-1949-03-31,SK,Slovak Republic,
-1949-03-31,TH,Thailand,
-1949-03-31,TR,Türkiye,
-1949-03-31,US,United States,
-1949-03-31,XM,Euro area,
-1949-03-31,XW,World,
-1949-03-31,ZA,South Africa,
-1949-06-30,4T,Emerging market economies (aggregate),
-1949-06-30,5R,Advanced economies,
-1949-06-30,AE,United Arab Emirates,
-1949-06-30,AT,Austria,
-1949-06-30,AU,Australia,
-1949-06-30,BE,Belgium,
-1949-06-30,BG,Bulgaria,
-1949-06-30,BR,Brazil,
-1949-06-30,CA,Canada,
-1949-06-30,CH,Switzerland,
-1949-06-30,CL,Chile,
-1949-06-30,CN,China,
-1949-06-30,CO,Colombia,
-1949-06-30,CY,Cyprus,
-1949-06-30,CZ,Czechia,
-1949-06-30,DE,Germany,
-1949-06-30,DK,Denmark,
-1949-06-30,EE,Estonia,
-1949-06-30,ES,Spain,
-1949-06-30,FI,Finland,
-1949-06-30,FR,France,
-1949-06-30,GB,United Kingdom,
-1949-06-30,GR,Greece,
-1949-06-30,HK,Hong Kong SAR,
-1949-06-30,HR,Croatia,
-1949-06-30,HU,Hungary,
-1949-06-30,ID,Indonesia,
-1949-06-30,IE,Ireland,
-1949-06-30,IL,Israel,
-1949-06-30,IN,India,
-1949-06-30,IS,Iceland,
-1949-06-30,IT,Italy,-4.806
-1949-06-30,JP,Japan,
-1949-06-30,KR,Korea,
-1949-06-30,LT,Lithuania,
-1949-06-30,LU,Luxembourg,
-1949-06-30,LV,Latvia,
-1949-06-30,MA,Morocco,
-1949-06-30,MK,North Macedonia,
-1949-06-30,MT,Malta,
-1949-06-30,MX,Mexico,
-1949-06-30,MY,Malaysia,
-1949-06-30,NL,Netherlands,
-1949-06-30,NO,Norway,
-1949-06-30,NZ,New Zealand,
-1949-06-30,PE,Peru,
-1949-06-30,PH,Philippines,
-1949-06-30,PL,Poland,
-1949-06-30,PT,Portugal,
-1949-06-30,RO,Romania,
-1949-06-30,RS,Serbia,
-1949-06-30,RU,Russia,
-1949-06-30,SE,Sweden,
-1949-06-30,SG,Singapore,
-1949-06-30,SI,Slovenia,
-1949-06-30,SK,Slovak Republic,
-1949-06-30,TH,Thailand,
-1949-06-30,TR,Türkiye,
-1949-06-30,US,United States,
-1949-06-30,XM,Euro area,
-1949-06-30,XW,World,
-1949-06-30,ZA,South Africa,
-1949-09-30,4T,Emerging market economies (aggregate),
-1949-09-30,5R,Advanced economies,
-1949-09-30,AE,United Arab Emirates,
-1949-09-30,AT,Austria,
-1949-09-30,AU,Australia,
-1949-09-30,BE,Belgium,
-1949-09-30,BG,Bulgaria,
-1949-09-30,BR,Brazil,
-1949-09-30,CA,Canada,
-1949-09-30,CH,Switzerland,
-1949-09-30,CL,Chile,
-1949-09-30,CN,China,
-1949-09-30,CO,Colombia,
-1949-09-30,CY,Cyprus,
-1949-09-30,CZ,Czechia,
-1949-09-30,DE,Germany,
-1949-09-30,DK,Denmark,
-1949-09-30,EE,Estonia,
-1949-09-30,ES,Spain,
-1949-09-30,FI,Finland,
-1949-09-30,FR,France,
-1949-09-30,GB,United Kingdom,
-1949-09-30,GR,Greece,
-1949-09-30,HK,Hong Kong SAR,
-1949-09-30,HR,Croatia,
-1949-09-30,HU,Hungary,
-1949-09-30,ID,Indonesia,
-1949-09-30,IE,Ireland,
-1949-09-30,IL,Israel,
-1949-09-30,IN,India,
-1949-09-30,IS,Iceland,
-1949-09-30,IT,Italy,-5.38
-1949-09-30,JP,Japan,
-1949-09-30,KR,Korea,
-1949-09-30,LT,Lithuania,
-1949-09-30,LU,Luxembourg,
-1949-09-30,LV,Latvia,
-1949-09-30,MA,Morocco,
-1949-09-30,MK,North Macedonia,
-1949-09-30,MT,Malta,
-1949-09-30,MX,Mexico,
-1949-09-30,MY,Malaysia,
-1949-09-30,NL,Netherlands,
-1949-09-30,NO,Norway,
-1949-09-30,NZ,New Zealand,
-1949-09-30,PE,Peru,
-1949-09-30,PH,Philippines,
-1949-09-30,PL,Poland,
-1949-09-30,PT,Portugal,
-1949-09-30,RO,Romania,
-1949-09-30,RS,Serbia,
-1949-09-30,RU,Russia,
-1949-09-30,SE,Sweden,
-1949-09-30,SG,Singapore,
-1949-09-30,SI,Slovenia,
-1949-09-30,SK,Slovak Republic,
-1949-09-30,TH,Thailand,
-1949-09-30,TR,Türkiye,
-1949-09-30,US,United States,
-1949-09-30,XM,Euro area,
-1949-09-30,XW,World,
-1949-09-30,ZA,South Africa,
-1949-12-31,4T,Emerging market economies (aggregate),
-1949-12-31,5R,Advanced economies,
-1949-12-31,AE,United Arab Emirates,
-1949-12-31,AT,Austria,
-1949-12-31,AU,Australia,
-1949-12-31,BE,Belgium,
-1949-12-31,BG,Bulgaria,
-1949-12-31,BR,Brazil,
-1949-12-31,CA,Canada,
-1949-12-31,CH,Switzerland,
-1949-12-31,CL,Chile,
-1949-12-31,CN,China,
-1949-12-31,CO,Colombia,
-1949-12-31,CY,Cyprus,
-1949-12-31,CZ,Czechia,
-1949-12-31,DE,Germany,
-1949-12-31,DK,Denmark,
-1949-12-31,EE,Estonia,
-1949-12-31,ES,Spain,
-1949-12-31,FI,Finland,
-1949-12-31,FR,France,
-1949-12-31,GB,United Kingdom,
-1949-12-31,GR,Greece,
-1949-12-31,HK,Hong Kong SAR,
-1949-12-31,HR,Croatia,
-1949-12-31,HU,Hungary,
-1949-12-31,ID,Indonesia,
-1949-12-31,IE,Ireland,
-1949-12-31,IL,Israel,
-1949-12-31,IN,India,
-1949-12-31,IS,Iceland,
-1949-12-31,IT,Italy,-7.5131
-1949-12-31,JP,Japan,
-1949-12-31,KR,Korea,
-1949-12-31,LT,Lithuania,
-1949-12-31,LU,Luxembourg,
-1949-12-31,LV,Latvia,
-1949-12-31,MA,Morocco,
-1949-12-31,MK,North Macedonia,
-1949-12-31,MT,Malta,
-1949-12-31,MX,Mexico,
-1949-12-31,MY,Malaysia,
-1949-12-31,NL,Netherlands,
-1949-12-31,NO,Norway,
-1949-12-31,NZ,New Zealand,
-1949-12-31,PE,Peru,
-1949-12-31,PH,Philippines,
-1949-12-31,PL,Poland,
-1949-12-31,PT,Portugal,
-1949-12-31,RO,Romania,
-1949-12-31,RS,Serbia,
-1949-12-31,RU,Russia,
-1949-12-31,SE,Sweden,
-1949-12-31,SG,Singapore,
-1949-12-31,SI,Slovenia,
-1949-12-31,SK,Slovak Republic,
-1949-12-31,TH,Thailand,
-1949-12-31,TR,Türkiye,
-1949-12-31,US,United States,
-1949-12-31,XM,Euro area,
-1949-12-31,XW,World,
-1949-12-31,ZA,South Africa,
-1950-03-31,4T,Emerging market economies (aggregate),
-1950-03-31,5R,Advanced economies,
-1950-03-31,AE,United Arab Emirates,
-1950-03-31,AT,Austria,
-1950-03-31,AU,Australia,
-1950-03-31,BE,Belgium,
-1950-03-31,BG,Bulgaria,
-1950-03-31,BR,Brazil,
-1950-03-31,CA,Canada,
-1950-03-31,CH,Switzerland,
-1950-03-31,CL,Chile,
-1950-03-31,CN,China,
-1950-03-31,CO,Colombia,
-1950-03-31,CY,Cyprus,
-1950-03-31,CZ,Czechia,
-1950-03-31,DE,Germany,
-1950-03-31,DK,Denmark,
-1950-03-31,EE,Estonia,
-1950-03-31,ES,Spain,
-1950-03-31,FI,Finland,
-1950-03-31,FR,France,
-1950-03-31,GB,United Kingdom,
-1950-03-31,GR,Greece,
-1950-03-31,HK,Hong Kong SAR,
-1950-03-31,HR,Croatia,
-1950-03-31,HU,Hungary,
-1950-03-31,ID,Indonesia,
-1950-03-31,IE,Ireland,
-1950-03-31,IL,Israel,
-1950-03-31,IN,India,
-1950-03-31,IS,Iceland,
-1950-03-31,IT,Italy,-7.2581
-1950-03-31,JP,Japan,
-1950-03-31,KR,Korea,
-1950-03-31,LT,Lithuania,
-1950-03-31,LU,Luxembourg,
-1950-03-31,LV,Latvia,
-1950-03-31,MA,Morocco,
-1950-03-31,MK,North Macedonia,
-1950-03-31,MT,Malta,
-1950-03-31,MX,Mexico,
-1950-03-31,MY,Malaysia,
-1950-03-31,NL,Netherlands,
-1950-03-31,NO,Norway,
-1950-03-31,NZ,New Zealand,
-1950-03-31,PE,Peru,
-1950-03-31,PH,Philippines,
-1950-03-31,PL,Poland,
-1950-03-31,PT,Portugal,
-1950-03-31,RO,Romania,
-1950-03-31,RS,Serbia,
-1950-03-31,RU,Russia,
-1950-03-31,SE,Sweden,
-1950-03-31,SG,Singapore,
-1950-03-31,SI,Slovenia,
-1950-03-31,SK,Slovak Republic,
-1950-03-31,TH,Thailand,
-1950-03-31,TR,Türkiye,
-1950-03-31,US,United States,
-1950-03-31,XM,Euro area,
-1950-03-31,XW,World,
-1950-03-31,ZA,South Africa,
-1950-06-30,4T,Emerging market economies (aggregate),
-1950-06-30,5R,Advanced economies,
-1950-06-30,AE,United Arab Emirates,
-1950-06-30,AT,Austria,
-1950-06-30,AU,Australia,
-1950-06-30,BE,Belgium,
-1950-06-30,BG,Bulgaria,
-1950-06-30,BR,Brazil,
-1950-06-30,CA,Canada,
-1950-06-30,CH,Switzerland,
-1950-06-30,CL,Chile,
-1950-06-30,CN,China,
-1950-06-30,CO,Colombia,
-1950-06-30,CY,Cyprus,
-1950-06-30,CZ,Czechia,
-1950-06-30,DE,Germany,
-1950-06-30,DK,Denmark,
-1950-06-30,EE,Estonia,
-1950-06-30,ES,Spain,
-1950-06-30,FI,Finland,
-1950-06-30,FR,France,
-1950-06-30,GB,United Kingdom,
-1950-06-30,GR,Greece,
-1950-06-30,HK,Hong Kong SAR,
-1950-06-30,HR,Croatia,
-1950-06-30,HU,Hungary,
-1950-06-30,ID,Indonesia,
-1950-06-30,IE,Ireland,
-1950-06-30,IL,Israel,
-1950-06-30,IN,India,
-1950-06-30,IS,Iceland,
-1950-06-30,IT,Italy,-1.4307
-1950-06-30,JP,Japan,
-1950-06-30,KR,Korea,
-1950-06-30,LT,Lithuania,
-1950-06-30,LU,Luxembourg,
-1950-06-30,LV,Latvia,
-1950-06-30,MA,Morocco,
-1950-06-30,MK,North Macedonia,
-1950-06-30,MT,Malta,
-1950-06-30,MX,Mexico,
-1950-06-30,MY,Malaysia,
-1950-06-30,NL,Netherlands,
-1950-06-30,NO,Norway,
-1950-06-30,NZ,New Zealand,
-1950-06-30,PE,Peru,
-1950-06-30,PH,Philippines,
-1950-06-30,PL,Poland,
-1950-06-30,PT,Portugal,
-1950-06-30,RO,Romania,
-1950-06-30,RS,Serbia,
-1950-06-30,RU,Russia,
-1950-06-30,SE,Sweden,
-1950-06-30,SG,Singapore,
-1950-06-30,SI,Slovenia,
-1950-06-30,SK,Slovak Republic,
-1950-06-30,TH,Thailand,
-1950-06-30,TR,Türkiye,
-1950-06-30,US,United States,
-1950-06-30,XM,Euro area,
-1950-06-30,XW,World,
-1950-06-30,ZA,South Africa,
-1950-09-30,4T,Emerging market economies (aggregate),
-1950-09-30,5R,Advanced economies,
-1950-09-30,AE,United Arab Emirates,
-1950-09-30,AT,Austria,
-1950-09-30,AU,Australia,
-1950-09-30,BE,Belgium,
-1950-09-30,BG,Bulgaria,
-1950-09-30,BR,Brazil,
-1950-09-30,CA,Canada,
-1950-09-30,CH,Switzerland,
-1950-09-30,CL,Chile,
-1950-09-30,CN,China,
-1950-09-30,CO,Colombia,
-1950-09-30,CY,Cyprus,
-1950-09-30,CZ,Czechia,
-1950-09-30,DE,Germany,
-1950-09-30,DK,Denmark,
-1950-09-30,EE,Estonia,
-1950-09-30,ES,Spain,
-1950-09-30,FI,Finland,
-1950-09-30,FR,France,
-1950-09-30,GB,United Kingdom,
-1950-09-30,GR,Greece,
-1950-09-30,HK,Hong Kong SAR,
-1950-09-30,HR,Croatia,
-1950-09-30,HU,Hungary,
-1950-09-30,ID,Indonesia,
-1950-09-30,IE,Ireland,
-1950-09-30,IL,Israel,
-1950-09-30,IN,India,
-1950-09-30,IS,Iceland,
-1950-09-30,IT,Italy,9.4227
-1950-09-30,JP,Japan,
-1950-09-30,KR,Korea,
-1950-09-30,LT,Lithuania,
-1950-09-30,LU,Luxembourg,
-1950-09-30,LV,Latvia,
-1950-09-30,MA,Morocco,
-1950-09-30,MK,North Macedonia,
-1950-09-30,MT,Malta,
-1950-09-30,MX,Mexico,
-1950-09-30,MY,Malaysia,
-1950-09-30,NL,Netherlands,
-1950-09-30,NO,Norway,
-1950-09-30,NZ,New Zealand,
-1950-09-30,PE,Peru,
-1950-09-30,PH,Philippines,
-1950-09-30,PL,Poland,
-1950-09-30,PT,Portugal,
-1950-09-30,RO,Romania,
-1950-09-30,RS,Serbia,
-1950-09-30,RU,Russia,
-1950-09-30,SE,Sweden,
-1950-09-30,SG,Singapore,
-1950-09-30,SI,Slovenia,
-1950-09-30,SK,Slovak Republic,
-1950-09-30,TH,Thailand,
-1950-09-30,TR,Türkiye,
-1950-09-30,US,United States,
-1950-09-30,XM,Euro area,
-1950-09-30,XW,World,
-1950-09-30,ZA,South Africa,
-1950-12-31,4T,Emerging market economies (aggregate),
-1950-12-31,5R,Advanced economies,
-1950-12-31,AE,United Arab Emirates,
-1950-12-31,AT,Austria,
-1950-12-31,AU,Australia,
-1950-12-31,BE,Belgium,
-1950-12-31,BG,Bulgaria,
-1950-12-31,BR,Brazil,
-1950-12-31,CA,Canada,
-1950-12-31,CH,Switzerland,
-1950-12-31,CL,Chile,
-1950-12-31,CN,China,
-1950-12-31,CO,Colombia,
-1950-12-31,CY,Cyprus,
-1950-12-31,CZ,Czechia,
-1950-12-31,DE,Germany,
-1950-12-31,DK,Denmark,
-1950-12-31,EE,Estonia,
-1950-12-31,ES,Spain,
-1950-12-31,FI,Finland,
-1950-12-31,FR,France,
-1950-12-31,GB,United Kingdom,
-1950-12-31,GR,Greece,
-1950-12-31,HK,Hong Kong SAR,
-1950-12-31,HR,Croatia,
-1950-12-31,HU,Hungary,
-1950-12-31,ID,Indonesia,
-1950-12-31,IE,Ireland,
-1950-12-31,IL,Israel,
-1950-12-31,IN,India,
-1950-12-31,IS,Iceland,
-1950-12-31,IT,Italy,11.1851
-1950-12-31,JP,Japan,
-1950-12-31,KR,Korea,
-1950-12-31,LT,Lithuania,
-1950-12-31,LU,Luxembourg,
-1950-12-31,LV,Latvia,
-1950-12-31,MA,Morocco,
-1950-12-31,MK,North Macedonia,
-1950-12-31,MT,Malta,
-1950-12-31,MX,Mexico,
-1950-12-31,MY,Malaysia,
-1950-12-31,NL,Netherlands,
-1950-12-31,NO,Norway,
-1950-12-31,NZ,New Zealand,
-1950-12-31,PE,Peru,
-1950-12-31,PH,Philippines,
-1950-12-31,PL,Poland,
-1950-12-31,PT,Portugal,
-1950-12-31,RO,Romania,
-1950-12-31,RS,Serbia,
-1950-12-31,RU,Russia,
-1950-12-31,SE,Sweden,
-1950-12-31,SG,Singapore,
-1950-12-31,SI,Slovenia,
-1950-12-31,SK,Slovak Republic,
-1950-12-31,TH,Thailand,
-1950-12-31,TR,Türkiye,
-1950-12-31,US,United States,
-1950-12-31,XM,Euro area,
-1950-12-31,XW,World,
-1950-12-31,ZA,South Africa,
-1951-03-31,4T,Emerging market economies (aggregate),
-1951-03-31,5R,Advanced economies,
-1951-03-31,AE,United Arab Emirates,
-1951-03-31,AT,Austria,
-1951-03-31,AU,Australia,
-1951-03-31,BE,Belgium,
-1951-03-31,BG,Bulgaria,
-1951-03-31,BR,Brazil,
-1951-03-31,CA,Canada,
-1951-03-31,CH,Switzerland,
-1951-03-31,CL,Chile,
-1951-03-31,CN,China,
-1951-03-31,CO,Colombia,
-1951-03-31,CY,Cyprus,
-1951-03-31,CZ,Czechia,
-1951-03-31,DE,Germany,
-1951-03-31,DK,Denmark,
-1951-03-31,EE,Estonia,
-1951-03-31,ES,Spain,
-1951-03-31,FI,Finland,
-1951-03-31,FR,France,
-1951-03-31,GB,United Kingdom,
-1951-03-31,GR,Greece,
-1951-03-31,HK,Hong Kong SAR,
-1951-03-31,HR,Croatia,
-1951-03-31,HU,Hungary,
-1951-03-31,ID,Indonesia,
-1951-03-31,IE,Ireland,
-1951-03-31,IL,Israel,
-1951-03-31,IN,India,
-1951-03-31,IS,Iceland,
-1951-03-31,IT,Italy,13.5326
-1951-03-31,JP,Japan,
-1951-03-31,KR,Korea,
-1951-03-31,LT,Lithuania,
-1951-03-31,LU,Luxembourg,
-1951-03-31,LV,Latvia,
-1951-03-31,MA,Morocco,
-1951-03-31,MK,North Macedonia,
-1951-03-31,MT,Malta,
-1951-03-31,MX,Mexico,
-1951-03-31,MY,Malaysia,
-1951-03-31,NL,Netherlands,
-1951-03-31,NO,Norway,
-1951-03-31,NZ,New Zealand,
-1951-03-31,PE,Peru,
-1951-03-31,PH,Philippines,
-1951-03-31,PL,Poland,
-1951-03-31,PT,Portugal,
-1951-03-31,RO,Romania,
-1951-03-31,RS,Serbia,
-1951-03-31,RU,Russia,
-1951-03-31,SE,Sweden,
-1951-03-31,SG,Singapore,
-1951-03-31,SI,Slovenia,
-1951-03-31,SK,Slovak Republic,
-1951-03-31,TH,Thailand,
-1951-03-31,TR,Türkiye,
-1951-03-31,US,United States,
-1951-03-31,XM,Euro area,
-1951-03-31,XW,World,
-1951-03-31,ZA,South Africa,
-1951-06-30,4T,Emerging market economies (aggregate),
-1951-06-30,5R,Advanced economies,
-1951-06-30,AE,United Arab Emirates,
-1951-06-30,AT,Austria,
-1951-06-30,AU,Australia,
-1951-06-30,BE,Belgium,
-1951-06-30,BG,Bulgaria,
-1951-06-30,BR,Brazil,
-1951-06-30,CA,Canada,
-1951-06-30,CH,Switzerland,
-1951-06-30,CL,Chile,
-1951-06-30,CN,China,
-1951-06-30,CO,Colombia,
-1951-06-30,CY,Cyprus,
-1951-06-30,CZ,Czechia,
-1951-06-30,DE,Germany,
-1951-06-30,DK,Denmark,
-1951-06-30,EE,Estonia,
-1951-06-30,ES,Spain,
-1951-06-30,FI,Finland,
-1951-06-30,FR,France,
-1951-06-30,GB,United Kingdom,
-1951-06-30,GR,Greece,
-1951-06-30,HK,Hong Kong SAR,
-1951-06-30,HR,Croatia,
-1951-06-30,HU,Hungary,
-1951-06-30,ID,Indonesia,
-1951-06-30,IE,Ireland,
-1951-06-30,IL,Israel,
-1951-06-30,IN,India,
-1951-06-30,IS,Iceland,
-1951-06-30,IT,Italy,11.4217
-1951-06-30,JP,Japan,
-1951-06-30,KR,Korea,
-1951-06-30,LT,Lithuania,
-1951-06-30,LU,Luxembourg,
-1951-06-30,LV,Latvia,
-1951-06-30,MA,Morocco,
-1951-06-30,MK,North Macedonia,
-1951-06-30,MT,Malta,
-1951-06-30,MX,Mexico,
-1951-06-30,MY,Malaysia,
-1951-06-30,NL,Netherlands,
-1951-06-30,NO,Norway,
-1951-06-30,NZ,New Zealand,
-1951-06-30,PE,Peru,
-1951-06-30,PH,Philippines,
-1951-06-30,PL,Poland,
-1951-06-30,PT,Portugal,
-1951-06-30,RO,Romania,
-1951-06-30,RS,Serbia,
-1951-06-30,RU,Russia,
-1951-06-30,SE,Sweden,
-1951-06-30,SG,Singapore,
-1951-06-30,SI,Slovenia,
-1951-06-30,SK,Slovak Republic,
-1951-06-30,TH,Thailand,
-1951-06-30,TR,Türkiye,
-1951-06-30,US,United States,
-1951-06-30,XM,Euro area,
-1951-06-30,XW,World,
-1951-06-30,ZA,South Africa,
-1951-09-30,4T,Emerging market economies (aggregate),
-1951-09-30,5R,Advanced economies,
-1951-09-30,AE,United Arab Emirates,
-1951-09-30,AT,Austria,
-1951-09-30,AU,Australia,
-1951-09-30,BE,Belgium,
-1951-09-30,BG,Bulgaria,
-1951-09-30,BR,Brazil,
-1951-09-30,CA,Canada,
-1951-09-30,CH,Switzerland,
-1951-09-30,CL,Chile,
-1951-09-30,CN,China,
-1951-09-30,CO,Colombia,
-1951-09-30,CY,Cyprus,
-1951-09-30,CZ,Czechia,
-1951-09-30,DE,Germany,
-1951-09-30,DK,Denmark,
-1951-09-30,EE,Estonia,
-1951-09-30,ES,Spain,
-1951-09-30,FI,Finland,
-1951-09-30,FR,France,
-1951-09-30,GB,United Kingdom,
-1951-09-30,GR,Greece,
-1951-09-30,HK,Hong Kong SAR,
-1951-09-30,HR,Croatia,
-1951-09-30,HU,Hungary,
-1951-09-30,ID,Indonesia,
-1951-09-30,IE,Ireland,
-1951-09-30,IL,Israel,
-1951-09-30,IN,India,
-1951-09-30,IS,Iceland,
-1951-09-30,IT,Italy,4.97
-1951-09-30,JP,Japan,
-1951-09-30,KR,Korea,
-1951-09-30,LT,Lithuania,
-1951-09-30,LU,Luxembourg,
-1951-09-30,LV,Latvia,
-1951-09-30,MA,Morocco,
-1951-09-30,MK,North Macedonia,
-1951-09-30,MT,Malta,
-1951-09-30,MX,Mexico,
-1951-09-30,MY,Malaysia,
-1951-09-30,NL,Netherlands,
-1951-09-30,NO,Norway,
-1951-09-30,NZ,New Zealand,
-1951-09-30,PE,Peru,
-1951-09-30,PH,Philippines,
-1951-09-30,PL,Poland,
-1951-09-30,PT,Portugal,
-1951-09-30,RO,Romania,
-1951-09-30,RS,Serbia,
-1951-09-30,RU,Russia,
-1951-09-30,SE,Sweden,
-1951-09-30,SG,Singapore,
-1951-09-30,SI,Slovenia,
-1951-09-30,SK,Slovak Republic,
-1951-09-30,TH,Thailand,
-1951-09-30,TR,Türkiye,
-1951-09-30,US,United States,
-1951-09-30,XM,Euro area,
-1951-09-30,XW,World,
-1951-09-30,ZA,South Africa,
-1951-12-31,4T,Emerging market economies (aggregate),
-1951-12-31,5R,Advanced economies,
-1951-12-31,AE,United Arab Emirates,
-1951-12-31,AT,Austria,
-1951-12-31,AU,Australia,
-1951-12-31,BE,Belgium,
-1951-12-31,BG,Bulgaria,
-1951-12-31,BR,Brazil,
-1951-12-31,CA,Canada,
-1951-12-31,CH,Switzerland,
-1951-12-31,CL,Chile,
-1951-12-31,CN,China,
-1951-12-31,CO,Colombia,
-1951-12-31,CY,Cyprus,
-1951-12-31,CZ,Czechia,
-1951-12-31,DE,Germany,
-1951-12-31,DK,Denmark,
-1951-12-31,EE,Estonia,
-1951-12-31,ES,Spain,
-1951-12-31,FI,Finland,
-1951-12-31,FR,France,
-1951-12-31,GB,United Kingdom,
-1951-12-31,GR,Greece,
-1951-12-31,HK,Hong Kong SAR,
-1951-12-31,HR,Croatia,
-1951-12-31,HU,Hungary,
-1951-12-31,ID,Indonesia,
-1951-12-31,IE,Ireland,
-1951-12-31,IL,Israel,
-1951-12-31,IN,India,
-1951-12-31,IS,Iceland,
-1951-12-31,IT,Italy,3.2417
-1951-12-31,JP,Japan,
-1951-12-31,KR,Korea,
-1951-12-31,LT,Lithuania,
-1951-12-31,LU,Luxembourg,
-1951-12-31,LV,Latvia,
-1951-12-31,MA,Morocco,
-1951-12-31,MK,North Macedonia,
-1951-12-31,MT,Malta,
-1951-12-31,MX,Mexico,
-1951-12-31,MY,Malaysia,
-1951-12-31,NL,Netherlands,
-1951-12-31,NO,Norway,
-1951-12-31,NZ,New Zealand,
-1951-12-31,PE,Peru,
-1951-12-31,PH,Philippines,
-1951-12-31,PL,Poland,
-1951-12-31,PT,Portugal,
-1951-12-31,RO,Romania,
-1951-12-31,RS,Serbia,
-1951-12-31,RU,Russia,
-1951-12-31,SE,Sweden,
-1951-12-31,SG,Singapore,
-1951-12-31,SI,Slovenia,
-1951-12-31,SK,Slovak Republic,
-1951-12-31,TH,Thailand,
-1951-12-31,TR,Türkiye,
-1951-12-31,US,United States,
-1951-12-31,XM,Euro area,
-1951-12-31,XW,World,
-1951-12-31,ZA,South Africa,
-1952-03-31,4T,Emerging market economies (aggregate),
-1952-03-31,5R,Advanced economies,
-1952-03-31,AE,United Arab Emirates,
-1952-03-31,AT,Austria,
-1952-03-31,AU,Australia,
-1952-03-31,BE,Belgium,
-1952-03-31,BG,Bulgaria,
-1952-03-31,BR,Brazil,
-1952-03-31,CA,Canada,
-1952-03-31,CH,Switzerland,
-1952-03-31,CL,Chile,
-1952-03-31,CN,China,
-1952-03-31,CO,Colombia,
-1952-03-31,CY,Cyprus,
-1952-03-31,CZ,Czechia,
-1952-03-31,DE,Germany,
-1952-03-31,DK,Denmark,
-1952-03-31,EE,Estonia,
-1952-03-31,ES,Spain,
-1952-03-31,FI,Finland,
-1952-03-31,FR,France,
-1952-03-31,GB,United Kingdom,
-1952-03-31,GR,Greece,
-1952-03-31,HK,Hong Kong SAR,
-1952-03-31,HR,Croatia,
-1952-03-31,HU,Hungary,
-1952-03-31,ID,Indonesia,
-1952-03-31,IE,Ireland,
-1952-03-31,IL,Israel,
-1952-03-31,IN,India,
-1952-03-31,IS,Iceland,
-1952-03-31,IT,Italy,-0.7828
-1952-03-31,JP,Japan,
-1952-03-31,KR,Korea,
-1952-03-31,LT,Lithuania,
-1952-03-31,LU,Luxembourg,
-1952-03-31,LV,Latvia,
-1952-03-31,MA,Morocco,
-1952-03-31,MK,North Macedonia,
-1952-03-31,MT,Malta,
-1952-03-31,MX,Mexico,
-1952-03-31,MY,Malaysia,
-1952-03-31,NL,Netherlands,
-1952-03-31,NO,Norway,
-1952-03-31,NZ,New Zealand,
-1952-03-31,PE,Peru,
-1952-03-31,PH,Philippines,
-1952-03-31,PL,Poland,
-1952-03-31,PT,Portugal,
-1952-03-31,RO,Romania,
-1952-03-31,RS,Serbia,
-1952-03-31,RU,Russia,
-1952-03-31,SE,Sweden,
-1952-03-31,SG,Singapore,
-1952-03-31,SI,Slovenia,
-1952-03-31,SK,Slovak Republic,
-1952-03-31,TH,Thailand,
-1952-03-31,TR,Türkiye,
-1952-03-31,US,United States,
-1952-03-31,XM,Euro area,
-1952-03-31,XW,World,
-1952-03-31,ZA,South Africa,
-1952-06-30,4T,Emerging market economies (aggregate),
-1952-06-30,5R,Advanced economies,
-1952-06-30,AE,United Arab Emirates,
-1952-06-30,AT,Austria,
-1952-06-30,AU,Australia,
-1952-06-30,BE,Belgium,
-1952-06-30,BG,Bulgaria,
-1952-06-30,BR,Brazil,
-1952-06-30,CA,Canada,
-1952-06-30,CH,Switzerland,
-1952-06-30,CL,Chile,
-1952-06-30,CN,China,
-1952-06-30,CO,Colombia,
-1952-06-30,CY,Cyprus,
-1952-06-30,CZ,Czechia,
-1952-06-30,DE,Germany,
-1952-06-30,DK,Denmark,
-1952-06-30,EE,Estonia,
-1952-06-30,ES,Spain,
-1952-06-30,FI,Finland,
-1952-06-30,FR,France,
-1952-06-30,GB,United Kingdom,
-1952-06-30,GR,Greece,
-1952-06-30,HK,Hong Kong SAR,
-1952-06-30,HR,Croatia,
-1952-06-30,HU,Hungary,
-1952-06-30,ID,Indonesia,
-1952-06-30,IE,Ireland,
-1952-06-30,IL,Israel,
-1952-06-30,IN,India,
-1952-06-30,IS,Iceland,
-1952-06-30,IT,Italy,-4.0476
-1952-06-30,JP,Japan,
-1952-06-30,KR,Korea,
-1952-06-30,LT,Lithuania,
-1952-06-30,LU,Luxembourg,
-1952-06-30,LV,Latvia,
-1952-06-30,MA,Morocco,
-1952-06-30,MK,North Macedonia,
-1952-06-30,MT,Malta,
-1952-06-30,MX,Mexico,
-1952-06-30,MY,Malaysia,
-1952-06-30,NL,Netherlands,
-1952-06-30,NO,Norway,
-1952-06-30,NZ,New Zealand,
-1952-06-30,PE,Peru,
-1952-06-30,PH,Philippines,
-1952-06-30,PL,Poland,
-1952-06-30,PT,Portugal,
-1952-06-30,RO,Romania,
-1952-06-30,RS,Serbia,
-1952-06-30,RU,Russia,
-1952-06-30,SE,Sweden,
-1952-06-30,SG,Singapore,
-1952-06-30,SI,Slovenia,
-1952-06-30,SK,Slovak Republic,
-1952-06-30,TH,Thailand,
-1952-06-30,TR,Türkiye,
-1952-06-30,US,United States,
-1952-06-30,XM,Euro area,
-1952-06-30,XW,World,
-1952-06-30,ZA,South Africa,
-1952-09-30,4T,Emerging market economies (aggregate),
-1952-09-30,5R,Advanced economies,
-1952-09-30,AE,United Arab Emirates,
-1952-09-30,AT,Austria,
-1952-09-30,AU,Australia,
-1952-09-30,BE,Belgium,
-1952-09-30,BG,Bulgaria,
-1952-09-30,BR,Brazil,
-1952-09-30,CA,Canada,
-1952-09-30,CH,Switzerland,
-1952-09-30,CL,Chile,
-1952-09-30,CN,China,
-1952-09-30,CO,Colombia,
-1952-09-30,CY,Cyprus,
-1952-09-30,CZ,Czechia,
-1952-09-30,DE,Germany,
-1952-09-30,DK,Denmark,
-1952-09-30,EE,Estonia,
-1952-09-30,ES,Spain,
-1952-09-30,FI,Finland,
-1952-09-30,FR,France,
-1952-09-30,GB,United Kingdom,
-1952-09-30,GR,Greece,
-1952-09-30,HK,Hong Kong SAR,
-1952-09-30,HR,Croatia,
-1952-09-30,HU,Hungary,
-1952-09-30,ID,Indonesia,
-1952-09-30,IE,Ireland,
-1952-09-30,IL,Israel,
-1952-09-30,IN,India,
-1952-09-30,IS,Iceland,
-1952-09-30,IT,Italy,-2.7322
-1952-09-30,JP,Japan,
-1952-09-30,KR,Korea,
-1952-09-30,LT,Lithuania,
-1952-09-30,LU,Luxembourg,
-1952-09-30,LV,Latvia,
-1952-09-30,MA,Morocco,
-1952-09-30,MK,North Macedonia,
-1952-09-30,MT,Malta,
-1952-09-30,MX,Mexico,
-1952-09-30,MY,Malaysia,
-1952-09-30,NL,Netherlands,
-1952-09-30,NO,Norway,
-1952-09-30,NZ,New Zealand,
-1952-09-30,PE,Peru,
-1952-09-30,PH,Philippines,
-1952-09-30,PL,Poland,
-1952-09-30,PT,Portugal,
-1952-09-30,RO,Romania,
-1952-09-30,RS,Serbia,
-1952-09-30,RU,Russia,
-1952-09-30,SE,Sweden,
-1952-09-30,SG,Singapore,
-1952-09-30,SI,Slovenia,
-1952-09-30,SK,Slovak Republic,
-1952-09-30,TH,Thailand,
-1952-09-30,TR,Türkiye,
-1952-09-30,US,United States,
-1952-09-30,XM,Euro area,
-1952-09-30,XW,World,
-1952-09-30,ZA,South Africa,
-1952-12-31,4T,Emerging market economies (aggregate),
-1952-12-31,5R,Advanced economies,
-1952-12-31,AE,United Arab Emirates,
-1952-12-31,AT,Austria,
-1952-12-31,AU,Australia,
-1952-12-31,BE,Belgium,
-1952-12-31,BG,Bulgaria,
-1952-12-31,BR,Brazil,
-1952-12-31,CA,Canada,
-1952-12-31,CH,Switzerland,
-1952-12-31,CL,Chile,
-1952-12-31,CN,China,
-1952-12-31,CO,Colombia,
-1952-12-31,CY,Cyprus,
-1952-12-31,CZ,Czechia,
-1952-12-31,DE,Germany,
-1952-12-31,DK,Denmark,
-1952-12-31,EE,Estonia,
-1952-12-31,ES,Spain,
-1952-12-31,FI,Finland,
-1952-12-31,FR,France,
-1952-12-31,GB,United Kingdom,
-1952-12-31,GR,Greece,
-1952-12-31,HK,Hong Kong SAR,
-1952-12-31,HR,Croatia,
-1952-12-31,HU,Hungary,
-1952-12-31,ID,Indonesia,
-1952-12-31,IE,Ireland,
-1952-12-31,IL,Israel,
-1952-12-31,IN,India,
-1952-12-31,IS,Iceland,
-1952-12-31,IT,Italy,-0.9924
-1952-12-31,JP,Japan,
-1952-12-31,KR,Korea,
-1952-12-31,LT,Lithuania,
-1952-12-31,LU,Luxembourg,
-1952-12-31,LV,Latvia,
-1952-12-31,MA,Morocco,
-1952-12-31,MK,North Macedonia,
-1952-12-31,MT,Malta,
-1952-12-31,MX,Mexico,
-1952-12-31,MY,Malaysia,
-1952-12-31,NL,Netherlands,
-1952-12-31,NO,Norway,
-1952-12-31,NZ,New Zealand,
-1952-12-31,PE,Peru,
-1952-12-31,PH,Philippines,
-1952-12-31,PL,Poland,
-1952-12-31,PT,Portugal,
-1952-12-31,RO,Romania,
-1952-12-31,RS,Serbia,
-1952-12-31,RU,Russia,
-1952-12-31,SE,Sweden,
-1952-12-31,SG,Singapore,
-1952-12-31,SI,Slovenia,
-1952-12-31,SK,Slovak Republic,
-1952-12-31,TH,Thailand,
-1952-12-31,TR,Türkiye,
-1952-12-31,US,United States,
-1952-12-31,XM,Euro area,
-1952-12-31,XW,World,
-1952-12-31,ZA,South Africa,
-1953-03-31,4T,Emerging market economies (aggregate),
-1953-03-31,5R,Advanced economies,
-1953-03-31,AE,United Arab Emirates,
-1953-03-31,AT,Austria,
-1953-03-31,AU,Australia,
-1953-03-31,BE,Belgium,
-1953-03-31,BG,Bulgaria,
-1953-03-31,BR,Brazil,
-1953-03-31,CA,Canada,
-1953-03-31,CH,Switzerland,
-1953-03-31,CL,Chile,
-1953-03-31,CN,China,
-1953-03-31,CO,Colombia,
-1953-03-31,CY,Cyprus,
-1953-03-31,CZ,Czechia,
-1953-03-31,DE,Germany,
-1953-03-31,DK,Denmark,
-1953-03-31,EE,Estonia,
-1953-03-31,ES,Spain,
-1953-03-31,FI,Finland,
-1953-03-31,FR,France,
-1953-03-31,GB,United Kingdom,
-1953-03-31,GR,Greece,
-1953-03-31,HK,Hong Kong SAR,
-1953-03-31,HR,Croatia,
-1953-03-31,HU,Hungary,
-1953-03-31,ID,Indonesia,
-1953-03-31,IE,Ireland,
-1953-03-31,IL,Israel,
-1953-03-31,IN,India,
-1953-03-31,IS,Iceland,
-1953-03-31,IT,Italy,-1.0939
-1953-03-31,JP,Japan,
-1953-03-31,KR,Korea,
-1953-03-31,LT,Lithuania,
-1953-03-31,LU,Luxembourg,
-1953-03-31,LV,Latvia,
-1953-03-31,MA,Morocco,
-1953-03-31,MK,North Macedonia,
-1953-03-31,MT,Malta,
-1953-03-31,MX,Mexico,
-1953-03-31,MY,Malaysia,
-1953-03-31,NL,Netherlands,
-1953-03-31,NO,Norway,
-1953-03-31,NZ,New Zealand,
-1953-03-31,PE,Peru,
-1953-03-31,PH,Philippines,
-1953-03-31,PL,Poland,
-1953-03-31,PT,Portugal,
-1953-03-31,RO,Romania,
-1953-03-31,RS,Serbia,
-1953-03-31,RU,Russia,
-1953-03-31,SE,Sweden,
-1953-03-31,SG,Singapore,
-1953-03-31,SI,Slovenia,
-1953-03-31,SK,Slovak Republic,
-1953-03-31,TH,Thailand,
-1953-03-31,TR,Türkiye,
-1953-03-31,US,United States,
-1953-03-31,XM,Euro area,
-1953-03-31,XW,World,
-1953-03-31,ZA,South Africa,
-1953-06-30,4T,Emerging market economies (aggregate),
-1953-06-30,5R,Advanced economies,
-1953-06-30,AE,United Arab Emirates,
-1953-06-30,AT,Austria,
-1953-06-30,AU,Australia,
-1953-06-30,BE,Belgium,
-1953-06-30,BG,Bulgaria,
-1953-06-30,BR,Brazil,
-1953-06-30,CA,Canada,
-1953-06-30,CH,Switzerland,
-1953-06-30,CL,Chile,
-1953-06-30,CN,China,
-1953-06-30,CO,Colombia,
-1953-06-30,CY,Cyprus,
-1953-06-30,CZ,Czechia,
-1953-06-30,DE,Germany,
-1953-06-30,DK,Denmark,
-1953-06-30,EE,Estonia,
-1953-06-30,ES,Spain,
-1953-06-30,FI,Finland,
-1953-06-30,FR,France,
-1953-06-30,GB,United Kingdom,
-1953-06-30,GR,Greece,
-1953-06-30,HK,Hong Kong SAR,
-1953-06-30,HR,Croatia,
-1953-06-30,HU,Hungary,
-1953-06-30,ID,Indonesia,
-1953-06-30,IE,Ireland,
-1953-06-30,IL,Israel,
-1953-06-30,IN,India,
-1953-06-30,IS,Iceland,
-1953-06-30,IT,Italy,0.4553
-1953-06-30,JP,Japan,
-1953-06-30,KR,Korea,
-1953-06-30,LT,Lithuania,
-1953-06-30,LU,Luxembourg,
-1953-06-30,LV,Latvia,
-1953-06-30,MA,Morocco,
-1953-06-30,MK,North Macedonia,
-1953-06-30,MT,Malta,
-1953-06-30,MX,Mexico,
-1953-06-30,MY,Malaysia,
-1953-06-30,NL,Netherlands,
-1953-06-30,NO,Norway,
-1953-06-30,NZ,New Zealand,
-1953-06-30,PE,Peru,
-1953-06-30,PH,Philippines,
-1953-06-30,PL,Poland,
-1953-06-30,PT,Portugal,
-1953-06-30,RO,Romania,
-1953-06-30,RS,Serbia,
-1953-06-30,RU,Russia,
-1953-06-30,SE,Sweden,
-1953-06-30,SG,Singapore,
-1953-06-30,SI,Slovenia,
-1953-06-30,SK,Slovak Republic,
-1953-06-30,TH,Thailand,
-1953-06-30,TR,Türkiye,
-1953-06-30,US,United States,
-1953-06-30,XM,Euro area,
-1953-06-30,XW,World,
-1953-06-30,ZA,South Africa,
-1953-09-30,4T,Emerging market economies (aggregate),
-1953-09-30,5R,Advanced economies,
-1953-09-30,AE,United Arab Emirates,
-1953-09-30,AT,Austria,
-1953-09-30,AU,Australia,
-1953-09-30,BE,Belgium,
-1953-09-30,BG,Bulgaria,
-1953-09-30,BR,Brazil,
-1953-09-30,CA,Canada,
-1953-09-30,CH,Switzerland,
-1953-09-30,CL,Chile,
-1953-09-30,CN,China,
-1953-09-30,CO,Colombia,
-1953-09-30,CY,Cyprus,
-1953-09-30,CZ,Czechia,
-1953-09-30,DE,Germany,
-1953-09-30,DK,Denmark,
-1953-09-30,EE,Estonia,
-1953-09-30,ES,Spain,
-1953-09-30,FI,Finland,
-1953-09-30,FR,France,
-1953-09-30,GB,United Kingdom,
-1953-09-30,GR,Greece,
-1953-09-30,HK,Hong Kong SAR,
-1953-09-30,HR,Croatia,
-1953-09-30,HU,Hungary,
-1953-09-30,ID,Indonesia,
-1953-09-30,IE,Ireland,
-1953-09-30,IL,Israel,
-1953-09-30,IN,India,
-1953-09-30,IS,Iceland,
-1953-09-30,IT,Italy,-2.2618
-1953-09-30,JP,Japan,
-1953-09-30,KR,Korea,
-1953-09-30,LT,Lithuania,
-1953-09-30,LU,Luxembourg,
-1953-09-30,LV,Latvia,
-1953-09-30,MA,Morocco,
-1953-09-30,MK,North Macedonia,
-1953-09-30,MT,Malta,
-1953-09-30,MX,Mexico,
-1953-09-30,MY,Malaysia,
-1953-09-30,NL,Netherlands,
-1953-09-30,NO,Norway,
-1953-09-30,NZ,New Zealand,
-1953-09-30,PE,Peru,
-1953-09-30,PH,Philippines,
-1953-09-30,PL,Poland,
-1953-09-30,PT,Portugal,
-1953-09-30,RO,Romania,
-1953-09-30,RS,Serbia,
-1953-09-30,RU,Russia,
-1953-09-30,SE,Sweden,
-1953-09-30,SG,Singapore,
-1953-09-30,SI,Slovenia,
-1953-09-30,SK,Slovak Republic,
-1953-09-30,TH,Thailand,
-1953-09-30,TR,Türkiye,
-1953-09-30,US,United States,
-1953-09-30,XM,Euro area,
-1953-09-30,XW,World,
-1953-09-30,ZA,South Africa,
-1953-12-31,4T,Emerging market economies (aggregate),
-1953-12-31,5R,Advanced economies,
-1953-12-31,AE,United Arab Emirates,
-1953-12-31,AT,Austria,
-1953-12-31,AU,Australia,
-1953-12-31,BE,Belgium,
-1953-12-31,BG,Bulgaria,
-1953-12-31,BR,Brazil,
-1953-12-31,CA,Canada,
-1953-12-31,CH,Switzerland,
-1953-12-31,CL,Chile,
-1953-12-31,CN,China,
-1953-12-31,CO,Colombia,
-1953-12-31,CY,Cyprus,
-1953-12-31,CZ,Czechia,
-1953-12-31,DE,Germany,
-1953-12-31,DK,Denmark,
-1953-12-31,EE,Estonia,
-1953-12-31,ES,Spain,
-1953-12-31,FI,Finland,
-1953-12-31,FR,France,
-1953-12-31,GB,United Kingdom,
-1953-12-31,GR,Greece,
-1953-12-31,HK,Hong Kong SAR,
-1953-12-31,HR,Croatia,
-1953-12-31,HU,Hungary,
-1953-12-31,ID,Indonesia,
-1953-12-31,IE,Ireland,
-1953-12-31,IL,Israel,
-1953-12-31,IN,India,
-1953-12-31,IS,Iceland,
-1953-12-31,IT,Italy,-1.491
-1953-12-31,JP,Japan,
-1953-12-31,KR,Korea,
-1953-12-31,LT,Lithuania,
-1953-12-31,LU,Luxembourg,
-1953-12-31,LV,Latvia,
-1953-12-31,MA,Morocco,
-1953-12-31,MK,North Macedonia,
-1953-12-31,MT,Malta,
-1953-12-31,MX,Mexico,
-1953-12-31,MY,Malaysia,
-1953-12-31,NL,Netherlands,
-1953-12-31,NO,Norway,
-1953-12-31,NZ,New Zealand,
-1953-12-31,PE,Peru,
-1953-12-31,PH,Philippines,
-1953-12-31,PL,Poland,
-1953-12-31,PT,Portugal,
-1953-12-31,RO,Romania,
-1953-12-31,RS,Serbia,
-1953-12-31,RU,Russia,
-1953-12-31,SE,Sweden,
-1953-12-31,SG,Singapore,
-1953-12-31,SI,Slovenia,
-1953-12-31,SK,Slovak Republic,
-1953-12-31,TH,Thailand,
-1953-12-31,TR,Türkiye,
-1953-12-31,US,United States,
-1953-12-31,XM,Euro area,
-1953-12-31,XW,World,
-1953-12-31,ZA,South Africa,
-1954-03-31,4T,Emerging market economies (aggregate),
-1954-03-31,5R,Advanced economies,
-1954-03-31,AE,United Arab Emirates,
-1954-03-31,AT,Austria,
-1954-03-31,AU,Australia,
-1954-03-31,BE,Belgium,
-1954-03-31,BG,Bulgaria,
-1954-03-31,BR,Brazil,
-1954-03-31,CA,Canada,
-1954-03-31,CH,Switzerland,
-1954-03-31,CL,Chile,
-1954-03-31,CN,China,
-1954-03-31,CO,Colombia,
-1954-03-31,CY,Cyprus,
-1954-03-31,CZ,Czechia,
-1954-03-31,DE,Germany,
-1954-03-31,DK,Denmark,
-1954-03-31,EE,Estonia,
-1954-03-31,ES,Spain,
-1954-03-31,FI,Finland,
-1954-03-31,FR,France,
-1954-03-31,GB,United Kingdom,
-1954-03-31,GR,Greece,
-1954-03-31,HK,Hong Kong SAR,
-1954-03-31,HR,Croatia,
-1954-03-31,HU,Hungary,
-1954-03-31,ID,Indonesia,
-1954-03-31,IE,Ireland,
-1954-03-31,IL,Israel,
-1954-03-31,IN,India,
-1954-03-31,IS,Iceland,
-1954-03-31,IT,Italy,-0.3968
-1954-03-31,JP,Japan,
-1954-03-31,KR,Korea,
-1954-03-31,LT,Lithuania,
-1954-03-31,LU,Luxembourg,
-1954-03-31,LV,Latvia,
-1954-03-31,MA,Morocco,
-1954-03-31,MK,North Macedonia,
-1954-03-31,MT,Malta,
-1954-03-31,MX,Mexico,
-1954-03-31,MY,Malaysia,
-1954-03-31,NL,Netherlands,
-1954-03-31,NO,Norway,
-1954-03-31,NZ,New Zealand,
-1954-03-31,PE,Peru,
-1954-03-31,PH,Philippines,
-1954-03-31,PL,Poland,
-1954-03-31,PT,Portugal,
-1954-03-31,RO,Romania,
-1954-03-31,RS,Serbia,
-1954-03-31,RU,Russia,
-1954-03-31,SE,Sweden,
-1954-03-31,SG,Singapore,
-1954-03-31,SI,Slovenia,
-1954-03-31,SK,Slovak Republic,
-1954-03-31,TH,Thailand,
-1954-03-31,TR,Türkiye,
-1954-03-31,US,United States,
-1954-03-31,XM,Euro area,
-1954-03-31,XW,World,
-1954-03-31,ZA,South Africa,
-1954-06-30,4T,Emerging market economies (aggregate),
-1954-06-30,5R,Advanced economies,
-1954-06-30,AE,United Arab Emirates,
-1954-06-30,AT,Austria,
-1954-06-30,AU,Australia,
-1954-06-30,BE,Belgium,
-1954-06-30,BG,Bulgaria,
-1954-06-30,BR,Brazil,
-1954-06-30,CA,Canada,
-1954-06-30,CH,Switzerland,
-1954-06-30,CL,Chile,
-1954-06-30,CN,China,
-1954-06-30,CO,Colombia,
-1954-06-30,CY,Cyprus,
-1954-06-30,CZ,Czechia,
-1954-06-30,DE,Germany,
-1954-06-30,DK,Denmark,
-1954-06-30,EE,Estonia,
-1954-06-30,ES,Spain,
-1954-06-30,FI,Finland,
-1954-06-30,FR,France,
-1954-06-30,GB,United Kingdom,
-1954-06-30,GR,Greece,
-1954-06-30,HK,Hong Kong SAR,
-1954-06-30,HR,Croatia,
-1954-06-30,HU,Hungary,
-1954-06-30,ID,Indonesia,
-1954-06-30,IE,Ireland,
-1954-06-30,IL,Israel,
-1954-06-30,IN,India,
-1954-06-30,IS,Iceland,
-1954-06-30,IT,Italy,0.3187
-1954-06-30,JP,Japan,
-1954-06-30,KR,Korea,
-1954-06-30,LT,Lithuania,
-1954-06-30,LU,Luxembourg,
-1954-06-30,LV,Latvia,
-1954-06-30,MA,Morocco,
-1954-06-30,MK,North Macedonia,
-1954-06-30,MT,Malta,
-1954-06-30,MX,Mexico,
-1954-06-30,MY,Malaysia,
-1954-06-30,NL,Netherlands,
-1954-06-30,NO,Norway,
-1954-06-30,NZ,New Zealand,
-1954-06-30,PE,Peru,
-1954-06-30,PH,Philippines,
-1954-06-30,PL,Poland,
-1954-06-30,PT,Portugal,
-1954-06-30,RO,Romania,
-1954-06-30,RS,Serbia,
-1954-06-30,RU,Russia,
-1954-06-30,SE,Sweden,
-1954-06-30,SG,Singapore,
-1954-06-30,SI,Slovenia,
-1954-06-30,SK,Slovak Republic,
-1954-06-30,TH,Thailand,
-1954-06-30,TR,Türkiye,
-1954-06-30,US,United States,
-1954-06-30,XM,Euro area,
-1954-06-30,XW,World,
-1954-06-30,ZA,South Africa,
-1954-09-30,4T,Emerging market economies (aggregate),
-1954-09-30,5R,Advanced economies,
-1954-09-30,AE,United Arab Emirates,
-1954-09-30,AT,Austria,
-1954-09-30,AU,Australia,
-1954-09-30,BE,Belgium,
-1954-09-30,BG,Bulgaria,
-1954-09-30,BR,Brazil,
-1954-09-30,CA,Canada,
-1954-09-30,CH,Switzerland,
-1954-09-30,CL,Chile,
-1954-09-30,CN,China,
-1954-09-30,CO,Colombia,
-1954-09-30,CY,Cyprus,
-1954-09-30,CZ,Czechia,
-1954-09-30,DE,Germany,
-1954-09-30,DK,Denmark,
-1954-09-30,EE,Estonia,
-1954-09-30,ES,Spain,
-1954-09-30,FI,Finland,
-1954-09-30,FR,France,
-1954-09-30,GB,United Kingdom,
-1954-09-30,GR,Greece,
-1954-09-30,HK,Hong Kong SAR,
-1954-09-30,HR,Croatia,
-1954-09-30,HU,Hungary,
-1954-09-30,ID,Indonesia,
-1954-09-30,IE,Ireland,
-1954-09-30,IL,Israel,
-1954-09-30,IN,India,
-1954-09-30,IS,Iceland,
-1954-09-30,IT,Italy,4.0439
-1954-09-30,JP,Japan,
-1954-09-30,KR,Korea,
-1954-09-30,LT,Lithuania,
-1954-09-30,LU,Luxembourg,
-1954-09-30,LV,Latvia,
-1954-09-30,MA,Morocco,
-1954-09-30,MK,North Macedonia,
-1954-09-30,MT,Malta,
-1954-09-30,MX,Mexico,
-1954-09-30,MY,Malaysia,
-1954-09-30,NL,Netherlands,
-1954-09-30,NO,Norway,
-1954-09-30,NZ,New Zealand,
-1954-09-30,PE,Peru,
-1954-09-30,PH,Philippines,
-1954-09-30,PL,Poland,
-1954-09-30,PT,Portugal,
-1954-09-30,RO,Romania,
-1954-09-30,RS,Serbia,
-1954-09-30,RU,Russia,
-1954-09-30,SE,Sweden,
-1954-09-30,SG,Singapore,
-1954-09-30,SI,Slovenia,
-1954-09-30,SK,Slovak Republic,
-1954-09-30,TH,Thailand,
-1954-09-30,TR,Türkiye,
-1954-09-30,US,United States,
-1954-09-30,XM,Euro area,
-1954-09-30,XW,World,
-1954-09-30,ZA,South Africa,
-1954-12-31,4T,Emerging market economies (aggregate),
-1954-12-31,5R,Advanced economies,
-1954-12-31,AE,United Arab Emirates,
-1954-12-31,AT,Austria,
-1954-12-31,AU,Australia,
-1954-12-31,BE,Belgium,
-1954-12-31,BG,Bulgaria,
-1954-12-31,BR,Brazil,
-1954-12-31,CA,Canada,
-1954-12-31,CH,Switzerland,
-1954-12-31,CL,Chile,
-1954-12-31,CN,China,
-1954-12-31,CO,Colombia,
-1954-12-31,CY,Cyprus,
-1954-12-31,CZ,Czechia,
-1954-12-31,DE,Germany,
-1954-12-31,DK,Denmark,
-1954-12-31,EE,Estonia,
-1954-12-31,ES,Spain,
-1954-12-31,FI,Finland,
-1954-12-31,FR,France,
-1954-12-31,GB,United Kingdom,
-1954-12-31,GR,Greece,
-1954-12-31,HK,Hong Kong SAR,
-1954-12-31,HR,Croatia,
-1954-12-31,HU,Hungary,
-1954-12-31,ID,Indonesia,
-1954-12-31,IE,Ireland,
-1954-12-31,IL,Israel,
-1954-12-31,IN,India,
-1954-12-31,IS,Iceland,
-1954-12-31,IT,Italy,2.1777
-1954-12-31,JP,Japan,
-1954-12-31,KR,Korea,
-1954-12-31,LT,Lithuania,
-1954-12-31,LU,Luxembourg,
-1954-12-31,LV,Latvia,
-1954-12-31,MA,Morocco,
-1954-12-31,MK,North Macedonia,
-1954-12-31,MT,Malta,
-1954-12-31,MX,Mexico,
-1954-12-31,MY,Malaysia,
-1954-12-31,NL,Netherlands,
-1954-12-31,NO,Norway,
-1954-12-31,NZ,New Zealand,
-1954-12-31,PE,Peru,
-1954-12-31,PH,Philippines,
-1954-12-31,PL,Poland,
-1954-12-31,PT,Portugal,
-1954-12-31,RO,Romania,
-1954-12-31,RS,Serbia,
-1954-12-31,RU,Russia,
-1954-12-31,SE,Sweden,
-1954-12-31,SG,Singapore,
-1954-12-31,SI,Slovenia,
-1954-12-31,SK,Slovak Republic,
-1954-12-31,TH,Thailand,
-1954-12-31,TR,Türkiye,
-1954-12-31,US,United States,
-1954-12-31,XM,Euro area,
-1954-12-31,XW,World,
-1954-12-31,ZA,South Africa,
-1955-03-31,4T,Emerging market economies (aggregate),
-1955-03-31,5R,Advanced economies,
-1955-03-31,AE,United Arab Emirates,
-1955-03-31,AT,Austria,
-1955-03-31,AU,Australia,
-1955-03-31,BE,Belgium,
-1955-03-31,BG,Bulgaria,
-1955-03-31,BR,Brazil,
-1955-03-31,CA,Canada,
-1955-03-31,CH,Switzerland,
-1955-03-31,CL,Chile,
-1955-03-31,CN,China,
-1955-03-31,CO,Colombia,
-1955-03-31,CY,Cyprus,
-1955-03-31,CZ,Czechia,
-1955-03-31,DE,Germany,
-1955-03-31,DK,Denmark,
-1955-03-31,EE,Estonia,
-1955-03-31,ES,Spain,
-1955-03-31,FI,Finland,
-1955-03-31,FR,France,
-1955-03-31,GB,United Kingdom,
-1955-03-31,GR,Greece,
-1955-03-31,HK,Hong Kong SAR,
-1955-03-31,HR,Croatia,
-1955-03-31,HU,Hungary,
-1955-03-31,ID,Indonesia,
-1955-03-31,IE,Ireland,
-1955-03-31,IL,Israel,
-1955-03-31,IN,India,
-1955-03-31,IS,Iceland,
-1955-03-31,IT,Italy,1.5503
-1955-03-31,JP,Japan,
-1955-03-31,KR,Korea,
-1955-03-31,LT,Lithuania,
-1955-03-31,LU,Luxembourg,
-1955-03-31,LV,Latvia,
-1955-03-31,MA,Morocco,
-1955-03-31,MK,North Macedonia,
-1955-03-31,MT,Malta,
-1955-03-31,MX,Mexico,
-1955-03-31,MY,Malaysia,
-1955-03-31,NL,Netherlands,
-1955-03-31,NO,Norway,
-1955-03-31,NZ,New Zealand,
-1955-03-31,PE,Peru,
-1955-03-31,PH,Philippines,
-1955-03-31,PL,Poland,
-1955-03-31,PT,Portugal,
-1955-03-31,RO,Romania,
-1955-03-31,RS,Serbia,
-1955-03-31,RU,Russia,
-1955-03-31,SE,Sweden,
-1955-03-31,SG,Singapore,
-1955-03-31,SI,Slovenia,
-1955-03-31,SK,Slovak Republic,
-1955-03-31,TH,Thailand,
-1955-03-31,TR,Türkiye,
-1955-03-31,US,United States,
-1955-03-31,XM,Euro area,
-1955-03-31,XW,World,
-1955-03-31,ZA,South Africa,
-1955-06-30,4T,Emerging market economies (aggregate),
-1955-06-30,5R,Advanced economies,
-1955-06-30,AE,United Arab Emirates,
-1955-06-30,AT,Austria,
-1955-06-30,AU,Australia,
-1955-06-30,BE,Belgium,
-1955-06-30,BG,Bulgaria,
-1955-06-30,BR,Brazil,
-1955-06-30,CA,Canada,
-1955-06-30,CH,Switzerland,
-1955-06-30,CL,Chile,
-1955-06-30,CN,China,
-1955-06-30,CO,Colombia,
-1955-06-30,CY,Cyprus,
-1955-06-30,CZ,Czechia,
-1955-06-30,DE,Germany,
-1955-06-30,DK,Denmark,
-1955-06-30,EE,Estonia,
-1955-06-30,ES,Spain,
-1955-06-30,FI,Finland,
-1955-06-30,FR,France,
-1955-06-30,GB,United Kingdom,
-1955-06-30,GR,Greece,
-1955-06-30,HK,Hong Kong SAR,
-1955-06-30,HR,Croatia,
-1955-06-30,HU,Hungary,
-1955-06-30,ID,Indonesia,
-1955-06-30,IE,Ireland,
-1955-06-30,IL,Israel,
-1955-06-30,IN,India,
-1955-06-30,IS,Iceland,
-1955-06-30,IT,Italy,1.2959
-1955-06-30,JP,Japan,
-1955-06-30,KR,Korea,
-1955-06-30,LT,Lithuania,
-1955-06-30,LU,Luxembourg,
-1955-06-30,LV,Latvia,
-1955-06-30,MA,Morocco,
-1955-06-30,MK,North Macedonia,
-1955-06-30,MT,Malta,
-1955-06-30,MX,Mexico,
-1955-06-30,MY,Malaysia,
-1955-06-30,NL,Netherlands,
-1955-06-30,NO,Norway,
-1955-06-30,NZ,New Zealand,
-1955-06-30,PE,Peru,
-1955-06-30,PH,Philippines,
-1955-06-30,PL,Poland,
-1955-06-30,PT,Portugal,
-1955-06-30,RO,Romania,
-1955-06-30,RS,Serbia,
-1955-06-30,RU,Russia,
-1955-06-30,SE,Sweden,
-1955-06-30,SG,Singapore,
-1955-06-30,SI,Slovenia,
-1955-06-30,SK,Slovak Republic,
-1955-06-30,TH,Thailand,
-1955-06-30,TR,Türkiye,
-1955-06-30,US,United States,
-1955-06-30,XM,Euro area,
-1955-06-30,XW,World,
-1955-06-30,ZA,South Africa,
-1955-09-30,4T,Emerging market economies (aggregate),
-1955-09-30,5R,Advanced economies,
-1955-09-30,AE,United Arab Emirates,
-1955-09-30,AT,Austria,
-1955-09-30,AU,Australia,
-1955-09-30,BE,Belgium,
-1955-09-30,BG,Bulgaria,
-1955-09-30,BR,Brazil,
-1955-09-30,CA,Canada,
-1955-09-30,CH,Switzerland,
-1955-09-30,CL,Chile,
-1955-09-30,CN,China,
-1955-09-30,CO,Colombia,
-1955-09-30,CY,Cyprus,
-1955-09-30,CZ,Czechia,
-1955-09-30,DE,Germany,
-1955-09-30,DK,Denmark,
-1955-09-30,EE,Estonia,
-1955-09-30,ES,Spain,
-1955-09-30,FI,Finland,
-1955-09-30,FR,France,
-1955-09-30,GB,United Kingdom,
-1955-09-30,GR,Greece,
-1955-09-30,HK,Hong Kong SAR,
-1955-09-30,HR,Croatia,
-1955-09-30,HU,Hungary,
-1955-09-30,ID,Indonesia,
-1955-09-30,IE,Ireland,
-1955-09-30,IL,Israel,
-1955-09-30,IN,India,
-1955-09-30,IS,Iceland,
-1955-09-30,IT,Italy,-1.2548
-1955-09-30,JP,Japan,
-1955-09-30,KR,Korea,
-1955-09-30,LT,Lithuania,
-1955-09-30,LU,Luxembourg,
-1955-09-30,LV,Latvia,
-1955-09-30,MA,Morocco,
-1955-09-30,MK,North Macedonia,
-1955-09-30,MT,Malta,
-1955-09-30,MX,Mexico,
-1955-09-30,MY,Malaysia,
-1955-09-30,NL,Netherlands,
-1955-09-30,NO,Norway,
-1955-09-30,NZ,New Zealand,
-1955-09-30,PE,Peru,
-1955-09-30,PH,Philippines,
-1955-09-30,PL,Poland,
-1955-09-30,PT,Portugal,
-1955-09-30,RO,Romania,
-1955-09-30,RS,Serbia,
-1955-09-30,RU,Russia,
-1955-09-30,SE,Sweden,
-1955-09-30,SG,Singapore,
-1955-09-30,SI,Slovenia,
-1955-09-30,SK,Slovak Republic,
-1955-09-30,TH,Thailand,
-1955-09-30,TR,Türkiye,
-1955-09-30,US,United States,
-1955-09-30,XM,Euro area,
-1955-09-30,XW,World,
-1955-09-30,ZA,South Africa,
-1955-12-31,4T,Emerging market economies (aggregate),
-1955-12-31,5R,Advanced economies,
-1955-12-31,AE,United Arab Emirates,
-1955-12-31,AT,Austria,
-1955-12-31,AU,Australia,
-1955-12-31,BE,Belgium,
-1955-12-31,BG,Bulgaria,
-1955-12-31,BR,Brazil,
-1955-12-31,CA,Canada,
-1955-12-31,CH,Switzerland,
-1955-12-31,CL,Chile,
-1955-12-31,CN,China,
-1955-12-31,CO,Colombia,
-1955-12-31,CY,Cyprus,
-1955-12-31,CZ,Czechia,
-1955-12-31,DE,Germany,
-1955-12-31,DK,Denmark,
-1955-12-31,EE,Estonia,
-1955-12-31,ES,Spain,
-1955-12-31,FI,Finland,
-1955-12-31,FR,France,
-1955-12-31,GB,United Kingdom,
-1955-12-31,GR,Greece,
-1955-12-31,HK,Hong Kong SAR,
-1955-12-31,HR,Croatia,
-1955-12-31,HU,Hungary,
-1955-12-31,ID,Indonesia,
-1955-12-31,IE,Ireland,
-1955-12-31,IL,Israel,
-1955-12-31,IN,India,
-1955-12-31,IS,Iceland,
-1955-12-31,IT,Italy,-2.956
-1955-12-31,JP,Japan,
-1955-12-31,KR,Korea,
-1955-12-31,LT,Lithuania,
-1955-12-31,LU,Luxembourg,
-1955-12-31,LV,Latvia,
-1955-12-31,MA,Morocco,
-1955-12-31,MK,North Macedonia,
-1955-12-31,MT,Malta,
-1955-12-31,MX,Mexico,
-1955-12-31,MY,Malaysia,
-1955-12-31,NL,Netherlands,
-1955-12-31,NO,Norway,
-1955-12-31,NZ,New Zealand,
-1955-12-31,PE,Peru,
-1955-12-31,PH,Philippines,
-1955-12-31,PL,Poland,
-1955-12-31,PT,Portugal,
-1955-12-31,RO,Romania,
-1955-12-31,RS,Serbia,
-1955-12-31,RU,Russia,
-1955-12-31,SE,Sweden,
-1955-12-31,SG,Singapore,
-1955-12-31,SI,Slovenia,
-1955-12-31,SK,Slovak Republic,
-1955-12-31,TH,Thailand,
-1955-12-31,TR,Türkiye,
-1955-12-31,US,United States,
-1955-12-31,XM,Euro area,
-1955-12-31,XW,World,
-1955-12-31,ZA,South Africa,
-1956-03-31,4T,Emerging market economies (aggregate),
-1956-03-31,5R,Advanced economies,
-1956-03-31,AE,United Arab Emirates,
-1956-03-31,AT,Austria,
-1956-03-31,AU,Australia,
-1956-03-31,BE,Belgium,
-1956-03-31,BG,Bulgaria,
-1956-03-31,BR,Brazil,
-1956-03-31,CA,Canada,
-1956-03-31,CH,Switzerland,
-1956-03-31,CL,Chile,
-1956-03-31,CN,China,
-1956-03-31,CO,Colombia,
-1956-03-31,CY,Cyprus,
-1956-03-31,CZ,Czechia,
-1956-03-31,DE,Germany,
-1956-03-31,DK,Denmark,
-1956-03-31,EE,Estonia,
-1956-03-31,ES,Spain,
-1956-03-31,FI,Finland,
-1956-03-31,FR,France,
-1956-03-31,GB,United Kingdom,
-1956-03-31,GR,Greece,
-1956-03-31,HK,Hong Kong SAR,
-1956-03-31,HR,Croatia,
-1956-03-31,HU,Hungary,
-1956-03-31,ID,Indonesia,
-1956-03-31,IE,Ireland,
-1956-03-31,IL,Israel,
-1956-03-31,IN,India,
-1956-03-31,IS,Iceland,
-1956-03-31,IT,Italy,-1.332
+1948-03-31,IT,Italy,5.5675
+1948-06-30,IT,Italy,15.2916
+1948-09-30,IT,Italy,16.6458
+1948-12-31,IT,Italy,12.9786
+1949-03-31,IT,Italy,-1.9583
+1949-06-30,IT,Italy,-4.6555
+1949-09-30,IT,Italy,-5.1044
+1949-12-31,IT,Italy,-7.8316
+1950-03-31,IT,Italy,-7.8779
+1950-06-30,IT,Italy,-1.7532
+1950-09-30,IT,Italy,9.991
+1950-12-31,IT,Italy,11.714
+1951-03-31,IT,Italy,14.1157
+1951-06-30,IT,Italy,11.5623
+1951-09-30,IT,Italy,4.5425
+1951-12-31,IT,Italy,3.0769
+1952-03-31,IT,Italy,-0.9785
+1952-06-30,IT,Italy,-4.2295
+1952-09-30,IT,Italy,-2.6081
+1952-12-31,IT,Italy,-0.7448
+1953-03-31,IT,Italy,-0.9416
+1953-06-30,IT,Italy,0.7023
+1953-09-30,IT,Italy,-2.4351
+1953-12-31,IT,Italy,-1.7067
+1954-03-31,IT,Italy,1.0244
+1954-06-30,IT,Italy,-0.8142
+1954-09-30,IT,Italy,3.0651
+1954-12-31,IT,Italy,2.9355
+1955-03-31,IT,Italy,1.6762
+1955-06-30,IT,Italy,1.1783
+1955-09-30,IT,Italy,-0.5023
+1955-12-31,IT,Italy,-2.0889
+1956-03-31,IT,Italy,-1.2415
 1956-03-31,JP,Japan,15.2051
-1956-03-31,KR,Korea,
-1956-03-31,LT,Lithuania,
-1956-03-31,LU,Luxembourg,
-1956-03-31,LV,Latvia,
-1956-03-31,MA,Morocco,
-1956-03-31,MK,North Macedonia,
-1956-03-31,MT,Malta,
-1956-03-31,MX,Mexico,
-1956-03-31,MY,Malaysia,
-1956-03-31,NL,Netherlands,
-1956-03-31,NO,Norway,
-1956-03-31,NZ,New Zealand,
-1956-03-31,PE,Peru,
-1956-03-31,PH,Philippines,
-1956-03-31,PL,Poland,
-1956-03-31,PT,Portugal,
-1956-03-31,RO,Romania,
-1956-03-31,RS,Serbia,
-1956-03-31,RU,Russia,
-1956-03-31,SE,Sweden,
-1956-03-31,SG,Singapore,
-1956-03-31,SI,Slovenia,
-1956-03-31,SK,Slovak Republic,
-1956-03-31,TH,Thailand,
-1956-03-31,TR,Türkiye,
-1956-03-31,US,United States,
-1956-03-31,XM,Euro area,
-1956-03-31,XW,World,
-1956-03-31,ZA,South Africa,
-1956-06-30,4T,Emerging market economies (aggregate),
-1956-06-30,5R,Advanced economies,
-1956-06-30,AE,United Arab Emirates,
-1956-06-30,AT,Austria,
-1956-06-30,AU,Australia,
-1956-06-30,BE,Belgium,
-1956-06-30,BG,Bulgaria,
-1956-06-30,BR,Brazil,
-1956-06-30,CA,Canada,
-1956-06-30,CH,Switzerland,
-1956-06-30,CL,Chile,
-1956-06-30,CN,China,
-1956-06-30,CO,Colombia,
-1956-06-30,CY,Cyprus,
-1956-06-30,CZ,Czechia,
-1956-06-30,DE,Germany,
-1956-06-30,DK,Denmark,
-1956-06-30,EE,Estonia,
-1956-06-30,ES,Spain,
-1956-06-30,FI,Finland,
-1956-06-30,FR,France,
-1956-06-30,GB,United Kingdom,
-1956-06-30,GR,Greece,
-1956-06-30,HK,Hong Kong SAR,
-1956-06-30,HR,Croatia,
-1956-06-30,HU,Hungary,
-1956-06-30,ID,Indonesia,
-1956-06-30,IE,Ireland,
-1956-06-30,IL,Israel,
-1956-06-30,IN,India,
-1956-06-30,IS,Iceland,
-1956-06-30,IT,Italy,-2.9749
+1956-06-30,IT,Italy,-0.7903
 1956-06-30,JP,Japan,16.4597
-1956-06-30,KR,Korea,
-1956-06-30,LT,Lithuania,
-1956-06-30,LU,Luxembourg,
-1956-06-30,LV,Latvia,
-1956-06-30,MA,Morocco,
-1956-06-30,MK,North Macedonia,
-1956-06-30,MT,Malta,
-1956-06-30,MX,Mexico,
-1956-06-30,MY,Malaysia,
-1956-06-30,NL,Netherlands,
-1956-06-30,NO,Norway,
-1956-06-30,NZ,New Zealand,
-1956-06-30,PE,Peru,
-1956-06-30,PH,Philippines,
-1956-06-30,PL,Poland,
-1956-06-30,PT,Portugal,
-1956-06-30,RO,Romania,
-1956-06-30,RS,Serbia,
-1956-06-30,RU,Russia,
-1956-06-30,SE,Sweden,
-1956-06-30,SG,Singapore,
-1956-06-30,SI,Slovenia,
-1956-06-30,SK,Slovak Republic,
-1956-06-30,TH,Thailand,
-1956-06-30,TR,Türkiye,
-1956-06-30,US,United States,
-1956-06-30,XM,Euro area,
-1956-06-30,XW,World,
-1956-06-30,ZA,South Africa,
-1956-09-30,4T,Emerging market economies (aggregate),
-1956-09-30,5R,Advanced economies,
-1956-09-30,AE,United Arab Emirates,
-1956-09-30,AT,Austria,
-1956-09-30,AU,Australia,
-1956-09-30,BE,Belgium,
-1956-09-30,BG,Bulgaria,
-1956-09-30,BR,Brazil,
-1956-09-30,CA,Canada,
-1956-09-30,CH,Switzerland,
-1956-09-30,CL,Chile,
-1956-09-30,CN,China,
-1956-09-30,CO,Colombia,
-1956-09-30,CY,Cyprus,
-1956-09-30,CZ,Czechia,
-1956-09-30,DE,Germany,
-1956-09-30,DK,Denmark,
-1956-09-30,EE,Estonia,
-1956-09-30,ES,Spain,
-1956-09-30,FI,Finland,
-1956-09-30,FR,France,
-1956-09-30,GB,United Kingdom,
-1956-09-30,GR,Greece,
-1956-09-30,HK,Hong Kong SAR,
-1956-09-30,HR,Croatia,
-1956-09-30,HU,Hungary,
-1956-09-30,ID,Indonesia,
-1956-09-30,IE,Ireland,
-1956-09-30,IL,Israel,
-1956-09-30,IN,India,
-1956-09-30,IS,Iceland,
-1956-09-30,IT,Italy,-3.1491
+1956-09-30,IT,Italy,-0.774
 1956-09-30,JP,Japan,19.2239
-1956-09-30,KR,Korea,
-1956-09-30,LT,Lithuania,
-1956-09-30,LU,Luxembourg,
-1956-09-30,LV,Latvia,
-1956-09-30,MA,Morocco,
-1956-09-30,MK,North Macedonia,
-1956-09-30,MT,Malta,
-1956-09-30,MX,Mexico,
-1956-09-30,MY,Malaysia,
-1956-09-30,NL,Netherlands,
-1956-09-30,NO,Norway,
-1956-09-30,NZ,New Zealand,
-1956-09-30,PE,Peru,
-1956-09-30,PH,Philippines,
-1956-09-30,PL,Poland,
-1956-09-30,PT,Portugal,
-1956-09-30,RO,Romania,
-1956-09-30,RS,Serbia,
-1956-09-30,RU,Russia,
-1956-09-30,SE,Sweden,
-1956-09-30,SG,Singapore,
-1956-09-30,SI,Slovenia,
-1956-09-30,SK,Slovak Republic,
-1956-09-30,TH,Thailand,
-1956-09-30,TR,Türkiye,
-1956-09-30,US,United States,
-1956-09-30,XM,Euro area,
-1956-09-30,XW,World,
-1956-09-30,ZA,South Africa,
-1956-12-31,4T,Emerging market economies (aggregate),
-1956-12-31,5R,Advanced economies,
-1956-12-31,AE,United Arab Emirates,
-1956-12-31,AT,Austria,
-1956-12-31,AU,Australia,
-1956-12-31,BE,Belgium,
-1956-12-31,BG,Bulgaria,
-1956-12-31,BR,Brazil,
-1956-12-31,CA,Canada,
-1956-12-31,CH,Switzerland,
-1956-12-31,CL,Chile,
-1956-12-31,CN,China,
-1956-12-31,CO,Colombia,
-1956-12-31,CY,Cyprus,
-1956-12-31,CZ,Czechia,
-1956-12-31,DE,Germany,
-1956-12-31,DK,Denmark,
-1956-12-31,EE,Estonia,
-1956-12-31,ES,Spain,
-1956-12-31,FI,Finland,
-1956-12-31,FR,France,
-1956-12-31,GB,United Kingdom,
-1956-12-31,GR,Greece,
-1956-12-31,HK,Hong Kong SAR,
-1956-12-31,HR,Croatia,
-1956-12-31,HU,Hungary,
-1956-12-31,ID,Indonesia,
-1956-12-31,IE,Ireland,
-1956-12-31,IL,Israel,
-1956-12-31,IN,India,
-1956-12-31,IS,Iceland,
-1956-12-31,IT,Italy,-0.4961
+1956-12-31,IT,Italy,1.0757
 1956-12-31,JP,Japan,21.2849
-1956-12-31,KR,Korea,
-1956-12-31,LT,Lithuania,
-1956-12-31,LU,Luxembourg,
-1956-12-31,LV,Latvia,
-1956-12-31,MA,Morocco,
-1956-12-31,MK,North Macedonia,
-1956-12-31,MT,Malta,
-1956-12-31,MX,Mexico,
-1956-12-31,MY,Malaysia,
-1956-12-31,NL,Netherlands,
-1956-12-31,NO,Norway,
-1956-12-31,NZ,New Zealand,
-1956-12-31,PE,Peru,
-1956-12-31,PH,Philippines,
-1956-12-31,PL,Poland,
-1956-12-31,PT,Portugal,
-1956-12-31,RO,Romania,
-1956-12-31,RS,Serbia,
-1956-12-31,RU,Russia,
-1956-12-31,SE,Sweden,
-1956-12-31,SG,Singapore,
-1956-12-31,SI,Slovenia,
-1956-12-31,SK,Slovak Republic,
-1956-12-31,TH,Thailand,
-1956-12-31,TR,Türkiye,
-1956-12-31,US,United States,
-1956-12-31,XM,Euro area,
-1956-12-31,XW,World,
-1956-12-31,ZA,South Africa,
-1957-03-31,4T,Emerging market economies (aggregate),
-1957-03-31,5R,Advanced economies,
-1957-03-31,AE,United Arab Emirates,
-1957-03-31,AT,Austria,
-1957-03-31,AU,Australia,
-1957-03-31,BE,Belgium,
-1957-03-31,BG,Bulgaria,
-1957-03-31,BR,Brazil,
-1957-03-31,CA,Canada,
-1957-03-31,CH,Switzerland,
-1957-03-31,CL,Chile,
-1957-03-31,CN,China,
-1957-03-31,CO,Colombia,
-1957-03-31,CY,Cyprus,
-1957-03-31,CZ,Czechia,
-1957-03-31,DE,Germany,
-1957-03-31,DK,Denmark,
-1957-03-31,EE,Estonia,
-1957-03-31,ES,Spain,
-1957-03-31,FI,Finland,
-1957-03-31,FR,France,
-1957-03-31,GB,United Kingdom,
-1957-03-31,GR,Greece,
-1957-03-31,HK,Hong Kong SAR,
-1957-03-31,HR,Croatia,
-1957-03-31,HU,Hungary,
-1957-03-31,ID,Indonesia,
-1957-03-31,IE,Ireland,
-1957-03-31,IL,Israel,
-1957-03-31,IN,India,
-1957-03-31,IS,Iceland,
-1957-03-31,IT,Italy,0.4993
+1957-03-31,IT,Italy,1.2416
 1957-03-31,JP,Japan,23.0786
-1957-03-31,KR,Korea,
-1957-03-31,LT,Lithuania,
-1957-03-31,LU,Luxembourg,
-1957-03-31,LV,Latvia,
-1957-03-31,MA,Morocco,
-1957-03-31,MK,North Macedonia,
-1957-03-31,MT,Malta,
-1957-03-31,MX,Mexico,
-1957-03-31,MY,Malaysia,
-1957-03-31,NL,Netherlands,
-1957-03-31,NO,Norway,
-1957-03-31,NZ,New Zealand,
-1957-03-31,PE,Peru,
-1957-03-31,PH,Philippines,
-1957-03-31,PL,Poland,
-1957-03-31,PT,Portugal,
-1957-03-31,RO,Romania,
-1957-03-31,RS,Serbia,
-1957-03-31,RU,Russia,
-1957-03-31,SE,Sweden,
-1957-03-31,SG,Singapore,
-1957-03-31,SI,Slovenia,
-1957-03-31,SK,Slovak Republic,
-1957-03-31,TH,Thailand,
-1957-03-31,TR,Türkiye,
-1957-03-31,US,United States,
-1957-03-31,XM,Euro area,
-1957-03-31,XW,World,
-1957-03-31,ZA,South Africa,
-1957-06-30,4T,Emerging market economies (aggregate),
-1957-06-30,5R,Advanced economies,
-1957-06-30,AE,United Arab Emirates,
-1957-06-30,AT,Austria,
-1957-06-30,AU,Australia,
-1957-06-30,BE,Belgium,
-1957-06-30,BG,Bulgaria,
-1957-06-30,BR,Brazil,
-1957-06-30,CA,Canada,
-1957-06-30,CH,Switzerland,
-1957-06-30,CL,Chile,
-1957-06-30,CN,China,
-1957-06-30,CO,Colombia,
-1957-06-30,CY,Cyprus,
-1957-06-30,CZ,Czechia,
-1957-06-30,DE,Germany,
-1957-06-30,DK,Denmark,
-1957-06-30,EE,Estonia,
-1957-06-30,ES,Spain,
-1957-06-30,FI,Finland,
-1957-06-30,FR,France,
-1957-06-30,GB,United Kingdom,
-1957-06-30,GR,Greece,
-1957-06-30,HK,Hong Kong SAR,
-1957-06-30,HR,Croatia,
-1957-06-30,HU,Hungary,
-1957-06-30,ID,Indonesia,
-1957-06-30,IE,Ireland,
-1957-06-30,IL,Israel,
-1957-06-30,IN,India,
-1957-06-30,IS,Iceland,
-1957-06-30,IT,Italy,0.1277
+1957-06-30,IT,Italy,1.2516
 1957-06-30,JP,Japan,22.5699
-1957-06-30,KR,Korea,
-1957-06-30,LT,Lithuania,
-1957-06-30,LU,Luxembourg,
-1957-06-30,LV,Latvia,
-1957-06-30,MA,Morocco,
-1957-06-30,MK,North Macedonia,
-1957-06-30,MT,Malta,
-1957-06-30,MX,Mexico,
-1957-06-30,MY,Malaysia,
-1957-06-30,NL,Netherlands,
-1957-06-30,NO,Norway,
-1957-06-30,NZ,New Zealand,
-1957-06-30,PE,Peru,
-1957-06-30,PH,Philippines,
-1957-06-30,PL,Poland,
-1957-06-30,PT,Portugal,
-1957-06-30,RO,Romania,
-1957-06-30,RS,Serbia,
-1957-06-30,RU,Russia,
-1957-06-30,SE,Sweden,
-1957-06-30,SG,Singapore,
-1957-06-30,SI,Slovenia,
-1957-06-30,SK,Slovak Republic,
-1957-06-30,TH,Thailand,
-1957-06-30,TR,Türkiye,
-1957-06-30,US,United States,
-1957-06-30,XM,Euro area,
-1957-06-30,XW,World,
-1957-06-30,ZA,South Africa,
-1957-09-30,4T,Emerging market economies (aggregate),
-1957-09-30,5R,Advanced economies,
-1957-09-30,AE,United Arab Emirates,
-1957-09-30,AT,Austria,
-1957-09-30,AU,Australia,
-1957-09-30,BE,Belgium,
-1957-09-30,BG,Bulgaria,
-1957-09-30,BR,Brazil,
-1957-09-30,CA,Canada,
-1957-09-30,CH,Switzerland,
-1957-09-30,CL,Chile,
-1957-09-30,CN,China,
-1957-09-30,CO,Colombia,
-1957-09-30,CY,Cyprus,
-1957-09-30,CZ,Czechia,
-1957-09-30,DE,Germany,
-1957-09-30,DK,Denmark,
-1957-09-30,EE,Estonia,
-1957-09-30,ES,Spain,
-1957-09-30,FI,Finland,
-1957-09-30,FR,France,
-1957-09-30,GB,United Kingdom,
-1957-09-30,GR,Greece,
-1957-09-30,HK,Hong Kong SAR,
-1957-09-30,HR,Croatia,
-1957-09-30,HU,Hungary,
-1957-09-30,ID,Indonesia,
-1957-09-30,IE,Ireland,
-1957-09-30,IL,Israel,
-1957-09-30,IN,India,
-1957-09-30,IS,Iceland,
-1957-09-30,IT,Italy,1.6697
+1957-09-30,IT,Italy,1.9334
 1957-09-30,JP,Japan,20.3829
-1957-09-30,KR,Korea,
-1957-09-30,LT,Lithuania,
-1957-09-30,LU,Luxembourg,
-1957-09-30,LV,Latvia,
-1957-09-30,MA,Morocco,
-1957-09-30,MK,North Macedonia,
-1957-09-30,MT,Malta,
-1957-09-30,MX,Mexico,
-1957-09-30,MY,Malaysia,
-1957-09-30,NL,Netherlands,
-1957-09-30,NO,Norway,
-1957-09-30,NZ,New Zealand,
-1957-09-30,PE,Peru,
-1957-09-30,PH,Philippines,
-1957-09-30,PL,Poland,
-1957-09-30,PT,Portugal,
-1957-09-30,RO,Romania,
-1957-09-30,RS,Serbia,
-1957-09-30,RU,Russia,
-1957-09-30,SE,Sweden,
-1957-09-30,SG,Singapore,
-1957-09-30,SI,Slovenia,
-1957-09-30,SK,Slovak Republic,
-1957-09-30,TH,Thailand,
-1957-09-30,TR,Türkiye,
-1957-09-30,US,United States,
-1957-09-30,XM,Euro area,
-1957-09-30,XW,World,
-1957-09-30,ZA,South Africa,
-1957-12-31,4T,Emerging market economies (aggregate),
-1957-12-31,5R,Advanced economies,
-1957-12-31,AE,United Arab Emirates,
-1957-12-31,AT,Austria,
-1957-12-31,AU,Australia,
-1957-12-31,BE,Belgium,
-1957-12-31,BG,Bulgaria,
-1957-12-31,BR,Brazil,
-1957-12-31,CA,Canada,
-1957-12-31,CH,Switzerland,
-1957-12-31,CL,Chile,
-1957-12-31,CN,China,
-1957-12-31,CO,Colombia,
-1957-12-31,CY,Cyprus,
-1957-12-31,CZ,Czechia,
-1957-12-31,DE,Germany,
-1957-12-31,DK,Denmark,
-1957-12-31,EE,Estonia,
-1957-12-31,ES,Spain,
-1957-12-31,FI,Finland,
-1957-12-31,FR,France,
-1957-12-31,GB,United Kingdom,
-1957-12-31,GR,Greece,
-1957-12-31,HK,Hong Kong SAR,
-1957-12-31,HR,Croatia,
-1957-12-31,HU,Hungary,
-1957-12-31,ID,Indonesia,
-1957-12-31,IE,Ireland,
-1957-12-31,IL,Israel,
-1957-12-31,IN,India,
-1957-12-31,IS,Iceland,
-1957-12-31,IT,Italy,0.255
+1957-12-31,IT,Italy,0.7047
 1957-12-31,JP,Japan,21.139
-1957-12-31,KR,Korea,
-1957-12-31,LT,Lithuania,
-1957-12-31,LU,Luxembourg,
-1957-12-31,LV,Latvia,
-1957-12-31,MA,Morocco,
-1957-12-31,MK,North Macedonia,
-1957-12-31,MT,Malta,
-1957-12-31,MX,Mexico,
-1957-12-31,MY,Malaysia,
-1957-12-31,NL,Netherlands,
-1957-12-31,NO,Norway,
-1957-12-31,NZ,New Zealand,
-1957-12-31,PE,Peru,
-1957-12-31,PH,Philippines,
-1957-12-31,PL,Poland,
-1957-12-31,PT,Portugal,
-1957-12-31,RO,Romania,
-1957-12-31,RS,Serbia,
-1957-12-31,RU,Russia,
-1957-12-31,SE,Sweden,
-1957-12-31,SG,Singapore,
-1957-12-31,SI,Slovenia,
-1957-12-31,SK,Slovak Republic,
-1957-12-31,TH,Thailand,
-1957-12-31,TR,Türkiye,
-1957-12-31,US,United States,
-1957-12-31,XM,Euro area,
-1957-12-31,XW,World,
-1957-12-31,ZA,South Africa,
-1958-03-31,4T,Emerging market economies (aggregate),
-1958-03-31,5R,Advanced economies,
-1958-03-31,AE,United Arab Emirates,
-1958-03-31,AT,Austria,
-1958-03-31,AU,Australia,
-1958-03-31,BE,Belgium,
-1958-03-31,BG,Bulgaria,
-1958-03-31,BR,Brazil,
-1958-03-31,CA,Canada,
-1958-03-31,CH,Switzerland,
-1958-03-31,CL,Chile,
-1958-03-31,CN,China,
-1958-03-31,CO,Colombia,
-1958-03-31,CY,Cyprus,
-1958-03-31,CZ,Czechia,
-1958-03-31,DE,Germany,
-1958-03-31,DK,Denmark,
-1958-03-31,EE,Estonia,
-1958-03-31,ES,Spain,
-1958-03-31,FI,Finland,
-1958-03-31,FR,France,
-1958-03-31,GB,United Kingdom,
-1958-03-31,GR,Greece,
-1958-03-31,HK,Hong Kong SAR,
-1958-03-31,HR,Croatia,
-1958-03-31,HU,Hungary,
-1958-03-31,ID,Indonesia,
-1958-03-31,IE,Ireland,
-1958-03-31,IL,Israel,
-1958-03-31,IN,India,
-1958-03-31,IS,Iceland,
-1958-03-31,IT,Italy,-3.4784
+1958-03-31,IT,Italy,-1.9725
 1958-03-31,JP,Japan,22.9607
-1958-03-31,KR,Korea,
-1958-03-31,LT,Lithuania,
-1958-03-31,LU,Luxembourg,
-1958-03-31,LV,Latvia,
-1958-03-31,MA,Morocco,
-1958-03-31,MK,North Macedonia,
-1958-03-31,MT,Malta,
-1958-03-31,MX,Mexico,
-1958-03-31,MY,Malaysia,
-1958-03-31,NL,Netherlands,
-1958-03-31,NO,Norway,
-1958-03-31,NZ,New Zealand,
-1958-03-31,PE,Peru,
-1958-03-31,PH,Philippines,
-1958-03-31,PL,Poland,
-1958-03-31,PT,Portugal,
-1958-03-31,RO,Romania,
-1958-03-31,RS,Serbia,
-1958-03-31,RU,Russia,
-1958-03-31,SE,Sweden,
-1958-03-31,SG,Singapore,
-1958-03-31,SI,Slovenia,
-1958-03-31,SK,Slovak Republic,
-1958-03-31,TH,Thailand,
-1958-03-31,TR,Türkiye,
-1958-03-31,US,United States,
-1958-03-31,XM,Euro area,
-1958-03-31,XW,World,
-1958-03-31,ZA,South Africa,
-1958-06-30,4T,Emerging market economies (aggregate),
-1958-06-30,5R,Advanced economies,
-1958-06-30,AE,United Arab Emirates,
-1958-06-30,AT,Austria,
-1958-06-30,AU,Australia,
-1958-06-30,BE,Belgium,
-1958-06-30,BG,Bulgaria,
-1958-06-30,BR,Brazil,
-1958-06-30,CA,Canada,
-1958-06-30,CH,Switzerland,
-1958-06-30,CL,Chile,
-1958-06-30,CN,China,
-1958-06-30,CO,Colombia,
-1958-06-30,CY,Cyprus,
-1958-06-30,CZ,Czechia,
-1958-06-30,DE,Germany,
-1958-06-30,DK,Denmark,
-1958-06-30,EE,Estonia,
-1958-06-30,ES,Spain,
-1958-06-30,FI,Finland,
-1958-06-30,FR,France,
-1958-06-30,GB,United Kingdom,
-1958-06-30,GR,Greece,
-1958-06-30,HK,Hong Kong SAR,
-1958-06-30,HR,Croatia,
-1958-06-30,HU,Hungary,
-1958-06-30,ID,Indonesia,
-1958-06-30,IE,Ireland,
-1958-06-30,IL,Israel,
-1958-06-30,IN,India,
-1958-06-30,IS,Iceland,
-1958-06-30,IT,Italy,-3.2379
+1958-06-30,IT,Italy,-1.7354
 1958-06-30,JP,Japan,24.7206
-1958-06-30,KR,Korea,
-1958-06-30,LT,Lithuania,
-1958-06-30,LU,Luxembourg,
-1958-06-30,LV,Latvia,
-1958-06-30,MA,Morocco,
-1958-06-30,MK,North Macedonia,
-1958-06-30,MT,Malta,
-1958-06-30,MX,Mexico,
-1958-06-30,MY,Malaysia,
-1958-06-30,NL,Netherlands,
-1958-06-30,NO,Norway,
-1958-06-30,NZ,New Zealand,
-1958-06-30,PE,Peru,
-1958-06-30,PH,Philippines,
-1958-06-30,PL,Poland,
-1958-06-30,PT,Portugal,
-1958-06-30,RO,Romania,
-1958-06-30,RS,Serbia,
-1958-06-30,RU,Russia,
-1958-06-30,SE,Sweden,
-1958-06-30,SG,Singapore,
-1958-06-30,SI,Slovenia,
-1958-06-30,SK,Slovak Republic,
-1958-06-30,TH,Thailand,
-1958-06-30,TR,Türkiye,
-1958-06-30,US,United States,
-1958-06-30,XM,Euro area,
-1958-06-30,XW,World,
-1958-06-30,ZA,South Africa,
-1958-09-30,4T,Emerging market economies (aggregate),
-1958-09-30,5R,Advanced economies,
-1958-09-30,AE,United Arab Emirates,
-1958-09-30,AT,Austria,
-1958-09-30,AU,Australia,
-1958-09-30,BE,Belgium,
-1958-09-30,BG,Bulgaria,
-1958-09-30,BR,Brazil,
-1958-09-30,CA,Canada,
-1958-09-30,CH,Switzerland,
-1958-09-30,CL,Chile,
-1958-09-30,CN,China,
-1958-09-30,CO,Colombia,
-1958-09-30,CY,Cyprus,
-1958-09-30,CZ,Czechia,
-1958-09-30,DE,Germany,
-1958-09-30,DK,Denmark,
-1958-09-30,EE,Estonia,
-1958-09-30,ES,Spain,
-1958-09-30,FI,Finland,
-1958-09-30,FR,France,
-1958-09-30,GB,United Kingdom,
-1958-09-30,GR,Greece,
-1958-09-30,HK,Hong Kong SAR,
-1958-09-30,HR,Croatia,
-1958-09-30,HU,Hungary,
-1958-09-30,ID,Indonesia,
-1958-09-30,IE,Ireland,
-1958-09-30,IL,Israel,
-1958-09-30,IN,India,
-1958-09-30,IS,Iceland,
-1958-09-30,IT,Italy,-4.3848
+1958-09-30,IT,Italy,-2.4357
 1958-09-30,JP,Japan,26.1787
-1958-09-30,KR,Korea,
-1958-09-30,LT,Lithuania,
-1958-09-30,LU,Luxembourg,
-1958-09-30,LV,Latvia,
-1958-09-30,MA,Morocco,
-1958-09-30,MK,North Macedonia,
-1958-09-30,MT,Malta,
-1958-09-30,MX,Mexico,
-1958-09-30,MY,Malaysia,
-1958-09-30,NL,Netherlands,
-1958-09-30,NO,Norway,
-1958-09-30,NZ,New Zealand,
-1958-09-30,PE,Peru,
-1958-09-30,PH,Philippines,
-1958-09-30,PL,Poland,
-1958-09-30,PT,Portugal,
-1958-09-30,RO,Romania,
-1958-09-30,RS,Serbia,
-1958-09-30,RU,Russia,
-1958-09-30,SE,Sweden,
-1958-09-30,SG,Singapore,
-1958-09-30,SI,Slovenia,
-1958-09-30,SK,Slovak Republic,
-1958-09-30,TH,Thailand,
-1958-09-30,TR,Türkiye,
-1958-09-30,US,United States,
-1958-09-30,XM,Euro area,
-1958-09-30,XW,World,
-1958-09-30,ZA,South Africa,
-1958-12-31,4T,Emerging market economies (aggregate),
-1958-12-31,5R,Advanced economies,
-1958-12-31,AE,United Arab Emirates,
-1958-12-31,AT,Austria,
-1958-12-31,AU,Australia,
-1958-12-31,BE,Belgium,
-1958-12-31,BG,Bulgaria,
-1958-12-31,BR,Brazil,
-1958-12-31,CA,Canada,
-1958-12-31,CH,Switzerland,
-1958-12-31,CL,Chile,
-1958-12-31,CN,China,
-1958-12-31,CO,Colombia,
-1958-12-31,CY,Cyprus,
-1958-12-31,CZ,Czechia,
-1958-12-31,DE,Germany,
-1958-12-31,DK,Denmark,
-1958-12-31,EE,Estonia,
-1958-12-31,ES,Spain,
-1958-12-31,FI,Finland,
-1958-12-31,FR,France,
-1958-12-31,GB,United Kingdom,
-1958-12-31,GR,Greece,
-1958-12-31,HK,Hong Kong SAR,
-1958-12-31,HR,Croatia,
-1958-12-31,HU,Hungary,
-1958-12-31,ID,Indonesia,
-1958-12-31,IE,Ireland,
-1958-12-31,IL,Israel,
-1958-12-31,IN,India,
-1958-12-31,IS,Iceland,
-1958-12-31,IT,Italy,-4.9378
+1958-12-31,IT,Italy,-2.9187
 1958-12-31,JP,Japan,23.9657
-1958-12-31,KR,Korea,
-1958-12-31,LT,Lithuania,
-1958-12-31,LU,Luxembourg,
-1958-12-31,LV,Latvia,
-1958-12-31,MA,Morocco,
-1958-12-31,MK,North Macedonia,
-1958-12-31,MT,Malta,
-1958-12-31,MX,Mexico,
-1958-12-31,MY,Malaysia,
-1958-12-31,NL,Netherlands,
-1958-12-31,NO,Norway,
-1958-12-31,NZ,New Zealand,
-1958-12-31,PE,Peru,
-1958-12-31,PH,Philippines,
-1958-12-31,PL,Poland,
-1958-12-31,PT,Portugal,
-1958-12-31,RO,Romania,
-1958-12-31,RS,Serbia,
-1958-12-31,RU,Russia,
-1958-12-31,SE,Sweden,
-1958-12-31,SG,Singapore,
-1958-12-31,SI,Slovenia,
-1958-12-31,SK,Slovak Republic,
-1958-12-31,TH,Thailand,
-1958-12-31,TR,Türkiye,
-1958-12-31,US,United States,
-1958-12-31,XM,Euro area,
-1958-12-31,XW,World,
-1958-12-31,ZA,South Africa,
-1959-03-31,4T,Emerging market economies (aggregate),
-1959-03-31,5R,Advanced economies,
-1959-03-31,AE,United Arab Emirates,
-1959-03-31,AT,Austria,
-1959-03-31,AU,Australia,
-1959-03-31,BE,Belgium,
-1959-03-31,BG,Bulgaria,
-1959-03-31,BR,Brazil,
-1959-03-31,CA,Canada,
-1959-03-31,CH,Switzerland,
-1959-03-31,CL,Chile,
-1959-03-31,CN,China,
-1959-03-31,CO,Colombia,
-1959-03-31,CY,Cyprus,
-1959-03-31,CZ,Czechia,
-1959-03-31,DE,Germany,
-1959-03-31,DK,Denmark,
-1959-03-31,EE,Estonia,
-1959-03-31,ES,Spain,
-1959-03-31,FI,Finland,
-1959-03-31,FR,France,
-1959-03-31,GB,United Kingdom,
-1959-03-31,GR,Greece,
-1959-03-31,HK,Hong Kong SAR,
-1959-03-31,HR,Croatia,
-1959-03-31,HU,Hungary,
-1959-03-31,ID,Indonesia,
-1959-03-31,IE,Ireland,
-1959-03-31,IL,Israel,
-1959-03-31,IN,India,
-1959-03-31,IS,Iceland,
-1959-03-31,IT,Italy,-2.4053
+1959-03-31,IT,Italy,-1.5634
 1959-03-31,JP,Japan,22.9274
-1959-03-31,KR,Korea,
-1959-03-31,LT,Lithuania,
-1959-03-31,LU,Luxembourg,
-1959-03-31,LV,Latvia,
-1959-03-31,MA,Morocco,
-1959-03-31,MK,North Macedonia,
-1959-03-31,MT,Malta,
-1959-03-31,MX,Mexico,
-1959-03-31,MY,Malaysia,
-1959-03-31,NL,Netherlands,
-1959-03-31,NO,Norway,
-1959-03-31,NZ,New Zealand,
-1959-03-31,PE,Peru,
-1959-03-31,PH,Philippines,
-1959-03-31,PL,Poland,
-1959-03-31,PT,Portugal,
-1959-03-31,RO,Romania,
-1959-03-31,RS,Serbia,
-1959-03-31,RU,Russia,
-1959-03-31,SE,Sweden,
-1959-03-31,SG,Singapore,
-1959-03-31,SI,Slovenia,
-1959-03-31,SK,Slovak Republic,
-1959-03-31,TH,Thailand,
-1959-03-31,TR,Türkiye,
-1959-03-31,US,United States,
-1959-03-31,XM,Euro area,
-1959-03-31,XW,World,
-1959-03-31,ZA,South Africa,
-1959-06-30,4T,Emerging market economies (aggregate),
-1959-06-30,5R,Advanced economies,
-1959-06-30,AE,United Arab Emirates,
-1959-06-30,AT,Austria,
-1959-06-30,AU,Australia,
-1959-06-30,BE,Belgium,
-1959-06-30,BG,Bulgaria,
-1959-06-30,BR,Brazil,
-1959-06-30,CA,Canada,
-1959-06-30,CH,Switzerland,
-1959-06-30,CL,Chile,
-1959-06-30,CN,China,
-1959-06-30,CO,Colombia,
-1959-06-30,CY,Cyprus,
-1959-06-30,CZ,Czechia,
-1959-06-30,DE,Germany,
-1959-06-30,DK,Denmark,
-1959-06-30,EE,Estonia,
-1959-06-30,ES,Spain,
-1959-06-30,FI,Finland,
-1959-06-30,FR,France,
-1959-06-30,GB,United Kingdom,
-1959-06-30,GR,Greece,
-1959-06-30,HK,Hong Kong SAR,
-1959-06-30,HR,Croatia,
-1959-06-30,HU,Hungary,
-1959-06-30,ID,Indonesia,
-1959-06-30,IE,Ireland,
-1959-06-30,IL,Israel,
-1959-06-30,IN,India,
-1959-06-30,IS,Iceland,
-1959-06-30,IT,Italy,-1.2121
+1959-06-30,IT,Italy,-0.5715
 1959-06-30,JP,Japan,22.6297
-1959-06-30,KR,Korea,
-1959-06-30,LT,Lithuania,
-1959-06-30,LU,Luxembourg,
-1959-06-30,LV,Latvia,
-1959-06-30,MA,Morocco,
-1959-06-30,MK,North Macedonia,
-1959-06-30,MT,Malta,
-1959-06-30,MX,Mexico,
-1959-06-30,MY,Malaysia,
-1959-06-30,NL,Netherlands,
-1959-06-30,NO,Norway,
-1959-06-30,NZ,New Zealand,
-1959-06-30,PE,Peru,
-1959-06-30,PH,Philippines,
-1959-06-30,PL,Poland,
-1959-06-30,PT,Portugal,
-1959-06-30,RO,Romania,
-1959-06-30,RS,Serbia,
-1959-06-30,RU,Russia,
-1959-06-30,SE,Sweden,
-1959-06-30,SG,Singapore,
-1959-06-30,SI,Slovenia,
-1959-06-30,SK,Slovak Republic,
-1959-06-30,TH,Thailand,
-1959-06-30,TR,Türkiye,
-1959-06-30,US,United States,
-1959-06-30,XM,Euro area,
-1959-06-30,XW,World,
-1959-06-30,ZA,South Africa,
-1959-09-30,4T,Emerging market economies (aggregate),
-1959-09-30,5R,Advanced economies,
-1959-09-30,AE,United Arab Emirates,
-1959-09-30,AT,Austria,
-1959-09-30,AU,Australia,
-1959-09-30,BE,Belgium,
-1959-09-30,BG,Bulgaria,
-1959-09-30,BR,Brazil,
-1959-09-30,CA,Canada,
-1959-09-30,CH,Switzerland,
-1959-09-30,CL,Chile,
-1959-09-30,CN,China,
-1959-09-30,CO,Colombia,
-1959-09-30,CY,Cyprus,
-1959-09-30,CZ,Czechia,
-1959-09-30,DE,Germany,
-1959-09-30,DK,Denmark,
-1959-09-30,EE,Estonia,
-1959-09-30,ES,Spain,
-1959-09-30,FI,Finland,
-1959-09-30,FR,France,
-1959-09-30,GB,United Kingdom,
-1959-09-30,GR,Greece,
-1959-09-30,HK,Hong Kong SAR,
-1959-09-30,HR,Croatia,
-1959-09-30,HU,Hungary,
-1959-09-30,ID,Indonesia,
-1959-09-30,IE,Ireland,
-1959-09-30,IL,Israel,
-1959-09-30,IN,India,
-1959-09-30,IS,Iceland,
-1959-09-30,IT,Italy,0.3548
+1959-09-30,IT,Italy,0.3069
 1959-09-30,JP,Japan,22.3471
-1959-09-30,KR,Korea,
-1959-09-30,LT,Lithuania,
-1959-09-30,LU,Luxembourg,
-1959-09-30,LV,Latvia,
-1959-09-30,MA,Morocco,
-1959-09-30,MK,North Macedonia,
-1959-09-30,MT,Malta,
-1959-09-30,MX,Mexico,
-1959-09-30,MY,Malaysia,
-1959-09-30,NL,Netherlands,
-1959-09-30,NO,Norway,
-1959-09-30,NZ,New Zealand,
-1959-09-30,PE,Peru,
-1959-09-30,PH,Philippines,
-1959-09-30,PL,Poland,
-1959-09-30,PT,Portugal,
-1959-09-30,RO,Romania,
-1959-09-30,RS,Serbia,
-1959-09-30,RU,Russia,
-1959-09-30,SE,Sweden,
-1959-09-30,SG,Singapore,
-1959-09-30,SI,Slovenia,
-1959-09-30,SK,Slovak Republic,
-1959-09-30,TH,Thailand,
-1959-09-30,TR,Türkiye,
-1959-09-30,US,United States,
-1959-09-30,XM,Euro area,
-1959-09-30,XW,World,
-1959-09-30,ZA,South Africa,
-1959-12-31,4T,Emerging market economies (aggregate),
-1959-12-31,5R,Advanced economies,
-1959-12-31,AE,United Arab Emirates,
-1959-12-31,AT,Austria,
-1959-12-31,AU,Australia,
-1959-12-31,BE,Belgium,
-1959-12-31,BG,Bulgaria,
-1959-12-31,BR,Brazil,
-1959-12-31,CA,Canada,
-1959-12-31,CH,Switzerland,
-1959-12-31,CL,Chile,
-1959-12-31,CN,China,
-1959-12-31,CO,Colombia,
-1959-12-31,CY,Cyprus,
-1959-12-31,CZ,Czechia,
-1959-12-31,DE,Germany,
-1959-12-31,DK,Denmark,
-1959-12-31,EE,Estonia,
-1959-12-31,ES,Spain,
-1959-12-31,FI,Finland,
-1959-12-31,FR,France,
-1959-12-31,GB,United Kingdom,
-1959-12-31,GR,Greece,
-1959-12-31,HK,Hong Kong SAR,
-1959-12-31,HR,Croatia,
-1959-12-31,HU,Hungary,
-1959-12-31,ID,Indonesia,
-1959-12-31,IE,Ireland,
-1959-12-31,IL,Israel,
-1959-12-31,IN,India,
-1959-12-31,IS,Iceland,
-1959-12-31,IT,Italy,3.3995
+1959-12-31,IT,Italy,2.4491
 1959-12-31,JP,Japan,21.3476
-1959-12-31,KR,Korea,
-1959-12-31,LT,Lithuania,
-1959-12-31,LU,Luxembourg,
-1959-12-31,LV,Latvia,
-1959-12-31,MA,Morocco,
-1959-12-31,MK,North Macedonia,
-1959-12-31,MT,Malta,
-1959-12-31,MX,Mexico,
-1959-12-31,MY,Malaysia,
-1959-12-31,NL,Netherlands,
-1959-12-31,NO,Norway,
-1959-12-31,NZ,New Zealand,
-1959-12-31,PE,Peru,
-1959-12-31,PH,Philippines,
-1959-12-31,PL,Poland,
-1959-12-31,PT,Portugal,
-1959-12-31,RO,Romania,
-1959-12-31,RS,Serbia,
-1959-12-31,RU,Russia,
-1959-12-31,SE,Sweden,
-1959-12-31,SG,Singapore,
-1959-12-31,SI,Slovenia,
-1959-12-31,SK,Slovak Republic,
-1959-12-31,TH,Thailand,
-1959-12-31,TR,Türkiye,
-1959-12-31,US,United States,
-1959-12-31,XM,Euro area,
-1959-12-31,XW,World,
-1959-12-31,ZA,South Africa,
-1960-03-31,4T,Emerging market economies (aggregate),
-1960-03-31,5R,Advanced economies,
-1960-03-31,AE,United Arab Emirates,
-1960-03-31,AT,Austria,
-1960-03-31,AU,Australia,
-1960-03-31,BE,Belgium,
-1960-03-31,BG,Bulgaria,
-1960-03-31,BR,Brazil,
-1960-03-31,CA,Canada,
-1960-03-31,CH,Switzerland,
-1960-03-31,CL,Chile,
-1960-03-31,CN,China,
-1960-03-31,CO,Colombia,
-1960-03-31,CY,Cyprus,
-1960-03-31,CZ,Czechia,
-1960-03-31,DE,Germany,
-1960-03-31,DK,Denmark,
-1960-03-31,EE,Estonia,
-1960-03-31,ES,Spain,
-1960-03-31,FI,Finland,
-1960-03-31,FR,France,
-1960-03-31,GB,United Kingdom,
-1960-03-31,GR,Greece,
-1960-03-31,HK,Hong Kong SAR,
-1960-03-31,HR,Croatia,
-1960-03-31,HU,Hungary,
-1960-03-31,ID,Indonesia,
-1960-03-31,IE,Ireland,
-1960-03-31,IL,Israel,
-1960-03-31,IN,India,
-1960-03-31,IS,Iceland,
-1960-03-31,IT,Italy,2.6295
+1960-03-31,IT,Italy,2.4555
 1960-03-31,JP,Japan,18.6767
-1960-03-31,KR,Korea,
-1960-03-31,LT,Lithuania,
-1960-03-31,LU,Luxembourg,
-1960-03-31,LV,Latvia,
-1960-03-31,MA,Morocco,
-1960-03-31,MK,North Macedonia,
-1960-03-31,MT,Malta,
-1960-03-31,MX,Mexico,
-1960-03-31,MY,Malaysia,
-1960-03-31,NL,Netherlands,
-1960-03-31,NO,Norway,
-1960-03-31,NZ,New Zealand,
-1960-03-31,PE,Peru,
-1960-03-31,PH,Philippines,
-1960-03-31,PL,Poland,
-1960-03-31,PT,Portugal,
-1960-03-31,RO,Romania,
-1960-03-31,RS,Serbia,
-1960-03-31,RU,Russia,
-1960-03-31,SE,Sweden,
-1960-03-31,SG,Singapore,
-1960-03-31,SI,Slovenia,
-1960-03-31,SK,Slovak Republic,
-1960-03-31,TH,Thailand,
-1960-03-31,TR,Türkiye,
-1960-03-31,US,United States,
-1960-03-31,XM,Euro area,
-1960-03-31,XW,World,
-1960-03-31,ZA,South Africa,
-1960-06-30,4T,Emerging market economies (aggregate),
-1960-06-30,5R,Advanced economies,
-1960-06-30,AE,United Arab Emirates,
-1960-06-30,AT,Austria,
-1960-06-30,AU,Australia,
-1960-06-30,BE,Belgium,
-1960-06-30,BG,Bulgaria,
-1960-06-30,BR,Brazil,
-1960-06-30,CA,Canada,
-1960-06-30,CH,Switzerland,
-1960-06-30,CL,Chile,
-1960-06-30,CN,China,
-1960-06-30,CO,Colombia,
-1960-06-30,CY,Cyprus,
-1960-06-30,CZ,Czechia,
-1960-06-30,DE,Germany,
-1960-06-30,DK,Denmark,
-1960-06-30,EE,Estonia,
-1960-06-30,ES,Spain,
-1960-06-30,FI,Finland,
-1960-06-30,FR,France,
-1960-06-30,GB,United Kingdom,
-1960-06-30,GR,Greece,
-1960-06-30,HK,Hong Kong SAR,
-1960-06-30,HR,Croatia,
-1960-06-30,HU,Hungary,
-1960-06-30,ID,Indonesia,
-1960-06-30,IE,Ireland,
-1960-06-30,IL,Israel,
-1960-06-30,IN,India,
-1960-06-30,IS,Iceland,
-1960-06-30,IT,Italy,0.0379
+1960-06-30,IT,Italy,-0.2598
 1960-06-30,JP,Japan,20.0495
-1960-06-30,KR,Korea,
-1960-06-30,LT,Lithuania,
-1960-06-30,LU,Luxembourg,
-1960-06-30,LV,Latvia,
-1960-06-30,MA,Morocco,
-1960-06-30,MK,North Macedonia,
-1960-06-30,MT,Malta,
-1960-06-30,MX,Mexico,
-1960-06-30,MY,Malaysia,
-1960-06-30,NL,Netherlands,
-1960-06-30,NO,Norway,
-1960-06-30,NZ,New Zealand,
-1960-06-30,PE,Peru,
-1960-06-30,PH,Philippines,
-1960-06-30,PL,Poland,
-1960-06-30,PT,Portugal,
-1960-06-30,RO,Romania,
-1960-06-30,RS,Serbia,
-1960-06-30,RU,Russia,
-1960-06-30,SE,Sweden,
-1960-06-30,SG,Singapore,
-1960-06-30,SI,Slovenia,
-1960-06-30,SK,Slovak Republic,
-1960-06-30,TH,Thailand,
-1960-06-30,TR,Türkiye,
-1960-06-30,US,United States,
-1960-06-30,XM,Euro area,
-1960-06-30,XW,World,
-1960-06-30,ZA,South Africa,
-1960-09-30,4T,Emerging market economies (aggregate),
-1960-09-30,5R,Advanced economies,
-1960-09-30,AE,United Arab Emirates,
-1960-09-30,AT,Austria,
-1960-09-30,AU,Australia,
-1960-09-30,BE,Belgium,
-1960-09-30,BG,Bulgaria,
-1960-09-30,BR,Brazil,
-1960-09-30,CA,Canada,
-1960-09-30,CH,Switzerland,
-1960-09-30,CL,Chile,
-1960-09-30,CN,China,
-1960-09-30,CO,Colombia,
-1960-09-30,CY,Cyprus,
-1960-09-30,CZ,Czechia,
-1960-09-30,DE,Germany,
-1960-09-30,DK,Denmark,
-1960-09-30,EE,Estonia,
-1960-09-30,ES,Spain,
-1960-09-30,FI,Finland,
-1960-09-30,FR,France,
-1960-09-30,GB,United Kingdom,
-1960-09-30,GR,Greece,
-1960-09-30,HK,Hong Kong SAR,
-1960-09-30,HR,Croatia,
-1960-09-30,HU,Hungary,
-1960-09-30,ID,Indonesia,
-1960-09-30,IE,Ireland,
-1960-09-30,IL,Israel,
-1960-09-30,IN,India,
-1960-09-30,IS,Iceland,
-1960-09-30,IT,Italy,-0.3234
+1960-09-30,IT,Italy,0.1615
 1960-09-30,JP,Japan,22.0213
-1960-09-30,KR,Korea,
-1960-09-30,LT,Lithuania,
-1960-09-30,LU,Luxembourg,
-1960-09-30,LV,Latvia,
-1960-09-30,MA,Morocco,
-1960-09-30,MK,North Macedonia,
-1960-09-30,MT,Malta,
-1960-09-30,MX,Mexico,
-1960-09-30,MY,Malaysia,
-1960-09-30,NL,Netherlands,
-1960-09-30,NO,Norway,
-1960-09-30,NZ,New Zealand,
-1960-09-30,PE,Peru,
-1960-09-30,PH,Philippines,
-1960-09-30,PL,Poland,
-1960-09-30,PT,Portugal,
-1960-09-30,RO,Romania,
-1960-09-30,RS,Serbia,
-1960-09-30,RU,Russia,
-1960-09-30,SE,Sweden,
-1960-09-30,SG,Singapore,
-1960-09-30,SI,Slovenia,
-1960-09-30,SK,Slovak Republic,
-1960-09-30,TH,Thailand,
-1960-09-30,TR,Türkiye,
-1960-09-30,US,United States,
-1960-09-30,XM,Euro area,
-1960-09-30,XW,World,
-1960-09-30,ZA,South Africa,
-1960-12-31,4T,Emerging market economies (aggregate),
-1960-12-31,5R,Advanced economies,
-1960-12-31,AE,United Arab Emirates,
-1960-12-31,AT,Austria,
-1960-12-31,AU,Australia,
-1960-12-31,BE,Belgium,
-1960-12-31,BG,Bulgaria,
-1960-12-31,BR,Brazil,
-1960-12-31,CA,Canada,
-1960-12-31,CH,Switzerland,
-1960-12-31,CL,Chile,
-1960-12-31,CN,China,
-1960-12-31,CO,Colombia,
-1960-12-31,CY,Cyprus,
-1960-12-31,CZ,Czechia,
-1960-12-31,DE,Germany,
-1960-12-31,DK,Denmark,
-1960-12-31,EE,Estonia,
-1960-12-31,ES,Spain,
-1960-12-31,FI,Finland,
-1960-12-31,FR,France,
-1960-12-31,GB,United Kingdom,
-1960-12-31,GR,Greece,
-1960-12-31,HK,Hong Kong SAR,
-1960-12-31,HR,Croatia,
-1960-12-31,HU,Hungary,
-1960-12-31,ID,Indonesia,
-1960-12-31,IE,Ireland,
-1960-12-31,IL,Israel,
-1960-12-31,IN,India,
-1960-12-31,IS,Iceland,
-1960-12-31,IT,Italy,-1.5874
+1960-12-31,IT,Italy,-0.6241
 1960-12-31,JP,Japan,27.9974
-1960-12-31,KR,Korea,
-1960-12-31,LT,Lithuania,
-1960-12-31,LU,Luxembourg,
-1960-12-31,LV,Latvia,
-1960-12-31,MA,Morocco,
-1960-12-31,MK,North Macedonia,
-1960-12-31,MT,Malta,
-1960-12-31,MX,Mexico,
-1960-12-31,MY,Malaysia,
-1960-12-31,NL,Netherlands,
-1960-12-31,NO,Norway,
-1960-12-31,NZ,New Zealand,
-1960-12-31,PE,Peru,
-1960-12-31,PH,Philippines,
-1960-12-31,PL,Poland,
-1960-12-31,PT,Portugal,
-1960-12-31,RO,Romania,
-1960-12-31,RS,Serbia,
-1960-12-31,RU,Russia,
-1960-12-31,SE,Sweden,
-1960-12-31,SG,Singapore,
-1960-12-31,SI,Slovenia,
-1960-12-31,SK,Slovak Republic,
-1960-12-31,TH,Thailand,
-1960-12-31,TR,Türkiye,
-1960-12-31,US,United States,
-1960-12-31,XM,Euro area,
-1960-12-31,XW,World,
-1960-12-31,ZA,South Africa,
-1961-03-31,4T,Emerging market economies (aggregate),
-1961-03-31,5R,Advanced economies,
-1961-03-31,AE,United Arab Emirates,
-1961-03-31,AT,Austria,
-1961-03-31,AU,Australia,
-1961-03-31,BE,Belgium,
-1961-03-31,BG,Bulgaria,
-1961-03-31,BR,Brazil,
-1961-03-31,CA,Canada,
-1961-03-31,CH,Switzerland,
-1961-03-31,CL,Chile,
-1961-03-31,CN,China,
-1961-03-31,CO,Colombia,
-1961-03-31,CY,Cyprus,
-1961-03-31,CZ,Czechia,
-1961-03-31,DE,Germany,
-1961-03-31,DK,Denmark,
-1961-03-31,EE,Estonia,
-1961-03-31,ES,Spain,
-1961-03-31,FI,Finland,
-1961-03-31,FR,France,
-1961-03-31,GB,United Kingdom,
-1961-03-31,GR,Greece,
-1961-03-31,HK,Hong Kong SAR,
-1961-03-31,HR,Croatia,
-1961-03-31,HU,Hungary,
-1961-03-31,ID,Indonesia,
-1961-03-31,IE,Ireland,
-1961-03-31,IL,Israel,
-1961-03-31,IN,India,
-1961-03-31,IS,Iceland,
-1961-03-31,IT,Italy,-0.0175
+1961-03-31,IT,Italy,0.6659
 1961-03-31,JP,Japan,32.3723
-1961-03-31,KR,Korea,
-1961-03-31,LT,Lithuania,
-1961-03-31,LU,Luxembourg,
-1961-03-31,LV,Latvia,
-1961-03-31,MA,Morocco,
-1961-03-31,MK,North Macedonia,
-1961-03-31,MT,Malta,
-1961-03-31,MX,Mexico,
-1961-03-31,MY,Malaysia,
-1961-03-31,NL,Netherlands,
-1961-03-31,NO,Norway,
-1961-03-31,NZ,New Zealand,
-1961-03-31,PE,Peru,
-1961-03-31,PH,Philippines,
-1961-03-31,PL,Poland,
-1961-03-31,PT,Portugal,
-1961-03-31,RO,Romania,
-1961-03-31,RS,Serbia,
-1961-03-31,RU,Russia,
-1961-03-31,SE,Sweden,
-1961-03-31,SG,Singapore,
-1961-03-31,SI,Slovenia,
-1961-03-31,SK,Slovak Republic,
-1961-03-31,TH,Thailand,
-1961-03-31,TR,Türkiye,
-1961-03-31,US,United States,
-1961-03-31,XM,Euro area,
-1961-03-31,XW,World,
-1961-03-31,ZA,South Africa,
-1961-06-30,4T,Emerging market economies (aggregate),
-1961-06-30,5R,Advanced economies,
-1961-06-30,AE,United Arab Emirates,
-1961-06-30,AT,Austria,
-1961-06-30,AU,Australia,
-1961-06-30,BE,Belgium,
-1961-06-30,BG,Bulgaria,
-1961-06-30,BR,Brazil,
-1961-06-30,CA,Canada,
-1961-06-30,CH,Switzerland,
-1961-06-30,CL,Chile,
-1961-06-30,CN,China,
-1961-06-30,CO,Colombia,
-1961-06-30,CY,Cyprus,
-1961-06-30,CZ,Czechia,
-1961-06-30,DE,Germany,
-1961-06-30,DK,Denmark,
-1961-06-30,EE,Estonia,
-1961-06-30,ES,Spain,
-1961-06-30,FI,Finland,
-1961-06-30,FR,France,
-1961-06-30,GB,United Kingdom,
-1961-06-30,GR,Greece,
-1961-06-30,HK,Hong Kong SAR,
-1961-06-30,HR,Croatia,
-1961-06-30,HU,Hungary,
-1961-06-30,ID,Indonesia,
-1961-06-30,IE,Ireland,
-1961-06-30,IL,Israel,
-1961-06-30,IN,India,
-1961-06-30,IS,Iceland,
-1961-06-30,IT,Italy,2.152
+1961-06-30,IT,Italy,3.3061
 1961-06-30,JP,Japan,33.085
-1961-06-30,KR,Korea,
-1961-06-30,LT,Lithuania,
-1961-06-30,LU,Luxembourg,
-1961-06-30,LV,Latvia,
-1961-06-30,MA,Morocco,
-1961-06-30,MK,North Macedonia,
-1961-06-30,MT,Malta,
-1961-06-30,MX,Mexico,
-1961-06-30,MY,Malaysia,
-1961-06-30,NL,Netherlands,
-1961-06-30,NO,Norway,
-1961-06-30,NZ,New Zealand,
-1961-06-30,PE,Peru,
-1961-06-30,PH,Philippines,
-1961-06-30,PL,Poland,
-1961-06-30,PT,Portugal,
-1961-06-30,RO,Romania,
-1961-06-30,RS,Serbia,
-1961-06-30,RU,Russia,
-1961-06-30,SE,Sweden,
-1961-06-30,SG,Singapore,
-1961-06-30,SI,Slovenia,
-1961-06-30,SK,Slovak Republic,
-1961-06-30,TH,Thailand,
-1961-06-30,TR,Türkiye,
-1961-06-30,US,United States,
-1961-06-30,XM,Euro area,
-1961-06-30,XW,World,
-1961-06-30,ZA,South Africa,
-1961-09-30,4T,Emerging market economies (aggregate),
-1961-09-30,5R,Advanced economies,
-1961-09-30,AE,United Arab Emirates,
-1961-09-30,AT,Austria,
-1961-09-30,AU,Australia,
-1961-09-30,BE,Belgium,
-1961-09-30,BG,Bulgaria,
-1961-09-30,BR,Brazil,
-1961-09-30,CA,Canada,
-1961-09-30,CH,Switzerland,
-1961-09-30,CL,Chile,
-1961-09-30,CN,China,
-1961-09-30,CO,Colombia,
-1961-09-30,CY,Cyprus,
-1961-09-30,CZ,Czechia,
-1961-09-30,DE,Germany,
-1961-09-30,DK,Denmark,
-1961-09-30,EE,Estonia,
-1961-09-30,ES,Spain,
-1961-09-30,FI,Finland,
-1961-09-30,FR,France,
-1961-09-30,GB,United Kingdom,
-1961-09-30,GR,Greece,
-1961-09-30,HK,Hong Kong SAR,
-1961-09-30,HR,Croatia,
-1961-09-30,HU,Hungary,
-1961-09-30,ID,Indonesia,
-1961-09-30,IE,Ireland,
-1961-09-30,IL,Israel,
-1961-09-30,IN,India,
-1961-09-30,IS,Iceland,
-1961-09-30,IT,Italy,1.9557
+1961-09-30,IT,Italy,3.2381
 1961-09-30,JP,Japan,31.614
-1961-09-30,KR,Korea,
-1961-09-30,LT,Lithuania,
-1961-09-30,LU,Luxembourg,
-1961-09-30,LV,Latvia,
-1961-09-30,MA,Morocco,
-1961-09-30,MK,North Macedonia,
-1961-09-30,MT,Malta,
-1961-09-30,MX,Mexico,
-1961-09-30,MY,Malaysia,
-1961-09-30,NL,Netherlands,
-1961-09-30,NO,Norway,
-1961-09-30,NZ,New Zealand,
-1961-09-30,PE,Peru,
-1961-09-30,PH,Philippines,
-1961-09-30,PL,Poland,
-1961-09-30,PT,Portugal,
-1961-09-30,RO,Romania,
-1961-09-30,RS,Serbia,
-1961-09-30,RU,Russia,
-1961-09-30,SE,Sweden,
-1961-09-30,SG,Singapore,
-1961-09-30,SI,Slovenia,
-1961-09-30,SK,Slovak Republic,
-1961-09-30,TH,Thailand,
-1961-09-30,TR,Türkiye,
-1961-09-30,US,United States,
-1961-09-30,XM,Euro area,
-1961-09-30,XW,World,
-1961-09-30,ZA,South Africa,
-1961-12-31,4T,Emerging market economies (aggregate),
-1961-12-31,5R,Advanced economies,
-1961-12-31,AE,United Arab Emirates,
-1961-12-31,AT,Austria,
-1961-12-31,AU,Australia,
-1961-12-31,BE,Belgium,
-1961-12-31,BG,Bulgaria,
-1961-12-31,BR,Brazil,
-1961-12-31,CA,Canada,
-1961-12-31,CH,Switzerland,
-1961-12-31,CL,Chile,
-1961-12-31,CN,China,
-1961-12-31,CO,Colombia,
-1961-12-31,CY,Cyprus,
-1961-12-31,CZ,Czechia,
-1961-12-31,DE,Germany,
-1961-12-31,DK,Denmark,
-1961-12-31,EE,Estonia,
-1961-12-31,ES,Spain,
-1961-12-31,FI,Finland,
-1961-12-31,FR,France,
-1961-12-31,GB,United Kingdom,
-1961-12-31,GR,Greece,
-1961-12-31,HK,Hong Kong SAR,
-1961-12-31,HR,Croatia,
-1961-12-31,HU,Hungary,
-1961-12-31,ID,Indonesia,
-1961-12-31,IE,Ireland,
-1961-12-31,IL,Israel,
-1961-12-31,IN,India,
-1961-12-31,IS,Iceland,
-1961-12-31,IT,Italy,2.6062
+1961-12-31,IT,Italy,3.0745
 1961-12-31,JP,Japan,21.7172
-1961-12-31,KR,Korea,
-1961-12-31,LT,Lithuania,
-1961-12-31,LU,Luxembourg,
-1961-12-31,LV,Latvia,
-1961-12-31,MA,Morocco,
-1961-12-31,MK,North Macedonia,
-1961-12-31,MT,Malta,
-1961-12-31,MX,Mexico,
-1961-12-31,MY,Malaysia,
-1961-12-31,NL,Netherlands,
-1961-12-31,NO,Norway,
-1961-12-31,NZ,New Zealand,
-1961-12-31,PE,Peru,
-1961-12-31,PH,Philippines,
-1961-12-31,PL,Poland,
-1961-12-31,PT,Portugal,
-1961-12-31,RO,Romania,
-1961-12-31,RS,Serbia,
-1961-12-31,RU,Russia,
-1961-12-31,SE,Sweden,
-1961-12-31,SG,Singapore,
-1961-12-31,SI,Slovenia,
-1961-12-31,SK,Slovak Republic,
-1961-12-31,TH,Thailand,
-1961-12-31,TR,Türkiye,
-1961-12-31,US,United States,
-1961-12-31,XM,Euro area,
-1961-12-31,XW,World,
-1961-12-31,ZA,South Africa,
-1962-03-31,4T,Emerging market economies (aggregate),
-1962-03-31,5R,Advanced economies,
-1962-03-31,AE,United Arab Emirates,
-1962-03-31,AT,Austria,
-1962-03-31,AU,Australia,
-1962-03-31,BE,Belgium,
-1962-03-31,BG,Bulgaria,
-1962-03-31,BR,Brazil,
-1962-03-31,CA,Canada,
-1962-03-31,CH,Switzerland,
-1962-03-31,CL,Chile,
-1962-03-31,CN,China,
-1962-03-31,CO,Colombia,
-1962-03-31,CY,Cyprus,
-1962-03-31,CZ,Czechia,
-1962-03-31,DE,Germany,
-1962-03-31,DK,Denmark,
-1962-03-31,EE,Estonia,
-1962-03-31,ES,Spain,
-1962-03-31,FI,Finland,
-1962-03-31,FR,France,
-1962-03-31,GB,United Kingdom,
-1962-03-31,GR,Greece,
-1962-03-31,HK,Hong Kong SAR,
-1962-03-31,HR,Croatia,
-1962-03-31,HU,Hungary,
-1962-03-31,ID,Indonesia,
-1962-03-31,IE,Ireland,
-1962-03-31,IL,Israel,
-1962-03-31,IN,India,
-1962-03-31,IS,Iceland,
-1962-03-31,IT,Italy,2.6802
+1962-03-31,IT,Italy,3.2262
 1962-03-31,JP,Japan,18.0595
-1962-03-31,KR,Korea,
-1962-03-31,LT,Lithuania,
-1962-03-31,LU,Luxembourg,
-1962-03-31,LV,Latvia,
-1962-03-31,MA,Morocco,
-1962-03-31,MK,North Macedonia,
-1962-03-31,MT,Malta,
-1962-03-31,MX,Mexico,
-1962-03-31,MY,Malaysia,
-1962-03-31,NL,Netherlands,
-1962-03-31,NO,Norway,
-1962-03-31,NZ,New Zealand,
-1962-03-31,PE,Peru,
-1962-03-31,PH,Philippines,
-1962-03-31,PL,Poland,
-1962-03-31,PT,Portugal,
-1962-03-31,RO,Romania,
-1962-03-31,RS,Serbia,
-1962-03-31,RU,Russia,
-1962-03-31,SE,Sweden,
-1962-03-31,SG,Singapore,
-1962-03-31,SI,Slovenia,
-1962-03-31,SK,Slovak Republic,
-1962-03-31,TH,Thailand,
-1962-03-31,TR,Türkiye,
-1962-03-31,US,United States,
-1962-03-31,XM,Euro area,
-1962-03-31,XW,World,
-1962-03-31,ZA,South Africa,
-1962-06-30,4T,Emerging market economies (aggregate),
-1962-06-30,5R,Advanced economies,
-1962-06-30,AE,United Arab Emirates,
-1962-06-30,AT,Austria,
-1962-06-30,AU,Australia,
-1962-06-30,BE,Belgium,
-1962-06-30,BG,Bulgaria,
-1962-06-30,BR,Brazil,
-1962-06-30,CA,Canada,
-1962-06-30,CH,Switzerland,
-1962-06-30,CL,Chile,
-1962-06-30,CN,China,
-1962-06-30,CO,Colombia,
-1962-06-30,CY,Cyprus,
-1962-06-30,CZ,Czechia,
-1962-06-30,DE,Germany,
-1962-06-30,DK,Denmark,
-1962-06-30,EE,Estonia,
-1962-06-30,ES,Spain,
-1962-06-30,FI,Finland,
-1962-06-30,FR,France,
-1962-06-30,GB,United Kingdom,
-1962-06-30,GR,Greece,
-1962-06-30,HK,Hong Kong SAR,
-1962-06-30,HR,Croatia,
-1962-06-30,HU,Hungary,
-1962-06-30,ID,Indonesia,
-1962-06-30,IE,Ireland,
-1962-06-30,IL,Israel,
-1962-06-30,IN,India,
-1962-06-30,IS,Iceland,
-1962-06-30,IT,Italy,3.5873
+1962-06-30,IT,Italy,3.8785
 1962-06-30,JP,Japan,12.8009
-1962-06-30,KR,Korea,
-1962-06-30,LT,Lithuania,
-1962-06-30,LU,Luxembourg,
-1962-06-30,LV,Latvia,
-1962-06-30,MA,Morocco,
-1962-06-30,MK,North Macedonia,
-1962-06-30,MT,Malta,
-1962-06-30,MX,Mexico,
-1962-06-30,MY,Malaysia,
-1962-06-30,NL,Netherlands,
-1962-06-30,NO,Norway,
-1962-06-30,NZ,New Zealand,
-1962-06-30,PE,Peru,
-1962-06-30,PH,Philippines,
-1962-06-30,PL,Poland,
-1962-06-30,PT,Portugal,
-1962-06-30,RO,Romania,
-1962-06-30,RS,Serbia,
-1962-06-30,RU,Russia,
-1962-06-30,SE,Sweden,
-1962-06-30,SG,Singapore,
-1962-06-30,SI,Slovenia,
-1962-06-30,SK,Slovak Republic,
-1962-06-30,TH,Thailand,
-1962-06-30,TR,Türkiye,
-1962-06-30,US,United States,
-1962-06-30,XM,Euro area,
-1962-06-30,XW,World,
-1962-06-30,ZA,South Africa,
-1962-09-30,4T,Emerging market economies (aggregate),
-1962-09-30,5R,Advanced economies,
-1962-09-30,AE,United Arab Emirates,
-1962-09-30,AT,Austria,
-1962-09-30,AU,Australia,
-1962-09-30,BE,Belgium,
-1962-09-30,BG,Bulgaria,
-1962-09-30,BR,Brazil,
-1962-09-30,CA,Canada,
-1962-09-30,CH,Switzerland,
-1962-09-30,CL,Chile,
-1962-09-30,CN,China,
-1962-09-30,CO,Colombia,
-1962-09-30,CY,Cyprus,
-1962-09-30,CZ,Czechia,
-1962-09-30,DE,Germany,
-1962-09-30,DK,Denmark,
-1962-09-30,EE,Estonia,
-1962-09-30,ES,Spain,
-1962-09-30,FI,Finland,
-1962-09-30,FR,France,
-1962-09-30,GB,United Kingdom,
-1962-09-30,GR,Greece,
-1962-09-30,HK,Hong Kong SAR,
-1962-09-30,HR,Croatia,
-1962-09-30,HU,Hungary,
-1962-09-30,ID,Indonesia,
-1962-09-30,IE,Ireland,
-1962-09-30,IL,Israel,
-1962-09-30,IN,India,
-1962-09-30,IS,Iceland,
-1962-09-30,IT,Italy,2.753
+1962-09-30,IT,Italy,2.7723
 1962-09-30,JP,Japan,10.2932
-1962-09-30,KR,Korea,
-1962-09-30,LT,Lithuania,
-1962-09-30,LU,Luxembourg,
-1962-09-30,LV,Latvia,
-1962-09-30,MA,Morocco,
-1962-09-30,MK,North Macedonia,
-1962-09-30,MT,Malta,
-1962-09-30,MX,Mexico,
-1962-09-30,MY,Malaysia,
-1962-09-30,NL,Netherlands,
-1962-09-30,NO,Norway,
-1962-09-30,NZ,New Zealand,
-1962-09-30,PE,Peru,
-1962-09-30,PH,Philippines,
-1962-09-30,PL,Poland,
-1962-09-30,PT,Portugal,
-1962-09-30,RO,Romania,
-1962-09-30,RS,Serbia,
-1962-09-30,RU,Russia,
-1962-09-30,SE,Sweden,
-1962-09-30,SG,Singapore,
-1962-09-30,SI,Slovenia,
-1962-09-30,SK,Slovak Republic,
-1962-09-30,TH,Thailand,
-1962-09-30,TR,Türkiye,
-1962-09-30,US,United States,
-1962-09-30,XM,Euro area,
-1962-09-30,XW,World,
-1962-09-30,ZA,South Africa,
-1962-12-31,4T,Emerging market economies (aggregate),
-1962-12-31,5R,Advanced economies,
-1962-12-31,AE,United Arab Emirates,
-1962-12-31,AT,Austria,
-1962-12-31,AU,Australia,
-1962-12-31,BE,Belgium,
-1962-12-31,BG,Bulgaria,
-1962-12-31,BR,Brazil,
-1962-12-31,CA,Canada,
-1962-12-31,CH,Switzerland,
-1962-12-31,CL,Chile,
-1962-12-31,CN,China,
-1962-12-31,CO,Colombia,
-1962-12-31,CY,Cyprus,
-1962-12-31,CZ,Czechia,
-1962-12-31,DE,Germany,
-1962-12-31,DK,Denmark,
-1962-12-31,EE,Estonia,
-1962-12-31,ES,Spain,
-1962-12-31,FI,Finland,
-1962-12-31,FR,France,
-1962-12-31,GB,United Kingdom,
-1962-12-31,GR,Greece,
-1962-12-31,HK,Hong Kong SAR,
-1962-12-31,HR,Croatia,
-1962-12-31,HU,Hungary,
-1962-12-31,ID,Indonesia,
-1962-12-31,IE,Ireland,
-1962-12-31,IL,Israel,
-1962-12-31,IN,India,
-1962-12-31,IS,Iceland,
-1962-12-31,IT,Italy,1.0414
+1962-12-31,IT,Italy,1.6988
 1962-12-31,JP,Japan,11.9647
-1962-12-31,KR,Korea,
-1962-12-31,LT,Lithuania,
-1962-12-31,LU,Luxembourg,
-1962-12-31,LV,Latvia,
-1962-12-31,MA,Morocco,
-1962-12-31,MK,North Macedonia,
-1962-12-31,MT,Malta,
-1962-12-31,MX,Mexico,
-1962-12-31,MY,Malaysia,
-1962-12-31,NL,Netherlands,
-1962-12-31,NO,Norway,
-1962-12-31,NZ,New Zealand,
-1962-12-31,PE,Peru,
-1962-12-31,PH,Philippines,
-1962-12-31,PL,Poland,
-1962-12-31,PT,Portugal,
-1962-12-31,RO,Romania,
-1962-12-31,RS,Serbia,
-1962-12-31,RU,Russia,
-1962-12-31,SE,Sweden,
-1962-12-31,SG,Singapore,
-1962-12-31,SI,Slovenia,
-1962-12-31,SK,Slovak Republic,
-1962-12-31,TH,Thailand,
-1962-12-31,TR,Türkiye,
-1962-12-31,US,United States,
-1962-12-31,XM,Euro area,
-1962-12-31,XW,World,
-1962-12-31,ZA,South Africa,
-1963-03-31,4T,Emerging market economies (aggregate),
-1963-03-31,5R,Advanced economies,
-1963-03-31,AE,United Arab Emirates,
-1963-03-31,AT,Austria,
-1963-03-31,AU,Australia,
-1963-03-31,BE,Belgium,
-1963-03-31,BG,Bulgaria,
-1963-03-31,BR,Brazil,
-1963-03-31,CA,Canada,
-1963-03-31,CH,Switzerland,
-1963-03-31,CL,Chile,
-1963-03-31,CN,China,
-1963-03-31,CO,Colombia,
-1963-03-31,CY,Cyprus,
-1963-03-31,CZ,Czechia,
-1963-03-31,DE,Germany,
-1963-03-31,DK,Denmark,
-1963-03-31,EE,Estonia,
-1963-03-31,ES,Spain,
-1963-03-31,FI,Finland,
-1963-03-31,FR,France,
-1963-03-31,GB,United Kingdom,
-1963-03-31,GR,Greece,
-1963-03-31,HK,Hong Kong SAR,
-1963-03-31,HR,Croatia,
-1963-03-31,HU,Hungary,
-1963-03-31,ID,Indonesia,
-1963-03-31,IE,Ireland,
-1963-03-31,IL,Israel,
-1963-03-31,IN,India,
-1963-03-31,IS,Iceland,
-1963-03-31,IT,Italy,2.4709
+1963-03-31,IT,Italy,2.6458
 1963-03-31,JP,Japan,6.9417
-1963-03-31,KR,Korea,
-1963-03-31,LT,Lithuania,
-1963-03-31,LU,Luxembourg,
-1963-03-31,LV,Latvia,
-1963-03-31,MA,Morocco,
-1963-03-31,MK,North Macedonia,
-1963-03-31,MT,Malta,
-1963-03-31,MX,Mexico,
-1963-03-31,MY,Malaysia,
-1963-03-31,NL,Netherlands,
-1963-03-31,NO,Norway,
-1963-03-31,NZ,New Zealand,
-1963-03-31,PE,Peru,
-1963-03-31,PH,Philippines,
-1963-03-31,PL,Poland,
-1963-03-31,PT,Portugal,
-1963-03-31,RO,Romania,
-1963-03-31,RS,Serbia,
-1963-03-31,RU,Russia,
-1963-03-31,SE,Sweden,
-1963-03-31,SG,Singapore,
-1963-03-31,SI,Slovenia,
-1963-03-31,SK,Slovak Republic,
-1963-03-31,TH,Thailand,
-1963-03-31,TR,Türkiye,
-1963-03-31,US,United States,
-1963-03-31,XM,Euro area,
-1963-03-31,XW,World,
-1963-03-31,ZA,South Africa,
-1963-06-30,4T,Emerging market economies (aggregate),
-1963-06-30,5R,Advanced economies,
-1963-06-30,AE,United Arab Emirates,
-1963-06-30,AT,Austria,
-1963-06-30,AU,Australia,
-1963-06-30,BE,Belgium,
-1963-06-30,BG,Bulgaria,
-1963-06-30,BR,Brazil,
-1963-06-30,CA,Canada,
-1963-06-30,CH,Switzerland,
-1963-06-30,CL,Chile,
-1963-06-30,CN,China,
-1963-06-30,CO,Colombia,
-1963-06-30,CY,Cyprus,
-1963-06-30,CZ,Czechia,
-1963-06-30,DE,Germany,
-1963-06-30,DK,Denmark,
-1963-06-30,EE,Estonia,
-1963-06-30,ES,Spain,
-1963-06-30,FI,Finland,
-1963-06-30,FR,France,
-1963-06-30,GB,United Kingdom,
-1963-06-30,GR,Greece,
-1963-06-30,HK,Hong Kong SAR,
-1963-06-30,HR,Croatia,
-1963-06-30,HU,Hungary,
-1963-06-30,ID,Indonesia,
-1963-06-30,IE,Ireland,
-1963-06-30,IL,Israel,
-1963-06-30,IN,India,
-1963-06-30,IS,Iceland,
-1963-06-30,IT,Italy,-0.2952
+1963-06-30,IT,Italy,0.0499
 1963-06-30,JP,Japan,6.3987
-1963-06-30,KR,Korea,
-1963-06-30,LT,Lithuania,
-1963-06-30,LU,Luxembourg,
-1963-06-30,LV,Latvia,
-1963-06-30,MA,Morocco,
-1963-06-30,MK,North Macedonia,
-1963-06-30,MT,Malta,
-1963-06-30,MX,Mexico,
-1963-06-30,MY,Malaysia,
-1963-06-30,NL,Netherlands,
-1963-06-30,NO,Norway,
-1963-06-30,NZ,New Zealand,
-1963-06-30,PE,Peru,
-1963-06-30,PH,Philippines,
-1963-06-30,PL,Poland,
-1963-06-30,PT,Portugal,
-1963-06-30,RO,Romania,
-1963-06-30,RS,Serbia,
-1963-06-30,RU,Russia,
-1963-06-30,SE,Sweden,
-1963-06-30,SG,Singapore,
-1963-06-30,SI,Slovenia,
-1963-06-30,SK,Slovak Republic,
-1963-06-30,TH,Thailand,
-1963-06-30,TR,Türkiye,
-1963-06-30,US,United States,
-1963-06-30,XM,Euro area,
-1963-06-30,XW,World,
-1963-06-30,ZA,South Africa,
-1963-09-30,4T,Emerging market economies (aggregate),
-1963-09-30,5R,Advanced economies,
-1963-09-30,AE,United Arab Emirates,
-1963-09-30,AT,Austria,
-1963-09-30,AU,Australia,
-1963-09-30,BE,Belgium,
-1963-09-30,BG,Bulgaria,
-1963-09-30,BR,Brazil,
-1963-09-30,CA,Canada,
-1963-09-30,CH,Switzerland,
-1963-09-30,CL,Chile,
-1963-09-30,CN,China,
-1963-09-30,CO,Colombia,
-1963-09-30,CY,Cyprus,
-1963-09-30,CZ,Czechia,
-1963-09-30,DE,Germany,
-1963-09-30,DK,Denmark,
-1963-09-30,EE,Estonia,
-1963-09-30,ES,Spain,
-1963-09-30,FI,Finland,
-1963-09-30,FR,France,
-1963-09-30,GB,United Kingdom,
-1963-09-30,GR,Greece,
-1963-09-30,HK,Hong Kong SAR,
-1963-09-30,HR,Croatia,
-1963-09-30,HU,Hungary,
-1963-09-30,ID,Indonesia,
-1963-09-30,IE,Ireland,
-1963-09-30,IL,Israel,
-1963-09-30,IN,India,
-1963-09-30,IS,Iceland,
-1963-09-30,IT,Italy,-0.1619
+1963-06-30,NZ,New Zealand,0.4379
+1963-09-30,IT,Italy,-0.1556
 1963-09-30,JP,Japan,6.1622
-1963-09-30,KR,Korea,
-1963-09-30,LT,Lithuania,
-1963-09-30,LU,Luxembourg,
-1963-09-30,LV,Latvia,
-1963-09-30,MA,Morocco,
-1963-09-30,MK,North Macedonia,
-1963-09-30,MT,Malta,
-1963-09-30,MX,Mexico,
-1963-09-30,MY,Malaysia,
-1963-09-30,NL,Netherlands,
-1963-09-30,NO,Norway,
-1963-09-30,NZ,New Zealand,
-1963-09-30,PE,Peru,
-1963-09-30,PH,Philippines,
-1963-09-30,PL,Poland,
-1963-09-30,PT,Portugal,
-1963-09-30,RO,Romania,
-1963-09-30,RS,Serbia,
-1963-09-30,RU,Russia,
-1963-09-30,SE,Sweden,
-1963-09-30,SG,Singapore,
-1963-09-30,SI,Slovenia,
-1963-09-30,SK,Slovak Republic,
-1963-09-30,TH,Thailand,
-1963-09-30,TR,Türkiye,
-1963-09-30,US,United States,
-1963-09-30,XM,Euro area,
-1963-09-30,XW,World,
-1963-09-30,ZA,South Africa,
-1963-12-31,4T,Emerging market economies (aggregate),
-1963-12-31,5R,Advanced economies,
-1963-12-31,AE,United Arab Emirates,
-1963-12-31,AT,Austria,
-1963-12-31,AU,Australia,
-1963-12-31,BE,Belgium,
-1963-12-31,BG,Bulgaria,
-1963-12-31,BR,Brazil,
-1963-12-31,CA,Canada,
-1963-12-31,CH,Switzerland,
-1963-12-31,CL,Chile,
-1963-12-31,CN,China,
-1963-12-31,CO,Colombia,
-1963-12-31,CY,Cyprus,
-1963-12-31,CZ,Czechia,
-1963-12-31,DE,Germany,
-1963-12-31,DK,Denmark,
-1963-12-31,EE,Estonia,
-1963-12-31,ES,Spain,
-1963-12-31,FI,Finland,
-1963-12-31,FR,France,
-1963-12-31,GB,United Kingdom,
-1963-12-31,GR,Greece,
-1963-12-31,HK,Hong Kong SAR,
-1963-12-31,HR,Croatia,
-1963-12-31,HU,Hungary,
-1963-12-31,ID,Indonesia,
-1963-12-31,IE,Ireland,
-1963-12-31,IL,Israel,
-1963-12-31,IN,India,
-1963-12-31,IS,Iceland,
-1963-12-31,IT,Italy,3.9754
+1963-09-30,NZ,New Zealand,1.2022
+1963-12-31,IT,Italy,3.8678
 1963-12-31,JP,Japan,5.727
-1963-12-31,KR,Korea,
-1963-12-31,LT,Lithuania,
-1963-12-31,LU,Luxembourg,
-1963-12-31,LV,Latvia,
-1963-12-31,MA,Morocco,
-1963-12-31,MK,North Macedonia,
-1963-12-31,MT,Malta,
-1963-12-31,MX,Mexico,
-1963-12-31,MY,Malaysia,
-1963-12-31,NL,Netherlands,
-1963-12-31,NO,Norway,
-1963-12-31,NZ,New Zealand,
-1963-12-31,PE,Peru,
-1963-12-31,PH,Philippines,
-1963-12-31,PL,Poland,
-1963-12-31,PT,Portugal,
-1963-12-31,RO,Romania,
-1963-12-31,RS,Serbia,
-1963-12-31,RU,Russia,
-1963-12-31,SE,Sweden,
-1963-12-31,SG,Singapore,
-1963-12-31,SI,Slovenia,
-1963-12-31,SK,Slovak Republic,
-1963-12-31,TH,Thailand,
-1963-12-31,TR,Türkiye,
-1963-12-31,US,United States,
-1963-12-31,XM,Euro area,
-1963-12-31,XW,World,
-1963-12-31,ZA,South Africa,
-1964-03-31,4T,Emerging market economies (aggregate),
-1964-03-31,5R,Advanced economies,
-1964-03-31,AE,United Arab Emirates,
-1964-03-31,AT,Austria,
-1964-03-31,AU,Australia,
-1964-03-31,BE,Belgium,
-1964-03-31,BG,Bulgaria,
-1964-03-31,BR,Brazil,
-1964-03-31,CA,Canada,
-1964-03-31,CH,Switzerland,
-1964-03-31,CL,Chile,
-1964-03-31,CN,China,
-1964-03-31,CO,Colombia,
-1964-03-31,CY,Cyprus,
-1964-03-31,CZ,Czechia,
-1964-03-31,DE,Germany,
-1964-03-31,DK,Denmark,
-1964-03-31,EE,Estonia,
-1964-03-31,ES,Spain,
-1964-03-31,FI,Finland,
-1964-03-31,FR,France,
-1964-03-31,GB,United Kingdom,
-1964-03-31,GR,Greece,
-1964-03-31,HK,Hong Kong SAR,
-1964-03-31,HR,Croatia,
-1964-03-31,HU,Hungary,
-1964-03-31,ID,Indonesia,
-1964-03-31,IE,Ireland,
-1964-03-31,IL,Israel,
-1964-03-31,IN,India,
-1964-03-31,IS,Iceland,
-1964-03-31,IT,Italy,3.2017
+1963-12-31,NZ,New Zealand,1.6232
+1964-03-31,IT,Italy,3.6854
 1964-03-31,JP,Japan,10.2162
-1964-03-31,KR,Korea,
-1964-03-31,LT,Lithuania,
-1964-03-31,LU,Luxembourg,
-1964-03-31,LV,Latvia,
-1964-03-31,MA,Morocco,
-1964-03-31,MK,North Macedonia,
-1964-03-31,MT,Malta,
-1964-03-31,MX,Mexico,
-1964-03-31,MY,Malaysia,
-1964-03-31,NL,Netherlands,
-1964-03-31,NO,Norway,
-1964-03-31,NZ,New Zealand,
-1964-03-31,PE,Peru,
-1964-03-31,PH,Philippines,
-1964-03-31,PL,Poland,
-1964-03-31,PT,Portugal,
-1964-03-31,RO,Romania,
-1964-03-31,RS,Serbia,
-1964-03-31,RU,Russia,
-1964-03-31,SE,Sweden,
-1964-03-31,SG,Singapore,
-1964-03-31,SI,Slovenia,
-1964-03-31,SK,Slovak Republic,
-1964-03-31,TH,Thailand,
-1964-03-31,TR,Türkiye,
-1964-03-31,US,United States,
-1964-03-31,XM,Euro area,
-1964-03-31,XW,World,
-1964-03-31,ZA,South Africa,
-1964-06-30,4T,Emerging market economies (aggregate),
-1964-06-30,5R,Advanced economies,
-1964-06-30,AE,United Arab Emirates,
-1964-06-30,AT,Austria,
-1964-06-30,AU,Australia,
-1964-06-30,BE,Belgium,
-1964-06-30,BG,Bulgaria,
-1964-06-30,BR,Brazil,
-1964-06-30,CA,Canada,
-1964-06-30,CH,Switzerland,
-1964-06-30,CL,Chile,
-1964-06-30,CN,China,
-1964-06-30,CO,Colombia,
-1964-06-30,CY,Cyprus,
-1964-06-30,CZ,Czechia,
-1964-06-30,DE,Germany,
-1964-06-30,DK,Denmark,
-1964-06-30,EE,Estonia,
-1964-06-30,ES,Spain,
-1964-06-30,FI,Finland,
-1964-06-30,FR,France,
-1964-06-30,GB,United Kingdom,
-1964-06-30,GR,Greece,
-1964-06-30,HK,Hong Kong SAR,
-1964-06-30,HR,Croatia,
-1964-06-30,HU,Hungary,
-1964-06-30,ID,Indonesia,
-1964-06-30,IE,Ireland,
-1964-06-30,IL,Israel,
-1964-06-30,IN,India,
-1964-06-30,IS,Iceland,
-1964-06-30,IT,Italy,6.1152
+1964-03-31,NZ,New Zealand,2.0565
+1964-06-30,IT,Italy,6.5054
 1964-06-30,JP,Japan,10.4662
-1964-06-30,KR,Korea,
-1964-06-30,LT,Lithuania,
-1964-06-30,LU,Luxembourg,
-1964-06-30,LV,Latvia,
-1964-06-30,MA,Morocco,
-1964-06-30,MK,North Macedonia,
-1964-06-30,MT,Malta,
-1964-06-30,MX,Mexico,
-1964-06-30,MY,Malaysia,
-1964-06-30,NL,Netherlands,
-1964-06-30,NO,Norway,
-1964-06-30,NZ,New Zealand,
-1964-06-30,PE,Peru,
-1964-06-30,PH,Philippines,
-1964-06-30,PL,Poland,
-1964-06-30,PT,Portugal,
-1964-06-30,RO,Romania,
-1964-06-30,RS,Serbia,
-1964-06-30,RU,Russia,
-1964-06-30,SE,Sweden,
-1964-06-30,SG,Singapore,
-1964-06-30,SI,Slovenia,
-1964-06-30,SK,Slovak Republic,
-1964-06-30,TH,Thailand,
-1964-06-30,TR,Türkiye,
-1964-06-30,US,United States,
-1964-06-30,XM,Euro area,
-1964-06-30,XW,World,
-1964-06-30,ZA,South Africa,
-1964-09-30,4T,Emerging market economies (aggregate),
-1964-09-30,5R,Advanced economies,
-1964-09-30,AE,United Arab Emirates,
-1964-09-30,AT,Austria,
-1964-09-30,AU,Australia,
-1964-09-30,BE,Belgium,
-1964-09-30,BG,Bulgaria,
-1964-09-30,BR,Brazil,
-1964-09-30,CA,Canada,
-1964-09-30,CH,Switzerland,
-1964-09-30,CL,Chile,
-1964-09-30,CN,China,
-1964-09-30,CO,Colombia,
-1964-09-30,CY,Cyprus,
-1964-09-30,CZ,Czechia,
-1964-09-30,DE,Germany,
-1964-09-30,DK,Denmark,
-1964-09-30,EE,Estonia,
-1964-09-30,ES,Spain,
-1964-09-30,FI,Finland,
-1964-09-30,FR,France,
-1964-09-30,GB,United Kingdom,
-1964-09-30,GR,Greece,
-1964-09-30,HK,Hong Kong SAR,
-1964-09-30,HR,Croatia,
-1964-09-30,HU,Hungary,
-1964-09-30,ID,Indonesia,
-1964-09-30,IE,Ireland,
-1964-09-30,IL,Israel,
-1964-09-30,IN,India,
-1964-09-30,IS,Iceland,
-1964-09-30,IT,Italy,7.8638
+1964-06-30,NZ,New Zealand,1.5468
+1964-09-30,IT,Italy,7.922
 1964-09-30,JP,Japan,10.323
-1964-09-30,KR,Korea,
-1964-09-30,LT,Lithuania,
-1964-09-30,LU,Luxembourg,
-1964-09-30,LV,Latvia,
-1964-09-30,MA,Morocco,
-1964-09-30,MK,North Macedonia,
-1964-09-30,MT,Malta,
-1964-09-30,MX,Mexico,
-1964-09-30,MY,Malaysia,
-1964-09-30,NL,Netherlands,
-1964-09-30,NO,Norway,
-1964-09-30,NZ,New Zealand,
-1964-09-30,PE,Peru,
-1964-09-30,PH,Philippines,
-1964-09-30,PL,Poland,
-1964-09-30,PT,Portugal,
-1964-09-30,RO,Romania,
-1964-09-30,RS,Serbia,
-1964-09-30,RU,Russia,
-1964-09-30,SE,Sweden,
-1964-09-30,SG,Singapore,
-1964-09-30,SI,Slovenia,
-1964-09-30,SK,Slovak Republic,
-1964-09-30,TH,Thailand,
-1964-09-30,TR,Türkiye,
-1964-09-30,US,United States,
-1964-09-30,XM,Euro area,
-1964-09-30,XW,World,
-1964-09-30,ZA,South Africa,
-1964-12-31,4T,Emerging market economies (aggregate),
-1964-12-31,5R,Advanced economies,
-1964-12-31,AE,United Arab Emirates,
-1964-12-31,AT,Austria,
-1964-12-31,AU,Australia,
-1964-12-31,BE,Belgium,
-1964-12-31,BG,Bulgaria,
-1964-12-31,BR,Brazil,
-1964-12-31,CA,Canada,
-1964-12-31,CH,Switzerland,
-1964-12-31,CL,Chile,
-1964-12-31,CN,China,
-1964-12-31,CO,Colombia,
-1964-12-31,CY,Cyprus,
-1964-12-31,CZ,Czechia,
-1964-12-31,DE,Germany,
-1964-12-31,DK,Denmark,
-1964-12-31,EE,Estonia,
-1964-12-31,ES,Spain,
-1964-12-31,FI,Finland,
-1964-12-31,FR,France,
-1964-12-31,GB,United Kingdom,
-1964-12-31,GR,Greece,
-1964-12-31,HK,Hong Kong SAR,
-1964-12-31,HR,Croatia,
-1964-12-31,HU,Hungary,
-1964-12-31,ID,Indonesia,
-1964-12-31,IE,Ireland,
-1964-12-31,IL,Israel,
-1964-12-31,IN,India,
-1964-12-31,IS,Iceland,
-1964-12-31,IT,Italy,3.4151
+1964-09-30,NZ,New Zealand,0.7039
+1964-12-31,IT,Italy,2.6584
 1964-12-31,JP,Japan,9.1204
-1964-12-31,KR,Korea,
-1964-12-31,LT,Lithuania,
-1964-12-31,LU,Luxembourg,
-1964-12-31,LV,Latvia,
-1964-12-31,MA,Morocco,
-1964-12-31,MK,North Macedonia,
-1964-12-31,MT,Malta,
-1964-12-31,MX,Mexico,
-1964-12-31,MY,Malaysia,
-1964-12-31,NL,Netherlands,
-1964-12-31,NO,Norway,
-1964-12-31,NZ,New Zealand,
-1964-12-31,PE,Peru,
-1964-12-31,PH,Philippines,
-1964-12-31,PL,Poland,
-1964-12-31,PT,Portugal,
-1964-12-31,RO,Romania,
-1964-12-31,RS,Serbia,
-1964-12-31,RU,Russia,
-1964-12-31,SE,Sweden,
-1964-12-31,SG,Singapore,
-1964-12-31,SI,Slovenia,
-1964-12-31,SK,Slovak Republic,
-1964-12-31,TH,Thailand,
-1964-12-31,TR,Türkiye,
-1964-12-31,US,United States,
-1964-12-31,XM,Euro area,
-1964-12-31,XW,World,
-1964-12-31,ZA,South Africa,
-1965-03-31,4T,Emerging market economies (aggregate),
-1965-03-31,5R,Advanced economies,
-1965-03-31,AE,United Arab Emirates,
-1965-03-31,AT,Austria,
-1965-03-31,AU,Australia,
-1965-03-31,BE,Belgium,
-1965-03-31,BG,Bulgaria,
-1965-03-31,BR,Brazil,
-1965-03-31,CA,Canada,
-1965-03-31,CH,Switzerland,
-1965-03-31,CL,Chile,
-1965-03-31,CN,China,
-1965-03-31,CO,Colombia,
-1965-03-31,CY,Cyprus,
-1965-03-31,CZ,Czechia,
-1965-03-31,DE,Germany,
-1965-03-31,DK,Denmark,
-1965-03-31,EE,Estonia,
-1965-03-31,ES,Spain,
-1965-03-31,FI,Finland,
-1965-03-31,FR,France,
-1965-03-31,GB,United Kingdom,
-1965-03-31,GR,Greece,
-1965-03-31,HK,Hong Kong SAR,
-1965-03-31,HR,Croatia,
-1965-03-31,HU,Hungary,
-1965-03-31,ID,Indonesia,
-1965-03-31,IE,Ireland,
-1965-03-31,IL,Israel,
-1965-03-31,IN,India,
-1965-03-31,IS,Iceland,
-1965-03-31,IT,Italy,-0.8137
+1964-12-31,NZ,New Zealand,0.6946
+1965-03-31,IT,Italy,-1.2676
 1965-03-31,JP,Japan,7.4715
-1965-03-31,KR,Korea,
-1965-03-31,LT,Lithuania,
-1965-03-31,LU,Luxembourg,
-1965-03-31,LV,Latvia,
-1965-03-31,MA,Morocco,
-1965-03-31,MK,North Macedonia,
-1965-03-31,MT,Malta,
-1965-03-31,MX,Mexico,
-1965-03-31,MY,Malaysia,
-1965-03-31,NL,Netherlands,
-1965-03-31,NO,Norway,
-1965-03-31,NZ,New Zealand,
-1965-03-31,PE,Peru,
-1965-03-31,PH,Philippines,
-1965-03-31,PL,Poland,
-1965-03-31,PT,Portugal,
-1965-03-31,RO,Romania,
-1965-03-31,RS,Serbia,
-1965-03-31,RU,Russia,
-1965-03-31,SE,Sweden,
-1965-03-31,SG,Singapore,
-1965-03-31,SI,Slovenia,
-1965-03-31,SK,Slovak Republic,
-1965-03-31,TH,Thailand,
-1965-03-31,TR,Türkiye,
-1965-03-31,US,United States,
-1965-03-31,XM,Euro area,
-1965-03-31,XW,World,
-1965-03-31,ZA,South Africa,
-1965-06-30,4T,Emerging market economies (aggregate),
-1965-06-30,5R,Advanced economies,
-1965-06-30,AE,United Arab Emirates,
-1965-06-30,AT,Austria,
-1965-06-30,AU,Australia,
-1965-06-30,BE,Belgium,
-1965-06-30,BG,Bulgaria,
-1965-06-30,BR,Brazil,
-1965-06-30,CA,Canada,
-1965-06-30,CH,Switzerland,
-1965-06-30,CL,Chile,
-1965-06-30,CN,China,
-1965-06-30,CO,Colombia,
-1965-06-30,CY,Cyprus,
-1965-06-30,CZ,Czechia,
-1965-06-30,DE,Germany,
-1965-06-30,DK,Denmark,
-1965-06-30,EE,Estonia,
-1965-06-30,ES,Spain,
-1965-06-30,FI,Finland,
-1965-06-30,FR,France,
-1965-06-30,GB,United Kingdom,
-1965-06-30,GR,Greece,
-1965-06-30,HK,Hong Kong SAR,
-1965-06-30,HR,Croatia,
-1965-06-30,HU,Hungary,
-1965-06-30,ID,Indonesia,
-1965-06-30,IE,Ireland,
-1965-06-30,IL,Israel,
-1965-06-30,IN,India,
-1965-06-30,IS,Iceland,
-1965-06-30,IT,Italy,-4.8435
+1965-03-31,NZ,New Zealand,2.2498
+1965-06-30,IT,Italy,-5.5607
 1965-06-30,JP,Japan,4.4918
-1965-06-30,KR,Korea,
-1965-06-30,LT,Lithuania,
-1965-06-30,LU,Luxembourg,
-1965-06-30,LV,Latvia,
-1965-06-30,MA,Morocco,
-1965-06-30,MK,North Macedonia,
-1965-06-30,MT,Malta,
-1965-06-30,MX,Mexico,
-1965-06-30,MY,Malaysia,
-1965-06-30,NL,Netherlands,
-1965-06-30,NO,Norway,
-1965-06-30,NZ,New Zealand,
-1965-06-30,PE,Peru,
-1965-06-30,PH,Philippines,
-1965-06-30,PL,Poland,
-1965-06-30,PT,Portugal,
-1965-06-30,RO,Romania,
-1965-06-30,RS,Serbia,
-1965-06-30,RU,Russia,
-1965-06-30,SE,Sweden,
-1965-06-30,SG,Singapore,
-1965-06-30,SI,Slovenia,
-1965-06-30,SK,Slovak Republic,
-1965-06-30,TH,Thailand,
-1965-06-30,TR,Türkiye,
-1965-06-30,US,United States,
-1965-06-30,XM,Euro area,
-1965-06-30,XW,World,
-1965-06-30,ZA,South Africa,
-1965-09-30,4T,Emerging market economies (aggregate),
-1965-09-30,5R,Advanced economies,
-1965-09-30,AE,United Arab Emirates,
-1965-09-30,AT,Austria,
-1965-09-30,AU,Australia,
-1965-09-30,BE,Belgium,
-1965-09-30,BG,Bulgaria,
-1965-09-30,BR,Brazil,
-1965-09-30,CA,Canada,
-1965-09-30,CH,Switzerland,
-1965-09-30,CL,Chile,
-1965-09-30,CN,China,
-1965-09-30,CO,Colombia,
-1965-09-30,CY,Cyprus,
-1965-09-30,CZ,Czechia,
-1965-09-30,DE,Germany,
-1965-09-30,DK,Denmark,
-1965-09-30,EE,Estonia,
-1965-09-30,ES,Spain,
-1965-09-30,FI,Finland,
-1965-09-30,FR,France,
-1965-09-30,GB,United Kingdom,
-1965-09-30,GR,Greece,
-1965-09-30,HK,Hong Kong SAR,
-1965-09-30,HR,Croatia,
-1965-09-30,HU,Hungary,
-1965-09-30,ID,Indonesia,
-1965-09-30,IE,Ireland,
-1965-09-30,IL,Israel,
-1965-09-30,IN,India,
-1965-09-30,IS,Iceland,
-1965-09-30,IT,Italy,-6.366
+1965-06-30,NZ,New Zealand,4.3634
+1965-09-30,IT,Italy,-6.5352
 1965-09-30,JP,Japan,3.1447
-1965-09-30,KR,Korea,
-1965-09-30,LT,Lithuania,
-1965-09-30,LU,Luxembourg,
-1965-09-30,LV,Latvia,
-1965-09-30,MA,Morocco,
-1965-09-30,MK,North Macedonia,
-1965-09-30,MT,Malta,
-1965-09-30,MX,Mexico,
-1965-09-30,MY,Malaysia,
-1965-09-30,NL,Netherlands,
-1965-09-30,NO,Norway,
-1965-09-30,NZ,New Zealand,
-1965-09-30,PE,Peru,
-1965-09-30,PH,Philippines,
-1965-09-30,PL,Poland,
-1965-09-30,PT,Portugal,
-1965-09-30,RO,Romania,
-1965-09-30,RS,Serbia,
-1965-09-30,RU,Russia,
-1965-09-30,SE,Sweden,
-1965-09-30,SG,Singapore,
-1965-09-30,SI,Slovenia,
-1965-09-30,SK,Slovak Republic,
-1965-09-30,TH,Thailand,
-1965-09-30,TR,Türkiye,
-1965-09-30,US,United States,
-1965-09-30,XM,Euro area,
-1965-09-30,XW,World,
-1965-09-30,ZA,South Africa,
-1965-12-31,4T,Emerging market economies (aggregate),
-1965-12-31,5R,Advanced economies,
-1965-12-31,AE,United Arab Emirates,
-1965-12-31,AT,Austria,
-1965-12-31,AU,Australia,
-1965-12-31,BE,Belgium,
-1965-12-31,BG,Bulgaria,
-1965-12-31,BR,Brazil,
-1965-12-31,CA,Canada,
-1965-12-31,CH,Switzerland,
-1965-12-31,CL,Chile,
-1965-12-31,CN,China,
-1965-12-31,CO,Colombia,
-1965-12-31,CY,Cyprus,
-1965-12-31,CZ,Czechia,
-1965-12-31,DE,Germany,
-1965-12-31,DK,Denmark,
-1965-12-31,EE,Estonia,
-1965-12-31,ES,Spain,
-1965-12-31,FI,Finland,
-1965-12-31,FR,France,
-1965-12-31,GB,United Kingdom,
-1965-12-31,GR,Greece,
-1965-12-31,HK,Hong Kong SAR,
-1965-12-31,HR,Croatia,
-1965-12-31,HU,Hungary,
-1965-12-31,ID,Indonesia,
-1965-12-31,IE,Ireland,
-1965-12-31,IL,Israel,
-1965-12-31,IN,India,
-1965-12-31,IS,Iceland,
-1965-12-31,IT,Italy,-5.1302
+1965-09-30,NZ,New Zealand,3.7619
+1965-12-31,IT,Italy,-4.5974
 1965-12-31,JP,Japan,1.8711
-1965-12-31,KR,Korea,
-1965-12-31,LT,Lithuania,
-1965-12-31,LU,Luxembourg,
-1965-12-31,LV,Latvia,
-1965-12-31,MA,Morocco,
-1965-12-31,MK,North Macedonia,
-1965-12-31,MT,Malta,
-1965-12-31,MX,Mexico,
-1965-12-31,MY,Malaysia,
-1965-12-31,NL,Netherlands,
-1965-12-31,NO,Norway,
-1965-12-31,NZ,New Zealand,
-1965-12-31,PE,Peru,
-1965-12-31,PH,Philippines,
-1965-12-31,PL,Poland,
-1965-12-31,PT,Portugal,
-1965-12-31,RO,Romania,
-1965-12-31,RS,Serbia,
-1965-12-31,RU,Russia,
-1965-12-31,SE,Sweden,
-1965-12-31,SG,Singapore,
-1965-12-31,SI,Slovenia,
-1965-12-31,SK,Slovak Republic,
-1965-12-31,TH,Thailand,
-1965-12-31,TR,Türkiye,
-1965-12-31,US,United States,
-1965-12-31,XM,Euro area,
-1965-12-31,XW,World,
-1965-12-31,ZA,South Africa,
-1966-03-31,4T,Emerging market economies (aggregate),
-1966-03-31,5R,Advanced economies,
-1966-03-31,AE,United Arab Emirates,
-1966-03-31,AT,Austria,
-1966-03-31,AU,Australia,
-1966-03-31,BE,Belgium,
-1966-03-31,BG,Bulgaria,
-1966-03-31,BR,Brazil,
-1966-03-31,CA,Canada,
-1966-03-31,CH,Switzerland,
-1966-03-31,CL,Chile,
-1966-03-31,CN,China,
-1966-03-31,CO,Colombia,
-1966-03-31,CY,Cyprus,
-1966-03-31,CZ,Czechia,
-1966-03-31,DE,Germany,
-1966-03-31,DK,Denmark,
-1966-03-31,EE,Estonia,
-1966-03-31,ES,Spain,
-1966-03-31,FI,Finland,
-1966-03-31,FR,France,
-1966-03-31,GB,United Kingdom,
-1966-03-31,GR,Greece,
-1966-03-31,HK,Hong Kong SAR,
-1966-03-31,HR,Croatia,
-1966-03-31,HU,Hungary,
-1966-03-31,ID,Indonesia,
-1966-03-31,IE,Ireland,
-1966-03-31,IL,Israel,
-1966-03-31,IN,India,
-1966-03-31,IS,Iceland,
-1966-03-31,IT,Italy,-2.9137
+1965-12-31,NZ,New Zealand,3.9066
+1966-03-31,IT,Italy,-2.4247
 1966-03-31,JP,Japan,0.4015
-1966-03-31,KR,Korea,
-1966-03-31,LT,Lithuania,
-1966-03-31,LU,Luxembourg,
-1966-03-31,LV,Latvia,
-1966-03-31,MA,Morocco,
-1966-03-31,MK,North Macedonia,
-1966-03-31,MT,Malta,
-1966-03-31,MX,Mexico,
-1966-03-31,MY,Malaysia,
-1966-03-31,NL,Netherlands,
-1966-03-31,NO,Norway,
-1966-03-31,NZ,New Zealand,
-1966-03-31,PE,Peru,
-1966-03-31,PH,Philippines,
-1966-03-31,PL,Poland,
-1966-03-31,PT,Portugal,
-1966-03-31,RO,Romania,
-1966-03-31,RS,Serbia,
-1966-03-31,RU,Russia,
-1966-03-31,SE,Sweden,
-1966-03-31,SG,Singapore,
-1966-03-31,SI,Slovenia,
-1966-03-31,SK,Slovak Republic,
-1966-03-31,TH,Thailand,
-1966-03-31,TR,Türkiye,
-1966-03-31,US,United States,
-1966-03-31,XM,Euro area,
-1966-03-31,XW,World,
-1966-03-31,ZA,South Africa,
-1966-06-30,4T,Emerging market economies (aggregate),
-1966-06-30,5R,Advanced economies,
-1966-06-30,AE,United Arab Emirates,
-1966-06-30,AT,Austria,
-1966-06-30,AU,Australia,
-1966-06-30,BE,Belgium,
-1966-06-30,BG,Bulgaria,
-1966-06-30,BR,Brazil,
-1966-06-30,CA,Canada,
-1966-06-30,CH,Switzerland,
-1966-06-30,CL,Chile,
-1966-06-30,CN,China,
-1966-06-30,CO,Colombia,
-1966-06-30,CY,Cyprus,
-1966-06-30,CZ,Czechia,
-1966-06-30,DE,Germany,
-1966-06-30,DK,Denmark,
-1966-06-30,EE,Estonia,
-1966-06-30,ES,Spain,
-1966-06-30,FI,Finland,
-1966-06-30,FR,France,
-1966-06-30,GB,United Kingdom,
-1966-06-30,GR,Greece,
-1966-06-30,HK,Hong Kong SAR,
-1966-06-30,HR,Croatia,
-1966-06-30,HU,Hungary,
-1966-06-30,ID,Indonesia,
-1966-06-30,IE,Ireland,
-1966-06-30,IL,Israel,
-1966-06-30,IN,India,
-1966-06-30,IS,Iceland,
-1966-06-30,IT,Italy,-0.4588
+1966-03-31,NZ,New Zealand,1.9684
+1966-06-30,IT,Italy,0.044
 1966-06-30,JP,Japan,1.9221
-1966-06-30,KR,Korea,
-1966-06-30,LT,Lithuania,
-1966-06-30,LU,Luxembourg,
-1966-06-30,LV,Latvia,
-1966-06-30,MA,Morocco,
-1966-06-30,MK,North Macedonia,
-1966-06-30,MT,Malta,
-1966-06-30,MX,Mexico,
-1966-06-30,MY,Malaysia,
-1966-06-30,NL,Netherlands,
-1966-06-30,NO,Norway,
-1966-06-30,NZ,New Zealand,
-1966-06-30,PE,Peru,
-1966-06-30,PH,Philippines,
-1966-06-30,PL,Poland,
-1966-06-30,PT,Portugal,
-1966-06-30,RO,Romania,
-1966-06-30,RS,Serbia,
-1966-06-30,RU,Russia,
-1966-06-30,SE,Sweden,
-1966-06-30,SG,Singapore,
-1966-06-30,SI,Slovenia,
-1966-06-30,SK,Slovak Republic,
-1966-06-30,TH,Thailand,
-1966-06-30,TR,Türkiye,
-1966-06-30,US,United States,
-1966-06-30,XM,Euro area,
-1966-06-30,XW,World,
-1966-06-30,ZA,South Africa,
-1966-09-30,4T,Emerging market economies (aggregate),
-1966-09-30,5R,Advanced economies,
-1966-09-30,AE,United Arab Emirates,
-1966-09-30,AT,Austria,
-1966-09-30,AU,Australia,
-1966-09-30,BE,Belgium,
-1966-09-30,BG,Bulgaria,
-1966-09-30,BR,Brazil,
-1966-09-30,CA,Canada,
-1966-09-30,CH,Switzerland,
-1966-09-30,CL,Chile,
-1966-09-30,CN,China,
-1966-09-30,CO,Colombia,
-1966-09-30,CY,Cyprus,
-1966-09-30,CZ,Czechia,
-1966-09-30,DE,Germany,
-1966-09-30,DK,Denmark,
-1966-09-30,EE,Estonia,
-1966-09-30,ES,Spain,
-1966-09-30,FI,Finland,
-1966-09-30,FR,France,
-1966-09-30,GB,United Kingdom,
-1966-09-30,GR,Greece,
-1966-09-30,HK,Hong Kong SAR,
-1966-09-30,HR,Croatia,
-1966-09-30,HU,Hungary,
-1966-09-30,ID,Indonesia,
-1966-09-30,IE,Ireland,
-1966-09-30,IL,Israel,
-1966-09-30,IN,India,
-1966-09-30,IS,Iceland,
-1966-09-30,IT,Italy,-0.3431
+1966-06-30,NZ,New Zealand,0.7714
+1966-09-30,IT,Italy,-0.7225
 1966-09-30,JP,Japan,2.5755
-1966-09-30,KR,Korea,
-1966-09-30,LT,Lithuania,
-1966-09-30,LU,Luxembourg,
-1966-09-30,LV,Latvia,
-1966-09-30,MA,Morocco,
-1966-09-30,MK,North Macedonia,
-1966-09-30,MT,Malta,
-1966-09-30,MX,Mexico,
-1966-09-30,MY,Malaysia,
-1966-09-30,NL,Netherlands,
-1966-09-30,NO,Norway,
-1966-09-30,NZ,New Zealand,
-1966-09-30,PE,Peru,
-1966-09-30,PH,Philippines,
-1966-09-30,PL,Poland,
-1966-09-30,PT,Portugal,
-1966-09-30,RO,Romania,
-1966-09-30,RS,Serbia,
-1966-09-30,RU,Russia,
-1966-09-30,SE,Sweden,
-1966-09-30,SG,Singapore,
-1966-09-30,SI,Slovenia,
-1966-09-30,SK,Slovak Republic,
-1966-09-30,TH,Thailand,
-1966-09-30,TR,Türkiye,
-1966-09-30,US,United States,
-1966-09-30,XM,Euro area,
-1966-09-30,XW,World,
-1966-09-30,ZA,South Africa,
-1966-12-31,4T,Emerging market economies (aggregate),
-1966-12-31,5R,Advanced economies,
-1966-12-31,AE,United Arab Emirates,
-1966-12-31,AT,Austria,
-1966-12-31,AU,Australia,
-1966-12-31,BE,Belgium,
-1966-12-31,BG,Bulgaria,
-1966-12-31,BR,Brazil,
-1966-12-31,CA,Canada,
-1966-12-31,CH,Switzerland,
-1966-12-31,CL,Chile,
-1966-12-31,CN,China,
-1966-12-31,CO,Colombia,
-1966-12-31,CY,Cyprus,
-1966-12-31,CZ,Czechia,
-1966-12-31,DE,Germany,
-1966-12-31,DK,Denmark,
-1966-12-31,EE,Estonia,
-1966-12-31,ES,Spain,
-1966-12-31,FI,Finland,
-1966-12-31,FR,France,
-1966-12-31,GB,United Kingdom,
-1966-12-31,GR,Greece,
-1966-12-31,HK,Hong Kong SAR,
-1966-12-31,HR,Croatia,
-1966-12-31,HU,Hungary,
-1966-12-31,ID,Indonesia,
-1966-12-31,IE,Ireland,
-1966-12-31,IL,Israel,
-1966-12-31,IN,India,
-1966-12-31,IS,Iceland,
-1966-12-31,IT,Italy,-0.8427
+1966-09-30,NZ,New Zealand,2.7809
+1966-12-31,IT,Italy,-2.6669
 1966-12-31,JP,Japan,4.4226
-1966-12-31,KR,Korea,
-1966-12-31,LT,Lithuania,
-1966-12-31,LU,Luxembourg,
-1966-12-31,LV,Latvia,
-1966-12-31,MA,Morocco,
-1966-12-31,MK,North Macedonia,
-1966-12-31,MT,Malta,
-1966-12-31,MX,Mexico,
-1966-12-31,MY,Malaysia,
-1966-12-31,NL,Netherlands,
-1966-12-31,NO,Norway,
-1966-12-31,NZ,New Zealand,
-1966-12-31,PE,Peru,
-1966-12-31,PH,Philippines,
-1966-12-31,PL,Poland,
-1966-12-31,PT,Portugal,
-1966-12-31,RO,Romania,
-1966-12-31,RS,Serbia,
-1966-12-31,RU,Russia,
-1966-12-31,SE,Sweden,
-1966-12-31,SG,Singapore,
-1966-12-31,SI,Slovenia,
-1966-12-31,SK,Slovak Republic,
-1966-12-31,TH,Thailand,
-1966-12-31,TR,Türkiye,
-1966-12-31,US,United States,
-1966-12-31,XM,Euro area,
-1966-12-31,XW,World,
-1966-12-31,ZA,South Africa,
-1967-03-31,4T,Emerging market economies (aggregate),
-1967-03-31,5R,Advanced economies,
-1967-03-31,AE,United Arab Emirates,
-1967-03-31,AT,Austria,
-1967-03-31,AU,Australia,
-1967-03-31,BE,Belgium,
-1967-03-31,BG,Bulgaria,
-1967-03-31,BR,Brazil,
-1967-03-31,CA,Canada,
-1967-03-31,CH,Switzerland,
-1967-03-31,CL,Chile,
-1967-03-31,CN,China,
-1967-03-31,CO,Colombia,
-1967-03-31,CY,Cyprus,
-1967-03-31,CZ,Czechia,
-1967-03-31,DE,Germany,
-1967-03-31,DK,Denmark,
-1967-03-31,EE,Estonia,
-1967-03-31,ES,Spain,
-1967-03-31,FI,Finland,
-1967-03-31,FR,France,
-1967-03-31,GB,United Kingdom,
-1967-03-31,GR,Greece,
-1967-03-31,HK,Hong Kong SAR,
-1967-03-31,HR,Croatia,
-1967-03-31,HU,Hungary,
-1967-03-31,ID,Indonesia,
-1967-03-31,IE,Ireland,
-1967-03-31,IL,Israel,
-1967-03-31,IN,India,
-1967-03-31,IS,Iceland,
-1967-03-31,IT,Italy,-1.8131
+1966-12-31,NZ,New Zealand,3.5629
+1967-03-31,IT,Italy,-2.9772
 1967-03-31,JP,Japan,5.2009
-1967-03-31,KR,Korea,
-1967-03-31,LT,Lithuania,
-1967-03-31,LU,Luxembourg,
-1967-03-31,LV,Latvia,
-1967-03-31,MA,Morocco,
-1967-03-31,MK,North Macedonia,
-1967-03-31,MT,Malta,
-1967-03-31,MX,Mexico,
-1967-03-31,MY,Malaysia,
-1967-03-31,NL,Netherlands,
-1967-03-31,NO,Norway,
-1967-03-31,NZ,New Zealand,
-1967-03-31,PE,Peru,
-1967-03-31,PH,Philippines,
-1967-03-31,PL,Poland,
-1967-03-31,PT,Portugal,
-1967-03-31,RO,Romania,
-1967-03-31,RS,Serbia,
-1967-03-31,RU,Russia,
-1967-03-31,SE,Sweden,
-1967-03-31,SG,Singapore,
-1967-03-31,SI,Slovenia,
-1967-03-31,SK,Slovak Republic,
-1967-03-31,TH,Thailand,
-1967-03-31,TR,Türkiye,
-1967-03-31,US,United States,
-1967-03-31,XM,Euro area,
-1967-03-31,XW,World,
-1967-03-31,ZA,South Africa,12.4215
-1967-06-30,4T,Emerging market economies (aggregate),
-1967-06-30,5R,Advanced economies,
-1967-06-30,AE,United Arab Emirates,
-1967-06-30,AT,Austria,
-1967-06-30,AU,Australia,
-1967-06-30,BE,Belgium,
-1967-06-30,BG,Bulgaria,
-1967-06-30,BR,Brazil,
-1967-06-30,CA,Canada,
-1967-06-30,CH,Switzerland,
-1967-06-30,CL,Chile,
-1967-06-30,CN,China,
-1967-06-30,CO,Colombia,
-1967-06-30,CY,Cyprus,
-1967-06-30,CZ,Czechia,
-1967-06-30,DE,Germany,
-1967-06-30,DK,Denmark,
-1967-06-30,EE,Estonia,
-1967-06-30,ES,Spain,
-1967-06-30,FI,Finland,
-1967-06-30,FR,France,
-1967-06-30,GB,United Kingdom,
-1967-06-30,GR,Greece,
-1967-06-30,HK,Hong Kong SAR,
-1967-06-30,HR,Croatia,
-1967-06-30,HU,Hungary,
-1967-06-30,ID,Indonesia,
-1967-06-30,IE,Ireland,
-1967-06-30,IL,Israel,
-1967-06-30,IN,India,
-1967-06-30,IS,Iceland,
-1967-06-30,IT,Italy,-2.3767
+1967-03-31,NZ,New Zealand,1.6692
+1967-03-31,ZA,South Africa,12.5412
+1967-06-30,IT,Italy,-4.5644
 1967-06-30,JP,Japan,8.6515
-1967-06-30,KR,Korea,
-1967-06-30,LT,Lithuania,
-1967-06-30,LU,Luxembourg,
-1967-06-30,LV,Latvia,
-1967-06-30,MA,Morocco,
-1967-06-30,MK,North Macedonia,
-1967-06-30,MT,Malta,
-1967-06-30,MX,Mexico,
-1967-06-30,MY,Malaysia,
-1967-06-30,NL,Netherlands,
-1967-06-30,NO,Norway,
-1967-06-30,NZ,New Zealand,
-1967-06-30,PE,Peru,
-1967-06-30,PH,Philippines,
-1967-06-30,PL,Poland,
-1967-06-30,PT,Portugal,
-1967-06-30,RO,Romania,
-1967-06-30,RS,Serbia,
-1967-06-30,RU,Russia,
-1967-06-30,SE,Sweden,
-1967-06-30,SG,Singapore,
-1967-06-30,SI,Slovenia,
-1967-06-30,SK,Slovak Republic,
-1967-06-30,TH,Thailand,
-1967-06-30,TR,Türkiye,
-1967-06-30,US,United States,
-1967-06-30,XM,Euro area,
-1967-06-30,XW,World,
-1967-06-30,ZA,South Africa,13.3163
-1967-09-30,4T,Emerging market economies (aggregate),
-1967-09-30,5R,Advanced economies,
-1967-09-30,AE,United Arab Emirates,
-1967-09-30,AT,Austria,
-1967-09-30,AU,Australia,
-1967-09-30,BE,Belgium,
-1967-09-30,BG,Bulgaria,
-1967-09-30,BR,Brazil,
-1967-09-30,CA,Canada,
-1967-09-30,CH,Switzerland,
-1967-09-30,CL,Chile,
-1967-09-30,CN,China,
-1967-09-30,CO,Colombia,
-1967-09-30,CY,Cyprus,
-1967-09-30,CZ,Czechia,
-1967-09-30,DE,Germany,
-1967-09-30,DK,Denmark,
-1967-09-30,EE,Estonia,
-1967-09-30,ES,Spain,
-1967-09-30,FI,Finland,
-1967-09-30,FR,France,
-1967-09-30,GB,United Kingdom,
-1967-09-30,GR,Greece,
-1967-09-30,HK,Hong Kong SAR,
-1967-09-30,HR,Croatia,
-1967-09-30,HU,Hungary,
-1967-09-30,ID,Indonesia,
-1967-09-30,IE,Ireland,
-1967-09-30,IL,Israel,
-1967-09-30,IN,India,
-1967-09-30,IS,Iceland,
-1967-09-30,IT,Italy,0.0187
+1967-06-30,NZ,New Zealand,-1.1369
+1967-06-30,ZA,South Africa,13.5031
+1967-09-30,IT,Italy,-2.0312
 1967-09-30,JP,Japan,10.2018
-1967-09-30,KR,Korea,
-1967-09-30,LT,Lithuania,
-1967-09-30,LU,Luxembourg,
-1967-09-30,LV,Latvia,
-1967-09-30,MA,Morocco,
-1967-09-30,MK,North Macedonia,
-1967-09-30,MT,Malta,
-1967-09-30,MX,Mexico,
-1967-09-30,MY,Malaysia,
-1967-09-30,NL,Netherlands,
-1967-09-30,NO,Norway,
-1967-09-30,NZ,New Zealand,
-1967-09-30,PE,Peru,
-1967-09-30,PH,Philippines,
-1967-09-30,PL,Poland,
-1967-09-30,PT,Portugal,
-1967-09-30,RO,Romania,
-1967-09-30,RS,Serbia,
-1967-09-30,RU,Russia,
-1967-09-30,SE,Sweden,
-1967-09-30,SG,Singapore,
-1967-09-30,SI,Slovenia,
-1967-09-30,SK,Slovak Republic,
-1967-09-30,TH,Thailand,
-1967-09-30,TR,Türkiye,
-1967-09-30,US,United States,
-1967-09-30,XM,Euro area,
-1967-09-30,XW,World,
-1967-09-30,ZA,South Africa,18.4774
-1967-12-31,4T,Emerging market economies (aggregate),
-1967-12-31,5R,Advanced economies,
-1967-12-31,AE,United Arab Emirates,
-1967-12-31,AT,Austria,
-1967-12-31,AU,Australia,
-1967-12-31,BE,Belgium,
-1967-12-31,BG,Bulgaria,
-1967-12-31,BR,Brazil,
-1967-12-31,CA,Canada,
-1967-12-31,CH,Switzerland,
-1967-12-31,CL,Chile,
-1967-12-31,CN,China,
-1967-12-31,CO,Colombia,
-1967-12-31,CY,Cyprus,
-1967-12-31,CZ,Czechia,
-1967-12-31,DE,Germany,
-1967-12-31,DK,Denmark,
-1967-12-31,EE,Estonia,
-1967-12-31,ES,Spain,
-1967-12-31,FI,Finland,
-1967-12-31,FR,France,
-1967-12-31,GB,United Kingdom,
-1967-12-31,GR,Greece,
-1967-12-31,HK,Hong Kong SAR,
-1967-12-31,HR,Croatia,
-1967-12-31,HU,Hungary,
-1967-12-31,ID,Indonesia,
-1967-12-31,IE,Ireland,
-1967-12-31,IL,Israel,
-1967-12-31,IN,India,
-1967-12-31,IS,Iceland,
-1967-12-31,IT,Italy,3.6649
+1967-09-30,NZ,New Zealand,-3.5328
+1967-09-30,ZA,South Africa,18.3317
+1967-12-31,IT,Italy,2.6428
 1967-12-31,JP,Japan,9.6284
-1967-12-31,KR,Korea,
-1967-12-31,LT,Lithuania,
-1967-12-31,LU,Luxembourg,
-1967-12-31,LV,Latvia,
-1967-12-31,MA,Morocco,
-1967-12-31,MK,North Macedonia,
-1967-12-31,MT,Malta,
-1967-12-31,MX,Mexico,
-1967-12-31,MY,Malaysia,
-1967-12-31,NL,Netherlands,
-1967-12-31,NO,Norway,
-1967-12-31,NZ,New Zealand,
-1967-12-31,PE,Peru,
-1967-12-31,PH,Philippines,
-1967-12-31,PL,Poland,
-1967-12-31,PT,Portugal,
-1967-12-31,RO,Romania,
-1967-12-31,RS,Serbia,
-1967-12-31,RU,Russia,
-1967-12-31,SE,Sweden,
-1967-12-31,SG,Singapore,
-1967-12-31,SI,Slovenia,
-1967-12-31,SK,Slovak Republic,
-1967-12-31,TH,Thailand,
-1967-12-31,TR,Türkiye,
-1967-12-31,US,United States,
-1967-12-31,XM,Euro area,
-1967-12-31,XW,World,
-1967-12-31,ZA,South Africa,15.7932
-1968-03-31,4T,Emerging market economies (aggregate),
-1968-03-31,5R,Advanced economies,
-1968-03-31,AE,United Arab Emirates,
-1968-03-31,AT,Austria,
-1968-03-31,AU,Australia,
-1968-03-31,BE,Belgium,
-1968-03-31,BG,Bulgaria,
-1968-03-31,BR,Brazil,
-1968-03-31,CA,Canada,
-1968-03-31,CH,Switzerland,
-1968-03-31,CL,Chile,
-1968-03-31,CN,China,
-1968-03-31,CO,Colombia,
-1968-03-31,CY,Cyprus,
-1968-03-31,CZ,Czechia,
-1968-03-31,DE,Germany,
-1968-03-31,DK,Denmark,
-1968-03-31,EE,Estonia,
-1968-03-31,ES,Spain,
-1968-03-31,FI,Finland,
-1968-03-31,FR,France,
-1968-03-31,GB,United Kingdom,
-1968-03-31,GR,Greece,
-1968-03-31,HK,Hong Kong SAR,
-1968-03-31,HR,Croatia,
-1968-03-31,HU,Hungary,
-1968-03-31,ID,Indonesia,
-1968-03-31,IE,Ireland,
-1968-03-31,IL,Israel,
-1968-03-31,IN,India,
-1968-03-31,IS,Iceland,
-1968-03-31,IT,Italy,7.0478
+1967-12-31,NZ,New Zealand,-4.9809
+1967-12-31,ZA,South Africa,15.7559
+1968-03-31,IT,Italy,5.3868
 1968-03-31,JP,Japan,10.9666
-1968-03-31,KR,Korea,
-1968-03-31,LT,Lithuania,
-1968-03-31,LU,Luxembourg,
-1968-03-31,LV,Latvia,
-1968-03-31,MA,Morocco,
-1968-03-31,MK,North Macedonia,
-1968-03-31,MT,Malta,
-1968-03-31,MX,Mexico,
-1968-03-31,MY,Malaysia,
-1968-03-31,NL,Netherlands,
-1968-03-31,NO,Norway,
-1968-03-31,NZ,New Zealand,
-1968-03-31,PE,Peru,
-1968-03-31,PH,Philippines,
-1968-03-31,PL,Poland,
-1968-03-31,PT,Portugal,
-1968-03-31,RO,Romania,
-1968-03-31,RS,Serbia,
-1968-03-31,RU,Russia,
-1968-03-31,SE,Sweden,
-1968-03-31,SG,Singapore,
-1968-03-31,SI,Slovenia,
-1968-03-31,SK,Slovak Republic,
-1968-03-31,TH,Thailand,
-1968-03-31,TR,Türkiye,
-1968-03-31,US,United States,
-1968-03-31,XM,Euro area,
-1968-03-31,XW,World,
-1968-03-31,ZA,South Africa,2.5992
-1968-06-30,4T,Emerging market economies (aggregate),
-1968-06-30,5R,Advanced economies,
-1968-06-30,AE,United Arab Emirates,
-1968-06-30,AT,Austria,
-1968-06-30,AU,Australia,
-1968-06-30,BE,Belgium,
-1968-06-30,BG,Bulgaria,
-1968-06-30,BR,Brazil,
-1968-06-30,CA,Canada,
-1968-06-30,CH,Switzerland,
-1968-06-30,CL,Chile,
-1968-06-30,CN,China,
-1968-06-30,CO,Colombia,
-1968-06-30,CY,Cyprus,
-1968-06-30,CZ,Czechia,
-1968-06-30,DE,Germany,
-1968-06-30,DK,Denmark,
-1968-06-30,EE,Estonia,
-1968-06-30,ES,Spain,
-1968-06-30,FI,Finland,
-1968-06-30,FR,France,
-1968-06-30,GB,United Kingdom,
-1968-06-30,GR,Greece,
-1968-06-30,HK,Hong Kong SAR,
-1968-06-30,HR,Croatia,
-1968-06-30,HU,Hungary,
-1968-06-30,ID,Indonesia,
-1968-06-30,IE,Ireland,
-1968-06-30,IL,Israel,
-1968-06-30,IN,India,
-1968-06-30,IS,Iceland,
-1968-06-30,IT,Italy,10.2226
+1968-03-31,NZ,New Zealand,-3.5628
+1968-03-31,ZA,South Africa,2.7967
+1968-06-30,IT,Italy,10.6437
 1968-06-30,JP,Japan,10.9567
-1968-06-30,KR,Korea,
-1968-06-30,LT,Lithuania,
-1968-06-30,LU,Luxembourg,
-1968-06-30,LV,Latvia,
-1968-06-30,MA,Morocco,
-1968-06-30,MK,North Macedonia,
-1968-06-30,MT,Malta,
-1968-06-30,MX,Mexico,
-1968-06-30,MY,Malaysia,
-1968-06-30,NL,Netherlands,
-1968-06-30,NO,Norway,
-1968-06-30,NZ,New Zealand,
-1968-06-30,PE,Peru,
-1968-06-30,PH,Philippines,
-1968-06-30,PL,Poland,
-1968-06-30,PT,Portugal,
-1968-06-30,RO,Romania,
-1968-06-30,RS,Serbia,
-1968-06-30,RU,Russia,
-1968-06-30,SE,Sweden,
-1968-06-30,SG,Singapore,
-1968-06-30,SI,Slovenia,
-1968-06-30,SK,Slovak Republic,
-1968-06-30,TH,Thailand,
-1968-06-30,TR,Türkiye,
-1968-06-30,US,United States,
-1968-06-30,XM,Euro area,
-1968-06-30,XW,World,
-1968-06-30,ZA,South Africa,0.9628
-1968-09-30,4T,Emerging market economies (aggregate),
-1968-09-30,5R,Advanced economies,
-1968-09-30,AE,United Arab Emirates,
-1968-09-30,AT,Austria,
-1968-09-30,AU,Australia,
-1968-09-30,BE,Belgium,
-1968-09-30,BG,Bulgaria,
-1968-09-30,BR,Brazil,
-1968-09-30,CA,Canada,
-1968-09-30,CH,Switzerland,
-1968-09-30,CL,Chile,
-1968-09-30,CN,China,
-1968-09-30,CO,Colombia,
-1968-09-30,CY,Cyprus,
-1968-09-30,CZ,Czechia,
-1968-09-30,DE,Germany,
-1968-09-30,DK,Denmark,
-1968-09-30,EE,Estonia,
-1968-09-30,ES,Spain,
-1968-09-30,FI,Finland,
-1968-09-30,FR,France,
-1968-09-30,GB,United Kingdom,
-1968-09-30,GR,Greece,
-1968-09-30,HK,Hong Kong SAR,
-1968-09-30,HR,Croatia,
-1968-09-30,HU,Hungary,
-1968-09-30,ID,Indonesia,
-1968-09-30,IE,Ireland,
-1968-09-30,IL,Israel,
-1968-09-30,IN,India,
-1968-09-30,IS,Iceland,
-1968-09-30,IT,Italy,8.946
+1968-06-30,NZ,New Zealand,-2.2521
+1968-06-30,ZA,South Africa,0.8086
+1968-09-30,IT,Italy,9.6472
 1968-09-30,JP,Japan,10.9116
-1968-09-30,KR,Korea,
-1968-09-30,LT,Lithuania,
-1968-09-30,LU,Luxembourg,
-1968-09-30,LV,Latvia,
-1968-09-30,MA,Morocco,
-1968-09-30,MK,North Macedonia,
-1968-09-30,MT,Malta,
-1968-09-30,MX,Mexico,
-1968-09-30,MY,Malaysia,
-1968-09-30,NL,Netherlands,
-1968-09-30,NO,Norway,
-1968-09-30,NZ,New Zealand,
-1968-09-30,PE,Peru,
-1968-09-30,PH,Philippines,
-1968-09-30,PL,Poland,
-1968-09-30,PT,Portugal,
-1968-09-30,RO,Romania,
-1968-09-30,RS,Serbia,
-1968-09-30,RU,Russia,
-1968-09-30,SE,Sweden,
-1968-09-30,SG,Singapore,
-1968-09-30,SI,Slovenia,
-1968-09-30,SK,Slovak Republic,
-1968-09-30,TH,Thailand,
-1968-09-30,TR,Türkiye,
-1968-09-30,US,United States,
-1968-09-30,XM,Euro area,
-1968-09-30,XW,World,
-1968-09-30,ZA,South Africa,1.093
-1968-12-31,4T,Emerging market economies (aggregate),
-1968-12-31,5R,Advanced economies,
-1968-12-31,AE,United Arab Emirates,
-1968-12-31,AT,Austria,
-1968-12-31,AU,Australia,
-1968-12-31,BE,Belgium,
-1968-12-31,BG,Bulgaria,
-1968-12-31,BR,Brazil,
-1968-12-31,CA,Canada,
-1968-12-31,CH,Switzerland,
-1968-12-31,CL,Chile,
-1968-12-31,CN,China,
-1968-12-31,CO,Colombia,
-1968-12-31,CY,Cyprus,
-1968-12-31,CZ,Czechia,
-1968-12-31,DE,Germany,
-1968-12-31,DK,Denmark,
-1968-12-31,EE,Estonia,
-1968-12-31,ES,Spain,
-1968-12-31,FI,Finland,
-1968-12-31,FR,France,
-1968-12-31,GB,United Kingdom,
-1968-12-31,GR,Greece,
-1968-12-31,HK,Hong Kong SAR,
-1968-12-31,HR,Croatia,
-1968-12-31,HU,Hungary,
-1968-12-31,ID,Indonesia,
-1968-12-31,IE,Ireland,
-1968-12-31,IL,Israel,
-1968-12-31,IN,India,
-1968-12-31,IS,Iceland,
-1968-12-31,IT,Italy,5.2551
+1968-09-30,NZ,New Zealand,-1.7009
+1968-09-30,ZA,South Africa,1.3474
+1968-12-31,IT,Italy,5.73
 1968-12-31,JP,Japan,13.1028
-1968-12-31,KR,Korea,
-1968-12-31,LT,Lithuania,
-1968-12-31,LU,Luxembourg,
-1968-12-31,LV,Latvia,
-1968-12-31,MA,Morocco,
-1968-12-31,MK,North Macedonia,
-1968-12-31,MT,Malta,
-1968-12-31,MX,Mexico,
-1968-12-31,MY,Malaysia,
-1968-12-31,NL,Netherlands,
-1968-12-31,NO,Norway,
-1968-12-31,NZ,New Zealand,
-1968-12-31,PE,Peru,
-1968-12-31,PH,Philippines,
-1968-12-31,PL,Poland,
-1968-12-31,PT,Portugal,
-1968-12-31,RO,Romania,
-1968-12-31,RS,Serbia,
-1968-12-31,RU,Russia,
-1968-12-31,SE,Sweden,
-1968-12-31,SG,Singapore,
-1968-12-31,SI,Slovenia,
-1968-12-31,SK,Slovak Republic,
-1968-12-31,TH,Thailand,
-1968-12-31,TR,Türkiye,
-1968-12-31,US,United States,
-1968-12-31,XM,Euro area,
-1968-12-31,XW,World,
-1968-12-31,ZA,South Africa,4.3335
-1969-03-31,4T,Emerging market economies (aggregate),
-1969-03-31,5R,Advanced economies,
-1969-03-31,AE,United Arab Emirates,
-1969-03-31,AT,Austria,
-1969-03-31,AU,Australia,
-1969-03-31,BE,Belgium,
-1969-03-31,BG,Bulgaria,
-1969-03-31,BR,Brazil,
-1969-03-31,CA,Canada,
-1969-03-31,CH,Switzerland,
-1969-03-31,CL,Chile,
-1969-03-31,CN,China,
-1969-03-31,CO,Colombia,
-1969-03-31,CY,Cyprus,
-1969-03-31,CZ,Czechia,
-1969-03-31,DE,Germany,
-1969-03-31,DK,Denmark,
-1969-03-31,EE,Estonia,
-1969-03-31,ES,Spain,
-1969-03-31,FI,Finland,
-1969-03-31,FR,France,
-1969-03-31,GB,United Kingdom,
-1969-03-31,GR,Greece,
-1969-03-31,HK,Hong Kong SAR,
-1969-03-31,HR,Croatia,
-1969-03-31,HU,Hungary,
-1969-03-31,ID,Indonesia,
-1969-03-31,IE,Ireland,
-1969-03-31,IL,Israel,
-1969-03-31,IN,India,
-1969-03-31,IS,Iceland,
-1969-03-31,IT,Italy,2.5715
+1968-12-31,NZ,New Zealand,-2.4624
+1968-12-31,ZA,South Africa,4.37
+1969-03-31,IT,Italy,2.9187
 1969-03-31,JP,Japan,15.285
-1969-03-31,KR,Korea,
-1969-03-31,LT,Lithuania,
-1969-03-31,LU,Luxembourg,
-1969-03-31,LV,Latvia,
-1969-03-31,MA,Morocco,
-1969-03-31,MK,North Macedonia,
-1969-03-31,MT,Malta,
-1969-03-31,MX,Mexico,
-1969-03-31,MY,Malaysia,
-1969-03-31,NL,Netherlands,
-1969-03-31,NO,Norway,
-1969-03-31,NZ,New Zealand,
-1969-03-31,PE,Peru,
-1969-03-31,PH,Philippines,
-1969-03-31,PL,Poland,
-1969-03-31,PT,Portugal,
-1969-03-31,RO,Romania,
-1969-03-31,RS,Serbia,
-1969-03-31,RU,Russia,
-1969-03-31,SE,Sweden,
-1969-03-31,SG,Singapore,
-1969-03-31,SI,Slovenia,
-1969-03-31,SK,Slovak Republic,
-1969-03-31,TH,Thailand,
-1969-03-31,TR,Türkiye,
-1969-03-31,US,United States,
-1969-03-31,XM,Euro area,
-1969-03-31,XW,World,
-1969-03-31,ZA,South Africa,6.9571
-1969-06-30,4T,Emerging market economies (aggregate),
-1969-06-30,5R,Advanced economies,
-1969-06-30,AE,United Arab Emirates,
-1969-06-30,AT,Austria,
-1969-06-30,AU,Australia,
-1969-06-30,BE,Belgium,
-1969-06-30,BG,Bulgaria,
-1969-06-30,BR,Brazil,
-1969-06-30,CA,Canada,
-1969-06-30,CH,Switzerland,
-1969-06-30,CL,Chile,
-1969-06-30,CN,China,
-1969-06-30,CO,Colombia,
-1969-06-30,CY,Cyprus,
-1969-06-30,CZ,Czechia,
-1969-06-30,DE,Germany,
-1969-06-30,DK,Denmark,
-1969-06-30,EE,Estonia,
-1969-06-30,ES,Spain,
-1969-06-30,FI,Finland,
-1969-06-30,FR,France,
+1969-03-31,NZ,New Zealand,-1.6758
+1969-03-31,ZA,South Africa,7.1142
 1969-06-30,GB,United Kingdom,0.4139
-1969-06-30,GR,Greece,
-1969-06-30,HK,Hong Kong SAR,
-1969-06-30,HR,Croatia,
-1969-06-30,HU,Hungary,
-1969-06-30,ID,Indonesia,
-1969-06-30,IE,Ireland,
-1969-06-30,IL,Israel,
-1969-06-30,IN,India,
-1969-06-30,IS,Iceland,
-1969-06-30,IT,Italy,0.4985
+1969-06-30,IT,Italy,0.2743
 1969-06-30,JP,Japan,15.2631
-1969-06-30,KR,Korea,
-1969-06-30,LT,Lithuania,
-1969-06-30,LU,Luxembourg,
-1969-06-30,LV,Latvia,
-1969-06-30,MA,Morocco,
-1969-06-30,MK,North Macedonia,
-1969-06-30,MT,Malta,
-1969-06-30,MX,Mexico,
-1969-06-30,MY,Malaysia,
-1969-06-30,NL,Netherlands,
-1969-06-30,NO,Norway,
-1969-06-30,NZ,New Zealand,
-1969-06-30,PE,Peru,
-1969-06-30,PH,Philippines,
-1969-06-30,PL,Poland,
-1969-06-30,PT,Portugal,
-1969-06-30,RO,Romania,
-1969-06-30,RS,Serbia,
-1969-06-30,RU,Russia,
-1969-06-30,SE,Sweden,
-1969-06-30,SG,Singapore,
-1969-06-30,SI,Slovenia,
-1969-06-30,SK,Slovak Republic,
-1969-06-30,TH,Thailand,
-1969-06-30,TR,Türkiye,
-1969-06-30,US,United States,
-1969-06-30,XM,Euro area,
-1969-06-30,XW,World,
-1969-06-30,ZA,South Africa,8.875
-1969-09-30,4T,Emerging market economies (aggregate),
-1969-09-30,5R,Advanced economies,
-1969-09-30,AE,United Arab Emirates,
-1969-09-30,AT,Austria,
-1969-09-30,AU,Australia,
-1969-09-30,BE,Belgium,
-1969-09-30,BG,Bulgaria,
-1969-09-30,BR,Brazil,
-1969-09-30,CA,Canada,
-1969-09-30,CH,Switzerland,
-1969-09-30,CL,Chile,
-1969-09-30,CN,China,
-1969-09-30,CO,Colombia,
-1969-09-30,CY,Cyprus,
-1969-09-30,CZ,Czechia,
-1969-09-30,DE,Germany,
-1969-09-30,DK,Denmark,
-1969-09-30,EE,Estonia,
-1969-09-30,ES,Spain,
-1969-09-30,FI,Finland,
-1969-09-30,FR,France,
+1969-06-30,NZ,New Zealand,-0.8803
+1969-06-30,ZA,South Africa,8.8093
 1969-09-30,GB,United Kingdom,-2.0057
-1969-09-30,GR,Greece,
-1969-09-30,HK,Hong Kong SAR,
-1969-09-30,HR,Croatia,
-1969-09-30,HU,Hungary,
-1969-09-30,ID,Indonesia,
-1969-09-30,IE,Ireland,
-1969-09-30,IL,Israel,
-1969-09-30,IN,India,
-1969-09-30,IS,Iceland,
-1969-09-30,IT,Italy,0.5415
+1969-09-30,IT,Italy,0.402
 1969-09-30,JP,Japan,14.8699
-1969-09-30,KR,Korea,
-1969-09-30,LT,Lithuania,
-1969-09-30,LU,Luxembourg,
-1969-09-30,LV,Latvia,
-1969-09-30,MA,Morocco,
-1969-09-30,MK,North Macedonia,
-1969-09-30,MT,Malta,
-1969-09-30,MX,Mexico,
-1969-09-30,MY,Malaysia,
-1969-09-30,NL,Netherlands,
-1969-09-30,NO,Norway,
-1969-09-30,NZ,New Zealand,
-1969-09-30,PE,Peru,
-1969-09-30,PH,Philippines,
-1969-09-30,PL,Poland,
-1969-09-30,PT,Portugal,
-1969-09-30,RO,Romania,
-1969-09-30,RS,Serbia,
-1969-09-30,RU,Russia,
-1969-09-30,SE,Sweden,
-1969-09-30,SG,Singapore,
-1969-09-30,SI,Slovenia,
-1969-09-30,SK,Slovak Republic,
-1969-09-30,TH,Thailand,
-1969-09-30,TR,Türkiye,
-1969-09-30,US,United States,
-1969-09-30,XM,Euro area,
-1969-09-30,XW,World,
-1969-09-30,ZA,South Africa,8.0161
-1969-12-31,4T,Emerging market economies (aggregate),
-1969-12-31,5R,Advanced economies,
-1969-12-31,AE,United Arab Emirates,
-1969-12-31,AT,Austria,
-1969-12-31,AU,Australia,
-1969-12-31,BE,Belgium,
-1969-12-31,BG,Bulgaria,
-1969-12-31,BR,Brazil,
-1969-12-31,CA,Canada,
-1969-12-31,CH,Switzerland,
-1969-12-31,CL,Chile,
-1969-12-31,CN,China,
-1969-12-31,CO,Colombia,
-1969-12-31,CY,Cyprus,
-1969-12-31,CZ,Czechia,
-1969-12-31,DE,Germany,
-1969-12-31,DK,Denmark,
-1969-12-31,EE,Estonia,
-1969-12-31,ES,Spain,
-1969-12-31,FI,Finland,
-1969-12-31,FR,France,
+1969-09-30,NZ,New Zealand,-0.1877
+1969-09-30,ZA,South Africa,8.1772
 1969-12-31,GB,United Kingdom,0.0609
-1969-12-31,GR,Greece,
-1969-12-31,HK,Hong Kong SAR,
-1969-12-31,HR,Croatia,
-1969-12-31,HU,Hungary,
-1969-12-31,ID,Indonesia,
-1969-12-31,IE,Ireland,
-1969-12-31,IL,Israel,
-1969-12-31,IN,India,
-1969-12-31,IS,Iceland,
-1969-12-31,IT,Italy,1.0866
+1969-12-31,IT,Italy,1.1446
 1969-12-31,JP,Japan,15.594
-1969-12-31,KR,Korea,
-1969-12-31,LT,Lithuania,
-1969-12-31,LU,Luxembourg,
-1969-12-31,LV,Latvia,
-1969-12-31,MA,Morocco,
-1969-12-31,MK,North Macedonia,
-1969-12-31,MT,Malta,
-1969-12-31,MX,Mexico,
-1969-12-31,MY,Malaysia,
-1969-12-31,NL,Netherlands,
-1969-12-31,NO,Norway,
-1969-12-31,NZ,New Zealand,
-1969-12-31,PE,Peru,
-1969-12-31,PH,Philippines,
-1969-12-31,PL,Poland,
-1969-12-31,PT,Portugal,
-1969-12-31,RO,Romania,
-1969-12-31,RS,Serbia,
-1969-12-31,RU,Russia,
-1969-12-31,SE,Sweden,
-1969-12-31,SG,Singapore,
-1969-12-31,SI,Slovenia,
-1969-12-31,SK,Slovak Republic,
-1969-12-31,TH,Thailand,
-1969-12-31,TR,Türkiye,
-1969-12-31,US,United States,
-1969-12-31,XM,Euro area,
-1969-12-31,XW,World,
-1969-12-31,ZA,South Africa,6.3465
-1970-03-31,4T,Emerging market economies (aggregate),
-1970-03-31,5R,Advanced economies,
-1970-03-31,AE,United Arab Emirates,
-1970-03-31,AT,Austria,
-1970-03-31,AU,Australia,
-1970-03-31,BE,Belgium,
-1970-03-31,BG,Bulgaria,
-1970-03-31,BR,Brazil,
-1970-03-31,CA,Canada,
-1970-03-31,CH,Switzerland,
-1970-03-31,CL,Chile,
-1970-03-31,CN,China,
-1970-03-31,CO,Colombia,
-1970-03-31,CY,Cyprus,
-1970-03-31,CZ,Czechia,
-1970-03-31,DE,Germany,
-1970-03-31,DK,Denmark,
-1970-03-31,EE,Estonia,
-1970-03-31,ES,Spain,
-1970-03-31,FI,Finland,
-1970-03-31,FR,France,
+1969-12-31,NZ,New Zealand,1.4324
+1969-12-31,ZA,South Africa,6.5086
 1970-03-31,GB,United Kingdom,0.1497
-1970-03-31,GR,Greece,
-1970-03-31,HK,Hong Kong SAR,
-1970-03-31,HR,Croatia,
-1970-03-31,HU,Hungary,
-1970-03-31,ID,Indonesia,
-1970-03-31,IE,Ireland,
-1970-03-31,IL,Israel,
-1970-03-31,IN,India,
-1970-03-31,IS,Iceland,
-1970-03-31,IT,Italy,2.019
+1970-03-31,IT,Italy,1.9517
 1970-03-31,JP,Japan,13.1351
-1970-03-31,KR,Korea,
-1970-03-31,LT,Lithuania,
-1970-03-31,LU,Luxembourg,
-1970-03-31,LV,Latvia,
-1970-03-31,MA,Morocco,
-1970-03-31,MK,North Macedonia,
-1970-03-31,MT,Malta,
-1970-03-31,MX,Mexico,
-1970-03-31,MY,Malaysia,
-1970-03-31,NL,Netherlands,
-1970-03-31,NO,Norway,
-1970-03-31,NZ,New Zealand,
-1970-03-31,PE,Peru,
-1970-03-31,PH,Philippines,
-1970-03-31,PL,Poland,
-1970-03-31,PT,Portugal,
-1970-03-31,RO,Romania,
-1970-03-31,RS,Serbia,
-1970-03-31,RU,Russia,
-1970-03-31,SE,Sweden,
-1970-03-31,SG,Singapore,
-1970-03-31,SI,Slovenia,
-1970-03-31,SK,Slovak Republic,
-1970-03-31,TH,Thailand,
-1970-03-31,TR,Türkiye,
-1970-03-31,US,United States,
-1970-03-31,XM,Euro area,
-1970-03-31,XW,World,
-1970-03-31,ZA,South Africa,10.7073
-1970-06-30,4T,Emerging market economies (aggregate),
-1970-06-30,5R,Advanced economies,
-1970-06-30,AE,United Arab Emirates,
-1970-06-30,AT,Austria,
-1970-06-30,AU,Australia,
-1970-06-30,BE,Belgium,
-1970-06-30,BG,Bulgaria,
-1970-06-30,BR,Brazil,
-1970-06-30,CA,Canada,
-1970-06-30,CH,Switzerland,
-1970-06-30,CL,Chile,
-1970-06-30,CN,China,
-1970-06-30,CO,Colombia,
-1970-06-30,CY,Cyprus,
-1970-06-30,CZ,Czechia,
-1970-06-30,DE,Germany,
-1970-06-30,DK,Denmark,
-1970-06-30,EE,Estonia,
-1970-06-30,ES,Spain,
-1970-06-30,FI,Finland,
-1970-06-30,FR,France,
+1970-03-31,NZ,New Zealand,0.568
+1970-03-31,ZA,South Africa,10.3236
 1970-06-30,GB,United Kingdom,-3.1935
-1970-06-30,GR,Greece,
-1970-06-30,HK,Hong Kong SAR,
-1970-06-30,HR,Croatia,
-1970-06-30,HU,Hungary,
-1970-06-30,ID,Indonesia,
-1970-06-30,IE,Ireland,
-1970-06-30,IL,Israel,
-1970-06-30,IN,India,
-1970-06-30,IS,Iceland,
-1970-06-30,IT,Italy,2.1371
+1970-06-30,IT,Italy,2.1859
 1970-06-30,JP,Japan,12.1543
-1970-06-30,KR,Korea,
-1970-06-30,LT,Lithuania,
-1970-06-30,LU,Luxembourg,
-1970-06-30,LV,Latvia,
-1970-06-30,MA,Morocco,
-1970-06-30,MK,North Macedonia,
-1970-06-30,MT,Malta,
-1970-06-30,MX,Mexico,
-1970-06-30,MY,Malaysia,
-1970-06-30,NL,Netherlands,
-1970-06-30,NO,Norway,
-1970-06-30,NZ,New Zealand,
-1970-06-30,PE,Peru,
-1970-06-30,PH,Philippines,
-1970-06-30,PL,Poland,
-1970-06-30,PT,Portugal,
-1970-06-30,RO,Romania,
-1970-06-30,RS,Serbia,
-1970-06-30,RU,Russia,
-1970-06-30,SE,Sweden,
-1970-06-30,SG,Singapore,
-1970-06-30,SI,Slovenia,
-1970-06-30,SK,Slovak Republic,
-1970-06-30,TH,Thailand,
-1970-06-30,TR,Türkiye,
-1970-06-30,US,United States,
-1970-06-30,XM,Euro area,
-1970-06-30,XW,World,
-1970-06-30,ZA,South Africa,11.4747
-1970-09-30,4T,Emerging market economies (aggregate),
-1970-09-30,5R,Advanced economies,
-1970-09-30,AE,United Arab Emirates,
-1970-09-30,AT,Austria,
-1970-09-30,AU,Australia,
-1970-09-30,BE,Belgium,
-1970-09-30,BG,Bulgaria,
-1970-09-30,BR,Brazil,
-1970-09-30,CA,Canada,
-1970-09-30,CH,Switzerland,
-1970-09-30,CL,Chile,
-1970-09-30,CN,China,
-1970-09-30,CO,Colombia,
-1970-09-30,CY,Cyprus,
-1970-09-30,CZ,Czechia,
-1970-09-30,DE,Germany,
-1970-09-30,DK,Denmark,
-1970-09-30,EE,Estonia,
-1970-09-30,ES,Spain,
-1970-09-30,FI,Finland,
-1970-09-30,FR,France,
+1970-06-30,NZ,New Zealand,1.1938
+1970-06-30,ZA,South Africa,11.7076
 1970-09-30,GB,United Kingdom,0.6825
-1970-09-30,GR,Greece,
-1970-09-30,HK,Hong Kong SAR,
-1970-09-30,HR,Croatia,
-1970-09-30,HU,Hungary,
-1970-09-30,ID,Indonesia,
-1970-09-30,IE,Ireland,
-1970-09-30,IL,Israel,
-1970-09-30,IN,India,
-1970-09-30,IS,Iceland,
-1970-09-30,IT,Italy,0.8124
+1970-09-30,IT,Italy,0.8851
 1970-09-30,JP,Japan,13.5544
-1970-09-30,KR,Korea,
-1970-09-30,LT,Lithuania,
-1970-09-30,LU,Luxembourg,
-1970-09-30,LV,Latvia,
-1970-09-30,MA,Morocco,
-1970-09-30,MK,North Macedonia,
-1970-09-30,MT,Malta,
-1970-09-30,MX,Mexico,
-1970-09-30,MY,Malaysia,
-1970-09-30,NL,Netherlands,
-1970-09-30,NO,Norway,
-1970-09-30,NZ,New Zealand,
-1970-09-30,PE,Peru,
-1970-09-30,PH,Philippines,
-1970-09-30,PL,Poland,
-1970-09-30,PT,Portugal,
-1970-09-30,RO,Romania,
-1970-09-30,RS,Serbia,
-1970-09-30,RU,Russia,
-1970-09-30,SE,Sweden,
-1970-09-30,SG,Singapore,
-1970-09-30,SI,Slovenia,
-1970-09-30,SK,Slovak Republic,
-1970-09-30,TH,Thailand,
-1970-09-30,TR,Türkiye,
-1970-09-30,US,United States,
-1970-09-30,XM,Euro area,
-1970-09-30,XW,World,
-1970-09-30,ZA,South Africa,10.8043
-1970-12-31,4T,Emerging market economies (aggregate),
-1970-12-31,5R,Advanced economies,
-1970-12-31,AE,United Arab Emirates,
-1970-12-31,AT,Austria,
-1970-12-31,AU,Australia,
-1970-12-31,BE,Belgium,
-1970-12-31,BG,Bulgaria,
-1970-12-31,BR,Brazil,
-1970-12-31,CA,Canada,
-1970-12-31,CH,Switzerland,
-1970-12-31,CL,Chile,
-1970-12-31,CN,China,
-1970-12-31,CO,Colombia,
-1970-12-31,CY,Cyprus,
-1970-12-31,CZ,Czechia,
-1970-12-31,DE,Germany,
-1970-12-31,DK,Denmark,
-1970-12-31,EE,Estonia,
-1970-12-31,ES,Spain,
-1970-12-31,FI,Finland,
-1970-12-31,FR,France,
+1970-09-30,NZ,New Zealand,1.3962
+1970-09-30,ZA,South Africa,10.6729
 1970-12-31,GB,United Kingdom,-2.3023
-1970-12-31,GR,Greece,
-1970-12-31,HK,Hong Kong SAR,
-1970-12-31,HR,Croatia,
-1970-12-31,HU,Hungary,
-1970-12-31,ID,Indonesia,
-1970-12-31,IE,Ireland,
-1970-12-31,IL,Israel,
-1970-12-31,IN,India,
-1970-12-31,IS,Iceland,
-1970-12-31,IT,Italy,0.1699
+1970-12-31,IT,Italy,0.2261
 1970-12-31,JP,Japan,10.6488
-1970-12-31,KR,Korea,
-1970-12-31,LT,Lithuania,
-1970-12-31,LU,Luxembourg,
-1970-12-31,LV,Latvia,
-1970-12-31,MA,Morocco,
-1970-12-31,MK,North Macedonia,
-1970-12-31,MT,Malta,
-1970-12-31,MX,Mexico,
-1970-12-31,MY,Malaysia,
-1970-12-31,NL,Netherlands,
-1970-12-31,NO,Norway,
-1970-12-31,NZ,New Zealand,
-1970-12-31,PE,Peru,
-1970-12-31,PH,Philippines,
-1970-12-31,PL,Poland,
-1970-12-31,PT,Portugal,
-1970-12-31,RO,Romania,
-1970-12-31,RS,Serbia,
-1970-12-31,RU,Russia,
-1970-12-31,SE,Sweden,
-1970-12-31,SG,Singapore,
-1970-12-31,SI,Slovenia,
-1970-12-31,SK,Slovak Republic,
-1970-12-31,TH,Thailand,
-1970-12-31,TR,Türkiye,
-1970-12-31,US,United States,
-1970-12-31,XM,Euro area,
-1970-12-31,XW,World,
-1970-12-31,ZA,South Africa,9.4701
-1971-03-31,4T,Emerging market economies (aggregate),
-1971-03-31,5R,Advanced economies,
-1971-03-31,AE,United Arab Emirates,
-1971-03-31,AT,Austria,
-1971-03-31,AU,Australia,5.4818
+1970-12-31,NZ,New Zealand,-0.6861
+1970-12-31,ZA,South Africa,9.2363
+1971-03-31,AU,Australia,6.0606
 1971-03-31,BE,Belgium,-6.4394
-1971-03-31,BG,Bulgaria,
-1971-03-31,BR,Brazil,
 1971-03-31,CA,Canada,3.174
 1971-03-31,CH,Switzerland,3.5429
-1971-03-31,CL,Chile,
-1971-03-31,CN,China,
-1971-03-31,CO,Colombia,
-1971-03-31,CY,Cyprus,
-1971-03-31,CZ,Czechia,
 1971-03-31,DE,Germany,5.6526
 1971-03-31,DK,Denmark,2.7581
-1971-03-31,EE,Estonia,
-1971-03-31,ES,Spain,
 1971-03-31,FI,Finland,2.0124
 1971-03-31,FR,France,-1.123
 1971-03-31,GB,United Kingdom,-0.8242
-1971-03-31,GR,Greece,
-1971-03-31,HK,Hong Kong SAR,
-1971-03-31,HR,Croatia,
-1971-03-31,HU,Hungary,
-1971-03-31,ID,Indonesia,
 1971-03-31,IE,Ireland,-0.2151
-1971-03-31,IL,Israel,
-1971-03-31,IN,India,
-1971-03-31,IS,Iceland,
-1971-03-31,IT,Italy,-3.3596
+1971-03-31,IT,Italy,-3.1677
 1971-03-31,JP,Japan,11.1434
-1971-03-31,KR,Korea,
-1971-03-31,LT,Lithuania,
-1971-03-31,LU,Luxembourg,
-1971-03-31,LV,Latvia,
-1971-03-31,MA,Morocco,
-1971-03-31,MK,North Macedonia,
-1971-03-31,MT,Malta,
-1971-03-31,MX,Mexico,
-1971-03-31,MY,Malaysia,
 1971-03-31,NL,Netherlands,5.981
-1971-03-31,NO,Norway,
-1971-03-31,NZ,New Zealand,0.4364
-1971-03-31,PE,Peru,
-1971-03-31,PH,Philippines,
-1971-03-31,PL,Poland,
-1971-03-31,PT,Portugal,
-1971-03-31,RO,Romania,
-1971-03-31,RS,Serbia,
-1971-03-31,RU,Russia,
+1971-03-31,NZ,New Zealand,0.3869
 1971-03-31,SE,Sweden,-3.0605
-1971-03-31,SG,Singapore,
-1971-03-31,SI,Slovenia,
-1971-03-31,SK,Slovak Republic,
-1971-03-31,TH,Thailand,
-1971-03-31,TR,Türkiye,
 1971-03-31,US,United States,1.3825
-1971-03-31,XM,Euro area,
-1971-03-31,XW,World,
-1971-03-31,ZA,South Africa,5.2024
-1971-06-30,4T,Emerging market economies (aggregate),
-1971-06-30,5R,Advanced economies,
-1971-06-30,AE,United Arab Emirates,
-1971-06-30,AT,Austria,
-1971-06-30,AU,Australia,6.0125
+1971-03-31,ZA,South Africa,5.1015
+1971-06-30,AU,Australia,6.1458
 1971-06-30,BE,Belgium,-5.9293
-1971-06-30,BG,Bulgaria,
-1971-06-30,BR,Brazil,
 1971-06-30,CA,Canada,3.5625
-1971-06-30,CH,Switzerland,3.2916
-1971-06-30,CL,Chile,
-1971-06-30,CN,China,
-1971-06-30,CO,Colombia,
-1971-06-30,CY,Cyprus,
-1971-06-30,CZ,Czechia,
+1971-06-30,CH,Switzerland,3.2915
 1971-06-30,DE,Germany,5.3278
 1971-06-30,DK,Denmark,2.9375
-1971-06-30,EE,Estonia,
-1971-06-30,ES,Spain,
 1971-06-30,FI,Finland,-2.514
 1971-06-30,FR,France,-0.3581
 1971-06-30,GB,United Kingdom,0.7281
-1971-06-30,GR,Greece,
-1971-06-30,HK,Hong Kong SAR,
-1971-06-30,HR,Croatia,
-1971-06-30,HU,Hungary,
-1971-06-30,ID,Indonesia,
 1971-06-30,IE,Ireland,0.3773
-1971-06-30,IL,Israel,
-1971-06-30,IN,India,
-1971-06-30,IS,Iceland,
-1971-06-30,IT,Italy,-2.8243
+1971-06-30,IT,Italy,-2.6724
 1971-06-30,JP,Japan,9.7689
-1971-06-30,KR,Korea,
-1971-06-30,LT,Lithuania,
-1971-06-30,LU,Luxembourg,
-1971-06-30,LV,Latvia,
-1971-06-30,MA,Morocco,
-1971-06-30,MK,North Macedonia,
-1971-06-30,MT,Malta,
-1971-06-30,MX,Mexico,
-1971-06-30,MY,Malaysia,
 1971-06-30,NL,Netherlands,3.6683
-1971-06-30,NO,Norway,
-1971-06-30,NZ,New Zealand,0.5603
-1971-06-30,PE,Peru,
-1971-06-30,PH,Philippines,
-1971-06-30,PL,Poland,
-1971-06-30,PT,Portugal,
-1971-06-30,RO,Romania,
-1971-06-30,RS,Serbia,
-1971-06-30,RU,Russia,
+1971-06-30,NZ,New Zealand,0.5135
 1971-06-30,SE,Sweden,-1.5967
-1971-06-30,SG,Singapore,
-1971-06-30,SI,Slovenia,
-1971-06-30,SK,Slovak Republic,
-1971-06-30,TH,Thailand,
-1971-06-30,TR,Türkiye,
 1971-06-30,US,United States,3.9645
-1971-06-30,XM,Euro area,
-1971-06-30,XW,World,
-1971-06-30,ZA,South Africa,1.5877
-1971-09-30,4T,Emerging market economies (aggregate),
-1971-09-30,5R,Advanced economies,
-1971-09-30,AE,United Arab Emirates,
-1971-09-30,AT,Austria,
-1971-09-30,AU,Australia,4.2977
+1971-06-30,ZA,South Africa,1.4948
+1971-09-30,AU,Australia,4.5226
 1971-09-30,BE,Belgium,-4.4376
-1971-09-30,BG,Bulgaria,
-1971-09-30,BR,Brazil,
 1971-09-30,CA,Canada,1.3624
 1971-09-30,CH,Switzerland,4.6673
-1971-09-30,CL,Chile,
-1971-09-30,CN,China,
-1971-09-30,CO,Colombia,
-1971-09-30,CY,Cyprus,
-1971-09-30,CZ,Czechia,
 1971-09-30,DE,Germany,4.9795
 1971-09-30,DK,Denmark,7.4342
-1971-09-30,EE,Estonia,
-1971-09-30,ES,Spain,
 1971-09-30,FI,Finland,-1.8415
 1971-09-30,FR,France,1.0075
 1971-09-30,GB,United Kingdom,1.6004
-1971-09-30,GR,Greece,
-1971-09-30,HK,Hong Kong SAR,
-1971-09-30,HR,Croatia,
-1971-09-30,HU,Hungary,
-1971-09-30,ID,Indonesia,
 1971-09-30,IE,Ireland,4.9947
-1971-09-30,IL,Israel,
-1971-09-30,IN,India,
-1971-09-30,IS,Iceland,
-1971-09-30,IT,Italy,-0.4509
+1971-09-30,IT,Italy,-0.3757
 1971-09-30,JP,Japan,7.8624
-1971-09-30,KR,Korea,
-1971-09-30,LT,Lithuania,
-1971-09-30,LU,Luxembourg,
-1971-09-30,LV,Latvia,
-1971-09-30,MA,Morocco,
-1971-09-30,MK,North Macedonia,
-1971-09-30,MT,Malta,
-1971-09-30,MX,Mexico,
-1971-09-30,MY,Malaysia,
-1971-09-30,NL,Netherlands,1.7254
-1971-09-30,NO,Norway,
-1971-09-30,NZ,New Zealand,0.2307
-1971-09-30,PE,Peru,
-1971-09-30,PH,Philippines,
-1971-09-30,PL,Poland,
-1971-09-30,PT,Portugal,
-1971-09-30,RO,Romania,
-1971-09-30,RS,Serbia,
-1971-09-30,RU,Russia,
+1971-09-30,NL,Netherlands,1.7255
+1971-09-30,NZ,New Zealand,0.1844
 1971-09-30,SE,Sweden,-1.5739
-1971-09-30,SG,Singapore,
-1971-09-30,SI,Slovenia,
-1971-09-30,SK,Slovak Republic,
-1971-09-30,TH,Thailand,
-1971-09-30,TR,Türkiye,
 1971-09-30,US,United States,3.5154
-1971-09-30,XM,Euro area,
-1971-09-30,XW,World,
-1971-09-30,ZA,South Africa,-0.3786
-1971-12-31,4T,Emerging market economies (aggregate),
-1971-12-31,5R,Advanced economies,
-1971-12-31,AE,United Arab Emirates,
-1971-12-31,AT,Austria,
-1971-12-31,AU,Australia,5.1622
+1971-09-30,ZA,South Africa,-0.3098
+1971-12-31,AU,Australia,4.9415
 1971-12-31,BE,Belgium,-2.7001
-1971-12-31,BG,Bulgaria,
-1971-12-31,BR,Brazil,
 1971-12-31,CA,Canada,2.4019
-1971-12-31,CH,Switzerland,6.511
-1971-12-31,CL,Chile,
-1971-12-31,CN,China,
-1971-12-31,CO,Colombia,
-1971-12-31,CY,Cyprus,
-1971-12-31,CZ,Czechia,
+1971-12-31,CH,Switzerland,6.5109
 1971-12-31,DE,Germany,4.0367
 1971-12-31,DK,Denmark,12.7442
-1971-12-31,EE,Estonia,
-1971-12-31,ES,Spain,
 1971-12-31,FI,Finland,-3.4224
 1971-12-31,FR,France,1.8648
 1971-12-31,GB,United Kingdom,7.2469
-1971-12-31,GR,Greece,
-1971-12-31,HK,Hong Kong SAR,
-1971-12-31,HR,Croatia,
-1971-12-31,HU,Hungary,
-1971-12-31,ID,Indonesia,
 1971-12-31,IE,Ireland,7.0652
-1971-12-31,IL,Israel,
-1971-12-31,IN,India,
-1971-12-31,IS,Iceland,
-1971-12-31,IT,Italy,-0.0146
+1971-12-31,IT,Italy,-0.0714
 1971-12-31,JP,Japan,8.7636
-1971-12-31,KR,Korea,
-1971-12-31,LT,Lithuania,
-1971-12-31,LU,Luxembourg,
-1971-12-31,LV,Latvia,
-1971-12-31,MA,Morocco,
-1971-12-31,MK,North Macedonia,
-1971-12-31,MT,Malta,
-1971-12-31,MX,Mexico,
-1971-12-31,MY,Malaysia,
 1971-12-31,NL,Netherlands,2.0736
-1971-12-31,NO,Norway,
-1971-12-31,NZ,New Zealand,1.6672
-1971-12-31,PE,Peru,
-1971-12-31,PH,Philippines,
-1971-12-31,PL,Poland,
-1971-12-31,PT,Portugal,
-1971-12-31,RO,Romania,
-1971-12-31,RS,Serbia,
-1971-12-31,RU,Russia,
+1971-12-31,NZ,New Zealand,1.7668
 1971-12-31,SE,Sweden,-1.7892
-1971-12-31,SG,Singapore,
-1971-12-31,SI,Slovenia,
-1971-12-31,SK,Slovak Republic,
-1971-12-31,TH,Thailand,
-1971-12-31,TR,Türkiye,
 1971-12-31,US,United States,5.586
-1971-12-31,XM,Euro area,
-1971-12-31,XW,World,
-1971-12-31,ZA,South Africa,-1.1194
-1972-03-31,4T,Emerging market economies (aggregate),
-1972-03-31,5R,Advanced economies,
-1972-03-31,AE,United Arab Emirates,
-1972-03-31,AT,Austria,
-1972-03-31,AU,Australia,4.566
+1971-12-31,ZA,South Africa,-0.7962
+1972-03-31,AU,Australia,4.3594
 1972-03-31,BE,Belgium,-0.0605
-1972-03-31,BG,Bulgaria,
-1972-03-31,BR,Brazil,
 1972-03-31,CA,Canada,3.0171
-1972-03-31,CH,Switzerland,3.6946
-1972-03-31,CL,Chile,
-1972-03-31,CN,China,
-1972-03-31,CO,Colombia,
-1972-03-31,CY,Cyprus,
-1972-03-31,CZ,Czechia,
+1972-03-31,CH,Switzerland,3.6947
 1972-03-31,DE,Germany,3.17
 1972-03-31,DK,Denmark,8.4917
-1972-03-31,EE,Estonia,
 1972-03-31,ES,Spain,-3.9172
 1972-03-31,FI,Finland,1.024
 1972-03-31,FR,France,2.6602
 1972-03-31,GB,United Kingdom,12.5296
-1972-03-31,GR,Greece,
-1972-03-31,HK,Hong Kong SAR,
-1972-03-31,HR,Croatia,
-1972-03-31,HU,Hungary,
-1972-03-31,ID,Indonesia,
 1972-03-31,IE,Ireland,4.1998
-1972-03-31,IL,Israel,
-1972-03-31,IN,India,
-1972-03-31,IS,Iceland,
-1972-03-31,IT,Italy,2.8606
+1972-03-31,IT,Italy,2.8404
 1972-03-31,JP,Japan,9.2751
-1972-03-31,KR,Korea,
-1972-03-31,LT,Lithuania,
-1972-03-31,LU,Luxembourg,
-1972-03-31,LV,Latvia,
-1972-03-31,MA,Morocco,
-1972-03-31,MK,North Macedonia,
-1972-03-31,MT,Malta,
-1972-03-31,MX,Mexico,
-1972-03-31,MY,Malaysia,
 1972-03-31,NL,Netherlands,3.0896
-1972-03-31,NO,Norway,
-1972-03-31,NZ,New Zealand,2.9181
-1972-03-31,PE,Peru,
-1972-03-31,PH,Philippines,
-1972-03-31,PL,Poland,
-1972-03-31,PT,Portugal,
-1972-03-31,RO,Romania,
-1972-03-31,RS,Serbia,
-1972-03-31,RU,Russia,
+1972-03-31,NZ,New Zealand,3.0165
 1972-03-31,SE,Sweden,2.2378
-1972-03-31,SG,Singapore,
-1972-03-31,SI,Slovenia,
-1972-03-31,SK,Slovak Republic,
-1972-03-31,TH,Thailand,
-1972-03-31,TR,Türkiye,
 1972-03-31,US,United States,3.1135
-1972-03-31,XM,Euro area,
-1972-03-31,XW,World,
-1972-03-31,ZA,South Africa,-1.6704
-1972-06-30,4T,Emerging market economies (aggregate),
-1972-06-30,5R,Advanced economies,
-1972-06-30,AE,United Arab Emirates,
-1972-06-30,AT,Austria,
-1972-06-30,AU,Australia,4.05
+1972-03-31,ZA,South Africa,-1.4883
+1972-06-30,AU,Australia,4.2967
 1972-06-30,BE,Belgium,2.6014
-1972-06-30,BG,Bulgaria,
-1972-06-30,BR,Brazil,
 1972-06-30,CA,Canada,2.1882
-1972-06-30,CH,Switzerland,10.5945
-1972-06-30,CL,Chile,
-1972-06-30,CN,China,
-1972-06-30,CO,Colombia,
-1972-06-30,CY,Cyprus,
-1972-06-30,CZ,Czechia,
+1972-06-30,CH,Switzerland,10.5946
 1972-06-30,DE,Germany,1.2436
 1972-06-30,DK,Denmark,12.6537
-1972-06-30,EE,Estonia,
 1972-06-30,ES,Spain,-2.6377
 1972-06-30,FI,Finland,2.9709
 1972-06-30,FR,France,3.1655
 1972-06-30,GB,United Kingdom,22.093
-1972-06-30,GR,Greece,
-1972-06-30,HK,Hong Kong SAR,
-1972-06-30,HR,Croatia,
-1972-06-30,HU,Hungary,
-1972-06-30,ID,Indonesia,
 1972-06-30,IE,Ireland,4.2028
-1972-06-30,IL,Israel,
-1972-06-30,IN,India,
-1972-06-30,IS,Iceland,
-1972-06-30,IT,Italy,3.4636
+1972-06-30,IT,Italy,3.4478
 1972-06-30,JP,Japan,9.6882
-1972-06-30,KR,Korea,
-1972-06-30,LT,Lithuania,
-1972-06-30,LU,Luxembourg,
-1972-06-30,LV,Latvia,
-1972-06-30,MA,Morocco,
-1972-06-30,MK,North Macedonia,
-1972-06-30,MT,Malta,
-1972-06-30,MX,Mexico,
-1972-06-30,MY,Malaysia,
-1972-06-30,NL,Netherlands,3.8435
-1972-06-30,NO,Norway,
-1972-06-30,NZ,New Zealand,5.0463
-1972-06-30,PE,Peru,
-1972-06-30,PH,Philippines,
-1972-06-30,PL,Poland,
-1972-06-30,PT,Portugal,
-1972-06-30,RO,Romania,
-1972-06-30,RS,Serbia,
-1972-06-30,RU,Russia,
+1972-06-30,NL,Netherlands,3.8434
+1972-06-30,NZ,New Zealand,5.0803
 1972-06-30,SE,Sweden,0.9075
-1972-06-30,SG,Singapore,
-1972-06-30,SI,Slovenia,
-1972-06-30,SK,Slovak Republic,
-1972-06-30,TH,Thailand,
-1972-06-30,TR,Türkiye,
 1972-06-30,US,United States,3.5292
-1972-06-30,XM,Euro area,
-1972-06-30,XW,World,
-1972-06-30,ZA,South Africa,-2.7944
-1972-09-30,4T,Emerging market economies (aggregate),
-1972-09-30,5R,Advanced economies,
-1972-09-30,AE,United Arab Emirates,
-1972-09-30,AT,Austria,
-1972-09-30,AU,Australia,4.9499
+1972-06-30,ZA,South Africa,-2.5403
+1972-09-30,AU,Australia,4.888
 1972-09-30,BE,Belgium,4.6029
-1972-09-30,BG,Bulgaria,
-1972-09-30,BR,Brazil,
 1972-09-30,CA,Canada,3.6947
-1972-09-30,CH,Switzerland,10.6378
-1972-09-30,CL,Chile,
-1972-09-30,CN,China,
-1972-09-30,CO,Colombia,
-1972-09-30,CY,Cyprus,
-1972-09-30,CZ,Czechia,
+1972-09-30,CH,Switzerland,10.6379
 1972-09-30,DE,Germany,0.3901
 1972-09-30,DK,Denmark,10.0982
-1972-09-30,EE,Estonia,
 1972-09-30,ES,Spain,-2.6682
 1972-09-30,FI,Finland,0.8112
 1972-09-30,FR,France,2.9361
 1972-09-30,GB,United Kingdom,30.8904
-1972-09-30,GR,Greece,
-1972-09-30,HK,Hong Kong SAR,
-1972-09-30,HR,Croatia,
-1972-09-30,HU,Hungary,
-1972-09-30,ID,Indonesia,
 1972-09-30,IE,Ireland,-1.1422
-1972-09-30,IL,Israel,
-1972-09-30,IN,India,
-1972-09-30,IS,Iceland,
-1972-09-30,IT,Italy,2.5674
+1972-09-30,IT,Italy,2.565
 1972-09-30,JP,Japan,10.7173
-1972-09-30,KR,Korea,
-1972-09-30,LT,Lithuania,
-1972-09-30,LU,Luxembourg,
-1972-09-30,LV,Latvia,
-1972-09-30,MA,Morocco,
-1972-09-30,MK,North Macedonia,
-1972-09-30,MT,Malta,
-1972-09-30,MX,Mexico,
-1972-09-30,MY,Malaysia,
-1972-09-30,NL,Netherlands,4.3041
-1972-09-30,NO,Norway,
-1972-09-30,NZ,New Zealand,7.1467
-1972-09-30,PE,Peru,
-1972-09-30,PH,Philippines,
-1972-09-30,PL,Poland,
-1972-09-30,PT,Portugal,
-1972-09-30,RO,Romania,
-1972-09-30,RS,Serbia,
-1972-09-30,RU,Russia,
+1972-09-30,NL,Netherlands,4.304
+1972-09-30,NZ,New Zealand,7.1187
 1972-09-30,SE,Sweden,0.9291
-1972-09-30,SG,Singapore,
-1972-09-30,SI,Slovenia,
-1972-09-30,SK,Slovak Republic,
-1972-09-30,TH,Thailand,
-1972-09-30,TR,Türkiye,
 1972-09-30,US,United States,4.5681
-1972-09-30,XM,Euro area,
-1972-09-30,XW,World,
-1972-09-30,ZA,South Africa,-1.3193
-1972-12-31,4T,Emerging market economies (aggregate),
-1972-12-31,5R,Advanced economies,
-1972-12-31,AE,United Arab Emirates,
-1972-12-31,AT,Austria,
-1972-12-31,AU,Australia,7.6076
+1972-09-30,ZA,South Africa,-1.3923
+1972-12-31,AU,Australia,7.5619
 1972-12-31,BE,Belgium,5.422
-1972-12-31,BG,Bulgaria,
-1972-12-31,BR,Brazil,
 1972-12-31,CA,Canada,3.1598
-1972-12-31,CH,Switzerland,13.6652
-1972-12-31,CL,Chile,
-1972-12-31,CN,China,
-1972-12-31,CO,Colombia,
-1972-12-31,CY,Cyprus,
-1972-12-31,CZ,Czechia,
+1972-12-31,CH,Switzerland,13.6653
 1972-12-31,DE,Germany,0.0664
 1972-12-31,DK,Denmark,8.8529
-1972-12-31,EE,Estonia,
 1972-12-31,ES,Spain,-0.2067
 1972-12-31,FI,Finland,4.5275
 1972-12-31,FR,France,2.5873
 1972-12-31,GB,United Kingdom,33.2083
-1972-12-31,GR,Greece,
-1972-12-31,HK,Hong Kong SAR,
-1972-12-31,HR,Croatia,
-1972-12-31,HU,Hungary,
-1972-12-31,ID,Indonesia,
 1972-12-31,IE,Ireland,-2.7412
-1972-12-31,IL,Israel,
-1972-12-31,IN,India,
-1972-12-31,IS,Iceland,
-1972-12-31,IT,Italy,0.6485
+1972-12-31,IT,Italy,0.651
 1972-12-31,JP,Japan,17.043
-1972-12-31,KR,Korea,
-1972-12-31,LT,Lithuania,
-1972-12-31,LU,Luxembourg,
-1972-12-31,LV,Latvia,
-1972-12-31,MA,Morocco,
-1972-12-31,MK,North Macedonia,
-1972-12-31,MT,Malta,
-1972-12-31,MX,Mexico,
-1972-12-31,MY,Malaysia,
-1972-12-31,NL,Netherlands,6.1452
-1972-12-31,NO,Norway,
-1972-12-31,NZ,New Zealand,10.1994
-1972-12-31,PE,Peru,
-1972-12-31,PH,Philippines,
-1972-12-31,PL,Poland,
-1972-12-31,PT,Portugal,
-1972-12-31,RO,Romania,
-1972-12-31,RS,Serbia,
-1972-12-31,RU,Russia,
+1972-12-31,NL,Netherlands,6.1454
+1972-12-31,NZ,New Zealand,10.1022
 1972-12-31,SE,Sweden,1.7754
-1972-12-31,SG,Singapore,
-1972-12-31,SI,Slovenia,
-1972-12-31,SK,Slovak Republic,
-1972-12-31,TH,Thailand,
-1972-12-31,TR,Türkiye,
 1972-12-31,US,United States,3.866
-1972-12-31,XM,Euro area,
-1972-12-31,XW,World,
-1972-12-31,ZA,South Africa,-0.1295
-1973-03-31,4T,Emerging market economies (aggregate),
-1973-03-31,5R,Advanced economies,
-1973-03-31,AE,United Arab Emirates,
-1973-03-31,AT,Austria,
-1973-03-31,AU,Australia,7.3839
+1972-12-31,ZA,South Africa,-0.0589
+1973-03-31,AU,Australia,7.2029
 1973-03-31,BE,Belgium,4.9315
-1973-03-31,BG,Bulgaria,
-1973-03-31,BR,Brazil,
 1973-03-31,CA,Canada,5.6066
 1973-03-31,CH,Switzerland,16.5511
-1973-03-31,CL,Chile,
-1973-03-31,CN,China,
-1973-03-31,CO,Colombia,
-1973-03-31,CY,Cyprus,
-1973-03-31,CZ,Czechia,
 1973-03-31,DE,Germany,-0.6651
 1973-03-31,DK,Denmark,7.1042
-1973-03-31,EE,Estonia,
 1973-03-31,ES,Spain,11.0861
 1973-03-31,FI,Finland,5.6725
 1973-03-31,FR,France,2.989
 1973-03-31,GB,United Kingdom,40.0542
-1973-03-31,GR,Greece,
-1973-03-31,HK,Hong Kong SAR,
-1973-03-31,HR,Croatia,
-1973-03-31,HU,Hungary,
-1973-03-31,ID,Indonesia,
 1973-03-31,IE,Ireland,-1.0066
-1973-03-31,IL,Israel,
-1973-03-31,IN,India,
-1973-03-31,IS,Iceland,
-1973-03-31,IT,Italy,-0.343
+1973-03-31,IT,Italy,-0.3984
 1973-03-31,JP,Japan,20.2057
-1973-03-31,KR,Korea,
-1973-03-31,LT,Lithuania,
-1973-03-31,LU,Luxembourg,
-1973-03-31,LV,Latvia,
-1973-03-31,MA,Morocco,
-1973-03-31,MK,North Macedonia,
-1973-03-31,MT,Malta,
-1973-03-31,MX,Mexico,
-1973-03-31,MY,Malaysia,
-1973-03-31,NL,Netherlands,6.3556
-1973-03-31,NO,Norway,
-1973-03-31,NZ,New Zealand,12.0598
-1973-03-31,PE,Peru,
-1973-03-31,PH,Philippines,
-1973-03-31,PL,Poland,
-1973-03-31,PT,Portugal,
-1973-03-31,RO,Romania,
-1973-03-31,RS,Serbia,
-1973-03-31,RU,Russia,
+1973-03-31,NL,Netherlands,6.3557
+1973-03-31,NZ,New Zealand,12.032
 1973-03-31,SE,Sweden,1.2346
-1973-03-31,SG,Singapore,
-1973-03-31,SI,Slovenia,
-1973-03-31,SK,Slovak Republic,
-1973-03-31,TH,Thailand,
-1973-03-31,TR,Türkiye,
 1973-03-31,US,United States,7.5698
-1973-03-31,XM,Euro area,
-1973-03-31,XW,World,
-1973-03-31,ZA,South Africa,2.1249
-1973-06-30,4T,Emerging market economies (aggregate),
-1973-06-30,5R,Advanced economies,
-1973-06-30,AE,United Arab Emirates,
-1973-06-30,AT,Austria,
-1973-06-30,AU,Australia,9.0327
+1973-03-31,ZA,South Africa,2.133
+1973-06-30,AU,Australia,9.1101
 1973-06-30,BE,Belgium,5.0625
-1973-06-30,BG,Bulgaria,
-1973-06-30,BR,Brazil,
 1973-06-30,CA,Canada,9.7425
 1973-06-30,CH,Switzerland,8.3186
-1973-06-30,CL,Chile,
-1973-06-30,CN,China,
-1973-06-30,CO,Colombia,
-1973-06-30,CY,Cyprus,
-1973-06-30,CZ,Czechia,
 1973-06-30,DE,Germany,0.5598
 1973-06-30,DK,Denmark,4.1237
-1973-06-30,EE,Estonia,
 1973-06-30,ES,Spain,3.9888
 1973-06-30,FI,Finland,15.318
 1973-06-30,FR,France,2.8757
 1973-06-30,GB,United Kingdom,32.385
-1973-06-30,GR,Greece,
-1973-06-30,HK,Hong Kong SAR,
-1973-06-30,HR,Croatia,
-1973-06-30,HU,Hungary,
-1973-06-30,ID,Indonesia,
 1973-06-30,IE,Ireland,1.5339
-1973-06-30,IL,Israel,
-1973-06-30,IN,India,
-1973-06-30,IS,Iceland,
-1973-06-30,IT,Italy,1.4557
+1973-06-30,IT,Italy,1.4644
 1973-06-30,JP,Japan,21.0759
-1973-06-30,KR,Korea,
-1973-06-30,LT,Lithuania,
-1973-06-30,LU,Luxembourg,
-1973-06-30,LV,Latvia,
-1973-06-30,MA,Morocco,
-1973-06-30,MK,North Macedonia,
-1973-06-30,MT,Malta,
-1973-06-30,MX,Mexico,
-1973-06-30,MY,Malaysia,
-1973-06-30,NL,Netherlands,7.7797
-1973-06-30,NO,Norway,
-1973-06-30,NZ,New Zealand,13.7597
-1973-06-30,PE,Peru,
-1973-06-30,PH,Philippines,
-1973-06-30,PL,Poland,
-1973-06-30,PT,Portugal,
-1973-06-30,RO,Romania,
-1973-06-30,RS,Serbia,
-1973-06-30,RU,Russia,
+1973-06-30,NL,Netherlands,7.7798
+1973-06-30,NZ,New Zealand,13.7532
 1973-06-30,SE,Sweden,0.6396
-1973-06-30,SG,Singapore,
-1973-06-30,SI,Slovenia,
-1973-06-30,SK,Slovak Republic,
-1973-06-30,TH,Thailand,
-1973-06-30,TR,Türkiye,
 1973-06-30,US,United States,5.6011
-1973-06-30,XM,Euro area,
-1973-06-30,XW,World,
-1973-06-30,ZA,South Africa,4.3658
-1973-09-30,4T,Emerging market economies (aggregate),
-1973-09-30,5R,Advanced economies,
-1973-09-30,AE,United Arab Emirates,
-1973-09-30,AT,Austria,
-1973-09-30,AU,Australia,12.928
+1973-06-30,ZA,South Africa,4.2801
+1973-09-30,AU,Australia,12.689
 1973-09-30,BE,Belgium,5.6521
-1973-09-30,BG,Bulgaria,
-1973-09-30,BR,Brazil,
 1973-09-30,CA,Canada,15.2461
-1973-09-30,CH,Switzerland,5.6032
-1973-09-30,CL,Chile,
-1973-09-30,CN,China,
-1973-09-30,CO,Colombia,
-1973-09-30,CY,Cyprus,
-1973-09-30,CZ,Czechia,
+1973-09-30,CH,Switzerland,5.6031
 1973-09-30,DE,Germany,0.8845
 1973-09-30,DK,Denmark,7.5123
-1973-09-30,EE,Estonia,
 1973-09-30,ES,Spain,8.1489
 1973-09-30,FI,Finland,18.054
 1973-09-30,FR,France,2.9085
 1973-09-30,GB,United Kingdom,22.8971
-1973-09-30,GR,Greece,
-1973-09-30,HK,Hong Kong SAR,
-1973-09-30,HR,Croatia,
-1973-09-30,HU,Hungary,
-1973-09-30,ID,Indonesia,
 1973-09-30,IE,Ireland,-2.7886
-1973-09-30,IL,Israel,
-1973-09-30,IN,India,
-1973-09-30,IS,Iceland,
-1973-09-30,IT,Italy,9.6692
+1973-09-30,IT,Italy,9.6026
 1973-09-30,JP,Japan,22.4486
-1973-09-30,KR,Korea,
-1973-09-30,LT,Lithuania,
-1973-09-30,LU,Luxembourg,
-1973-09-30,LV,Latvia,
-1973-09-30,MA,Morocco,
-1973-09-30,MK,North Macedonia,
-1973-09-30,MT,Malta,
-1973-09-30,MX,Mexico,
-1973-09-30,MY,Malaysia,
 1973-09-30,NL,Netherlands,8.8437
-1973-09-30,NO,Norway,
-1973-09-30,NZ,New Zealand,17.2195
-1973-09-30,PE,Peru,
-1973-09-30,PH,Philippines,
-1973-09-30,PL,Poland,
-1973-09-30,PT,Portugal,
-1973-09-30,RO,Romania,
-1973-09-30,RS,Serbia,
-1973-09-30,RU,Russia,
+1973-09-30,NZ,New Zealand,17.2407
 1973-09-30,SE,Sweden,0.7309
-1973-09-30,SG,Singapore,
-1973-09-30,SI,Slovenia,
-1973-09-30,SK,Slovak Republic,
-1973-09-30,TH,Thailand,
-1973-09-30,TR,Türkiye,
 1973-09-30,US,United States,4.9116
-1973-09-30,XM,Euro area,
-1973-09-30,XW,World,
-1973-09-30,ZA,South Africa,7.5072
-1973-12-31,4T,Emerging market economies (aggregate),
-1973-12-31,5R,Advanced economies,
-1973-12-31,AE,United Arab Emirates,
-1973-12-31,AT,Austria,
-1973-12-31,AU,Australia,11.9366
+1973-09-30,ZA,South Africa,7.4778
+1973-12-31,AU,Australia,11.4424
 1973-12-31,BE,Belgium,6.8188
-1973-12-31,BG,Bulgaria,
-1973-12-31,BR,Brazil,
 1973-12-31,CA,Canada,19.2882
 1973-12-31,CH,Switzerland,-3.1356
-1973-12-31,CL,Chile,
-1973-12-31,CN,China,
-1973-12-31,CO,Colombia,
-1973-12-31,CY,Cyprus,
-1973-12-31,CZ,Czechia,
 1973-12-31,DE,Germany,-0.0799
 1973-12-31,DK,Denmark,3.9078
-1973-12-31,EE,Estonia,
 1973-12-31,ES,Spain,10.3641
 1973-12-31,FI,Finland,16.5085
 1973-12-31,FR,France,3.1788
 1973-12-31,GB,United Kingdom,13.7057
-1973-12-31,GR,Greece,
-1973-12-31,HK,Hong Kong SAR,
-1973-12-31,HR,Croatia,
-1973-12-31,HU,Hungary,
-1973-12-31,ID,Indonesia,
 1973-12-31,IE,Ireland,-7.2879
-1973-12-31,IL,Israel,
-1973-12-31,IN,India,
-1973-12-31,IS,Iceland,
-1973-12-31,IT,Italy,22.4554
+1973-12-31,IT,Italy,22.373
 1973-12-31,JP,Japan,13.5295
-1973-12-31,KR,Korea,
-1973-12-31,LT,Lithuania,
-1973-12-31,LU,Luxembourg,
-1973-12-31,LV,Latvia,
-1973-12-31,MA,Morocco,
-1973-12-31,MK,North Macedonia,
-1973-12-31,MT,Malta,
-1973-12-31,MX,Mexico,
-1973-12-31,MY,Malaysia,
-1973-12-31,NL,Netherlands,9.3731
-1973-12-31,NO,Norway,
-1973-12-31,NZ,New Zealand,21.4974
-1973-12-31,PE,Peru,
-1973-12-31,PH,Philippines,
-1973-12-31,PL,Poland,
-1973-12-31,PT,Portugal,
-1973-12-31,RO,Romania,
-1973-12-31,RS,Serbia,
-1973-12-31,RU,Russia,
+1973-12-31,NL,Netherlands,9.3729
+1973-12-31,NZ,New Zealand,21.5332
 1973-12-31,SE,Sweden,-0.6983
-1973-12-31,SG,Singapore,
-1973-12-31,SI,Slovenia,
-1973-12-31,SK,Slovak Republic,
-1973-12-31,TH,Thailand,
-1973-12-31,TR,Türkiye,
 1973-12-31,US,United States,3.4597
-1973-12-31,XM,Euro area,
-1973-12-31,XW,World,
-1973-12-31,ZA,South Africa,8.1808
-1974-03-31,4T,Emerging market economies (aggregate),
-1974-03-31,5R,Advanced economies,
-1974-03-31,AE,United Arab Emirates,
-1974-03-31,AT,Austria,
-1974-03-31,AU,Australia,14.3675
+1973-12-31,ZA,South Africa,7.869
+1974-03-31,AU,Australia,14.786
 1974-03-31,BE,Belgium,3.5188
-1974-03-31,BG,Bulgaria,
-1974-03-31,BR,Brazil,
 1974-03-31,CA,Canada,24.76
 1974-03-31,CH,Switzerland,-9.9785
-1974-03-31,CL,Chile,
-1974-03-31,CN,China,
-1974-03-31,CO,Colombia,
-1974-03-31,CY,Cyprus,
-1974-03-31,CZ,Czechia,
 1974-03-31,DE,Germany,0.4568
 1974-03-31,DK,Denmark,-2.8728
-1974-03-31,EE,Estonia,
 1974-03-31,ES,Spain,10.1834
 1974-03-31,FI,Finland,12.3435
 1974-03-31,FR,France,2.2747
 1974-03-31,GB,United Kingdom,0.8013
-1974-03-31,GR,Greece,
-1974-03-31,HK,Hong Kong SAR,
-1974-03-31,HR,Croatia,
-1974-03-31,HU,Hungary,
-1974-03-31,ID,Indonesia,
 1974-03-31,IE,Ireland,-1.4969
-1974-03-31,IL,Israel,
-1974-03-31,IN,India,
-1974-03-31,IS,Iceland,
-1974-03-31,IT,Italy,31.5079
+1974-03-31,IT,Italy,31.4888
 1974-03-31,JP,Japan,2.3506
-1974-03-31,KR,Korea,
-1974-03-31,LT,Lithuania,
-1974-03-31,LU,Luxembourg,
-1974-03-31,LV,Latvia,
-1974-03-31,MA,Morocco,
-1974-03-31,MK,North Macedonia,
-1974-03-31,MT,Malta,
-1974-03-31,MX,Mexico,
-1974-03-31,MY,Malaysia,
-1974-03-31,NL,Netherlands,10.7919
-1974-03-31,NO,Norway,
-1974-03-31,NZ,New Zealand,27.3359
-1974-03-31,PE,Peru,
-1974-03-31,PH,Philippines,
-1974-03-31,PL,Poland,
-1974-03-31,PT,Portugal,
-1974-03-31,RO,Romania,
-1974-03-31,RS,Serbia,
-1974-03-31,RU,Russia,
+1974-03-31,NL,Netherlands,10.792
+1974-03-31,NZ,New Zealand,27.2675
 1974-03-31,SE,Sweden,-2.6295
-1974-03-31,SG,Singapore,
-1974-03-31,SI,Slovenia,
-1974-03-31,SK,Slovak Republic,
-1974-03-31,TH,Thailand,
-1974-03-31,TR,Türkiye,
 1974-03-31,US,United States,-0.0448
-1974-03-31,XM,Euro area,
-1974-03-31,XW,World,
-1974-03-31,ZA,South Africa,3.4184
-1974-06-30,4T,Emerging market economies (aggregate),
-1974-06-30,5R,Advanced economies,
-1974-06-30,AE,United Arab Emirates,
-1974-06-30,AT,Austria,
-1974-06-30,AU,Australia,11.2566
+1974-03-31,ZA,South Africa,3.6096
+1974-06-30,AU,Australia,11.1548
 1974-06-30,BE,Belgium,4.4586
-1974-06-30,BG,Bulgaria,
-1974-06-30,BR,Brazil,
 1974-06-30,CA,Canada,22.366
 1974-06-30,CH,Switzerland,-8.2058
-1974-06-30,CL,Chile,
-1974-06-30,CN,China,
-1974-06-30,CO,Colombia,
-1974-06-30,CY,Cyprus,
-1974-06-30,CZ,Czechia,
 1974-06-30,DE,Germany,0.3105
 1974-06-30,DK,Denmark,-9.2816
-1974-06-30,EE,Estonia,
 1974-06-30,ES,Spain,22.5079
 1974-06-30,FI,Finland,4.8829
 1974-06-30,FR,France,1.1485
 1974-06-30,GB,United Kingdom,-6.0824
-1974-06-30,GR,Greece,
-1974-06-30,HK,Hong Kong SAR,
-1974-06-30,HR,Croatia,
-1974-06-30,HU,Hungary,
-1974-06-30,ID,Indonesia,
 1974-06-30,IE,Ireland,0.2666
-1974-06-30,IL,Israel,
-1974-06-30,IN,India,
-1974-06-30,IS,Iceland,
-1974-06-30,IT,Italy,34.7101
+1974-06-30,IT,Italy,34.7014
 1974-06-30,JP,Japan,-4.0681
-1974-06-30,KR,Korea,
-1974-06-30,LT,Lithuania,
-1974-06-30,LU,Luxembourg,
-1974-06-30,LV,Latvia,
-1974-06-30,MA,Morocco,
-1974-06-30,MK,North Macedonia,
-1974-06-30,MT,Malta,
-1974-06-30,MX,Mexico,
-1974-06-30,MY,Malaysia,
-1974-06-30,NL,Netherlands,10.3942
-1974-06-30,NO,Norway,
-1974-06-30,NZ,New Zealand,30.6891
-1974-06-30,PE,Peru,
-1974-06-30,PH,Philippines,
-1974-06-30,PL,Poland,
-1974-06-30,PT,Portugal,
-1974-06-30,RO,Romania,
-1974-06-30,RS,Serbia,
-1974-06-30,RU,Russia,
+1974-06-30,NL,Netherlands,10.3943
+1974-06-30,NZ,New Zealand,30.6985
 1974-06-30,SE,Sweden,-2.0069
-1974-06-30,SG,Singapore,
-1974-06-30,SI,Slovenia,
-1974-06-30,SK,Slovak Republic,
-1974-06-30,TH,Thailand,
-1974-06-30,TR,Türkiye,
 1974-06-30,US,United States,-1.0483
-1974-06-30,XM,Euro area,
-1974-06-30,XW,World,
-1974-06-30,ZA,South Africa,1.4142
-1974-09-30,4T,Emerging market economies (aggregate),
-1974-09-30,5R,Advanced economies,
-1974-09-30,AE,United Arab Emirates,
-1974-09-30,AT,Austria,
-1974-09-30,AU,Australia,2.3397
+1974-06-30,ZA,South Africa,1.5531
+1974-09-30,AU,Australia,2.3239
 1974-09-30,BE,Belgium,2.0717
-1974-09-30,BG,Bulgaria,
-1974-09-30,BR,Brazil,
 1974-09-30,CA,Canada,12.8916
-1974-09-30,CH,Switzerland,-10.3926
-1974-09-30,CL,Chile,
-1974-09-30,CN,China,
-1974-09-30,CO,Colombia,
-1974-09-30,CY,Cyprus,
-1974-09-30,CZ,Czechia,
+1974-09-30,CH,Switzerland,-10.3927
 1974-09-30,DE,Germany,0.3071
 1974-09-30,DK,Denmark,-13.6646
-1974-09-30,EE,Estonia,
 1974-09-30,ES,Spain,18.4698
 1974-09-30,FI,Finland,0.8151
 1974-09-30,FR,France,0.6051
 1974-09-30,GB,United Kingdom,-11.137
-1974-09-30,GR,Greece,
-1974-09-30,HK,Hong Kong SAR,
-1974-09-30,HR,Croatia,
-1974-09-30,HU,Hungary,
-1974-09-30,ID,Indonesia,
 1974-09-30,IE,Ireland,4.3395
-1974-09-30,IL,Israel,
-1974-09-30,IN,India,
-1974-09-30,IS,Iceland,
-1974-09-30,IT,Italy,27.7855
+1974-09-30,IT,Italy,27.8742
 1974-09-30,JP,Japan,-10.7758
-1974-09-30,KR,Korea,
-1974-09-30,LT,Lithuania,
-1974-09-30,LU,Luxembourg,
-1974-09-30,LV,Latvia,
-1974-09-30,MA,Morocco,
-1974-09-30,MK,North Macedonia,
-1974-09-30,MT,Malta,
-1974-09-30,MX,Mexico,
-1974-09-30,MY,Malaysia,
 1974-09-30,NL,Netherlands,10.1481
-1974-09-30,NO,Norway,
-1974-09-30,NZ,New Zealand,27.3208
-1974-09-30,PE,Peru,
-1974-09-30,PH,Philippines,
-1974-09-30,PL,Poland,
-1974-09-30,PT,Portugal,
-1974-09-30,RO,Romania,
-1974-09-30,RS,Serbia,
-1974-09-30,RU,Russia,
+1974-09-30,NZ,New Zealand,27.3428
 1974-09-30,SE,Sweden,0.0095
-1974-09-30,SG,Singapore,
-1974-09-30,SI,Slovenia,
-1974-09-30,SK,Slovak Republic,
-1974-09-30,TH,Thailand,
-1974-09-30,TR,Türkiye,
 1974-09-30,US,United States,-1.7424
-1974-09-30,XM,Euro area,
-1974-09-30,XW,World,
-1974-09-30,ZA,South Africa,-5.8607
-1974-12-31,4T,Emerging market economies (aggregate),
-1974-12-31,5R,Advanced economies,
-1974-12-31,AE,United Arab Emirates,
-1974-12-31,AT,Austria,
-1974-12-31,AU,Australia,-2.2503
+1974-09-30,ZA,South Africa,-5.9442
+1974-12-31,AU,Australia,-1.9309
 1974-12-31,BE,Belgium,-1.5261
-1974-12-31,BG,Bulgaria,
-1974-12-31,BR,Brazil,
 1974-12-31,CA,Canada,2.2734
 1974-12-31,CH,Switzerland,-8.2765
-1974-12-31,CL,Chile,
-1974-12-31,CN,China,
-1974-12-31,CO,Colombia,
-1974-12-31,CY,Cyprus,
-1974-12-31,CZ,Czechia,
 1974-12-31,DE,Germany,0.2695
 1974-12-31,DK,Denmark,-9.8262
-1974-12-31,EE,Estonia,
 1974-12-31,ES,Spain,10.4633
 1974-12-31,FI,Finland,-2.9651
 1974-12-31,FR,France,0.1195
 1974-12-31,GB,United Kingdom,-11.7595
-1974-12-31,GR,Greece,
-1974-12-31,HK,Hong Kong SAR,
-1974-12-31,HR,Croatia,
-1974-12-31,HU,Hungary,
-1974-12-31,ID,Indonesia,
 1974-12-31,IE,Ireland,10.32
-1974-12-31,IL,Israel,
-1974-12-31,IN,India,
-1974-12-31,IS,Iceland,
-1974-12-31,IT,Italy,16.185
+1974-12-31,IT,Italy,16.1662
 1974-12-31,JP,Japan,-16.795
-1974-12-31,KR,Korea,
-1974-12-31,LT,Lithuania,
-1974-12-31,LU,Luxembourg,
-1974-12-31,LV,Latvia,
-1974-12-31,MA,Morocco,
-1974-12-31,MK,North Macedonia,
-1974-12-31,MT,Malta,
-1974-12-31,MX,Mexico,
-1974-12-31,MY,Malaysia,
-1974-12-31,NL,Netherlands,8.6156
-1974-12-31,NO,Norway,
-1974-12-31,NZ,New Zealand,18.6438
-1974-12-31,PE,Peru,
-1974-12-31,PH,Philippines,
-1974-12-31,PL,Poland,
-1974-12-31,PT,Portugal,
-1974-12-31,RO,Romania,
-1974-12-31,RS,Serbia,
-1974-12-31,RU,Russia,
+1974-12-31,NL,Netherlands,8.6157
+1974-12-31,NZ,New Zealand,18.6444
 1974-12-31,SE,Sweden,1.4103
-1974-12-31,SG,Singapore,
-1974-12-31,SI,Slovenia,
-1974-12-31,SK,Slovak Republic,
-1974-12-31,TH,Thailand,
-1974-12-31,TR,Türkiye,
 1974-12-31,US,United States,-3.8414
-1974-12-31,XM,Euro area,
-1974-12-31,XW,World,
-1974-12-31,ZA,South Africa,-9.8785
-1975-03-31,4T,Emerging market economies (aggregate),
-1975-03-31,5R,Advanced economies,
-1975-03-31,AE,United Arab Emirates,
-1975-03-31,AT,Austria,
-1975-03-31,AU,Australia,-7.1714
+1974-12-31,ZA,South Africa,-9.8086
+1975-03-31,AU,Australia,-7.0479
 1975-03-31,BE,Belgium,3.1162
-1975-03-31,BG,Bulgaria,
-1975-03-31,BR,Brazil,
 1975-03-31,CA,Canada,-2.12
 1975-03-31,CH,Switzerland,-10.6803
-1975-03-31,CL,Chile,
-1975-03-31,CN,China,
-1975-03-31,CO,Colombia,
-1975-03-31,CY,Cyprus,
-1975-03-31,CZ,Czechia,
-1975-03-31,DE,Germany,-0.9713
+1975-03-31,DE,Germany,-1.0587
 1975-03-31,DK,Denmark,-1.3747
-1975-03-31,EE,Estonia,
 1975-03-31,ES,Spain,-1.6846
 1975-03-31,FI,Finland,-9.1491
 1975-03-31,FR,France,-1.1681
 1975-03-31,GB,United Kingdom,-13.2102
-1975-03-31,GR,Greece,
-1975-03-31,HK,Hong Kong SAR,
-1975-03-31,HR,Croatia,
-1975-03-31,HU,Hungary,
-1975-03-31,ID,Indonesia,
 1975-03-31,IE,Ireland,6.3008
-1975-03-31,IL,Israel,
-1975-03-31,IN,India,
-1975-03-31,IS,Iceland,
-1975-03-31,IT,Italy,8.4474
+1975-03-31,IT,Italy,8.4939
 1975-03-31,JP,Japan,-16.8184
-1975-03-31,KR,Korea,
-1975-03-31,LT,Lithuania,
-1975-03-31,LU,Luxembourg,
-1975-03-31,LV,Latvia,
-1975-03-31,MA,Morocco,
-1975-03-31,MK,North Macedonia,
-1975-03-31,MT,Malta,
-1975-03-31,MX,Mexico,
-1975-03-31,MY,Malaysia,
 1975-03-31,NL,Netherlands,5.4123
-1975-03-31,NO,Norway,
-1975-03-31,NZ,New Zealand,6.4642
-1975-03-31,PE,Peru,
-1975-03-31,PH,Philippines,
-1975-03-31,PL,Poland,
-1975-03-31,PT,Portugal,
-1975-03-31,RO,Romania,
-1975-03-31,RS,Serbia,
-1975-03-31,RU,Russia,
+1975-03-31,NZ,New Zealand,6.4795
 1975-03-31,SE,Sweden,5.8865
-1975-03-31,SG,Singapore,
-1975-03-31,SI,Slovenia,
-1975-03-31,SK,Slovak Republic,
-1975-03-31,TH,Thailand,
-1975-03-31,TR,Türkiye,
 1975-03-31,US,United States,-2.6831
-1975-03-31,XM,Euro area,
-1975-03-31,XW,World,
-1975-03-31,ZA,South Africa,-4.4414
-1975-06-30,4T,Emerging market economies (aggregate),
-1975-06-30,5R,Advanced economies,
-1975-06-30,AE,United Arab Emirates,
-1975-06-30,AT,Austria,
-1975-06-30,AU,Australia,-5.9486
+1975-03-31,ZA,South Africa,-4.49
+1975-06-30,AU,Australia,-5.8647
 1975-06-30,BE,Belgium,-0.0484
-1975-06-30,BG,Bulgaria,
-1975-06-30,BR,Brazil,
 1975-06-30,CA,Canada,-2.2398
 1975-06-30,CH,Switzerland,-12.3727
-1975-06-30,CL,Chile,
-1975-06-30,CN,China,
-1975-06-30,CO,Colombia,
-1975-06-30,CY,Cyprus,
-1975-06-30,CZ,Czechia,
-1975-06-30,DE,Germany,-4.0233
+1975-06-30,DE,Germany,-3.9037
 1975-06-30,DK,Denmark,7.2387
-1975-06-30,EE,Estonia,
 1975-06-30,ES,Spain,-7.6888
 1975-06-30,FI,Finland,-12.6815
 1975-06-30,FR,France,-0.3775
 1975-06-30,GB,United Kingdom,-13.8772
-1975-06-30,GR,Greece,
-1975-06-30,HK,Hong Kong SAR,
-1975-06-30,HR,Croatia,
-1975-06-30,HU,Hungary,
-1975-06-30,ID,Indonesia,
 1975-06-30,IE,Ireland,4.7764
-1975-06-30,IL,Israel,
-1975-06-30,IN,India,
-1975-06-30,IS,Iceland,
-1975-06-30,IT,Italy,1.0346
+1975-06-30,IT,Italy,1.091
 1975-06-30,JP,Japan,-15.8533
-1975-06-30,KR,Korea,
-1975-06-30,LT,Lithuania,
-1975-06-30,LU,Luxembourg,
-1975-06-30,LV,Latvia,
-1975-06-30,MA,Morocco,
-1975-06-30,MK,North Macedonia,
-1975-06-30,MT,Malta,
-1975-06-30,MX,Mexico,
-1975-06-30,MY,Malaysia,
 1975-06-30,NL,Netherlands,4.0595
-1975-06-30,NO,Norway,
-1975-06-30,NZ,New Zealand,-4.505
-1975-06-30,PE,Peru,
-1975-06-30,PH,Philippines,
-1975-06-30,PL,Poland,
-1975-06-30,PT,Portugal,
-1975-06-30,RO,Romania,
-1975-06-30,RS,Serbia,
-1975-06-30,RU,Russia,
+1975-06-30,NZ,New Zealand,-4.515
 1975-06-30,SE,Sweden,8.0756
-1975-06-30,SG,Singapore,
-1975-06-30,SI,Slovenia,
-1975-06-30,SK,Slovak Republic,
-1975-06-30,TH,Thailand,
-1975-06-30,TR,Türkiye,
 1975-06-30,US,United States,-0.5639
-1975-06-30,XM,Euro area,
-1975-06-30,XW,World,
-1975-06-30,ZA,South Africa,-4.0472
-1975-09-30,4T,Emerging market economies (aggregate),
-1975-09-30,5R,Advanced economies,
-1975-09-30,AE,United Arab Emirates,
-1975-09-30,AT,Austria,
-1975-09-30,AU,Australia,-0.0959
+1975-06-30,ZA,South Africa,-4.3301
+1975-09-30,AU,Australia,-0.2724
 1975-09-30,BE,Belgium,0.5982
-1975-09-30,BG,Bulgaria,
-1975-09-30,BR,Brazil,
 1975-09-30,CA,Canada,1.491
 1975-09-30,CH,Switzerland,-12.2784
-1975-09-30,CL,Chile,
-1975-09-30,CN,China,
-1975-09-30,CO,Colombia,
-1975-09-30,CY,Cyprus,
-1975-09-30,CZ,Czechia,
-1975-09-30,DE,Germany,-4.6812
+1975-09-30,DE,Germany,-4.6337
 1975-09-30,DK,Denmark,13.7007
-1975-09-30,EE,Estonia,
 1975-09-30,ES,Spain,-10.4833
 1975-09-30,FI,Finland,-12.3741
 1975-09-30,FR,France,0.4705
 1975-09-30,GB,United Kingdom,-13.7387
-1975-09-30,GR,Greece,
-1975-09-30,HK,Hong Kong SAR,
-1975-09-30,HR,Croatia,
-1975-09-30,HU,Hungary,
-1975-09-30,ID,Indonesia,
 1975-09-30,IE,Ireland,10.4341
-1975-09-30,IL,Israel,
-1975-09-30,IN,India,
-1975-09-30,IS,Iceland,
-1975-09-30,IT,Italy,-1.041
+1975-09-30,IT,Italy,-1.0594
 1975-09-30,JP,Japan,-14.1195
-1975-09-30,KR,Korea,
-1975-09-30,LT,Lithuania,
-1975-09-30,LU,Luxembourg,
-1975-09-30,LV,Latvia,
-1975-09-30,MA,Morocco,
-1975-09-30,MK,North Macedonia,
-1975-09-30,MT,Malta,
-1975-09-30,MX,Mexico,
-1975-09-30,MY,Malaysia,
-1975-09-30,NL,Netherlands,4.8732
-1975-09-30,NO,Norway,
-1975-09-30,NZ,New Zealand,-8.8149
-1975-09-30,PE,Peru,
-1975-09-30,PH,Philippines,
-1975-09-30,PL,Poland,
-1975-09-30,PT,Portugal,
-1975-09-30,RO,Romania,
-1975-09-30,RS,Serbia,
-1975-09-30,RU,Russia,
+1975-09-30,NL,Netherlands,4.8731
+1975-09-30,NZ,New Zealand,-8.8041
 1975-09-30,SE,Sweden,7.8677
-1975-09-30,SG,Singapore,
-1975-09-30,SI,Slovenia,
-1975-09-30,SK,Slovak Republic,
-1975-09-30,TH,Thailand,
-1975-09-30,TR,Türkiye,
 1975-09-30,US,United States,-0.5519
-1975-09-30,XM,Euro area,
-1975-09-30,XW,World,
-1975-09-30,ZA,South Africa,-3.3159
-1975-12-31,4T,Emerging market economies (aggregate),
-1975-12-31,5R,Advanced economies,
-1975-12-31,AE,United Arab Emirates,
-1975-12-31,AT,Austria,
-1975-12-31,AU,Australia,-1.5908
+1975-09-30,ZA,South Africa,-3.3114
+1975-12-31,AU,Australia,-1.6875
 1975-12-31,BE,Belgium,6.0136
-1975-12-31,BG,Bulgaria,
-1975-12-31,BR,Brazil,
 1975-12-31,CA,Canada,6.2829
 1975-12-31,CH,Switzerland,-9.9235
-1975-12-31,CL,Chile,
-1975-12-31,CN,China,
-1975-12-31,CO,Colombia,
-1975-12-31,CY,Cyprus,
-1975-12-31,CZ,Czechia,
-1975-12-31,DE,Germany,-3.6884
+1975-12-31,DE,Germany,-3.7732
 1975-12-31,DK,Denmark,10.7938
-1975-12-31,EE,Estonia,
 1975-12-31,ES,Spain,-6.8375
 1975-12-31,FI,Finland,-10.8397
 1975-12-31,FR,France,1.7517
 1975-12-31,GB,United Kingdom,-12.7939
-1975-12-31,GR,Greece,
-1975-12-31,HK,Hong Kong SAR,
-1975-12-31,HR,Croatia,
-1975-12-31,HU,Hungary,
-1975-12-31,ID,Indonesia,
 1975-12-31,IE,Ireland,7.5521
-1975-12-31,IL,Israel,
-1975-12-31,IN,India,
-1975-12-31,IS,Iceland,
-1975-12-31,IT,Italy,0.2204
+1975-12-31,IT,Italy,0.3057
 1975-12-31,JP,Japan,-9.8033
-1975-12-31,KR,Korea,
-1975-12-31,LT,Lithuania,
-1975-12-31,LU,Luxembourg,
-1975-12-31,LV,Latvia,
-1975-12-31,MA,Morocco,
-1975-12-31,MK,North Macedonia,
-1975-12-31,MT,Malta,
-1975-12-31,MX,Mexico,
-1975-12-31,MY,Malaysia,
 1975-12-31,NL,Netherlands,6.0341
-1975-12-31,NO,Norway,
-1975-12-31,NZ,New Zealand,-10.0277
-1975-12-31,PE,Peru,
-1975-12-31,PH,Philippines,
-1975-12-31,PL,Poland,
-1975-12-31,PT,Portugal,
-1975-12-31,RO,Romania,
-1975-12-31,RS,Serbia,
-1975-12-31,RU,Russia,
+1975-12-31,NZ,New Zealand,-10.0183
 1975-12-31,SE,Sweden,7.7475
-1975-12-31,SG,Singapore,
-1975-12-31,SI,Slovenia,
-1975-12-31,SK,Slovak Republic,
-1975-12-31,TH,Thailand,
-1975-12-31,TR,Türkiye,
 1975-12-31,US,United States,2.0696
-1975-12-31,XM,Euro area,
-1975-12-31,XW,World,
-1975-12-31,ZA,South Africa,-0.4697
-1976-03-31,4T,Emerging market economies (aggregate),
-1976-03-31,5R,Advanced economies,
-1976-03-31,AE,United Arab Emirates,
-1976-03-31,AT,Austria,
-1976-03-31,AU,Australia,1.2657
+1975-12-31,ZA,South Africa,-0.3796
+1976-03-31,AU,Australia,1.2179
 1976-03-31,BE,Belgium,10.2148
-1976-03-31,BG,Bulgaria,
-1976-03-31,BR,Brazil,
 1976-03-31,CA,Canada,5.6852
-1976-03-31,CH,Switzerland,-7.6205
-1976-03-31,CL,Chile,
-1976-03-31,CN,China,
-1976-03-31,CO,Colombia,
-1976-03-31,CY,Cyprus,
-1976-03-31,CZ,Czechia,
-1976-03-31,DE,Germany,-3.6888
+1976-03-31,CH,Switzerland,-7.6206
+1976-03-31,DE,Germany,-3.6731
 1976-03-31,DK,Denmark,5.2549
-1976-03-31,EE,Estonia,
 1976-03-31,ES,Spain,-4.6394
 1976-03-31,FI,Finland,-8.2787
 1976-03-31,FR,France,4.1367
 1976-03-31,GB,United Kingdom,-10.0465
-1976-03-31,GR,Greece,
-1976-03-31,HK,Hong Kong SAR,
-1976-03-31,HR,Croatia,
-1976-03-31,HU,Hungary,
-1976-03-31,ID,Indonesia,
 1976-03-31,IE,Ireland,6.8489
-1976-03-31,IL,Israel,
-1976-03-31,IN,India,
-1976-03-31,IS,Iceland,
-1976-03-31,IT,Italy,0.4446
+1976-03-31,IT,Italy,0.4112
 1976-03-31,JP,Japan,-6.9258
 1976-03-31,KR,Korea,10.5871
-1976-03-31,LT,Lithuania,
-1976-03-31,LU,Luxembourg,
-1976-03-31,LV,Latvia,
-1976-03-31,MA,Morocco,
-1976-03-31,MK,North Macedonia,
-1976-03-31,MT,Malta,
-1976-03-31,MX,Mexico,
-1976-03-31,MY,Malaysia,
 1976-03-31,NL,Netherlands,9.2448
-1976-03-31,NO,Norway,
-1976-03-31,NZ,New Zealand,-9.6214
-1976-03-31,PE,Peru,
-1976-03-31,PH,Philippines,
-1976-03-31,PL,Poland,
-1976-03-31,PT,Portugal,
-1976-03-31,RO,Romania,
-1976-03-31,RS,Serbia,
-1976-03-31,RU,Russia,
+1976-03-31,NZ,New Zealand,-9.6083
 1976-03-31,SE,Sweden,5.4929
-1976-03-31,SG,Singapore,
-1976-03-31,SI,Slovenia,
-1976-03-31,SK,Slovak Republic,
-1976-03-31,TH,Thailand,
-1976-03-31,TR,Türkiye,
-1976-03-31,US,United States,-2.352
-1976-03-31,XM,Euro area,-1.6927
-1976-03-31,XW,World,
-1976-03-31,ZA,South Africa,-3.8559
-1976-06-30,4T,Emerging market economies (aggregate),
-1976-06-30,5R,Advanced economies,
-1976-06-30,AE,United Arab Emirates,
-1976-06-30,AT,Austria,
-1976-06-30,AU,Australia,0.4346
+1976-03-31,US,United States,-2.4414
+1976-03-31,XM,Euro area,-1.7286
+1976-03-31,ZA,South Africa,-3.9922
+1976-06-30,AU,Australia,0.5191
 1976-06-30,BE,Belgium,9.6028
-1976-06-30,BG,Bulgaria,
-1976-06-30,BR,Brazil,
 1976-06-30,CA,Canada,4.4852
 1976-06-30,CH,Switzerland,-4.6011
-1976-06-30,CL,Chile,
-1976-06-30,CN,China,
-1976-06-30,CO,Colombia,
-1976-06-30,CY,Cyprus,
-1976-06-30,CZ,Czechia,
-1976-06-30,DE,Germany,-2.6485
+1976-06-30,DE,Germany,-2.6799
 1976-06-30,DK,Denmark,1.1538
-1976-06-30,EE,Estonia,
 1976-06-30,ES,Spain,-1.7146
 1976-06-30,FI,Finland,-7.5935
 1976-06-30,FR,France,5.8351
 1976-06-30,GB,United Kingdom,-4.8136
-1976-06-30,GR,Greece,
-1976-06-30,HK,Hong Kong SAR,
-1976-06-30,HR,Croatia,
-1976-06-30,HU,Hungary,
-1976-06-30,ID,Indonesia,
 1976-06-30,IE,Ireland,2.2561
-1976-06-30,IL,Israel,
-1976-06-30,IN,India,
-1976-06-30,IS,Iceland,
-1976-06-30,IT,Italy,-0.4405
+1976-06-30,IT,Italy,-0.4866
 1976-06-30,JP,Japan,-6.7282
 1976-06-30,KR,Korea,9.0982
-1976-06-30,LT,Lithuania,
-1976-06-30,LU,Luxembourg,
-1976-06-30,LV,Latvia,
-1976-06-30,MA,Morocco,
-1976-06-30,MK,North Macedonia,
-1976-06-30,MT,Malta,
-1976-06-30,MX,Mexico,
-1976-06-30,MY,Malaysia,
-1976-06-30,NL,Netherlands,15.7438
-1976-06-30,NO,Norway,
-1976-06-30,NZ,New Zealand,-8.2882
-1976-06-30,PE,Peru,
-1976-06-30,PH,Philippines,
-1976-06-30,PL,Poland,
-1976-06-30,PT,Portugal,
-1976-06-30,RO,Romania,
-1976-06-30,RS,Serbia,
-1976-06-30,RU,Russia,
+1976-06-30,NL,Netherlands,15.7437
+1976-06-30,NZ,New Zealand,-8.2983
 1976-06-30,SE,Sweden,4.9644
-1976-06-30,SG,Singapore,
-1976-06-30,SI,Slovenia,
-1976-06-30,SK,Slovak Republic,
-1976-06-30,TH,Thailand,
-1976-06-30,TR,Türkiye,
-1976-06-30,US,United States,-1.8562
-1976-06-30,XM,Euro area,0.8959
-1976-06-30,XW,World,
-1976-06-30,ZA,South Africa,-4.0442
-1976-09-30,4T,Emerging market economies (aggregate),
-1976-09-30,5R,Advanced economies,
-1976-09-30,AE,United Arab Emirates,
-1976-09-30,AT,Austria,
-1976-09-30,AU,Australia,-4.0024
+1976-06-30,US,United States,-1.8042
+1976-06-30,XM,Euro area,0.8907
+1976-06-30,ZA,South Africa,-4.0707
+1976-09-30,AU,Australia,-4.0761
 1976-09-30,BE,Belgium,11.6532
-1976-09-30,BG,Bulgaria,
-1976-09-30,BR,Brazil,
 1976-09-30,CA,Canada,3.2264
-1976-09-30,CH,Switzerland,-4.4722
-1976-09-30,CL,Chile,
-1976-09-30,CN,China,
-1976-09-30,CO,Colombia,
-1976-09-30,CY,Cyprus,
-1976-09-30,CZ,Czechia,
-1976-09-30,DE,Germany,-1.5518
+1976-09-30,CH,Switzerland,-4.4723
+1976-09-30,DE,Germany,-1.687
 1976-09-30,DK,Denmark,-1.6319
-1976-09-30,EE,Estonia,
 1976-09-30,ES,Spain,2.8349
 1976-09-30,FI,Finland,-5.8841
 1976-09-30,FR,France,6.5793
 1976-09-30,GB,United Kingdom,-4.1456
-1976-09-30,GR,Greece,
-1976-09-30,HK,Hong Kong SAR,
-1976-09-30,HR,Croatia,
-1976-09-30,HU,Hungary,
-1976-09-30,ID,Indonesia,
 1976-09-30,IE,Ireland,-1.4668
-1976-09-30,IL,Israel,
-1976-09-30,IN,India,
-1976-09-30,IS,Iceland,
-1976-09-30,IT,Italy,0.2256
+1976-09-30,IT,Italy,0.2362
 1976-09-30,JP,Japan,-6.4381
 1976-09-30,KR,Korea,9.8161
-1976-09-30,LT,Lithuania,
-1976-09-30,LU,Luxembourg,
-1976-09-30,LV,Latvia,
-1976-09-30,MA,Morocco,
-1976-09-30,MK,North Macedonia,
-1976-09-30,MT,Malta,
-1976-09-30,MX,Mexico,
-1976-09-30,MY,Malaysia,
 1976-09-30,NL,Netherlands,20.346
-1976-09-30,NO,Norway,
-1976-09-30,NZ,New Zealand,-8.1813
-1976-09-30,PE,Peru,
-1976-09-30,PH,Philippines,
-1976-09-30,PL,Poland,
-1976-09-30,PT,Portugal,
-1976-09-30,RO,Romania,
-1976-09-30,RS,Serbia,
-1976-09-30,RU,Russia,
+1976-09-30,NZ,New Zealand,-8.1646
 1976-09-30,SE,Sweden,8.8247
-1976-09-30,SG,Singapore,
-1976-09-30,SI,Slovenia,
-1976-09-30,SK,Slovak Republic,
-1976-09-30,TH,Thailand,
-1976-09-30,TR,Türkiye,
-1976-09-30,US,United States,-0.5824
-1976-09-30,XM,Euro area,2.9755
-1976-09-30,XW,World,
-1976-09-30,ZA,South Africa,-4.2482
-1976-12-31,4T,Emerging market economies (aggregate),
-1976-12-31,5R,Advanced economies,
-1976-12-31,AE,United Arab Emirates,
-1976-12-31,AT,Austria,
-1976-12-31,AU,Australia,-4.0881
+1976-09-30,US,United States,-0.5673
+1976-09-30,XM,Euro area,2.9917
+1976-09-30,ZA,South Africa,-4.1239
+1976-12-31,AU,Australia,-4.0264
 1976-12-31,BE,Belgium,12.425
-1976-12-31,BG,Bulgaria,
-1976-12-31,BR,Brazil,
 1976-12-31,CA,Canada,3.5233
-1976-12-31,CH,Switzerland,-0.8791
-1976-12-31,CL,Chile,
-1976-12-31,CN,China,
-1976-12-31,CO,Colombia,
-1976-12-31,CY,Cyprus,
-1976-12-31,CZ,Czechia,
-1976-12-31,DE,Germany,0.0281
+1976-12-31,CH,Switzerland,-0.8792
+1976-12-31,DE,Germany,0.1818
 1976-12-31,DK,Denmark,-1.8631
-1976-12-31,EE,Estonia,
 1976-12-31,ES,Spain,2.5456
 1976-12-31,FI,Finland,-7.2262
 1976-12-31,FR,France,6.2185
 1976-12-31,GB,United Kingdom,-4.2324
-1976-12-31,GR,Greece,
-1976-12-31,HK,Hong Kong SAR,
-1976-12-31,HR,Croatia,
-1976-12-31,HU,Hungary,
-1976-12-31,ID,Indonesia,
 1976-12-31,IE,Ireland,2.2438
-1976-12-31,IL,Israel,
-1976-12-31,IN,India,
-1976-12-31,IS,Iceland,
-1976-12-31,IT,Italy,-2.8677
+1976-12-31,IT,Italy,-2.8689
 1976-12-31,JP,Japan,-5.6409
-1976-12-31,KR,Korea,10.4596
-1976-12-31,LT,Lithuania,
-1976-12-31,LU,Luxembourg,
-1976-12-31,LV,Latvia,
-1976-12-31,MA,Morocco,
-1976-12-31,MK,North Macedonia,
-1976-12-31,MT,Malta,
-1976-12-31,MX,Mexico,
-1976-12-31,MY,Malaysia,
+1976-12-31,KR,Korea,10.4597
 1976-12-31,NL,Netherlands,22.93
-1976-12-31,NO,Norway,
-1976-12-31,NZ,New Zealand,-7.4744
-1976-12-31,PE,Peru,
-1976-12-31,PH,Philippines,
-1976-12-31,PL,Poland,
-1976-12-31,PT,Portugal,
-1976-12-31,RO,Romania,
-1976-12-31,RS,Serbia,
-1976-12-31,RU,Russia,
+1976-12-31,NZ,New Zealand,-7.4594
 1976-12-31,SE,Sweden,5.1929
-1976-12-31,SG,Singapore,
-1976-12-31,SI,Slovenia,
-1976-12-31,SK,Slovak Republic,
-1976-12-31,TH,Thailand,
-1976-12-31,TR,Türkiye,
-1976-12-31,US,United States,2.0001
-1976-12-31,XM,Euro area,3.1967
-1976-12-31,XW,World,
-1976-12-31,ZA,South Africa,-5.8729
-1977-03-31,4T,Emerging market economies (aggregate),
-1977-03-31,5R,Advanced economies,
-1977-03-31,AE,United Arab Emirates,
-1977-03-31,AT,Austria,
-1977-03-31,AU,Australia,-4.4249
+1976-12-31,US,United States,2.0188
+1976-12-31,XM,Euro area,3.1944
+1976-12-31,ZA,South Africa,-6.022
+1977-03-31,AU,Australia,-4.966
 1977-03-31,BE,Belgium,6.9595
-1977-03-31,BG,Bulgaria,
-1977-03-31,BR,Brazil,
 1977-03-31,CA,Canada,-0.4926
 1977-03-31,CH,Switzerland,1.4281
-1977-03-31,CL,Chile,
-1977-03-31,CN,China,
-1977-03-31,CO,Colombia,
-1977-03-31,CY,Cyprus,
-1977-03-31,CZ,Czechia,
-1977-03-31,DE,Germany,0.8154
+1977-03-31,DE,Germany,0.7355
 1977-03-31,DK,Denmark,-2.7235
-1977-03-31,EE,Estonia,
 1977-03-31,ES,Spain,8.1908
 1977-03-31,FI,Finland,-8.6314
 1977-03-31,FR,France,6.6524
 1977-03-31,GB,United Kingdom,-7.4621
-1977-03-31,GR,Greece,
-1977-03-31,HK,Hong Kong SAR,
-1977-03-31,HR,Croatia,
-1977-03-31,HU,Hungary,
-1977-03-31,ID,Indonesia,
 1977-03-31,IE,Ireland,-0.2814
-1977-03-31,IL,Israel,
-1977-03-31,IN,India,
-1977-03-31,IS,Iceland,
-1977-03-31,IT,Italy,-4.9172
+1977-03-31,IT,Italy,-3.7742
 1977-03-31,JP,Japan,-4.9786
-1977-03-31,KR,Korea,15.0366
-1977-03-31,LT,Lithuania,
-1977-03-31,LU,Luxembourg,
-1977-03-31,LV,Latvia,
-1977-03-31,MA,Morocco,
-1977-03-31,MK,North Macedonia,
-1977-03-31,MT,Malta,
-1977-03-31,MX,Mexico,
-1977-03-31,MY,Malaysia,
-1977-03-31,NL,Netherlands,31.6881
-1977-03-31,NO,Norway,
-1977-03-31,NZ,New Zealand,-5.7755
-1977-03-31,PE,Peru,
-1977-03-31,PH,Philippines,
-1977-03-31,PL,Poland,
-1977-03-31,PT,Portugal,
-1977-03-31,RO,Romania,
-1977-03-31,RS,Serbia,
-1977-03-31,RU,Russia,
+1977-03-31,KR,Korea,15.0365
+1977-03-31,NL,Netherlands,31.688
+1977-03-31,NZ,New Zealand,-5.7875
 1977-03-31,SE,Sweden,6.0283
-1977-03-31,SG,Singapore,
-1977-03-31,SI,Slovenia,
-1977-03-31,SK,Slovak Republic,
-1977-03-31,TH,Thailand,
-1977-03-31,TR,Türkiye,
-1977-03-31,US,United States,8.2422
-1977-03-31,XM,Euro area,3.1108
-1977-03-31,XW,World,
-1977-03-31,ZA,South Africa,-8.0653
-1977-06-30,4T,Emerging market economies (aggregate),
-1977-06-30,5R,Advanced economies,
-1977-06-30,AE,United Arab Emirates,
-1977-06-30,AT,Austria,
-1977-06-30,AU,Australia,-4.6242
+1977-03-31,US,United States,8.4061
+1977-03-31,XM,Euro area,3.154
+1977-03-31,ZA,South Africa,-8.1183
+1977-06-30,AU,Australia,-4.6485
 1977-06-30,BE,Belgium,8.2691
-1977-06-30,BG,Bulgaria,
-1977-06-30,BR,Brazil,
 1977-06-30,CA,Canada,-2.3583
 1977-06-30,CH,Switzerland,1.4365
-1977-06-30,CL,Chile,
-1977-06-30,CN,China,
-1977-06-30,CO,Colombia,
-1977-06-30,CY,Cyprus,
-1977-06-30,CZ,Czechia,
-1977-06-30,DE,Germany,1.4634
+1977-06-30,DE,Germany,1.5132
 1977-06-30,DK,Denmark,3.0616
-1977-06-30,EE,Estonia,
 1977-06-30,ES,Spain,9.8883
 1977-06-30,FI,Finland,-6.9944
 1977-06-30,FR,France,5.0913
 1977-06-30,GB,United Kingdom,-8.9742
-1977-06-30,GR,Greece,
-1977-06-30,HK,Hong Kong SAR,
-1977-06-30,HR,Croatia,
-1977-06-30,HU,Hungary,
-1977-06-30,ID,Indonesia,
 1977-06-30,IE,Ireland,4.5242
-1977-06-30,IL,Israel,
-1977-06-30,IN,India,
-1977-06-30,IS,Iceland,
-1977-06-30,IT,Italy,-4.959
+1977-06-30,IT,Italy,-3.8454
 1977-06-30,JP,Japan,-4.4074
 1977-06-30,KR,Korea,17.8527
-1977-06-30,LT,Lithuania,
-1977-06-30,LU,Luxembourg,
-1977-06-30,LV,Latvia,
-1977-06-30,MA,Morocco,
-1977-06-30,MK,North Macedonia,
-1977-06-30,MT,Malta,
-1977-06-30,MX,Mexico,
-1977-06-30,MY,Malaysia,
-1977-06-30,NL,Netherlands,36.487
-1977-06-30,NO,Norway,
-1977-06-30,NZ,New Zealand,-5.8294
-1977-06-30,PE,Peru,
-1977-06-30,PH,Philippines,
-1977-06-30,PL,Poland,
-1977-06-30,PT,Portugal,
-1977-06-30,RO,Romania,
-1977-06-30,RS,Serbia,
-1977-06-30,RU,Russia,
+1977-06-30,NL,Netherlands,36.4869
+1977-06-30,NZ,New Zealand,-5.8383
 1977-06-30,SE,Sweden,5.1529
-1977-06-30,SG,Singapore,
-1977-06-30,SI,Slovenia,
-1977-06-30,SK,Slovak Republic,
-1977-06-30,TH,Thailand,
-1977-06-30,TR,Türkiye,
-1977-06-30,US,United States,8.8474
-1977-06-30,XM,Euro area,2.1104
-1977-06-30,XW,World,
-1977-06-30,ZA,South Africa,-8.9628
-1977-09-30,4T,Emerging market economies (aggregate),
-1977-09-30,5R,Advanced economies,
-1977-09-30,AE,United Arab Emirates,
-1977-09-30,AT,Austria,
-1977-09-30,AU,Australia,-3.9415
+1977-06-30,US,United States,8.8893
+1977-06-30,XM,Euro area,2.1365
+1977-06-30,ZA,South Africa,-8.904
+1977-09-30,AU,Australia,-3.6671
 1977-09-30,BE,Belgium,8.5575
-1977-09-30,BG,Bulgaria,
-1977-09-30,BR,Brazil,
 1977-09-30,CA,Canada,-3.4488
 1977-09-30,CH,Switzerland,4.6401
-1977-09-30,CL,Chile,
-1977-09-30,CN,China,
-1977-09-30,CO,Colombia,
-1977-09-30,CY,Cyprus,
-1977-09-30,CZ,Czechia,
-1977-09-30,DE,Germany,2.2374
+1977-09-30,DE,Germany,2.437
 1977-09-30,DK,Denmark,3.8691
-1977-09-30,EE,Estonia,
 1977-09-30,ES,Spain,7.4471
 1977-09-30,FI,Finland,-9.6135
 1977-09-30,FR,France,4.4719
 1977-09-30,GB,United Kingdom,-7.7491
-1977-09-30,GR,Greece,
-1977-09-30,HK,Hong Kong SAR,
-1977-09-30,HR,Croatia,
-1977-09-30,HU,Hungary,
-1977-09-30,ID,Indonesia,
 1977-09-30,IE,Ireland,10.1457
-1977-09-30,IL,Israel,
-1977-09-30,IN,India,
-1977-09-30,IS,Iceland,
-1977-09-30,IT,Italy,-7.4149
+1977-09-30,IT,Italy,-6.3841
 1977-09-30,JP,Japan,-3.3115
 1977-09-30,KR,Korea,21.855
-1977-09-30,LT,Lithuania,
-1977-09-30,LU,Luxembourg,
-1977-09-30,LV,Latvia,
-1977-09-30,MA,Morocco,
-1977-09-30,MK,North Macedonia,
-1977-09-30,MT,Malta,
-1977-09-30,MX,Mexico,
-1977-09-30,MY,Malaysia,
-1977-09-30,NL,Netherlands,29.3581
-1977-09-30,NO,Norway,
-1977-09-30,NZ,New Zealand,-6.598
-1977-09-30,PE,Peru,
-1977-09-30,PH,Philippines,
-1977-09-30,PL,Poland,
-1977-09-30,PT,Portugal,
-1977-09-30,RO,Romania,
-1977-09-30,RS,Serbia,
-1977-09-30,RU,Russia,
+1977-09-30,NL,Netherlands,29.358
+1977-09-30,NZ,New Zealand,-6.6096
 1977-09-30,SE,Sweden,0.372
-1977-09-30,SG,Singapore,
-1977-09-30,SI,Slovenia,
-1977-09-30,SK,Slovak Republic,
-1977-09-30,TH,Thailand,
-1977-09-30,TR,Türkiye,
-1977-09-30,US,United States,10.0508
-1977-09-30,XM,Euro area,1.6639
-1977-09-30,XW,World,
-1977-09-30,ZA,South Africa,-8.0593
-1977-12-31,4T,Emerging market economies (aggregate),
-1977-12-31,5R,Advanced economies,
-1977-12-31,AE,United Arab Emirates,
-1977-12-31,AT,Austria,
-1977-12-31,AU,Australia,-1.8956
+1977-09-30,US,United States,10.1814
+1977-09-30,XM,Euro area,1.6756
+1977-09-30,ZA,South Africa,-8.2412
+1977-12-31,AU,Australia,-1.7564
 1977-12-31,BE,Belgium,10.907
-1977-12-31,BG,Bulgaria,
-1977-12-31,BR,Brazil,
 1977-12-31,CA,Canada,-4.9012
 1977-12-31,CH,Switzerland,1.3743
-1977-12-31,CL,Chile,
-1977-12-31,CN,China,
-1977-12-31,CO,Colombia,
-1977-12-31,CY,Cyprus,
-1977-12-31,CZ,Czechia,
-1977-12-31,DE,Germany,2.4781
+1977-12-31,DE,Germany,2.3071
 1977-12-31,DK,Denmark,3.5722
-1977-12-31,EE,Estonia,
 1977-12-31,ES,Spain,13.2344
 1977-12-31,FI,Finland,-9.7259
 1977-12-31,FR,France,4.7728
 1977-12-31,GB,United Kingdom,-3.3426
-1977-12-31,GR,Greece,
-1977-12-31,HK,Hong Kong SAR,
-1977-12-31,HR,Croatia,
-1977-12-31,HU,Hungary,
-1977-12-31,ID,Indonesia,
 1977-12-31,IE,Ireland,5.583
-1977-12-31,IL,Israel,
-1977-12-31,IN,India,
-1977-12-31,IS,Iceland,
-1977-12-31,IT,Italy,-6.7356
+1977-12-31,IT,Italy,-5.6682
 1977-12-31,JP,Japan,-1.7757
 1977-12-31,KR,Korea,29.0183
-1977-12-31,LT,Lithuania,
-1977-12-31,LU,Luxembourg,
-1977-12-31,LV,Latvia,
-1977-12-31,MA,Morocco,
-1977-12-31,MK,North Macedonia,
-1977-12-31,MT,Malta,
-1977-12-31,MX,Mexico,
-1977-12-31,MY,Malaysia,
-1977-12-31,NL,Netherlands,24.206
-1977-12-31,NO,Norway,
-1977-12-31,NZ,New Zealand,-8.9803
-1977-12-31,PE,Peru,
-1977-12-31,PH,Philippines,
-1977-12-31,PL,Poland,
-1977-12-31,PT,Portugal,
-1977-12-31,RO,Romania,
-1977-12-31,RS,Serbia,
-1977-12-31,RU,Russia,
+1977-12-31,NL,Netherlands,24.2059
+1977-12-31,NZ,New Zealand,-9.0207
 1977-12-31,SE,Sweden,3.0535
-1977-12-31,SG,Singapore,
-1977-12-31,SI,Slovenia,
-1977-12-31,SK,Slovak Republic,
-1977-12-31,TH,Thailand,
-1977-12-31,TR,Türkiye,
-1977-12-31,US,United States,8.8112
-1977-12-31,XM,Euro area,2.9454
-1977-12-31,XW,World,
-1977-12-31,ZA,South Africa,-8.0514
-1978-03-31,4T,Emerging market economies (aggregate),
-1978-03-31,5R,Advanced economies,
-1978-03-31,AE,United Arab Emirates,
-1978-03-31,AT,Austria,
-1978-03-31,AU,Australia,-1.2068
+1977-12-31,US,United States,8.9387
+1977-12-31,XM,Euro area,2.992
+1977-12-31,ZA,South Africa,-7.9021
+1978-03-31,AU,Australia,-0.7794
 1978-03-31,BE,Belgium,8.1263
-1978-03-31,BG,Bulgaria,
-1978-03-31,BR,Brazil,
 1978-03-31,CA,Canada,-6.0009
 1978-03-31,CH,Switzerland,0.5064
-1978-03-31,CL,Chile,
-1978-03-31,CN,China,
-1978-03-31,CO,Colombia,
-1978-03-31,CY,Cyprus,
-1978-03-31,CZ,Czechia,
-1978-03-31,DE,Germany,3.6814
+1978-03-31,DE,Germany,3.8085
 1978-03-31,DK,Denmark,6.5419
-1978-03-31,EE,Estonia,
 1978-03-31,ES,Spain,14.6404
 1978-03-31,FI,Finland,-5.0383
 1978-03-31,FR,France,3.8449
 1978-03-31,GB,United Kingdom,1.4342
-1978-03-31,GR,Greece,
-1978-03-31,HK,Hong Kong SAR,
-1978-03-31,HR,Croatia,
-1978-03-31,HU,Hungary,
-1978-03-31,ID,Indonesia,
 1978-03-31,IE,Ireland,20.6311
-1978-03-31,IL,Israel,
-1978-03-31,IN,India,
-1978-03-31,IS,Iceland,
-1978-03-31,IT,Italy,-4.3343
+1978-03-31,IT,Italy,-4.318
 1978-03-31,JP,Japan,0.0413
 1978-03-31,KR,Korea,33.9918
-1978-03-31,LT,Lithuania,
-1978-03-31,LU,Luxembourg,
-1978-03-31,LV,Latvia,
-1978-03-31,MA,Morocco,
-1978-03-31,MK,North Macedonia,
-1978-03-31,MT,Malta,
-1978-03-31,MX,Mexico,
-1978-03-31,MY,Malaysia,
-1978-03-31,NL,Netherlands,14.9601
-1978-03-31,NO,Norway,
-1978-03-31,NZ,New Zealand,-10.3209
-1978-03-31,PE,Peru,
-1978-03-31,PH,Philippines,
-1978-03-31,PL,Poland,
-1978-03-31,PT,Portugal,
-1978-03-31,RO,Romania,
-1978-03-31,RS,Serbia,
-1978-03-31,RU,Russia,
+1978-03-31,NL,Netherlands,14.96
+1978-03-31,NZ,New Zealand,-10.3145
 1978-03-31,SE,Sweden,-0.8995
-1978-03-31,SG,Singapore,
-1978-03-31,SI,Slovenia,
-1978-03-31,SK,Slovak Republic,
-1978-03-31,TH,Thailand,
-1978-03-31,TR,Türkiye,
-1978-03-31,US,United States,8.9839
-1978-03-31,XM,Euro area,4.3698
-1978-03-31,XW,World,
-1978-03-31,ZA,South Africa,-6.656
-1978-06-30,4T,Emerging market economies (aggregate),
-1978-06-30,5R,Advanced economies,
-1978-06-30,AE,United Arab Emirates,
-1978-06-30,AT,Austria,
-1978-06-30,AU,Australia,-3.1546
+1978-03-31,US,United States,9.0692
+1978-03-31,XM,Euro area,4.3799
+1978-03-31,ZA,South Africa,-6.6033
+1978-06-30,AU,Australia,-3.2109
 1978-06-30,BE,Belgium,7.5744
-1978-06-30,BG,Bulgaria,
-1978-06-30,BR,Brazil,
 1978-06-30,CA,Canada,-3.3959
-1978-06-30,CH,Switzerland,1.8098
-1978-06-30,CL,Chile,
-1978-06-30,CN,China,
-1978-06-30,CO,Colombia,
-1978-06-30,CY,Cyprus,
-1978-06-30,CZ,Czechia,
-1978-06-30,DE,Germany,4.042
+1978-06-30,CH,Switzerland,1.8097
+1978-06-30,DE,Germany,4.0062
 1978-06-30,DK,Denmark,5.7918
-1978-06-30,EE,Estonia,
 1978-06-30,ES,Spain,12.8629
 1978-06-30,FI,Finland,-4.2856
 1978-06-30,FR,France,2.8237
 1978-06-30,GB,United Kingdom,6.3121
-1978-06-30,GR,Greece,
-1978-06-30,HK,Hong Kong SAR,
-1978-06-30,HR,Croatia,
-1978-06-30,HU,Hungary,
-1978-06-30,ID,Indonesia,
 1978-06-30,IE,Ireland,25.821
-1978-06-30,IL,Israel,
-1978-06-30,IN,India,
-1978-06-30,IS,Iceland,
-1978-06-30,IT,Italy,0.0708
+1978-06-30,IT,Italy,0.1195
 1978-06-30,JP,Japan,1.2112
-1978-06-30,KR,Korea,37.719
-1978-06-30,LT,Lithuania,
-1978-06-30,LU,Luxembourg,
-1978-06-30,LV,Latvia,
-1978-06-30,MA,Morocco,
-1978-06-30,MK,North Macedonia,
-1978-06-30,MT,Malta,
-1978-06-30,MX,Mexico,
-1978-06-30,MY,Malaysia,
+1978-06-30,KR,Korea,37.7189
 1978-06-30,NL,Netherlands,7.6296
-1978-06-30,NO,Norway,
-1978-06-30,NZ,New Zealand,-9.8815
-1978-06-30,PE,Peru,
-1978-06-30,PH,Philippines,
-1978-06-30,PL,Poland,
-1978-06-30,PT,Portugal,
-1978-06-30,RO,Romania,
-1978-06-30,RS,Serbia,
-1978-06-30,RU,Russia,
+1978-06-30,NZ,New Zealand,-9.8784
 1978-06-30,SE,Sweden,1.9615
-1978-06-30,SG,Singapore,
-1978-06-30,SI,Slovenia,
-1978-06-30,SK,Slovak Republic,
-1978-06-30,TH,Thailand,
-1978-06-30,TR,Türkiye,
-1978-06-30,US,United States,7.321
-1978-06-30,XM,Euro area,3.966
-1978-06-30,XW,World,
-1978-06-30,ZA,South Africa,-6.4121
-1978-09-30,4T,Emerging market economies (aggregate),
-1978-09-30,5R,Advanced economies,
-1978-09-30,AE,United Arab Emirates,
-1978-09-30,AT,Austria,
-1978-09-30,AU,Australia,-2.8438
+1978-06-30,US,United States,7.3868
+1978-06-30,XM,Euro area,3.9598
+1978-06-30,ZA,South Africa,-6.5581
+1978-09-30,AU,Australia,-2.9027
 1978-09-30,BE,Belgium,8.0901
-1978-09-30,BG,Bulgaria,
-1978-09-30,BR,Brazil,
 1978-09-30,CA,Canada,-3.5761
 1978-09-30,CH,Switzerland,1.7787
-1978-09-30,CL,Chile,
-1978-09-30,CN,China,
-1978-09-30,CO,Colombia,
-1978-09-30,CY,Cyprus,
-1978-09-30,CZ,Czechia,
-1978-09-30,DE,Germany,4.9326
+1978-09-30,DE,Germany,4.8205
 1978-09-30,DK,Denmark,5.8496
-1978-09-30,EE,Estonia,
 1978-09-30,ES,Spain,11.7041
 1978-09-30,FI,Finland,-3.4584
 1978-09-30,FR,France,1.4307
 1978-09-30,GB,United Kingdom,10.4078
-1978-09-30,GR,Greece,
-1978-09-30,HK,Hong Kong SAR,
-1978-09-30,HR,Croatia,
-1978-09-30,HU,Hungary,
-1978-09-30,ID,Indonesia,
 1978-09-30,IE,Ireland,19.3117
-1978-09-30,IL,Israel,
-1978-09-30,IN,India,
-1978-09-30,IS,Iceland,
-1978-09-30,IT,Italy,4.8636
+1978-09-30,IT,Italy,4.9157
 1978-09-30,JP,Japan,1.4033
 1978-09-30,KR,Korea,31.7762
-1978-09-30,LT,Lithuania,
-1978-09-30,LU,Luxembourg,
-1978-09-30,LV,Latvia,
-1978-09-30,MA,Morocco,
-1978-09-30,MK,North Macedonia,
-1978-09-30,MT,Malta,
-1978-09-30,MX,Mexico,
-1978-09-30,MY,Malaysia,
 1978-09-30,NL,Netherlands,-1.5787
-1978-09-30,NO,Norway,
-1978-09-30,NZ,New Zealand,-8.6045
-1978-09-30,PE,Peru,
-1978-09-30,PH,Philippines,
-1978-09-30,PL,Poland,
-1978-09-30,PT,Portugal,
-1978-09-30,RO,Romania,
-1978-09-30,RS,Serbia,
-1978-09-30,RU,Russia,
+1978-09-30,NZ,New Zealand,-8.6011
 1978-09-30,SE,Sweden,6.5792
-1978-09-30,SG,Singapore,
-1978-09-30,SI,Slovenia,
-1978-09-30,SK,Slovak Republic,
-1978-09-30,TH,Thailand,
-1978-09-30,TR,Türkiye,
-1978-09-30,US,United States,6.9169
-1978-09-30,XM,Euro area,3.7141
-1978-09-30,XW,World,
-1978-09-30,ZA,South Africa,-7.0492
-1978-12-31,4T,Emerging market economies (aggregate),
-1978-12-31,5R,Advanced economies,
-1978-12-31,AE,United Arab Emirates,
-1978-12-31,AT,Austria,
-1978-12-31,AU,Australia,-3.373
+1978-09-30,US,United States,6.9324
+1978-09-30,XM,Euro area,3.731
+1978-09-30,ZA,South Africa,-6.9913
+1978-12-31,AU,Australia,-3.4956
 1978-12-31,BE,Belgium,4.1069
-1978-12-31,BG,Bulgaria,
-1978-12-31,BR,Brazil,
 1978-12-31,CA,Canada,-1.4682
 1978-12-31,CH,Switzerland,5.6825
-1978-12-31,CL,Chile,
-1978-12-31,CN,China,
-1978-12-31,CO,Colombia,
-1978-12-31,CY,Cyprus,
-1978-12-31,CZ,Czechia,
-1978-12-31,DE,Germany,5.1932
+1978-12-31,DE,Germany,5.2197
 1978-12-31,DK,Denmark,3.8575
-1978-12-31,EE,Estonia,
 1978-12-31,ES,Spain,5.212
 1978-12-31,FI,Finland,-2.3738
 1978-12-31,FR,France,0.916
 1978-12-31,GB,United Kingdom,14.4513
-1978-12-31,GR,Greece,
-1978-12-31,HK,Hong Kong SAR,
-1978-12-31,HR,Croatia,
-1978-12-31,HU,Hungary,
-1978-12-31,ID,Indonesia,
 1978-12-31,IE,Ireland,15.7147
-1978-12-31,IL,Israel,
-1978-12-31,IN,India,
-1978-12-31,IS,Iceland,
-1978-12-31,IT,Italy,8.7659
+1978-12-31,IT,Italy,8.7814
 1978-12-31,JP,Japan,2.8945
 1978-12-31,KR,Korea,19.5249
-1978-12-31,LT,Lithuania,
-1978-12-31,LU,Luxembourg,
-1978-12-31,LV,Latvia,
-1978-12-31,MA,Morocco,
-1978-12-31,MK,North Macedonia,
-1978-12-31,MT,Malta,
-1978-12-31,MX,Mexico,
-1978-12-31,MY,Malaysia,
 1978-12-31,NL,Netherlands,-3.0903
-1978-12-31,NO,Norway,
-1978-12-31,NZ,New Zealand,-6.5451
-1978-12-31,PE,Peru,
-1978-12-31,PH,Philippines,
-1978-12-31,PL,Poland,
-1978-12-31,PT,Portugal,
-1978-12-31,RO,Romania,
-1978-12-31,RS,Serbia,
-1978-12-31,RU,Russia,
+1978-12-31,NZ,New Zealand,-6.5124
 1978-12-31,SE,Sweden,4.4891
-1978-12-31,SG,Singapore,
-1978-12-31,SI,Slovenia,
-1978-12-31,SK,Slovak Republic,
-1978-12-31,TH,Thailand,
-1978-12-31,TR,Türkiye,
-1978-12-31,US,United States,6.0329
-1978-12-31,XM,Euro area,4.169
-1978-12-31,XW,World,
-1978-12-31,ZA,South Africa,-4.612
-1979-03-31,4T,Emerging market economies (aggregate),
-1979-03-31,5R,Advanced economies,
-1979-03-31,AE,United Arab Emirates,
-1979-03-31,AT,Austria,
-1979-03-31,AU,Australia,-1.1468
+1978-12-31,US,United States,6.004
+1978-12-31,XM,Euro area,4.1664
+1978-12-31,ZA,South Africa,-4.6063
+1979-03-31,AU,Australia,-1.2781
 1979-03-31,BE,Belgium,5.97
-1979-03-31,BG,Bulgaria,
-1979-03-31,BR,Brazil,
 1979-03-31,CA,Canada,2.1237
 1979-03-31,CH,Switzerland,6.8452
-1979-03-31,CL,Chile,
-1979-03-31,CN,China,
-1979-03-31,CO,Colombia,
-1979-03-31,CY,Cyprus,
-1979-03-31,CZ,Czechia,
-1979-03-31,DE,Germany,4.9711
+1979-03-31,DE,Germany,4.9106
 1979-03-31,DK,Denmark,3.171
-1979-03-31,EE,Estonia,
 1979-03-31,ES,Spain,-3.038
 1979-03-31,FI,Finland,-4.0981
 1979-03-31,FR,France,0.7287
 1979-03-31,GB,United Kingdom,17.0148
-1979-03-31,GR,Greece,
-1979-03-31,HK,Hong Kong SAR,
-1979-03-31,HR,Croatia,
-1979-03-31,HU,Hungary,
-1979-03-31,ID,Indonesia,
 1979-03-31,IE,Ireland,9.5071
-1979-03-31,IL,Israel,
-1979-03-31,IN,India,
-1979-03-31,IS,Iceland,
-1979-03-31,IT,Italy,8.9846
+1979-03-31,IT,Italy,8.9409
 1979-03-31,JP,Japan,4.4121
 1979-03-31,KR,Korea,8.7717
-1979-03-31,LT,Lithuania,
-1979-03-31,LU,Luxembourg,
-1979-03-31,LV,Latvia,
-1979-03-31,MA,Morocco,
-1979-03-31,MK,North Macedonia,
-1979-03-31,MT,Malta,
-1979-03-31,MX,Mexico,
-1979-03-31,MY,Malaysia,
-1979-03-31,NL,Netherlands,-7.0815
-1979-03-31,NO,Norway,
-1979-03-31,NZ,New Zealand,-5.1871
-1979-03-31,PE,Peru,
-1979-03-31,PH,Philippines,
-1979-03-31,PL,Poland,
-1979-03-31,PT,Portugal,
-1979-03-31,RO,Romania,
-1979-03-31,RS,Serbia,
-1979-03-31,RU,Russia,
+1979-03-31,NL,Netherlands,-7.0814
+1979-03-31,NZ,New Zealand,-5.1766
 1979-03-31,SE,Sweden,6.3735
-1979-03-31,SG,Singapore,
-1979-03-31,SI,Slovenia,
-1979-03-31,SK,Slovak Republic,
-1979-03-31,TH,Thailand,
-1979-03-31,TR,Türkiye,
-1979-03-31,US,United States,5.4025
-1979-03-31,XM,Euro area,5.2847
-1979-03-31,XW,World,
-1979-03-31,ZA,South Africa,-3.5456
-1979-06-30,4T,Emerging market economies (aggregate),
-1979-06-30,5R,Advanced economies,
-1979-06-30,AE,United Arab Emirates,
-1979-06-30,AT,Austria,
-1979-06-30,AU,Australia,4.633
+1979-03-31,US,United States,5.414
+1979-03-31,XM,Euro area,5.2883
+1979-03-31,ZA,South Africa,-3.5449
+1979-06-30,AU,Australia,4.6994
 1979-06-30,BE,Belgium,5.0814
-1979-06-30,BG,Bulgaria,
-1979-06-30,BR,Brazil,
 1979-06-30,CA,Canada,0.9851
 1979-06-30,CH,Switzerland,2.9825
-1979-06-30,CL,Chile,
-1979-06-30,CN,China,
-1979-06-30,CO,Colombia,
-1979-06-30,CY,Cyprus,
-1979-06-30,CZ,Czechia,
-1979-06-30,DE,Germany,5.9281
+1979-06-30,DE,Germany,5.9695
 1979-06-30,DK,Denmark,2.8177
-1979-06-30,EE,Estonia,
 1979-06-30,ES,Spain,-9.3403
 1979-06-30,FI,Finland,-4.6923
 1979-06-30,FR,France,1.6467
 1979-06-30,GB,United Kingdom,19.635
-1979-06-30,GR,Greece,
-1979-06-30,HK,Hong Kong SAR,
-1979-06-30,HR,Croatia,
-1979-06-30,HU,Hungary,
-1979-06-30,ID,Indonesia,
 1979-06-30,IE,Ireland,11.1487
-1979-06-30,IL,Israel,
-1979-06-30,IN,India,
-1979-06-30,IS,Iceland,
-1979-06-30,IT,Italy,6.1011
+1979-06-30,IT,Italy,6.0849
 1979-06-30,JP,Japan,5.314
 1979-06-30,KR,Korea,0.9822
-1979-06-30,LT,Lithuania,
-1979-06-30,LU,Luxembourg,
-1979-06-30,LV,Latvia,
-1979-06-30,MA,Morocco,
-1979-06-30,MK,North Macedonia,
-1979-06-30,MT,Malta,
-1979-06-30,MX,Mexico,
-1979-06-30,MY,Malaysia,
 1979-06-30,NL,Netherlands,-11.6058
-1979-06-30,NO,Norway,
-1979-06-30,NZ,New Zealand,-6.2314
-1979-06-30,PE,Peru,
-1979-06-30,PH,Philippines,
-1979-06-30,PL,Poland,
-1979-06-30,PT,Portugal,
-1979-06-30,RO,Romania,
-1979-06-30,RS,Serbia,
-1979-06-30,RU,Russia,
+1979-06-30,NZ,New Zealand,-6.2182
 1979-06-30,SE,Sweden,5.0922
-1979-06-30,SG,Singapore,
-1979-06-30,SI,Slovenia,
-1979-06-30,SK,Slovak Republic,
-1979-06-30,TH,Thailand,
-1979-06-30,TR,Türkiye,
-1979-06-30,US,United States,5.5531
-1979-06-30,XM,Euro area,5.6462
-1979-06-30,XW,World,
-1979-06-30,ZA,South Africa,-0.9417
-1979-09-30,4T,Emerging market economies (aggregate),
-1979-09-30,5R,Advanced economies,
-1979-09-30,AE,United Arab Emirates,
-1979-09-30,AT,Austria,
-1979-09-30,AU,Australia,5.6978
+1979-06-30,US,United States,5.5513
+1979-06-30,XM,Euro area,5.6325
+1979-06-30,ZA,South Africa,-0.835
+1979-09-30,AU,Australia,5.8776
 1979-09-30,BE,Belgium,3.2193
-1979-09-30,BG,Bulgaria,
-1979-09-30,BR,Brazil,
 1979-09-30,CA,Canada,1.2351
-1979-09-30,CH,Switzerland,4.0282
-1979-09-30,CL,Chile,
-1979-09-30,CN,China,
-1979-09-30,CO,Colombia,
-1979-09-30,CY,Cyprus,
-1979-09-30,CZ,Czechia,
-1979-09-30,DE,Germany,4.546
+1979-09-30,CH,Switzerland,4.0283
+1979-09-30,DE,Germany,4.5846
 1979-09-30,DK,Denmark,-1.8826
-1979-09-30,EE,Estonia,
 1979-09-30,ES,Spain,-10.4399
 1979-09-30,FI,Finland,-1.8163
 1979-09-30,FR,France,2.6832
 1979-09-30,GB,United Kingdom,15.6698
-1979-09-30,GR,Greece,
-1979-09-30,HK,Hong Kong SAR,
-1979-09-30,HR,Croatia,
-1979-09-30,HU,Hungary,
-1979-09-30,ID,Indonesia,
 1979-09-30,IE,Ireland,6.0911
-1979-09-30,IL,Israel,
-1979-09-30,IN,India,
-1979-09-30,IS,Iceland,
-1979-09-30,IT,Italy,2.3646
+1979-09-30,IT,Italy,2.3579
 1979-09-30,JP,Japan,6.2026
 1979-09-30,KR,Korea,-4.7174
-1979-09-30,LT,Lithuania,
-1979-09-30,LU,Luxembourg,
-1979-09-30,LV,Latvia,
-1979-09-30,MA,Morocco,
-1979-09-30,MK,North Macedonia,
-1979-09-30,MT,Malta,
-1979-09-30,MX,Mexico,
-1979-09-30,MY,Malaysia,
-1979-09-30,NL,Netherlands,-6.9521
-1979-09-30,NO,Norway,
-1979-09-30,NZ,New Zealand,-8.3437
-1979-09-30,PE,Peru,
-1979-09-30,PH,Philippines,
-1979-09-30,PL,Poland,
-1979-09-30,PT,Portugal,
-1979-09-30,RO,Romania,
-1979-09-30,RS,Serbia,
-1979-09-30,RU,Russia,
+1979-09-30,NL,Netherlands,-6.952
+1979-09-30,NZ,New Zealand,-8.3555
 1979-09-30,SE,Sweden,2.5537
-1979-09-30,SG,Singapore,
-1979-09-30,SI,Slovenia,
-1979-09-30,SK,Slovak Republic,
-1979-09-30,TH,Thailand,
-1979-09-30,TR,Türkiye,
-1979-09-30,US,United States,4.1675
-1979-09-30,XM,Euro area,4.15
-1979-09-30,XW,World,
-1979-09-30,ZA,South Africa,-0.1929
-1979-12-31,4T,Emerging market economies (aggregate),
-1979-12-31,5R,Advanced economies,
-1979-12-31,AE,United Arab Emirates,
-1979-12-31,AT,Austria,
-1979-12-31,AU,Australia,5.7139
+1979-09-30,US,United States,4.1583
+1979-09-30,XM,Euro area,4.1193
+1979-09-30,ZA,South Africa,-0.098
+1979-12-31,AU,Australia,5.8228
 1979-12-31,BE,Belgium,1.0951
-1979-12-31,BG,Bulgaria,
-1979-12-31,BR,Brazil,
 1979-12-31,CA,Canada,0.341
 1979-12-31,CH,Switzerland,3.2409
-1979-12-31,CL,Chile,
-1979-12-31,CN,China,
-1979-12-31,CO,Colombia,
-1979-12-31,CY,Cyprus,
-1979-12-31,CZ,Czechia,
-1979-12-31,DE,Germany,3.1419
+1979-12-31,DE,Germany,3.1189
 1979-12-31,DK,Denmark,-2.7285
-1979-12-31,EE,Estonia,
 1979-12-31,ES,Spain,-12.6157
 1979-12-31,FI,Finland,0.5273
 1979-12-31,FR,France,3.8306
 1979-12-31,GB,United Kingdom,12.9377
-1979-12-31,GR,Greece,
-1979-12-31,HK,Hong Kong SAR,
-1979-12-31,HR,Croatia,
-1979-12-31,HU,Hungary,
-1979-12-31,ID,Indonesia,
 1979-12-31,IE,Ireland,3.648
-1979-12-31,IL,Israel,
-1979-12-31,IN,India,
-1979-12-31,IS,Iceland,
-1979-12-31,IT,Italy,-0.7156
+1979-12-31,IT,Italy,-0.7287
 1979-12-31,JP,Japan,6.0924
 1979-12-31,KR,Korea,-8.5789
-1979-12-31,LT,Lithuania,
-1979-12-31,LU,Luxembourg,
-1979-12-31,LV,Latvia,
-1979-12-31,MA,Morocco,
-1979-12-31,MK,North Macedonia,
-1979-12-31,MT,Malta,
-1979-12-31,MX,Mexico,
-1979-12-31,MY,Malaysia,
 1979-12-31,NL,Netherlands,-10.1582
-1979-12-31,NO,Norway,
-1979-12-31,NZ,New Zealand,-9.3124
-1979-12-31,PE,Peru,
-1979-12-31,PH,Philippines,
-1979-12-31,PL,Poland,
-1979-12-31,PT,Portugal,
-1979-12-31,RO,Romania,
-1979-12-31,RS,Serbia,
-1979-12-31,RU,Russia,
+1979-12-31,NZ,New Zealand,-9.3005
 1979-12-31,SE,Sweden,0.3601
-1979-12-31,SG,Singapore,
-1979-12-31,SI,Slovenia,
-1979-12-31,SK,Slovak Republic,
-1979-12-31,TH,Thailand,
-1979-12-31,TR,Türkiye,
-1979-12-31,US,United States,3.9895
-1979-12-31,XM,Euro area,0.7759
-1979-12-31,XW,World,
-1979-12-31,ZA,South Africa,0.4835
-1980-03-31,4T,Emerging market economies (aggregate),
-1980-03-31,5R,Advanced economies,
-1980-03-31,AE,United Arab Emirates,
-1980-03-31,AT,Austria,
-1980-03-31,AU,Australia,2.3144
+1979-12-31,US,United States,4.0005
+1979-12-31,XM,Euro area,0.7375
+1979-12-31,ZA,South Africa,0.3221
+1980-03-31,AU,Australia,2.1201
 1980-03-31,BE,Belgium,-0.3295
-1980-03-31,BG,Bulgaria,
-1980-03-31,BR,Brazil,
 1980-03-31,CA,Canada,-1.5789
 1980-03-31,CH,Switzerland,6.8796
-1980-03-31,CL,Chile,
-1980-03-31,CN,China,
-1980-03-31,CO,Colombia,
-1980-03-31,CY,Cyprus,
-1980-03-31,CZ,Czechia,
-1980-03-31,DE,Germany,2.8127
+1980-03-31,DE,Germany,2.8431
 1980-03-31,DK,Denmark,-8.1565
-1980-03-31,EE,Estonia,
 1980-03-31,ES,Spain,-10.0716
 1980-03-31,FI,Finland,3.3873
 1980-03-31,FR,France,4.8344
 1980-03-31,GB,United Kingdom,11.4658
-1980-03-31,GR,Greece,
-1980-03-31,HK,Hong Kong SAR,
-1980-03-31,HR,Croatia,
-1980-03-31,HU,Hungary,
-1980-03-31,ID,Indonesia,
 1980-03-31,IE,Ireland,3.5868
-1980-03-31,IL,Israel,
-1980-03-31,IN,India,
-1980-03-31,IS,Iceland,
-1980-03-31,IT,Italy,-0.4546
+1980-03-31,IT,Italy,-0.4392
 1980-03-31,JP,Japan,5.1163
 1980-03-31,KR,Korea,-10.9733
-1980-03-31,LT,Lithuania,
-1980-03-31,LU,Luxembourg,
-1980-03-31,LV,Latvia,
-1980-03-31,MA,Morocco,
-1980-03-31,MK,North Macedonia,
-1980-03-31,MT,Malta,
-1980-03-31,MX,Mexico,
-1980-03-31,MY,Malaysia,
-1980-03-31,NL,Netherlands,-10.9355
-1980-03-31,NO,Norway,
-1980-03-31,NZ,New Zealand,-10.4471
-1980-03-31,PE,Peru,
-1980-03-31,PH,Philippines,
-1980-03-31,PL,Poland,
-1980-03-31,PT,Portugal,
-1980-03-31,RO,Romania,
-1980-03-31,RS,Serbia,
-1980-03-31,RU,Russia,
-1980-03-31,SE,Sweden,-5.2203
-1980-03-31,SG,Singapore,
-1980-03-31,SI,Slovenia,
-1980-03-31,SK,Slovak Republic,
-1980-03-31,TH,Thailand,
-1980-03-31,TR,Türkiye,
-1980-03-31,US,United States,0.3098
-1980-03-31,XM,Euro area,-2.6192
-1980-03-31,XW,World,
-1980-03-31,ZA,South Africa,2.3841
-1980-06-30,4T,Emerging market economies (aggregate),
-1980-06-30,5R,Advanced economies,
-1980-06-30,AE,United Arab Emirates,
-1980-06-30,AT,Austria,
-1980-06-30,AU,Australia,0.6629
+1980-03-31,NL,Netherlands,-10.9354
+1980-03-31,NZ,New Zealand,-10.4625
+1980-03-31,SE,Sweden,-5.223
+1980-03-31,US,United States,0.3458
+1980-03-31,XM,Euro area,-2.6703
+1980-03-31,ZA,South Africa,2.3646
+1980-06-30,AU,Australia,0.8051
 1980-06-30,BE,Belgium,-3.6352
-1980-06-30,BG,Bulgaria,
-1980-06-30,BR,Brazil,
 1980-06-30,CA,Canada,0.2253
 1980-06-30,CH,Switzerland,5.5826
-1980-06-30,CL,Chile,
-1980-06-30,CN,China,
-1980-06-30,CO,Colombia,
-1980-06-30,CY,Cyprus,
-1980-06-30,CZ,Czechia,
-1980-06-30,DE,Germany,1.2358
+1980-06-30,DE,Germany,1.1863
 1980-06-30,DK,Denmark,-15.2012
-1980-06-30,EE,Estonia,
 1980-06-30,ES,Spain,-7.7711
 1980-06-30,FI,Finland,3.3265
 1980-06-30,FR,France,6.2363
 1980-06-30,GB,United Kingdom,4.6423
-1980-06-30,GR,Greece,
-1980-06-30,HK,Hong Kong SAR,
-1980-06-30,HR,Croatia,
-1980-06-30,HU,Hungary,
-1980-06-30,ID,Indonesia,
 1980-06-30,IE,Ireland,-6.3503
-1980-06-30,IL,Israel,
-1980-06-30,IN,India,
-1980-06-30,IS,Iceland,
-1980-06-30,IT,Italy,6.4459
+1980-06-30,IT,Italy,6.4228
 1980-06-30,JP,Japan,4.7407
 1980-06-30,KR,Korea,-13.611
-1980-06-30,LT,Lithuania,
-1980-06-30,LU,Luxembourg,
-1980-06-30,LV,Latvia,
-1980-06-30,MA,Morocco,
-1980-06-30,MK,North Macedonia,
-1980-06-30,MT,Malta,
-1980-06-30,MX,Mexico,
-1980-06-30,MY,Malaysia,
-1980-06-30,NL,Netherlands,-12.8722
-1980-06-30,NO,Norway,
-1980-06-30,NZ,New Zealand,-8.4645
-1980-06-30,PE,Peru,
-1980-06-30,PH,Philippines,
-1980-06-30,PL,Poland,
-1980-06-30,PT,Portugal,
-1980-06-30,RO,Romania,
-1980-06-30,RS,Serbia,
-1980-06-30,RU,Russia,
-1980-06-30,SE,Sweden,-8.7533
-1980-06-30,SG,Singapore,
-1980-06-30,SI,Slovenia,
-1980-06-30,SK,Slovak Republic,
-1980-06-30,TH,Thailand,
-1980-06-30,TR,Türkiye,
-1980-06-30,US,United States,-2.9342
-1980-06-30,XM,Euro area,-2.2925
-1980-06-30,XW,World,
-1980-06-30,ZA,South Africa,5.1064
-1980-09-30,4T,Emerging market economies (aggregate),
-1980-09-30,5R,Advanced economies,
-1980-09-30,AE,United Arab Emirates,
-1980-09-30,AT,Austria,
-1980-09-30,AU,Australia,2.6336
+1980-06-30,NL,Netherlands,-12.8721
+1980-06-30,NZ,New Zealand,-8.4591
+1980-06-30,SE,Sweden,-8.7503
+1980-06-30,US,United States,-2.9226
+1980-06-30,XM,Euro area,-2.3221
+1980-06-30,ZA,South Africa,5.1343
+1980-09-30,AU,Australia,2.4344
 1980-09-30,BE,Belgium,-7.0516
-1980-09-30,BG,Bulgaria,
-1980-09-30,BR,Brazil,
 1980-09-30,CA,Canada,3.8958
-1980-09-30,CH,Switzerland,3.8752
-1980-09-30,CL,Chile,
-1980-09-30,CN,China,
-1980-09-30,CO,Colombia,
-1980-09-30,CY,Cyprus,
-1980-09-30,CZ,Czechia,
-1980-09-30,DE,Germany,1.2375
+1980-09-30,CH,Switzerland,3.8751
+1980-09-30,DE,Germany,1.2196
 1980-09-30,DK,Denmark,-13.2039
-1980-09-30,EE,Estonia,
 1980-09-30,ES,Spain,-9.2544
 1980-09-30,FI,Finland,4.4627
 1980-09-30,FR,France,6.6666
 1980-09-30,GB,United Kingdom,5.0808
-1980-09-30,GR,Greece,
-1980-09-30,HK,Hong Kong SAR,
-1980-09-30,HR,Croatia,
-1980-09-30,HU,Hungary,
-1980-09-30,ID,Indonesia,
 1980-09-30,IE,Ireland,-0.0328
-1980-09-30,IL,Israel,
-1980-09-30,IN,India,
-1980-09-30,IS,Iceland,
-1980-09-30,IT,Italy,13.5377
+1980-09-30,IT,Italy,13.5352
 1980-09-30,JP,Japan,5.1386
 1980-09-30,KR,Korea,-14.606
-1980-09-30,LT,Lithuania,
-1980-09-30,LU,Luxembourg,
-1980-09-30,LV,Latvia,
-1980-09-30,MA,Morocco,
-1980-09-30,MK,North Macedonia,
-1980-09-30,MT,Malta,
-1980-09-30,MX,Mexico,
-1980-09-30,MY,Malaysia,
-1980-09-30,NL,Netherlands,-17.0737
-1980-09-30,NO,Norway,
-1980-09-30,NZ,New Zealand,-5.1791
-1980-09-30,PE,Peru,
-1980-09-30,PH,Philippines,
-1980-09-30,PL,Poland,
-1980-09-30,PT,Portugal,
-1980-09-30,RO,Romania,
-1980-09-30,RS,Serbia,
-1980-09-30,RU,Russia,
-1980-09-30,SE,Sweden,-10.8695
-1980-09-30,SG,Singapore,
-1980-09-30,SI,Slovenia,
-1980-09-30,SK,Slovak Republic,
-1980-09-30,TH,Thailand,
-1980-09-30,TR,Türkiye,
-1980-09-30,US,United States,-1.9981
-1980-09-30,XM,Euro area,1.0644
-1980-09-30,XW,World,
-1980-09-30,ZA,South Africa,12.1315
-1980-12-31,4T,Emerging market economies (aggregate),
-1980-12-31,5R,Advanced economies,
-1980-12-31,AE,United Arab Emirates,
-1980-12-31,AT,Austria,
-1980-12-31,AU,Australia,4.9343
+1980-09-30,NL,Netherlands,-17.0736
+1980-09-30,NZ,New Zealand,-5.1763
+1980-09-30,SE,Sweden,-10.8687
+1980-09-30,US,United States,-1.9602
+1980-09-30,XM,Euro area,1.0384
+1980-09-30,ZA,South Africa,12.1096
+1980-12-31,AU,Australia,4.9686
 1980-12-31,BE,Belgium,-10.6402
-1980-12-31,BG,Bulgaria,
-1980-12-31,BR,Brazil,
 1980-12-31,CA,Canada,5.3233
-1980-12-31,CH,Switzerland,2.4315
-1980-12-31,CL,Chile,
-1980-12-31,CN,China,
-1980-12-31,CO,Colombia,
-1980-12-31,CY,Cyprus,
-1980-12-31,CZ,Czechia,
-1980-12-31,DE,Germany,2.326
+1980-12-31,CH,Switzerland,2.4314
+1980-12-31,DE,Germany,2.366
 1980-12-31,DK,Denmark,-12.3782
-1980-12-31,EE,Estonia,
 1980-12-31,ES,Spain,-9.4546
 1980-12-31,FI,Finland,0.1755
 1980-12-31,FR,France,4.488
 1980-12-31,GB,United Kingdom,0.1949
-1980-12-31,GR,Greece,
 1980-12-31,HK,Hong Kong SAR,20.0849
-1980-12-31,HR,Croatia,
-1980-12-31,HU,Hungary,
-1980-12-31,ID,Indonesia,
 1980-12-31,IE,Ireland,5.8373
-1980-12-31,IL,Israel,
-1980-12-31,IN,India,
-1980-12-31,IS,Iceland,
-1980-12-31,IT,Italy,19.2797
+1980-12-31,IT,Italy,19.3063
 1980-12-31,JP,Japan,4.8785
 1980-12-31,KR,Korea,-13.3259
-1980-12-31,LT,Lithuania,
-1980-12-31,LU,Luxembourg,
-1980-12-31,LV,Latvia,
-1980-12-31,MA,Morocco,
-1980-12-31,MK,North Macedonia,
-1980-12-31,MT,Malta,
-1980-12-31,MX,Mexico,
-1980-12-31,MY,Malaysia,
 1980-12-31,NL,Netherlands,-14.8101
-1980-12-31,NO,Norway,
-1980-12-31,NZ,New Zealand,-3.2338
-1980-12-31,PE,Peru,
-1980-12-31,PH,Philippines,
-1980-12-31,PL,Poland,
-1980-12-31,PT,Portugal,
-1980-12-31,RO,Romania,
-1980-12-31,RS,Serbia,
-1980-12-31,RU,Russia,
-1980-12-31,SE,Sweden,-13.5175
-1980-12-31,SG,Singapore,
-1980-12-31,SI,Slovenia,
-1980-12-31,SK,Slovak Republic,
-1980-12-31,TH,Thailand,
-1980-12-31,TR,Türkiye,
-1980-12-31,US,United States,-3.2088
-1980-12-31,XM,Euro area,4.7752
-1980-12-31,XW,World,
-1980-12-31,ZA,South Africa,15.2269
-1981-03-31,4T,Emerging market economies (aggregate),
-1981-03-31,5R,Advanced economies,
-1981-03-31,AE,United Arab Emirates,
-1981-03-31,AT,Austria,
-1981-03-31,AU,Australia,8.9708
+1980-12-31,NZ,New Zealand,-3.259
+1980-12-31,SE,Sweden,-13.5189
+1980-12-31,US,United States,-3.1307
+1980-12-31,XM,Euro area,4.7722
+1980-12-31,ZA,South Africa,15.2283
+1981-03-31,AU,Australia,9.025
 1981-03-31,BE,Belgium,-13.3009
-1981-03-31,BG,Bulgaria,
-1981-03-31,BR,Brazil,
 1981-03-31,CA,Canada,6.4665
 1981-03-31,CH,Switzerland,0.83
-1981-03-31,CL,Chile,
-1981-03-31,CN,China,
-1981-03-31,CO,Colombia,
-1981-03-31,CY,Cyprus,
-1981-03-31,CZ,Czechia,
-1981-03-31,DE,Germany,1.6726
+1981-03-31,DE,Germany,1.5932
 1981-03-31,DK,Denmark,-11.3884
-1981-03-31,EE,Estonia,
 1981-03-31,ES,Spain,-10.0663
 1981-03-31,FI,Finland,1.2939
 1981-03-31,FR,France,2.2357
 1981-03-31,GB,United Kingdom,-3.5371
-1981-03-31,GR,Greece,
 1981-03-31,HK,Hong Kong SAR,18.2434
-1981-03-31,HR,Croatia,
-1981-03-31,HU,Hungary,
-1981-03-31,ID,Indonesia,
 1981-03-31,IE,Ireland,-1.9598
-1981-03-31,IL,Israel,
-1981-03-31,IN,India,
-1981-03-31,IS,Iceland,
-1981-03-31,IT,Italy,21.6406
+1981-03-31,IT,Italy,23.4223
 1981-03-31,JP,Japan,5.3154
 1981-03-31,KR,Korea,-13.3713
-1981-03-31,LT,Lithuania,
-1981-03-31,LU,Luxembourg,
-1981-03-31,LV,Latvia,
-1981-03-31,MA,Morocco,
-1981-03-31,MK,North Macedonia,
-1981-03-31,MT,Malta,
-1981-03-31,MX,Mexico,
-1981-03-31,MY,Malaysia,
 1981-03-31,NL,Netherlands,-13.3999
-1981-03-31,NO,Norway,
 1981-03-31,NZ,New Zealand,-0.6605
-1981-03-31,PE,Peru,
-1981-03-31,PH,Philippines,
-1981-03-31,PL,Poland,
-1981-03-31,PT,Portugal,
-1981-03-31,RO,Romania,
-1981-03-31,RS,Serbia,
-1981-03-31,RU,Russia,
-1981-03-31,SE,Sweden,-10.5354
-1981-03-31,SG,Singapore,
-1981-03-31,SI,Slovenia,
-1981-03-31,SK,Slovak Republic,
-1981-03-31,TH,Thailand,
-1981-03-31,TR,Türkiye,
-1981-03-31,US,United States,-2.2678
-1981-03-31,XM,Euro area,7.322
-1981-03-31,XW,World,
-1981-03-31,ZA,South Africa,19.4384
-1981-06-30,4T,Emerging market economies (aggregate),
-1981-06-30,5R,Advanced economies,
-1981-06-30,AE,United Arab Emirates,
-1981-06-30,AT,Austria,
-1981-06-30,AU,Australia,8.1096
+1981-03-31,SE,Sweden,-10.5249
+1981-03-31,US,United States,-2.3024
+1981-03-31,XM,Euro area,7.3646
+1981-03-31,ZA,South Africa,19.4605
+1981-06-30,AU,Australia,7.758
 1981-06-30,BE,Belgium,-12.1718
-1981-06-30,BG,Bulgaria,
-1981-06-30,BR,Brazil,
 1981-06-30,CA,Canada,2.9129
 1981-06-30,CH,Switzerland,5.2749
-1981-06-30,CL,Chile,
-1981-06-30,CN,China,
-1981-06-30,CO,Colombia,
-1981-06-30,CY,Cyprus,
-1981-06-30,CZ,Czechia,
-1981-06-30,DE,Germany,2.1168
+1981-06-30,DE,Germany,2.075
 1981-06-30,DK,Denmark,-13.3355
-1981-06-30,EE,Estonia,
 1981-06-30,ES,Spain,-9.0037
 1981-06-30,FI,Finland,1.3816
 1981-06-30,FR,France,-0.691
 1981-06-30,GB,United Kingdom,-3.8503
-1981-06-30,GR,Greece,
 1981-06-30,HK,Hong Kong SAR,16.7657
-1981-06-30,HR,Croatia,
-1981-06-30,HU,Hungary,
-1981-06-30,ID,Indonesia,
 1981-06-30,IE,Ireland,-0.4149
-1981-06-30,IL,Israel,
-1981-06-30,IN,India,
-1981-06-30,IS,Iceland,
-1981-06-30,IT,Italy,16.1684
+1981-06-30,IT,Italy,17.8433
 1981-06-30,JP,Japan,6.045
 1981-06-30,KR,Korea,-13.1631
-1981-06-30,LT,Lithuania,
-1981-06-30,LU,Luxembourg,
-1981-06-30,LV,Latvia,
-1981-06-30,MA,Morocco,
-1981-06-30,MK,North Macedonia,
-1981-06-30,MT,Malta,
-1981-06-30,MX,Mexico,
-1981-06-30,MY,Malaysia,
 1981-06-30,NL,Netherlands,-15.9775
-1981-06-30,NO,Norway,
 1981-06-30,NZ,New Zealand,4.7245
-1981-06-30,PE,Peru,
-1981-06-30,PH,Philippines,
-1981-06-30,PL,Poland,
-1981-06-30,PT,Portugal,
-1981-06-30,RO,Romania,
-1981-06-30,RS,Serbia,
-1981-06-30,RU,Russia,
-1981-06-30,SE,Sweden,-11.6039
-1981-06-30,SG,Singapore,
-1981-06-30,SI,Slovenia,
-1981-06-30,SK,Slovak Republic,
-1981-06-30,TH,Thailand,
-1981-06-30,TR,Türkiye,
-1981-06-30,US,United States,-1.0429
-1981-06-30,XM,Euro area,5.9429
-1981-06-30,XW,World,
-1981-06-30,ZA,South Africa,22.6942
-1981-09-30,4T,Emerging market economies (aggregate),
-1981-09-30,5R,Advanced economies,
-1981-09-30,AE,United Arab Emirates,
-1981-09-30,AT,Austria,
-1981-09-30,AU,Australia,2.2214
+1981-06-30,SE,Sweden,-11.5904
+1981-06-30,US,United States,-1.0202
+1981-06-30,XM,Euro area,5.9881
+1981-06-30,ZA,South Africa,22.6524
+1981-09-30,AU,Australia,2.2588
 1981-09-30,BE,Belgium,-12.6005
-1981-09-30,BG,Bulgaria,
-1981-09-30,BR,Brazil,
 1981-09-30,CA,Canada,1.21
 1981-09-30,CH,Switzerland,2.6291
-1981-09-30,CL,Chile,
-1981-09-30,CN,China,
-1981-09-30,CO,Colombia,
-1981-09-30,CY,Cyprus,
-1981-09-30,CZ,Czechia,
-1981-09-30,DE,Germany,0.7381
+1981-09-30,DE,Germany,0.8383
 1981-09-30,DK,Denmark,-17.587
-1981-09-30,EE,Estonia,
 1981-09-30,ES,Spain,-9.3085
 1981-09-30,FI,Finland,2.2362
 1981-09-30,FR,France,-3.7559
 1981-09-30,GB,United Kingdom,-5.9362
-1981-09-30,GR,Greece,
 1981-09-30,HK,Hong Kong SAR,6.6207
-1981-09-30,HR,Croatia,
-1981-09-30,HU,Hungary,
-1981-09-30,ID,Indonesia,
 1981-09-30,IE,Ireland,-4.5833
-1981-09-30,IL,Israel,
-1981-09-30,IN,India,
-1981-09-30,IS,Iceland,
-1981-09-30,IT,Italy,10.1189
+1981-09-30,IT,Italy,11.7412
 1981-09-30,JP,Japan,5.9242
 1981-09-30,KR,Korea,-10.7647
-1981-09-30,LT,Lithuania,
-1981-09-30,LU,Luxembourg,
-1981-09-30,LV,Latvia,
-1981-09-30,MA,Morocco,
-1981-09-30,MK,North Macedonia,
-1981-09-30,MT,Malta,
-1981-09-30,MX,Mexico,
-1981-09-30,MY,Malaysia,
-1981-09-30,NL,Netherlands,-14.2547
-1981-09-30,NO,Norway,
+1981-09-30,NL,Netherlands,-14.2548
 1981-09-30,NZ,New Zealand,8.71
-1981-09-30,PE,Peru,
-1981-09-30,PH,Philippines,
-1981-09-30,PL,Poland,
-1981-09-30,PT,Portugal,
-1981-09-30,RO,Romania,
-1981-09-30,RS,Serbia,
-1981-09-30,RU,Russia,
-1981-09-30,SE,Sweden,-13.5693
-1981-09-30,SG,Singapore,
-1981-09-30,SI,Slovenia,
-1981-09-30,SK,Slovak Republic,
-1981-09-30,TH,Thailand,
-1981-09-30,TR,Türkiye,
-1981-09-30,US,United States,-4.0972
-1981-09-30,XM,Euro area,0.5982
-1981-09-30,XW,World,
-1981-09-30,ZA,South Africa,20.2314
-1981-12-31,4T,Emerging market economies (aggregate),
-1981-12-31,5R,Advanced economies,
-1981-12-31,AE,United Arab Emirates,
-1981-12-31,AT,Austria,
-1981-12-31,AU,Australia,1.686
+1981-09-30,SE,Sweden,-13.5583
+1981-09-30,US,United States,-4.1282
+1981-09-30,XM,Euro area,0.6137
+1981-09-30,ZA,South Africa,20.1895
+1981-12-31,AU,Australia,1.4982
 1981-12-31,BE,Belgium,-10.3075
-1981-12-31,BG,Bulgaria,
-1981-12-31,BR,Brazil,
 1981-12-31,CA,Canada,-3.1626
 1981-12-31,CH,Switzerland,2.5744
-1981-12-31,CL,Chile,
-1981-12-31,CN,China,
-1981-12-31,CO,Colombia,
-1981-12-31,CY,Cyprus,
-1981-12-31,CZ,Czechia,
-1981-12-31,DE,Germany,-1.7873
+1981-12-31,DE,Germany,-1.7754
 1981-12-31,DK,Denmark,-16.4453
-1981-12-31,EE,Estonia,
 1981-12-31,ES,Spain,-10.4974
 1981-12-31,FI,Finland,4.6864
 1981-12-31,FR,France,-5.4057
 1981-12-31,GB,United Kingdom,-8.2112
-1981-12-31,GR,Greece,
 1981-12-31,HK,Hong Kong SAR,-6.0189
-1981-12-31,HR,Croatia,
-1981-12-31,HU,Hungary,
-1981-12-31,ID,Indonesia,
 1981-12-31,IE,Ireland,-8.9073
-1981-12-31,IL,Israel,
-1981-12-31,IN,India,
-1981-12-31,IS,Iceland,
-1981-12-31,IT,Italy,3.3951
+1981-12-31,IT,Italy,4.8697
 1981-12-31,JP,Japan,5.3796
 1981-12-31,KR,Korea,-8.7182
-1981-12-31,LT,Lithuania,
-1981-12-31,LU,Luxembourg,
-1981-12-31,LV,Latvia,
-1981-12-31,MA,Morocco,
-1981-12-31,MK,North Macedonia,
-1981-12-31,MT,Malta,
-1981-12-31,MX,Mexico,
-1981-12-31,MY,Malaysia,
-1981-12-31,NL,Netherlands,-19.5181
-1981-12-31,NO,Norway,
+1981-12-31,NL,Netherlands,-19.518
 1981-12-31,NZ,New Zealand,13.7137
-1981-12-31,PE,Peru,
-1981-12-31,PH,Philippines,
-1981-12-31,PL,Poland,
-1981-12-31,PT,Portugal,
-1981-12-31,RO,Romania,
-1981-12-31,RS,Serbia,
-1981-12-31,RU,Russia,
-1981-12-31,SE,Sweden,-10.8428
-1981-12-31,SG,Singapore,
-1981-12-31,SI,Slovenia,
-1981-12-31,SK,Slovak Republic,
-1981-12-31,TH,Thailand,
-1981-12-31,TR,Türkiye,
-1981-12-31,US,United States,-3.8452
-1981-12-31,XM,Euro area,-3.5807
-1981-12-31,XW,World,
-1981-12-31,ZA,South Africa,17.8465
-1982-03-31,4T,Emerging market economies (aggregate),
-1982-03-31,5R,Advanced economies,
-1982-03-31,AE,United Arab Emirates,
-1982-03-31,AT,Austria,
-1982-03-31,AU,Australia,-5.2225
+1981-12-31,SE,Sweden,-10.8416
+1981-12-31,US,United States,-3.8431
+1981-12-31,XM,Euro area,-3.5847
+1981-12-31,ZA,South Africa,17.8495
+1982-03-31,AU,Australia,-5.0628
 1982-03-31,BE,Belgium,-12.5865
-1982-03-31,BG,Bulgaria,
-1982-03-31,BR,Brazil,
 1982-03-31,CA,Canada,-9.7315
 1982-03-31,CH,Switzerland,2.5111
-1982-03-31,CL,Chile,
-1982-03-31,CN,China,
-1982-03-31,CO,Colombia,
-1982-03-31,CY,Cyprus,
-1982-03-31,CZ,Czechia,
-1982-03-31,DE,Germany,-2.3354
+1982-03-31,DE,Germany,-2.1035
 1982-03-31,DK,Denmark,-16.2578
-1982-03-31,EE,Estonia,
 1982-03-31,ES,Spain,-11.0373
 1982-03-31,FI,Finland,6.8285
 1982-03-31,FR,France,-6.5876
 1982-03-31,GB,United Kingdom,-9.2223
-1982-03-31,GR,Greece,
 1982-03-31,HK,Hong Kong SAR,-17.7704
-1982-03-31,HR,Croatia,
-1982-03-31,HU,Hungary,
-1982-03-31,ID,Indonesia,
 1982-03-31,IE,Ireland,-6.985
-1982-03-31,IL,Israel,
-1982-03-31,IN,India,
-1982-03-31,IS,Iceland,
-1982-03-31,IT,Italy,-1.4728
+1982-03-31,IS,Iceland,21.8686
+1982-03-31,IT,Italy,-1.4954
 1982-03-31,JP,Japan,5.7494
-1982-03-31,KR,Korea,-6.4217
-1982-03-31,LT,Lithuania,
-1982-03-31,LU,Luxembourg,
-1982-03-31,LV,Latvia,
-1982-03-31,MA,Morocco,
-1982-03-31,MK,North Macedonia,
-1982-03-31,MT,Malta,
-1982-03-31,MX,Mexico,
-1982-03-31,MY,Malaysia,
-1982-03-31,NL,Netherlands,-21.8612
-1982-03-31,NO,Norway,
+1982-03-31,KR,Korea,-6.4216
+1982-03-31,NL,Netherlands,-21.8613
 1982-03-31,NZ,New Zealand,18.4056
-1982-03-31,PE,Peru,
-1982-03-31,PH,Philippines,
-1982-03-31,PL,Poland,
-1982-03-31,PT,Portugal,
-1982-03-31,RO,Romania,
-1982-03-31,RS,Serbia,
-1982-03-31,RU,Russia,
-1982-03-31,SE,Sweden,-9.6483
-1982-03-31,SG,Singapore,
-1982-03-31,SI,Slovenia,
-1982-03-31,SK,Slovak Republic,
-1982-03-31,TH,Thailand,
-1982-03-31,TR,Türkiye,
-1982-03-31,US,United States,-3.4933
-1982-03-31,XM,Euro area,-6.0122
-1982-03-31,XW,World,
-1982-03-31,ZA,South Africa,12.9611
-1982-06-30,4T,Emerging market economies (aggregate),
-1982-06-30,5R,Advanced economies,
-1982-06-30,AE,United Arab Emirates,
-1982-06-30,AT,Austria,
-1982-06-30,AU,Australia,-5.5183
+1982-03-31,SE,Sweden,-9.655
+1982-03-31,US,United States,-3.4937
+1982-03-31,XM,Euro area,-6.0332
+1982-03-31,ZA,South Africa,13.0318
+1982-06-30,AU,Australia,-5.3591
 1982-06-30,BE,Belgium,-13.4418
-1982-06-30,BG,Bulgaria,
-1982-06-30,BR,Brazil,
 1982-06-30,CA,Canada,-14.294
-1982-06-30,CH,Switzerland,-1.7258
-1982-06-30,CL,Chile,
-1982-06-30,CN,China,
-1982-06-30,CO,Colombia,
-1982-06-30,CY,Cyprus,
-1982-06-30,CZ,Czechia,
-1982-06-30,DE,Germany,-4.5279
+1982-06-30,CH,Switzerland,-1.7257
+1982-06-30,DE,Germany,-4.594
 1982-06-30,DK,Denmark,-10.3809
-1982-06-30,EE,Estonia,
 1982-06-30,ES,Spain,-12.6795
 1982-06-30,FI,Finland,7.7099
 1982-06-30,FR,France,-7.0735
 1982-06-30,GB,United Kingdom,-6.6206
-1982-06-30,GR,Greece,
 1982-06-30,HK,Hong Kong SAR,-20.5134
-1982-06-30,HR,Croatia,
-1982-06-30,HU,Hungary,
-1982-06-30,ID,Indonesia,
 1982-06-30,IE,Ireland,-8.0857
-1982-06-30,IL,Israel,
-1982-06-30,IN,India,
-1982-06-30,IS,Iceland,
-1982-06-30,IT,Italy,-3.3536
+1982-06-30,IS,Iceland,25.1189
+1982-06-30,IT,Italy,-3.3446
 1982-06-30,JP,Japan,5.488
 1982-06-30,KR,Korea,-4.0435
-1982-06-30,LT,Lithuania,
-1982-06-30,LU,Luxembourg,
-1982-06-30,LV,Latvia,
-1982-06-30,MA,Morocco,
-1982-06-30,MK,North Macedonia,
-1982-06-30,MT,Malta,
-1982-06-30,MX,Mexico,
-1982-06-30,MY,Malaysia,
 1982-06-30,NL,Netherlands,-18.628
-1982-06-30,NO,Norway,
 1982-06-30,NZ,New Zealand,17.0063
-1982-06-30,PE,Peru,
-1982-06-30,PH,Philippines,
-1982-06-30,PL,Poland,
-1982-06-30,PT,Portugal,
-1982-06-30,RO,Romania,
-1982-06-30,RS,Serbia,
-1982-06-30,RU,Russia,
-1982-06-30,SE,Sweden,-7.6177
-1982-06-30,SG,Singapore,
-1982-06-30,SI,Slovenia,
-1982-06-30,SK,Slovak Republic,
-1982-06-30,TH,Thailand,
-1982-06-30,TR,Türkiye,
-1982-06-30,US,United States,-3.744
-1982-06-30,XM,Euro area,-7.3661
-1982-06-30,XW,World,
-1982-06-30,ZA,South Africa,5.5737
-1982-09-30,4T,Emerging market economies (aggregate),
-1982-09-30,5R,Advanced economies,
-1982-09-30,AE,United Arab Emirates,
-1982-09-30,AT,Austria,
-1982-09-30,AU,Australia,-6.673
+1982-06-30,SE,Sweden,-7.6303
+1982-06-30,US,United States,-3.7374
+1982-06-30,XM,Euro area,-7.3842
+1982-06-30,ZA,South Africa,5.5833
+1982-09-30,AU,Australia,-6.7136
 1982-09-30,BE,Belgium,-9.6771
-1982-09-30,BG,Bulgaria,
-1982-09-30,BR,Brazil,
 1982-09-30,CA,Canada,-17.305
 1982-09-30,CH,Switzerland,-1.4725
-1982-09-30,CL,Chile,
-1982-09-30,CN,China,
-1982-09-30,CO,Colombia,
-1982-09-30,CY,Cyprus,
-1982-09-30,CZ,Czechia,
-1982-09-30,DE,Germany,-5.0212
+1982-09-30,DE,Germany,-5.1009
 1982-09-30,DK,Denmark,-9.2261
-1982-09-30,EE,Estonia,
 1982-09-30,ES,Spain,-10.3262
 1982-09-30,FI,Finland,7.0164
 1982-09-30,FR,France,-5.1295
 1982-09-30,GB,United Kingdom,-4.655
-1982-09-30,GR,Greece,
 1982-09-30,HK,Hong Kong SAR,-23.9256
-1982-09-30,HR,Croatia,
-1982-09-30,HU,Hungary,
-1982-09-30,ID,Indonesia,
 1982-09-30,IE,Ireland,-8.4871
-1982-09-30,IL,Israel,
-1982-09-30,IN,India,
-1982-09-30,IS,Iceland,
-1982-09-30,IT,Italy,-5.8018
+1982-09-30,IS,Iceland,17.3888
+1982-09-30,IT,Italy,-5.8127
 1982-09-30,JP,Japan,4.5441
 1982-09-30,KR,Korea,-0.91
-1982-09-30,LT,Lithuania,
-1982-09-30,LU,Luxembourg,
-1982-09-30,LV,Latvia,
-1982-09-30,MA,Morocco,
-1982-09-30,MK,North Macedonia,
-1982-09-30,MT,Malta,
-1982-09-30,MX,Mexico,
-1982-09-30,MY,Malaysia,
-1982-09-30,NL,Netherlands,-13.215
-1982-09-30,NO,Norway,
+1982-09-30,NL,Netherlands,-13.2151
 1982-09-30,NZ,New Zealand,11.5793
-1982-09-30,PE,Peru,
-1982-09-30,PH,Philippines,
-1982-09-30,PL,Poland,
-1982-09-30,PT,Portugal,
-1982-09-30,RO,Romania,
-1982-09-30,RS,Serbia,
-1982-09-30,RU,Russia,
-1982-09-30,SE,Sweden,-5.1104
-1982-09-30,SG,Singapore,
-1982-09-30,SI,Slovenia,
-1982-09-30,SK,Slovak Republic,
-1982-09-30,TH,Thailand,
-1982-09-30,TR,Türkiye,
-1982-09-30,US,United States,-3.7116
-1982-09-30,XM,Euro area,-5.756
-1982-09-30,XW,World,
-1982-09-30,ZA,South Africa,2.875
-1982-12-31,4T,Emerging market economies (aggregate),
-1982-12-31,5R,Advanced economies,
-1982-12-31,AE,United Arab Emirates,
-1982-12-31,AT,Austria,
-1982-12-31,AU,Australia,-10.3433
+1982-09-30,SE,Sweden,-5.1157
+1982-09-30,US,United States,-3.6643
+1982-09-30,XM,Euro area,-5.7404
+1982-09-30,ZA,South Africa,2.9093
+1982-12-31,AU,Australia,-10.1774
 1982-12-31,BE,Belgium,-9.8342
-1982-12-31,BG,Bulgaria,
-1982-12-31,BR,Brazil,
 1982-12-31,CA,Canada,-15.9756
 1982-12-31,CH,Switzerland,-1.8338
-1982-12-31,CL,Chile,
-1982-12-31,CN,China,
-1982-12-31,CO,Colombia,
-1982-12-31,CY,Cyprus,
-1982-12-31,CZ,Czechia,
-1982-12-31,DE,Germany,-4.5806
+1982-12-31,DE,Germany,-4.6524
 1982-12-31,DK,Denmark,-8.9406
-1982-12-31,EE,Estonia,
 1982-12-31,ES,Spain,-4.5835
 1982-12-31,FI,Finland,11.0721
 1982-12-31,FR,France,-4.0586
 1982-12-31,GB,United Kingdom,-0.8312
-1982-12-31,GR,Greece,
 1982-12-31,HK,Hong Kong SAR,-26.2232
-1982-12-31,HR,Croatia,
-1982-12-31,HU,Hungary,
-1982-12-31,ID,Indonesia,
 1982-12-31,IE,Ireland,-5.8751
-1982-12-31,IL,Israel,
-1982-12-31,IN,India,
-1982-12-31,IS,Iceland,
-1982-12-31,IT,Italy,-5.5449
+1982-12-31,IS,Iceland,6.3901
+1982-12-31,IT,Italy,-5.5366
 1982-12-31,JP,Japan,4.0261
 1982-12-31,KR,Korea,4.6392
-1982-12-31,LT,Lithuania,
-1982-12-31,LU,Luxembourg,
-1982-12-31,LV,Latvia,
-1982-12-31,MA,Morocco,
-1982-12-31,MK,North Macedonia,
-1982-12-31,MT,Malta,
-1982-12-31,MX,Mexico,
-1982-12-31,MY,Malaysia,
 1982-12-31,NL,Netherlands,-9.1086
-1982-12-31,NO,Norway,
 1982-12-31,NZ,New Zealand,6.6673
-1982-12-31,PE,Peru,
-1982-12-31,PH,Philippines,
-1982-12-31,PL,Poland,
-1982-12-31,PT,Portugal,
-1982-12-31,RO,Romania,
-1982-12-31,RS,Serbia,
-1982-12-31,RU,Russia,
-1982-12-31,SE,Sweden,-5.0836
-1982-12-31,SG,Singapore,
-1982-12-31,SI,Slovenia,
-1982-12-31,SK,Slovak Republic,
-1982-12-31,TH,Thailand,
-1982-12-31,TR,Türkiye,
-1982-12-31,US,United States,-3.0105
-1982-12-31,XM,Euro area,-4.4565
-1982-12-31,XW,World,
-1982-12-31,ZA,South Africa,-0.2701
-1983-03-31,4T,Emerging market economies (aggregate),
-1983-03-31,5R,Advanced economies,
-1983-03-31,AE,United Arab Emirates,
-1983-03-31,AT,Austria,
-1983-03-31,AU,Australia,-7.0788
+1982-12-31,SE,Sweden,-5.0735
+1982-12-31,US,United States,-3.019
+1982-12-31,XM,Euro area,-4.4275
+1982-12-31,ZA,South Africa,-0.2686
+1983-03-31,AU,Australia,-7.0808
 1983-03-31,BE,Belgium,-8.3965
-1983-03-31,BG,Bulgaria,
-1983-03-31,BR,Brazil,
 1983-03-31,CA,Canada,-4.7423
 1983-03-31,CH,Switzerland,-2.9979
-1983-03-31,CL,Chile,
-1983-03-31,CN,China,
-1983-03-31,CO,Colombia,
-1983-03-31,CY,Cyprus,
-1983-03-31,CZ,Czechia,
-1983-03-31,DE,Germany,-4.0017
+1983-03-31,DE,Germany,-4.2173
 1983-03-31,DK,Denmark,0.9693
-1983-03-31,EE,Estonia,
 1983-03-31,ES,Spain,3.6782
 1983-03-31,FI,Finland,11.9495
 1983-03-31,FR,France,-3.9211
 1983-03-31,GB,United Kingdom,5.2215
-1983-03-31,GR,Greece,
 1983-03-31,HK,Hong Kong SAR,-24.8752
-1983-03-31,HR,Croatia,
-1983-03-31,HU,Hungary,
-1983-03-31,ID,Indonesia,
 1983-03-31,IE,Ireland,-6.9765
-1983-03-31,IL,Israel,
-1983-03-31,IN,India,
-1983-03-31,IS,Iceland,
-1983-03-31,IT,Italy,-5.0567
+1983-03-31,IS,Iceland,-8.075
+1983-03-31,IT,Italy,-5.0464
 1983-03-31,JP,Japan,3.5915
 1983-03-31,KR,Korea,10.5674
-1983-03-31,LT,Lithuania,
-1983-03-31,LU,Luxembourg,
-1983-03-31,LV,Latvia,
-1983-03-31,MA,Morocco,
-1983-03-31,MK,North Macedonia,
-1983-03-31,MT,Malta,
-1983-03-31,MX,Mexico,
-1983-03-31,MY,Malaysia,
-1983-03-31,NL,Netherlands,-4.0297
-1983-03-31,NO,Norway,
+1983-03-31,NL,Netherlands,-4.0296
 1983-03-31,NZ,New Zealand,2.002
-1983-03-31,PE,Peru,
-1983-03-31,PH,Philippines,
-1983-03-31,PL,Poland,
-1983-03-31,PT,Portugal,
-1983-03-31,RO,Romania,
-1983-03-31,RS,Serbia,
-1983-03-31,RU,Russia,
-1983-03-31,SE,Sweden,-6.6183
-1983-03-31,SG,Singapore,
-1983-03-31,SI,Slovenia,
-1983-03-31,SK,Slovak Republic,
-1983-03-31,TH,Thailand,
-1983-03-31,TR,Türkiye,
-1983-03-31,US,United States,-1.5554
-1983-03-31,XM,Euro area,-3.5486
-1983-03-31,XW,World,
-1983-03-31,ZA,South Africa,1.4417
-1983-06-30,4T,Emerging market economies (aggregate),
-1983-06-30,5R,Advanced economies,
-1983-06-30,AE,United Arab Emirates,
-1983-06-30,AT,Austria,
-1983-06-30,AU,Australia,-6.4766
+1983-03-31,SE,Sweden,-6.6059
+1983-03-31,US,United States,-1.5015
+1983-03-31,XM,Euro area,-3.4999
+1983-03-31,ZA,South Africa,1.3385
+1983-06-30,AU,Australia,-6.5108
 1983-06-30,BE,Belgium,-7.3993
-1983-06-30,BG,Bulgaria,
-1983-06-30,BR,Brazil,
 1983-06-30,CA,Canada,1.0814
-1983-06-30,CH,Switzerland,0.5863
-1983-06-30,CL,Chile,
-1983-06-30,CN,China,
-1983-06-30,CO,Colombia,
-1983-06-30,CY,Cyprus,
-1983-06-30,CZ,Czechia,
-1983-06-30,DE,Germany,-2.7302
+1983-06-30,CH,Switzerland,0.5864
+1983-06-30,DE,Germany,-2.6847
 1983-06-30,DK,Denmark,13.773
-1983-06-30,EE,Estonia,
 1983-06-30,ES,Spain,7.7558
 1983-06-30,FI,Finland,11.3692
 1983-06-30,FR,France,-3.5796
 1983-06-30,GB,United Kingdom,6.129
-1983-06-30,GR,Greece,
 1983-06-30,HK,Hong Kong SAR,-21.7148
-1983-06-30,HR,Croatia,
-1983-06-30,HU,Hungary,
-1983-06-30,ID,Indonesia,
 1983-06-30,IE,Ireland,-8.2697
-1983-06-30,IL,Israel,
-1983-06-30,IN,India,
-1983-06-30,IS,Iceland,
-1983-06-30,IT,Italy,-6.2266
+1983-06-30,IS,Iceland,-21.0796
+1983-06-30,IT,Italy,-6.2276
 1983-06-30,JP,Japan,2.8402
 1983-06-30,KR,Korea,15.5694
-1983-06-30,LT,Lithuania,
-1983-06-30,LU,Luxembourg,
-1983-06-30,LV,Latvia,
-1983-06-30,MA,Morocco,
-1983-06-30,MK,North Macedonia,
-1983-06-30,MT,Malta,
-1983-06-30,MX,Mexico,
-1983-06-30,MY,Malaysia,
-1983-06-30,NL,Netherlands,0.7912
-1983-06-30,NO,Norway,
+1983-06-30,NL,Netherlands,0.7911
 1983-06-30,NZ,New Zealand,-0.3118
-1983-06-30,PE,Peru,
-1983-06-30,PH,Philippines,
-1983-06-30,PL,Poland,
-1983-06-30,PT,Portugal,
-1983-06-30,RO,Romania,
-1983-06-30,RS,Serbia,
-1983-06-30,RU,Russia,
-1983-06-30,SE,Sweden,-7.7792
-1983-06-30,SG,Singapore,
-1983-06-30,SI,Slovenia,
-1983-06-30,SK,Slovak Republic,
-1983-06-30,TH,Thailand,
-1983-06-30,TR,Türkiye,
-1983-06-30,US,United States,-0.1738
-1983-06-30,XM,Euro area,-2.8467
-1983-06-30,XW,World,
-1983-06-30,ZA,South Africa,5.4008
-1983-09-30,4T,Emerging market economies (aggregate),
-1983-09-30,5R,Advanced economies,
-1983-09-30,AE,United Arab Emirates,
-1983-09-30,AT,Austria,
-1983-09-30,AU,Australia,-3.7514
+1983-06-30,SE,Sweden,-7.7687
+1983-06-30,US,United States,-0.1716
+1983-06-30,XM,Euro area,-2.7915
+1983-06-30,ZA,South Africa,5.5023
+1983-09-30,AU,Australia,-3.7734
 1983-09-30,BE,Belgium,-10.038
-1983-09-30,BG,Bulgaria,
-1983-09-30,BR,Brazil,
 1983-09-30,CA,Canada,2.2372
 1983-09-30,CH,Switzerland,4.3002
-1983-09-30,CL,Chile,
-1983-09-30,CN,China,
-1983-09-30,CO,Colombia,
-1983-09-30,CY,Cyprus,
-1983-09-30,CZ,Czechia,
-1983-09-30,DE,Germany,-2.4045
+1983-09-30,DE,Germany,-2.4155
 1983-09-30,DK,Denmark,19.5792
-1983-09-30,EE,Estonia,
 1983-09-30,ES,Spain,8.9172
 1983-09-30,FI,Finland,12.2277
 1983-09-30,FR,France,-4.1585
 1983-09-30,GB,United Kingdom,7.5483
-1983-09-30,GR,Greece,
 1983-09-30,HK,Hong Kong SAR,-20.4951
-1983-09-30,HR,Croatia,
-1983-09-30,HU,Hungary,
-1983-09-30,ID,Indonesia,
 1983-09-30,IE,Ireland,-7.0772
-1983-09-30,IL,Israel,
-1983-09-30,IN,India,
-1983-09-30,IS,Iceland,
-1983-09-30,IT,Italy,-6.0185
+1983-09-30,IS,Iceland,-27.9761
+1983-09-30,IT,Italy,-6.018
 1983-09-30,JP,Japan,2.9832
-1983-09-30,KR,Korea,17.0095
-1983-09-30,LT,Lithuania,
-1983-09-30,LU,Luxembourg,
-1983-09-30,LV,Latvia,
-1983-09-30,MA,Morocco,
-1983-09-30,MK,North Macedonia,
-1983-09-30,MT,Malta,
-1983-09-30,MX,Mexico,
-1983-09-30,MY,Malaysia,
-1983-09-30,NL,Netherlands,0.069
-1983-09-30,NO,Norway,
+1983-09-30,KR,Korea,17.0094
+1983-09-30,NL,Netherlands,0.0692
 1983-09-30,NZ,New Zealand,2.6422
-1983-09-30,PE,Peru,
-1983-09-30,PH,Philippines,
-1983-09-30,PL,Poland,
-1983-09-30,PT,Portugal,
-1983-09-30,RO,Romania,
-1983-09-30,RS,Serbia,
-1983-09-30,RU,Russia,
-1983-09-30,SE,Sweden,-8.8978
-1983-09-30,SG,Singapore,
-1983-09-30,SI,Slovenia,
-1983-09-30,SK,Slovak Republic,
-1983-09-30,TH,Thailand,
-1983-09-30,TR,Türkiye,
-1983-09-30,US,United States,1.8011
-1983-09-30,XM,Euro area,-2.5398
-1983-09-30,XW,World,
-1983-09-30,ZA,South Africa,8.1286
-1983-12-31,4T,Emerging market economies (aggregate),
-1983-12-31,5R,Advanced economies,
-1983-12-31,AE,United Arab Emirates,
-1983-12-31,AT,Austria,
-1983-12-31,AU,Australia,1.6333
+1983-09-30,SE,Sweden,-8.8991
+1983-09-30,US,United States,1.8161
+1983-09-30,XM,Euro area,-2.499
+1983-09-30,ZA,South Africa,8.1564
+1983-12-31,AU,Australia,1.6407
 1983-12-31,BE,Belgium,-8.6682
-1983-12-31,BG,Bulgaria,
-1983-12-31,BR,Brazil,
 1983-12-31,CA,Canada,1.0802
-1983-12-31,CH,Switzerland,4.2016
-1983-12-31,CL,Chile,
-1983-12-31,CN,China,
-1983-12-31,CO,Colombia,
-1983-12-31,CY,Cyprus,
-1983-12-31,CZ,Czechia,
-1983-12-31,DE,Germany,-2.6632
+1983-12-31,CH,Switzerland,4.2015
+1983-12-31,DE,Germany,-2.4831
 1983-12-31,DK,Denmark,20.6697
-1983-12-31,EE,Estonia,
 1983-12-31,ES,Spain,5.1959
 1983-12-31,FI,Finland,10.8332
 1983-12-31,FR,France,-4.2246
 1983-12-31,GB,United Kingdom,7.0175
-1983-12-31,GR,Greece,
 1983-12-31,HK,Hong Kong SAR,-21.7406
-1983-12-31,HR,Croatia,
-1983-12-31,HU,Hungary,
-1983-12-31,ID,Indonesia,
 1983-12-31,IE,Ireland,-11.2007
-1983-12-31,IL,Israel,
-1983-12-31,IN,India,
-1983-12-31,IS,Iceland,
-1983-12-31,IT,Italy,-6.4527
+1983-12-31,IS,Iceland,-18.9944
+1983-12-31,IT,Italy,-6.4427
 1983-12-31,JP,Japan,2.3514
 1983-12-31,KR,Korea,15.1628
-1983-12-31,LT,Lithuania,
-1983-12-31,LU,Luxembourg,
-1983-12-31,LV,Latvia,
-1983-12-31,MA,Morocco,
-1983-12-31,MK,North Macedonia,
-1983-12-31,MT,Malta,
-1983-12-31,MX,Mexico,
-1983-12-31,MY,Malaysia,
-1983-12-31,NL,Netherlands,-0.6443
-1983-12-31,NO,Norway,
+1983-12-31,NL,Netherlands,-0.6442
 1983-12-31,NZ,New Zealand,5.5007
-1983-12-31,PE,Peru,
-1983-12-31,PH,Philippines,
-1983-12-31,PL,Poland,
-1983-12-31,PT,Portugal,
-1983-12-31,RO,Romania,
-1983-12-31,RS,Serbia,
-1983-12-31,RU,Russia,
-1983-12-31,SE,Sweden,-6.7886
-1983-12-31,SG,Singapore,
-1983-12-31,SI,Slovenia,
-1983-12-31,SK,Slovak Republic,
-1983-12-31,TH,Thailand,
-1983-12-31,TR,Türkiye,
-1983-12-31,US,United States,1.7189
-1983-12-31,XM,Euro area,-3.5335
-1983-12-31,XW,World,
-1983-12-31,ZA,South Africa,12.8221
-1984-03-31,4T,Emerging market economies (aggregate),
-1984-03-31,5R,Advanced economies,
-1984-03-31,AE,United Arab Emirates,
-1984-03-31,AT,Austria,
-1984-03-31,AU,Australia,4.9918
+1983-12-31,SE,Sweden,-6.7909
+1983-12-31,US,United States,1.7422
+1983-12-31,XM,Euro area,-3.485
+1983-12-31,ZA,South Africa,12.7812
+1984-03-31,AU,Australia,4.9434
 1984-03-31,BE,Belgium,-5.8796
-1984-03-31,BG,Bulgaria,
-1984-03-31,BR,Brazil,
 1984-03-31,CA,Canada,-5.9261
 1984-03-31,CH,Switzerland,4.191
-1984-03-31,CL,Chile,
-1984-03-31,CN,China,
-1984-03-31,CO,Colombia,
-1984-03-31,CY,Cyprus,
-1984-03-31,CZ,Czechia,
-1984-03-31,DE,Germany,-3.7575
+1984-03-31,DE,Germany,-3.6968
 1984-03-31,DK,Denmark,16.7107
-1984-03-31,EE,Estonia,
 1984-03-31,ES,Spain,-1.4014
 1984-03-31,FI,Finland,7.1391
 1984-03-31,FR,France,-3.6601
 1984-03-31,GB,United Kingdom,5.091
-1984-03-31,GR,Greece,
 1984-03-31,HK,Hong Kong SAR,-14.6953
-1984-03-31,HR,Croatia,
-1984-03-31,HU,Hungary,
-1984-03-31,ID,Indonesia,
 1984-03-31,IE,Ireland,-8.4017
-1984-03-31,IL,Israel,
-1984-03-31,IN,India,
-1984-03-31,IS,Iceland,
-1984-03-31,IT,Italy,-6.9872
+1984-03-31,IS,Iceland,-9.9973
+1984-03-31,IT,Italy,-6.9959
 1984-03-31,JP,Japan,1.1724
 1984-03-31,KR,Korea,13.1282
-1984-03-31,LT,Lithuania,
-1984-03-31,LU,Luxembourg,
-1984-03-31,LV,Latvia,
-1984-03-31,MA,Morocco,
-1984-03-31,MK,North Macedonia,
-1984-03-31,MT,Malta,
-1984-03-31,MX,Mexico,
-1984-03-31,MY,Malaysia,
-1984-03-31,NL,Netherlands,-2.0826
-1984-03-31,NO,Norway,
+1984-03-31,NL,Netherlands,-2.0827
 1984-03-31,NZ,New Zealand,7.8491
-1984-03-31,PE,Peru,
-1984-03-31,PH,Philippines,
-1984-03-31,PL,Poland,
-1984-03-31,PT,Portugal,
-1984-03-31,RO,Romania,
-1984-03-31,RS,Serbia,
-1984-03-31,RU,Russia,
-1984-03-31,SE,Sweden,-5.7793
-1984-03-31,SG,Singapore,
-1984-03-31,SI,Slovenia,
-1984-03-31,SK,Slovak Republic,
-1984-03-31,TH,Thailand,
-1984-03-31,TR,Türkiye,
-1984-03-31,US,United States,0.6722
-1984-03-31,XM,Euro area,-4.7185
-1984-03-31,XW,World,
-1984-03-31,ZA,South Africa,9.3909
-1984-06-30,4T,Emerging market economies (aggregate),
-1984-06-30,5R,Advanced economies,
-1984-06-30,AE,United Arab Emirates,
-1984-06-30,AT,Austria,
-1984-06-30,AU,Australia,5.6402
+1984-03-31,SE,Sweden,-5.7869
+1984-03-31,US,United States,0.6534
+1984-03-31,XM,Euro area,-4.6934
+1984-03-31,ZA,South Africa,9.4345
+1984-06-30,AU,Australia,5.6936
 1984-06-30,BE,Belgium,-4.8033
-1984-06-30,BG,Bulgaria,
-1984-06-30,BR,Brazil,
 1984-06-30,CA,Canada,-4.8503
-1984-06-30,CH,Switzerland,4.8877
-1984-06-30,CL,Chile,
-1984-06-30,CN,China,
-1984-06-30,CO,Colombia,
-1984-06-30,CY,Cyprus,
-1984-06-30,CZ,Czechia,
-1984-06-30,DE,Germany,-4.895
+1984-06-30,CH,Switzerland,4.8876
+1984-06-30,DE,Germany,-4.8976
 1984-06-30,DK,Denmark,5.4672
-1984-06-30,EE,Estonia,
 1984-06-30,ES,Spain,-3.5341
 1984-06-30,FI,Finland,5.9844
 1984-06-30,FR,France,-3.366
 1984-06-30,GB,United Kingdom,4.2805
-1984-06-30,GR,Greece,
 1984-06-30,HK,Hong Kong SAR,-13.8471
-1984-06-30,HR,Croatia,
-1984-06-30,HU,Hungary,
-1984-06-30,ID,Indonesia,
 1984-06-30,IE,Ireland,-6.4508
-1984-06-30,IL,Israel,
-1984-06-30,IN,India,
-1984-06-30,IS,Iceland,
-1984-06-30,IT,Italy,-7.5761
+1984-06-30,IS,Iceland,3.7743
+1984-06-30,IT,Italy,-7.564
 1984-06-30,JP,Japan,1.2953
 1984-06-30,KR,Korea,11.708
-1984-06-30,LT,Lithuania,
-1984-06-30,LU,Luxembourg,
-1984-06-30,LV,Latvia,
-1984-06-30,MA,Morocco,
-1984-06-30,MK,North Macedonia,
-1984-06-30,MT,Malta,
-1984-06-30,MX,Mexico,
-1984-06-30,MY,Malaysia,
-1984-06-30,NL,Netherlands,-5.6048
-1984-06-30,NO,Norway,
+1984-06-30,NL,Netherlands,-5.6047
 1984-06-30,NZ,New Zealand,8.0987
-1984-06-30,PE,Peru,
-1984-06-30,PH,Philippines,
-1984-06-30,PL,Poland,
-1984-06-30,PT,Portugal,
-1984-06-30,RO,Romania,
-1984-06-30,RS,Serbia,
-1984-06-30,RU,Russia,
-1984-06-30,SE,Sweden,-4.1844
-1984-06-30,SG,Singapore,
-1984-06-30,SI,Slovenia,
-1984-06-30,SK,Slovak Republic,
-1984-06-30,TH,Thailand,
-1984-06-30,TR,Türkiye,
-1984-06-30,US,United States,0.8481
-1984-06-30,XM,Euro area,-5.2084
-1984-06-30,XW,World,
-1984-06-30,ZA,South Africa,1.8398
-1984-09-30,4T,Emerging market economies (aggregate),
-1984-09-30,5R,Advanced economies,
-1984-09-30,AE,United Arab Emirates,
-1984-09-30,AT,Austria,
-1984-09-30,AU,Australia,11.1085
+1984-06-30,SE,Sweden,-4.187
+1984-06-30,US,United States,0.8421
+1984-06-30,XM,Euro area,-5.1871
+1984-06-30,ZA,South Africa,1.7861
+1984-09-30,AU,Australia,11.3405
 1984-09-30,BE,Belgium,-2.8116
-1984-09-30,BG,Bulgaria,
-1984-09-30,BR,Brazil,
 1984-09-30,CA,Canada,-4.6647
 1984-09-30,CH,Switzerland,2.321
-1984-09-30,CL,Chile,
-1984-09-30,CN,China,
-1984-09-30,CO,Colombia,
-1984-09-30,CY,Cyprus,
-1984-09-30,CZ,Czechia,
-1984-09-30,DE,Germany,-4.7282
+1984-09-30,DE,Germany,-4.7076
 1984-09-30,DK,Denmark,5.4052
-1984-09-30,EE,Estonia,
 1984-09-30,ES,Spain,-5.1921
 1984-09-30,FI,Finland,4.471
 1984-09-30,FR,France,-3.6756
 1984-09-30,GB,United Kingdom,4.5453
-1984-09-30,GR,Greece,
 1984-09-30,HK,Hong Kong SAR,-14.2156
-1984-09-30,HR,Croatia,
-1984-09-30,HU,Hungary,
-1984-09-30,ID,Indonesia,
 1984-09-30,IE,Ireland,-5.741
-1984-09-30,IL,Israel,
-1984-09-30,IN,India,
-1984-09-30,IS,Iceland,
-1984-09-30,IT,Italy,-7.6152
+1984-09-30,IS,Iceland,9.4205
+1984-09-30,IT,Italy,-7.6293
 1984-09-30,JP,Japan,0.8049
 1984-09-30,KR,Korea,10.0412
-1984-09-30,LT,Lithuania,
-1984-09-30,LU,Luxembourg,
-1984-09-30,LV,Latvia,
-1984-09-30,MA,Morocco,
-1984-09-30,MK,North Macedonia,
-1984-09-30,MT,Malta,
-1984-09-30,MX,Mexico,
-1984-09-30,MY,Malaysia,
-1984-09-30,NL,Netherlands,-4.5379
-1984-09-30,NO,Norway,
+1984-09-30,NL,Netherlands,-4.538
 1984-09-30,NZ,New Zealand,6.1278
-1984-09-30,PE,Peru,
-1984-09-30,PH,Philippines,
-1984-09-30,PL,Poland,
-1984-09-30,PT,Portugal,
-1984-09-30,RO,Romania,
-1984-09-30,RS,Serbia,
-1984-09-30,RU,Russia,
-1984-09-30,SE,Sweden,-2.5032
-1984-09-30,SG,Singapore,
-1984-09-30,SI,Slovenia,
-1984-09-30,SK,Slovak Republic,
-1984-09-30,TH,Thailand,
-1984-09-30,TR,Türkiye,
-1984-09-30,US,United States,1.051
-1984-09-30,XM,Euro area,-5.4315
-1984-09-30,XW,World,
-1984-09-30,ZA,South Africa,-4.5309
-1984-12-31,4T,Emerging market economies (aggregate),
-1984-12-31,5R,Advanced economies,
-1984-12-31,AE,United Arab Emirates,
-1984-12-31,AT,Austria,
-1984-12-31,AU,Australia,7.322
+1984-09-30,SE,Sweden,-2.5041
+1984-09-30,US,United States,1.0504
+1984-09-30,XM,Euro area,-5.4214
+1984-09-30,ZA,South Africa,-4.5551
+1984-12-31,AU,Australia,7.1747
 1984-12-31,BE,Belgium,-2.7664
-1984-12-31,BG,Bulgaria,
-1984-12-31,BR,Brazil,
 1984-12-31,CA,Canada,-3.687
 1984-12-31,CH,Switzerland,1.4201
-1984-12-31,CL,Chile,
-1984-12-31,CN,China,
-1984-12-31,CO,Colombia,
-1984-12-31,CY,Cyprus,
-1984-12-31,CZ,Czechia,
-1984-12-31,DE,Germany,-4.3187
+1984-12-31,DE,Germany,-4.3944
 1984-12-31,DK,Denmark,7.5819
-1984-12-31,EE,Estonia,
 1984-12-31,ES,Spain,-3.083
 1984-12-31,FI,Finland,1.2366
 1984-12-31,FR,France,-3.3385
 1984-12-31,GB,United Kingdom,5.3529
-1984-12-31,GR,Greece,
 1984-12-31,HK,Hong Kong SAR,-5.3161
-1984-12-31,HR,Croatia,
-1984-12-31,HU,Hungary,
-1984-12-31,ID,Indonesia,
 1984-12-31,IE,Ireland,-2.7045
-1984-12-31,IL,Israel,
-1984-12-31,IN,India,
-1984-12-31,IS,Iceland,
-1984-12-31,IT,Italy,-7.0882
+1984-12-31,IS,Iceland,3.4145
+1984-12-31,IT,Italy,-7.087
 1984-12-31,JP,Japan,0.6024
 1984-12-31,KR,Korea,8.1524
-1984-12-31,LT,Lithuania,
-1984-12-31,LU,Luxembourg,
-1984-12-31,LV,Latvia,
-1984-12-31,MA,Morocco,
-1984-12-31,MK,North Macedonia,
-1984-12-31,MT,Malta,
-1984-12-31,MX,Mexico,
-1984-12-31,MY,Malaysia,
-1984-12-31,NL,Netherlands,-2.9907
-1984-12-31,NO,Norway,
+1984-12-31,NL,Netherlands,-2.9908
 1984-12-31,NZ,New Zealand,3.3321
-1984-12-31,PE,Peru,
-1984-12-31,PH,Philippines,
-1984-12-31,PL,Poland,
-1984-12-31,PT,Portugal,
-1984-12-31,RO,Romania,
-1984-12-31,RS,Serbia,
-1984-12-31,RU,Russia,
-1984-12-31,SE,Sweden,-3.1456
-1984-12-31,SG,Singapore,
-1984-12-31,SI,Slovenia,
-1984-12-31,SK,Slovak Republic,
-1984-12-31,TH,Thailand,
-1984-12-31,TR,Türkiye,
-1984-12-31,US,United States,0.6812
-1984-12-31,XM,Euro area,-4.6998
-1984-12-31,XW,World,
-1984-12-31,ZA,South Africa,-13.2732
-1985-03-31,4T,Emerging market economies (aggregate),
-1985-03-31,5R,Advanced economies,
-1985-03-31,AE,United Arab Emirates,
-1985-03-31,AT,Austria,
-1985-03-31,AU,Australia,7.165
+1984-12-31,SE,Sweden,-3.1335
+1984-12-31,US,United States,0.6426
+1984-12-31,XM,Euro area,-4.6958
+1984-12-31,ZA,South Africa,-13.2089
+1985-03-31,AU,Australia,7.1291
 1985-03-31,BE,Belgium,-3.7417
-1985-03-31,BG,Bulgaria,
-1985-03-31,BR,Brazil,
 1985-03-31,CA,Canada,-1.5282
-1985-03-31,CH,Switzerland,4.4158
-1985-03-31,CL,Chile,
-1985-03-31,CN,China,
-1985-03-31,CO,Colombia,
-1985-03-31,CY,Cyprus,
-1985-03-31,CZ,Czechia,
-1985-03-31,DE,Germany,-3.8605
+1985-03-31,CH,Switzerland,4.5097
+1985-03-31,DE,Germany,-3.8285
 1985-03-31,DK,Denmark,6.1267
-1985-03-31,EE,Estonia,
 1985-03-31,ES,Spain,-0.5985
 1985-03-31,FI,Finland,-0.2473
 1985-03-31,FR,France,-3.0951
 1985-03-31,GB,United Kingdom,3.7226
-1985-03-31,GR,Greece,
 1985-03-31,HK,Hong Kong SAR,-3.3632
-1985-03-31,HR,Croatia,
-1985-03-31,HU,Hungary,
-1985-03-31,ID,Indonesia,
 1985-03-31,IE,Ireland,-4.4696
-1985-03-31,IL,Israel,
-1985-03-31,IN,India,
-1985-03-31,IS,Iceland,
-1985-03-31,IT,Italy,-7.0489
+1985-03-31,IS,Iceland,-6.8525
+1985-03-31,IT,Italy,-7.0373
 1985-03-31,JP,Japan,0.751
 1985-03-31,KR,Korea,6.1205
-1985-03-31,LT,Lithuania,
-1985-03-31,LU,Luxembourg,
-1985-03-31,LV,Latvia,
-1985-03-31,MA,Morocco,
-1985-03-31,MK,North Macedonia,
-1985-03-31,MT,Malta,
-1985-03-31,MX,Mexico,
-1985-03-31,MY,Malaysia,
-1985-03-31,NL,Netherlands,-2.9953
-1985-03-31,NO,Norway,
+1985-03-31,NL,Netherlands,-2.9952
 1985-03-31,NZ,New Zealand,-0.3347
-1985-03-31,PE,Peru,
-1985-03-31,PH,Philippines,
-1985-03-31,PL,Poland,
-1985-03-31,PT,Portugal,
-1985-03-31,RO,Romania,
-1985-03-31,RS,Serbia,
-1985-03-31,RU,Russia,
-1985-03-31,SE,Sweden,-2.5025
-1985-03-31,SG,Singapore,
-1985-03-31,SI,Slovenia,
-1985-03-31,SK,Slovak Republic,
-1985-03-31,TH,Thailand,
-1985-03-31,TR,Türkiye,
-1985-03-31,US,United States,1.147
-1985-03-31,XM,Euro area,-4.3076
-1985-03-31,XW,World,
-1985-03-31,ZA,South Africa,-19.3212
-1985-06-30,4T,Emerging market economies (aggregate),
-1985-06-30,5R,Advanced economies,
-1985-06-30,AE,United Arab Emirates,
-1985-06-30,AT,Austria,
-1985-06-30,AU,Australia,3.5859
+1985-03-31,SE,Sweden,-2.4973
+1985-03-31,US,United States,1.1534
+1985-03-31,XM,Euro area,-4.2828
+1985-03-31,ZA,South Africa,-19.2949
+1985-06-30,AU,Australia,3.5737
 1985-06-30,BE,Belgium,-5.104
-1985-06-30,BG,Bulgaria,
-1985-06-30,BR,Brazil,
 1985-06-30,CA,Canada,-0.1558
-1985-06-30,CH,Switzerland,0.2447
-1985-06-30,CL,Chile,
-1985-06-30,CN,China,
-1985-06-30,CO,Colombia,
-1985-06-30,CY,Cyprus,
-1985-06-30,CZ,Czechia,
-1985-06-30,DE,Germany,-3.6755
+1985-06-30,CH,Switzerland,0.2035
+1985-06-30,DE,Germany,-3.7917
 1985-06-30,DK,Denmark,8.972
-1985-06-30,EE,Estonia,
 1985-06-30,ES,Spain,0.0983
 1985-06-30,FI,Finland,-0.197
 1985-06-30,FR,France,-3.0432
 1985-06-30,GB,United Kingdom,3.8179
-1985-06-30,GR,Greece,
 1985-06-30,HK,Hong Kong SAR,1.5262
-1985-06-30,HR,Croatia,
-1985-06-30,HU,Hungary,
-1985-06-30,ID,Indonesia,
 1985-06-30,IE,Ireland,-3.0377
-1985-06-30,IL,Israel,
-1985-06-30,IN,India,
-1985-06-30,IS,Iceland,
-1985-06-30,IT,Italy,-6.9929
+1985-06-30,IS,Iceland,-9.9293
+1985-06-30,IT,Italy,-7.0055
 1985-06-30,JP,Japan,0.4261
 1985-06-30,KR,Korea,4.4388
-1985-06-30,LT,Lithuania,
-1985-06-30,LU,Luxembourg,
-1985-06-30,LV,Latvia,
-1985-06-30,MA,Morocco,
-1985-06-30,MK,North Macedonia,
-1985-06-30,MT,Malta,
-1985-06-30,MX,Mexico,
-1985-06-30,MY,Malaysia,
 1985-06-30,NL,Netherlands,-1.4124
-1985-06-30,NO,Norway,
 1985-06-30,NZ,New Zealand,-2.5906
-1985-06-30,PE,Peru,
-1985-06-30,PH,Philippines,
-1985-06-30,PL,Poland,
-1985-06-30,PT,Portugal,
-1985-06-30,RO,Romania,
-1985-06-30,RS,Serbia,
-1985-06-30,RU,Russia,
-1985-06-30,SE,Sweden,-3.0832
-1985-06-30,SG,Singapore,
-1985-06-30,SI,Slovenia,
-1985-06-30,SK,Slovak Republic,
-1985-06-30,TH,Thailand,
-1985-06-30,TR,Türkiye,
-1985-06-30,US,United States,1.8921
-1985-06-30,XM,Euro area,-4.2123
-1985-06-30,XW,World,
-1985-06-30,ZA,South Africa,-21.39
-1985-09-30,4T,Emerging market economies (aggregate),
-1985-09-30,5R,Advanced economies,
-1985-09-30,AE,United Arab Emirates,
-1985-09-30,AT,Austria,
-1985-09-30,AU,Australia,0.7883
+1985-06-30,SE,Sweden,-3.0866
+1985-06-30,US,United States,1.9022
+1985-06-30,XM,Euro area,-4.2025
+1985-06-30,ZA,South Africa,-21.3576
+1985-09-30,AU,Australia,0.6853
 1985-09-30,BE,Belgium,-2.6618
-1985-09-30,BG,Bulgaria,
-1985-09-30,BR,Brazil,
 1985-09-30,CA,Canada,2.0968
-1985-09-30,CH,Switzerland,1.4417
-1985-09-30,CL,Chile,
-1985-09-30,CN,China,
-1985-09-30,CO,Colombia,
-1985-09-30,CY,Cyprus,
-1985-09-30,CZ,Czechia,
-1985-09-30,DE,Germany,-2.6808
+1985-09-30,CH,Switzerland,1.4303
+1985-09-30,DE,Germany,-2.6643
 1985-09-30,DK,Denmark,16.7184
-1985-09-30,EE,Estonia,
 1985-09-30,ES,Spain,2.5393
 1985-09-30,FI,Finland,-1.9212
 1985-09-30,FR,France,-2.2026
 1985-09-30,GB,United Kingdom,2.2933
-1985-09-30,GR,Greece,
 1985-09-30,HK,Hong Kong SAR,13.6521
-1985-09-30,HR,Croatia,
-1985-09-30,HU,Hungary,
-1985-09-30,ID,Indonesia,
 1985-09-30,IE,Ireland,-3.5481
-1985-09-30,IL,Israel,
-1985-09-30,IN,India,
-1985-09-30,IS,Iceland,
-1985-09-30,IT,Italy,-6.4304
+1985-09-30,IS,Iceland,-16.3451
+1985-09-30,IT,Italy,-6.4226
 1985-09-30,JP,Japan,0.0545
 1985-09-30,KR,Korea,3.6253
-1985-09-30,LT,Lithuania,
-1985-09-30,LU,Luxembourg,
-1985-09-30,LV,Latvia,
-1985-09-30,MA,Morocco,
-1985-09-30,MK,North Macedonia,
-1985-09-30,MT,Malta,
-1985-09-30,MX,Mexico,
-1985-09-30,MY,Malaysia,
-1985-09-30,NL,Netherlands,-2.9989
-1985-09-30,NO,Norway,
+1985-09-30,NL,Netherlands,-2.9988
 1985-09-30,NZ,New Zealand,-1.3164
-1985-09-30,PE,Peru,
-1985-09-30,PH,Philippines,
-1985-09-30,PL,Poland,
-1985-09-30,PT,Portugal,
-1985-09-30,RO,Romania,
-1985-09-30,RS,Serbia,
-1985-09-30,RU,Russia,
-1985-09-30,SE,Sweden,-3.1038
-1985-09-30,SG,Singapore,
-1985-09-30,SI,Slovenia,
-1985-09-30,SK,Slovak Republic,
-1985-09-30,TH,Thailand,
-1985-09-30,TR,Türkiye,
-1985-09-30,US,United States,1.6577
-1985-09-30,XM,Euro area,-3.0342
-1985-09-30,XW,World,
-1985-09-30,ZA,South Africa,-21.6271
-1985-12-31,4T,Emerging market economies (aggregate),
-1985-12-31,5R,Advanced economies,
-1985-12-31,AE,United Arab Emirates,
-1985-12-31,AT,Austria,
-1985-12-31,AU,Australia,1.7248
+1985-09-30,SE,Sweden,-3.0934
+1985-09-30,US,United States,1.6436
+1985-09-30,XM,Euro area,-3.0138
+1985-09-30,ZA,South Africa,-21.6195
+1985-12-31,AU,Australia,1.8095
 1985-12-31,BE,Belgium,-1.4121
-1985-12-31,BG,Bulgaria,
-1985-12-31,BR,Brazil,
 1985-12-31,CA,Canada,5.0984
-1985-12-31,CH,Switzerland,0.679
-1985-12-31,CL,Chile,
-1985-12-31,CN,China,
-1985-12-31,CO,Colombia,
-1985-12-31,CY,Cyprus,
-1985-12-31,CZ,Czechia,
-1985-12-31,DE,Germany,-1.8839
+1985-12-31,CH,Switzerland,0.642
+1985-12-31,DE,Germany,-1.8166
 1985-12-31,DK,Denmark,15.2365
-1985-12-31,EE,Estonia,
 1985-12-31,ES,Spain,2.4496
 1985-12-31,FI,Finland,-0.9992
 1985-12-31,FR,France,-1.2703
 1985-12-31,GB,United Kingdom,4.4993
-1985-12-31,GR,Greece,
 1985-12-31,HK,Hong Kong SAR,16.2085
-1985-12-31,HR,Croatia,
-1985-12-31,HU,Hungary,
-1985-12-31,ID,Indonesia,
 1985-12-31,IE,Ireland,-0.0089
-1985-12-31,IL,Israel,
-1985-12-31,IN,India,
-1985-12-31,IS,Iceland,
-1985-12-31,IT,Italy,-6.141
+1985-12-31,IS,Iceland,-14.083
+1985-12-31,IT,Italy,-6.148
 1985-12-31,JP,Japan,0.6187
 1985-12-31,KR,Korea,3.5901
-1985-12-31,LT,Lithuania,
-1985-12-31,LU,Luxembourg,
-1985-12-31,LV,Latvia,
-1985-12-31,MA,Morocco,
-1985-12-31,MK,North Macedonia,
-1985-12-31,MT,Malta,
-1985-12-31,MX,Mexico,
-1985-12-31,MY,Malaysia,
 1985-12-31,NL,Netherlands,-0.7277
-1985-12-31,NO,Norway,
 1985-12-31,NZ,New Zealand,-0.0861
-1985-12-31,PE,Peru,
-1985-12-31,PH,Philippines,
-1985-12-31,PL,Poland,
-1985-12-31,PT,Portugal,
-1985-12-31,RO,Romania,
-1985-12-31,RS,Serbia,
-1985-12-31,RU,Russia,
-1985-12-31,SE,Sweden,-3.3089
-1985-12-31,SG,Singapore,
-1985-12-31,SI,Slovenia,
-1985-12-31,SK,Slovak Republic,
-1985-12-31,TH,Thailand,
-1985-12-31,TR,Türkiye,
-1985-12-31,US,United States,2.744
-1985-12-31,XM,Euro area,-1.96
-1985-12-31,XW,World,
-1985-12-31,ZA,South Africa,-20.2246
-1986-03-31,4T,Emerging market economies (aggregate),
-1986-03-31,5R,Advanced economies,
-1986-03-31,AE,United Arab Emirates,
-1986-03-31,AT,Austria,
-1986-03-31,AU,Australia,-1.9215
+1985-12-31,SE,Sweden,-3.3072
+1985-12-31,US,United States,2.7299
+1985-12-31,XM,Euro area,-1.9443
+1985-12-31,ZA,South Africa,-20.2503
+1986-03-31,AU,Australia,-1.9162
 1986-03-31,BE,Belgium,0.0692
-1986-03-31,BG,Bulgaria,
-1986-03-31,BR,Brazil,
 1986-03-31,CA,Canada,8.7577
-1986-03-31,CH,Switzerland,0.5942
-1986-03-31,CL,Chile,
-1986-03-31,CN,China,
-1986-03-31,CO,Colombia,
-1986-03-31,CY,Cyprus,
-1986-03-31,CZ,Czechia,
-1986-03-31,DE,Germany,-0.7538
+1986-03-31,CH,Switzerland,0.6429
+1986-03-31,DE,Germany,-0.7963
 1986-03-31,DK,Denmark,18.5787
-1986-03-31,EE,Estonia,
 1986-03-31,ES,Spain,-0.6542
 1986-03-31,FI,Finland,-0.0101
 1986-03-31,FR,France,0.5873
 1986-03-31,GB,United Kingdom,7.301
-1986-03-31,GR,Greece,
 1986-03-31,HK,Hong Kong SAR,12.2907
-1986-03-31,HR,Croatia,
-1986-03-31,HU,Hungary,
-1986-03-31,ID,Indonesia,
 1986-03-31,IE,Ireland,-1.1855
-1986-03-31,IL,Israel,
-1986-03-31,IN,India,
-1986-03-31,IS,Iceland,
-1986-03-31,IT,Italy,-4.7565
+1986-03-31,IS,Iceland,-15.7308
+1986-03-31,IT,Italy,-4.7644
 1986-03-31,JP,Japan,0.5679
-1986-03-31,KR,Korea,7.7045
-1986-03-31,LT,Lithuania,
-1986-03-31,LU,Luxembourg,
-1986-03-31,LV,Latvia,
-1986-03-31,MA,Morocco,
-1986-03-31,MK,North Macedonia,
-1986-03-31,MT,Malta,
-1986-03-31,MX,Mexico,
-1986-03-31,MY,Malaysia,
-1986-03-31,NL,Netherlands,2.4545
-1986-03-31,NO,Norway,
+1986-03-31,KR,Korea,7.7023
+1986-03-31,NL,Netherlands,2.4544
 1986-03-31,NZ,New Zealand,0.4976
-1986-03-31,PE,Peru,
-1986-03-31,PH,Philippines,
-1986-03-31,PL,Poland,
-1986-03-31,PT,Portugal,
-1986-03-31,RO,Romania,
-1986-03-31,RS,Serbia,
-1986-03-31,RU,Russia,
-1986-03-31,SE,Sweden,-1.649
-1986-03-31,SG,Singapore,
-1986-03-31,SI,Slovenia,
-1986-03-31,SK,Slovak Republic,
-1986-03-31,TH,Thailand,
-1986-03-31,TR,Türkiye,
-1986-03-31,US,United States,4.0261
-1986-03-31,XM,Euro area,-1.1443
-1986-03-31,XW,World,
-1986-03-31,ZA,South Africa,-19.9892
-1986-06-30,4T,Emerging market economies (aggregate),
-1986-06-30,5R,Advanced economies,
-1986-06-30,AE,United Arab Emirates,
-1986-06-30,AT,Austria,
-1986-06-30,AU,Australia,0.4081
+1986-03-31,SE,Sweden,-1.6495
+1986-03-31,US,United States,4
+1986-03-31,XM,Euro area,-1.1399
+1986-03-31,ZA,South Africa,-20.0148
+1986-06-30,AU,Australia,0.4499
 1986-06-30,BE,Belgium,3.4588
-1986-06-30,BG,Bulgaria,
-1986-06-30,BR,Brazil,
 1986-06-30,CA,Canada,12.0402
-1986-06-30,CH,Switzerland,0.0755
-1986-06-30,CL,Chile,
-1986-06-30,CN,China,
-1986-06-30,CO,Colombia,
-1986-06-30,CY,Cyprus,
-1986-06-30,CZ,Czechia,
-1986-06-30,DE,Germany,0.8525
+1986-06-30,CH,Switzerland,0.061
+1986-06-30,DE,Germany,0.9696
 1986-06-30,DK,Denmark,11.8966
-1986-06-30,EE,Estonia,
 1986-06-30,ES,Spain,2.2504
 1986-06-30,FI,Finland,0.2591
 1986-06-30,FR,France,1.9929
 1986-06-30,GB,United Kingdom,9.3375
-1986-06-30,GR,Greece,
 1986-06-30,HK,Hong Kong SAR,7.6766
-1986-06-30,HR,Croatia,
-1986-06-30,HU,Hungary,
-1986-06-30,ID,Indonesia,
 1986-06-30,IE,Ireland,-0.1871
-1986-06-30,IL,Israel,
-1986-06-30,IN,India,
-1986-06-30,IS,Iceland,
-1986-06-30,IT,Italy,-3.043
+1986-06-30,IS,Iceland,-13.9827
+1986-06-30,IT,Italy,-3.0293
 1986-06-30,JP,Japan,1.4394
-1986-06-30,KR,Korea,4.999
-1986-06-30,LT,Lithuania,
-1986-06-30,LU,Luxembourg,
-1986-06-30,LV,Latvia,
-1986-06-30,MA,Morocco,
-1986-06-30,MK,North Macedonia,
-1986-06-30,MT,Malta,
-1986-06-30,MX,Mexico,
-1986-06-30,MY,Malaysia,
-1986-06-30,NL,Netherlands,3.0323
-1986-06-30,NO,Norway,
+1986-06-30,KR,Korea,4.9817
+1986-06-30,NL,Netherlands,3.0324
 1986-06-30,NZ,New Zealand,0.3883
-1986-06-30,PE,Peru,
-1986-06-30,PH,Philippines,
-1986-06-30,PL,Poland,
-1986-06-30,PT,Portugal,
-1986-06-30,RO,Romania,
-1986-06-30,RS,Serbia,
-1986-06-30,RU,Russia,
-1986-06-30,SE,Sweden,-1.0287
-1986-06-30,SG,Singapore,
-1986-06-30,SI,Slovenia,
-1986-06-30,SK,Slovak Republic,
-1986-06-30,TH,Thailand,
-1986-06-30,TR,Türkiye,
-1986-06-30,US,United States,5.2294
-1986-06-30,XM,Euro area,0.7232
-1986-06-30,XW,World,
-1986-06-30,ZA,South Africa,-18.6821
-1986-09-30,4T,Emerging market economies (aggregate),
-1986-09-30,5R,Advanced economies,
-1986-09-30,AE,United Arab Emirates,
-1986-09-30,AT,Austria,
-1986-09-30,AU,Australia,-4.8061
+1986-06-30,SE,Sweden,-1.0323
+1986-06-30,US,United States,5.2237
+1986-06-30,XM,Euro area,0.7234
+1986-06-30,ZA,South Africa,-18.7011
+1986-09-30,AU,Australia,-4.8386
 1986-09-30,BE,Belgium,5.173
-1986-09-30,BG,Bulgaria,
-1986-09-30,BR,Brazil,
 1986-09-30,CA,Canada,13.1498
-1986-09-30,CH,Switzerland,0.8664
-1986-09-30,CL,Chile,
-1986-09-30,CN,China,
-1986-09-30,CO,Colombia,
-1986-09-30,CY,Cyprus,
-1986-09-30,CZ,Czechia,
-1986-09-30,DE,Germany,0.7347
+1986-09-30,CH,Switzerland,0.874
+1986-09-30,DE,Germany,0.7066
 1986-09-30,DK,Denmark,1.5866
-1986-09-30,EE,Estonia,
 1986-09-30,ES,Spain,6.5366
 1986-09-30,FI,Finland,1.4619
 1986-09-30,FR,France,2.5433
 1986-09-30,GB,United Kingdom,11.6376
-1986-09-30,GR,Greece,
 1986-09-30,HK,Hong Kong SAR,6.2425
-1986-09-30,HR,Croatia,
-1986-09-30,HU,Hungary,
-1986-09-30,ID,Indonesia,
 1986-09-30,IE,Ireland,1.9833
-1986-09-30,IL,Israel,
-1986-09-30,IN,India,
-1986-09-30,IS,Iceland,
-1986-09-30,IT,Italy,-2.3451
+1986-09-30,IS,Iceland,-3.762
+1986-09-30,IT,Italy,-2.3373
 1986-09-30,JP,Japan,2.2683
-1986-09-30,KR,Korea,3.0183
-1986-09-30,LT,Lithuania,
-1986-09-30,LU,Luxembourg,
-1986-09-30,LV,Latvia,
-1986-09-30,MA,Morocco,
-1986-09-30,MK,North Macedonia,
-1986-09-30,MT,Malta,
-1986-09-30,MX,Mexico,
-1986-09-30,MY,Malaysia,
+1986-09-30,KR,Korea,2.9738
 1986-09-30,NL,Netherlands,7.1437
-1986-09-30,NO,Norway,
 1986-09-30,NZ,New Zealand,-1.7578
-1986-09-30,PE,Peru,
-1986-09-30,PH,Philippines,
-1986-09-30,PL,Poland,
-1986-09-30,PT,Portugal,
-1986-09-30,RO,Romania,
-1986-09-30,RS,Serbia,
-1986-09-30,RU,Russia,
-1986-09-30,SE,Sweden,1.1656
-1986-09-30,SG,Singapore,
-1986-09-30,SI,Slovenia,
-1986-09-30,SK,Slovak Republic,
-1986-09-30,TH,Thailand,
-1986-09-30,TR,Türkiye,
-1986-09-30,US,United States,6.7772
-1986-09-30,XM,Euro area,1.3194
-1986-09-30,XW,World,
-1986-09-30,ZA,South Africa,-19.1836
-1986-12-31,4T,Emerging market economies (aggregate),
-1986-12-31,5R,Advanced economies,
-1986-12-31,AE,United Arab Emirates,
-1986-12-31,AT,Austria,
-1986-12-31,AU,Australia,-5.7984
+1986-09-30,SE,Sweden,1.1618
+1986-09-30,US,United States,6.703
+1986-09-30,XM,Euro area,1.3429
+1986-09-30,ZA,South Africa,-19.1916
+1986-12-31,AU,Australia,-5.8993
 1986-12-31,BE,Belgium,4.558
-1986-12-31,BG,Bulgaria,
-1986-12-31,BR,Brazil,
 1986-12-31,CA,Canada,15.7753
-1986-12-31,CH,Switzerland,0.8121
-1986-12-31,CL,Chile,
-1986-12-31,CN,China,
-1986-12-31,CO,Colombia,
-1986-12-31,CY,Cyprus,
-1986-12-31,CZ,Czechia,
-1986-12-31,DE,Germany,0.7308
+1986-12-31,CH,Switzerland,0.7688
+1986-12-31,DE,Germany,0.6855
 1986-12-31,DK,Denmark,0.411
-1986-12-31,EE,Estonia,
 1986-12-31,ES,Spain,15.5786
 1986-12-31,FI,Finland,2.8677
 1986-12-31,FR,France,3.0804
 1986-12-31,GB,United Kingdom,11.1157
-1986-12-31,GR,Greece,
 1986-12-31,HK,Hong Kong SAR,7.5956
-1986-12-31,HR,Croatia,
-1986-12-31,HU,Hungary,
-1986-12-31,ID,Indonesia,
 1986-12-31,IE,Ireland,-1.7125
-1986-12-31,IL,Israel,
-1986-12-31,IN,India,
-1986-12-31,IS,Iceland,
-1986-12-31,IT,Italy,-1.26
+1986-12-31,IS,Iceland,2.6457
+1986-12-31,IT,Italy,-1.2564
 1986-12-31,JP,Japan,3.7589
-1986-12-31,KR,Korea,2.2884
-1986-12-31,LT,Lithuania,
-1986-12-31,LU,Luxembourg,
-1986-12-31,LV,Latvia,
-1986-12-31,MA,Morocco,
-1986-12-31,MK,North Macedonia,
-1986-12-31,MT,Malta,
-1986-12-31,MX,Mexico,
-1986-12-31,MY,Malaysia,
+1986-12-31,KR,Korea,2.3519
 1986-12-31,NL,Netherlands,6.0965
-1986-12-31,NO,Norway,
 1986-12-31,NZ,New Zealand,-8.7265
-1986-12-31,PE,Peru,
-1986-12-31,PH,Philippines,
-1986-12-31,PL,Poland,
-1986-12-31,PT,Portugal,
-1986-12-31,RO,Romania,
-1986-12-31,RS,Serbia,
-1986-12-31,RU,Russia,
-1986-12-31,SE,Sweden,5.0474
-1986-12-31,SG,Singapore,
-1986-12-31,SI,Slovenia,
-1986-12-31,SK,Slovak Republic,
-1986-12-31,TH,Thailand,
-1986-12-31,TR,Türkiye,
-1986-12-31,US,United States,6.7177
-1986-12-31,XM,Euro area,2.3046
-1986-12-31,XW,World,
-1986-12-31,ZA,South Africa,-18.3405
-1987-03-31,4T,Emerging market economies (aggregate),
-1987-03-31,5R,Advanced economies,
-1987-03-31,AE,United Arab Emirates,
-1987-03-31,AT,Austria,
-1987-03-31,AU,Australia,-6.6192
+1986-12-31,SE,Sweden,5.0329
+1986-12-31,US,United States,6.6984
+1986-12-31,XM,Euro area,2.3583
+1986-12-31,ZA,South Africa,-18.3392
+1987-03-31,AU,Australia,-6.6214
 1987-03-31,BE,Belgium,6.7748
-1987-03-31,BG,Bulgaria,
-1987-03-31,BR,Brazil,
 1987-03-31,CA,Canada,19.0389
-1987-03-31,CH,Switzerland,-1.1003
-1987-03-31,CL,Chile,
-1987-03-31,CN,China,
-1987-03-31,CO,Colombia,
-1987-03-31,CY,Cyprus,
-1987-03-31,CZ,Czechia,
-1987-03-31,DE,Germany,-0.2745
+1987-03-31,CH,Switzerland,-1.2211
+1987-03-31,DE,Germany,-0.1727
 1987-03-31,DK,Denmark,-11.7234
-1987-03-31,EE,Estonia,
 1987-03-31,ES,Spain,29.8002
 1987-03-31,FI,Finland,1.8701
 1987-03-31,FR,France,2.3863
 1987-03-31,GB,United Kingdom,11.7424
-1987-03-31,GR,Greece,
 1987-03-31,HK,Hong Kong SAR,15.3178
-1987-03-31,HR,Croatia,
-1987-03-31,HU,Hungary,
-1987-03-31,ID,Indonesia,
 1987-03-31,IE,Ireland,-1.6868
-1987-03-31,IL,Israel,
-1987-03-31,IN,India,
-1987-03-31,IS,Iceland,
-1987-03-31,IT,Italy,-0.4952
+1987-03-31,IS,Iceland,16.1742
+1987-03-31,IT,Italy,-0.4834
 1987-03-31,JP,Japan,5.3771
-1987-03-31,KR,Korea,-3.7907
-1987-03-31,LT,Lithuania,
-1987-03-31,LU,Luxembourg,
-1987-03-31,LV,Latvia,
-1987-03-31,MA,Morocco,
-1987-03-31,MK,North Macedonia,
-1987-03-31,MT,Malta,
-1987-03-31,MX,Mexico,
-1987-03-31,MY,Malaysia,
-1987-03-31,NL,Netherlands,6.6388
-1987-03-31,NO,Norway,
+1987-03-31,KR,Korea,-3.8244
+1987-03-31,NL,Netherlands,6.6389
 1987-03-31,NZ,New Zealand,-5.4804
-1987-03-31,PE,Peru,
-1987-03-31,PH,Philippines,
-1987-03-31,PL,Poland,
-1987-03-31,PT,Portugal,
-1987-03-31,RO,Romania,
-1987-03-31,RS,Serbia,
-1987-03-31,RU,Russia,
-1987-03-31,SE,Sweden,8.0262
-1987-03-31,SG,Singapore,
-1987-03-31,SI,Slovenia,
-1987-03-31,SK,Slovak Republic,
-1987-03-31,TH,Thailand,
-1987-03-31,TR,Türkiye,
-1987-03-31,US,United States,7.0948
-1987-03-31,XM,Euro area,4.1848
-1987-03-31,XW,World,
-1987-03-31,ZA,South Africa,-12.7884
-1987-06-30,4T,Emerging market economies (aggregate),
-1987-06-30,5R,Advanced economies,
-1987-06-30,AE,United Arab Emirates,
-1987-06-30,AT,Austria,
-1987-06-30,AU,Australia,-7.9402
+1987-03-31,SE,Sweden,8.0347
+1987-03-31,US,United States,7.0621
+1987-03-31,XM,Euro area,4.2651
+1987-03-31,ZA,South Africa,-12.7949
+1987-06-30,AU,Australia,-7.9178
 1987-06-30,BE,Belgium,4.9733
-1987-06-30,BG,Bulgaria,
-1987-06-30,BR,Brazil,
 1987-06-30,CA,Canada,11.2885
-1987-06-30,CH,Switzerland,3.4098
-1987-06-30,CL,Chile,
-1987-06-30,CN,China,
-1987-06-30,CO,Colombia,
-1987-06-30,CY,Cyprus,
-1987-06-30,CZ,Czechia,
-1987-06-30,DE,Germany,-1.4037
+1987-06-30,CH,Switzerland,3.5291
+1987-06-30,DE,Germany,-1.4806
 1987-06-30,DK,Denmark,-10.7423
-1987-06-30,EE,Estonia,
 1987-06-30,ES,Spain,32.5682
 1987-06-30,FI,Finland,5.4547
 1987-06-30,FR,France,3.0709
 1987-06-30,GB,United Kingdom,11.9862
-1987-06-30,GR,Greece,
 1987-06-30,HK,Hong Kong SAR,20.5529
-1987-06-30,HR,Croatia,
-1987-06-30,HU,Hungary,
-1987-06-30,ID,Indonesia,
 1987-06-30,IE,Ireland,-4.5551
-1987-06-30,IL,Israel,
-1987-06-30,IN,India,
-1987-06-30,IS,Iceland,
-1987-06-30,IT,Italy,0.4811
+1987-06-30,IS,Iceland,15.8828
+1987-06-30,IT,Italy,0.4614
 1987-06-30,JP,Japan,6.7957
-1987-06-30,KR,Korea,-4.151
-1987-06-30,LT,Lithuania,
-1987-06-30,LU,Luxembourg,
-1987-06-30,LV,Latvia,
-1987-06-30,MA,Morocco,
-1987-06-30,MK,North Macedonia,
-1987-06-30,MT,Malta,
-1987-06-30,MX,Mexico,
-1987-06-30,MY,Malaysia,
-1987-06-30,NL,Netherlands,7.0795
-1987-06-30,NO,Norway,
+1987-06-30,KR,Korea,-4.2896
+1987-06-30,NL,Netherlands,7.0794
 1987-06-30,NZ,New Zealand,-2.6662
-1987-06-30,PE,Peru,
-1987-06-30,PH,Philippines,
-1987-06-30,PL,Poland,
-1987-06-30,PT,Portugal,
-1987-06-30,RO,Romania,
-1987-06-30,RS,Serbia,
-1987-06-30,RU,Russia,
-1987-06-30,SE,Sweden,8.7065
-1987-06-30,SG,Singapore,
-1987-06-30,SI,Slovenia,
-1987-06-30,SK,Slovak Republic,
-1987-06-30,TH,Thailand,
-1987-06-30,TR,Türkiye,
-1987-06-30,US,United States,5.8192
-1987-06-30,XM,Euro area,4.2141
-1987-06-30,XW,World,
-1987-06-30,ZA,South Africa,-7.8568
-1987-09-30,4T,Emerging market economies (aggregate),
-1987-09-30,5R,Advanced economies,
-1987-09-30,AE,United Arab Emirates,
-1987-09-30,AT,Austria,
-1987-09-30,AU,Australia,-2.8901
+1987-06-30,SE,Sweden,8.716
+1987-06-30,US,United States,5.7233
+1987-06-30,XM,Euro area,4.3254
+1987-06-30,ZA,South Africa,-7.8867
+1987-09-30,AT,Austria,-2.7321
+1987-09-30,AU,Australia,-2.8005
 1987-09-30,BE,Belgium,2.927
-1987-09-30,BG,Bulgaria,
-1987-09-30,BR,Brazil,
 1987-09-30,CA,Canada,9.5286
-1987-09-30,CH,Switzerland,1.4557
-1987-09-30,CL,Chile,
-1987-09-30,CN,China,
-1987-09-30,CO,Colombia,
-1987-09-30,CY,Cyprus,
-1987-09-30,CZ,Czechia,
-1987-09-30,DE,Germany,-1.6908
+1987-09-30,CH,Switzerland,1.4721
+1987-09-30,DE,Germany,-1.7263
 1987-09-30,DK,Denmark,-9.5919
-1987-09-30,EE,Estonia,
 1987-09-30,ES,Spain,32.2497
 1987-09-30,FI,Finland,8.194
 1987-09-30,FR,France,4.259
 1987-09-30,GB,United Kingdom,12.8324
-1987-09-30,GR,Greece,
 1987-09-30,HK,Hong Kong SAR,18.6149
-1987-09-30,HR,Croatia,
-1987-09-30,HU,Hungary,
-1987-09-30,ID,Indonesia,
 1987-09-30,IE,Ireland,-3.2916
-1987-09-30,IL,Israel,
-1987-09-30,IN,India,
-1987-09-30,IS,Iceland,
-1987-09-30,IT,Italy,1.4137
+1987-09-30,IS,Iceland,14.165
+1987-09-30,IT,Italy,1.4144
 1987-09-30,JP,Japan,8.9437
-1987-09-30,KR,Korea,-2.8941
-1987-09-30,LT,Lithuania,
-1987-09-30,LU,Luxembourg,
-1987-09-30,LV,Latvia,
-1987-09-30,MA,Morocco,
-1987-09-30,MK,North Macedonia,
-1987-09-30,MT,Malta,
-1987-09-30,MX,Mexico,
-1987-09-30,MY,Malaysia,
+1987-09-30,KR,Korea,-2.8767
 1987-09-30,NL,Netherlands,3.6153
-1987-09-30,NO,Norway,
 1987-09-30,NZ,New Zealand,1.5488
-1987-09-30,PE,Peru,
-1987-09-30,PH,Philippines,
-1987-09-30,PL,Poland,
-1987-09-30,PT,Portugal,
-1987-09-30,RO,Romania,
-1987-09-30,RS,Serbia,
-1987-09-30,RU,Russia,
-1987-09-30,SE,Sweden,7.8205
-1987-09-30,SG,Singapore,
-1987-09-30,SI,Slovenia,
-1987-09-30,SK,Slovak Republic,
-1987-09-30,TH,Thailand,
-1987-09-30,TR,Türkiye,
-1987-09-30,US,United States,5.1943
-1987-09-30,XM,Euro area,3.5466
-1987-09-30,XW,World,
-1987-09-30,ZA,South Africa,-2.8659
-1987-12-31,4T,Emerging market economies (aggregate),
-1987-12-31,5R,Advanced economies,
-1987-12-31,AE,United Arab Emirates,
-1987-12-31,AT,Austria,
-1987-12-31,AU,Australia,1.6726
+1987-09-30,SE,Sweden,7.8289
+1987-09-30,US,United States,5.1926
+1987-09-30,XM,Euro area,3.6324
+1987-09-30,ZA,South Africa,-2.9007
+1987-12-31,AT,Austria,12.8734
+1987-12-31,AU,Australia,1.7445
 1987-12-31,BE,Belgium,4.5298
-1987-12-31,BG,Bulgaria,
-1987-12-31,BR,Brazil,
 1987-12-31,CA,Canada,8.4336
-1987-12-31,CH,Switzerland,1.5462
-1987-12-31,CL,Chile,
-1987-12-31,CN,China,
-1987-12-31,CO,Colombia,
-1987-12-31,CY,Cyprus,
-1987-12-31,CZ,Czechia,
-1987-12-31,DE,Germany,-1.2265
+1987-12-31,CH,Switzerland,1.5389
+1987-12-31,DE,Germany,-1.213
 1987-12-31,DK,Denmark,-11.7873
-1987-12-31,EE,Estonia,
 1987-12-31,ES,Spain,29.244
 1987-12-31,FI,Finland,12.5771
 1987-12-31,FR,France,5.0057
 1987-12-31,GB,United Kingdom,15.9732
-1987-12-31,GR,Greece,
 1987-12-31,HK,Hong Kong SAR,12.604
-1987-12-31,HR,Croatia,
-1987-12-31,HU,Hungary,
-1987-12-31,ID,Indonesia,
 1987-12-31,IE,Ireland,3.3723
-1987-12-31,IL,Israel,
-1987-12-31,IN,India,
-1987-12-31,IS,Iceland,
-1987-12-31,IT,Italy,2.4628
+1987-12-31,IS,Iceland,13.1084
+1987-12-31,IT,Italy,2.4617
 1987-12-31,JP,Japan,8.0482
-1987-12-31,KR,Korea,0.6651
-1987-12-31,LT,Lithuania,
-1987-12-31,LU,Luxembourg,
-1987-12-31,LV,Latvia,
-1987-12-31,MA,Morocco,
-1987-12-31,MK,North Macedonia,
-1987-12-31,MT,Malta,
-1987-12-31,MX,Mexico,
-1987-12-31,MY,Malaysia,
+1987-12-31,KR,Korea,0.6305
 1987-12-31,NL,Netherlands,4.5968
-1987-12-31,NO,Norway,
 1987-12-31,NZ,New Zealand,11.0552
-1987-12-31,PE,Peru,
-1987-12-31,PH,Philippines,
-1987-12-31,PL,Poland,
-1987-12-31,PT,Portugal,
-1987-12-31,RO,Romania,
-1987-12-31,RS,Serbia,
-1987-12-31,RU,Russia,
-1987-12-31,SE,Sweden,8.6434
-1987-12-31,SG,Singapore,
-1987-12-31,SI,Slovenia,
-1987-12-31,SK,Slovak Republic,
-1987-12-31,TH,Thailand,
-1987-12-31,TR,Türkiye,
-1987-12-31,US,United States,5.3742
-1987-12-31,XM,Euro area,5.1744
-1987-12-31,XW,World,
-1987-12-31,ZA,South Africa,1.5995
-1988-03-31,4T,Emerging market economies (aggregate),
-1988-03-31,5R,Advanced economies,
-1988-03-31,AE,United Arab Emirates,
-1988-03-31,AT,Austria,
-1988-03-31,AU,Australia,5.3447
+1987-12-31,SE,Sweden,8.6566
+1987-12-31,US,United States,5.3316
+1987-12-31,XM,Euro area,5.2413
+1987-12-31,ZA,South Africa,1.6076
+1988-03-31,AT,Austria,-0.9733
+1988-03-31,AU,Australia,5.3247
 1988-03-31,BE,Belgium,4.1621
-1988-03-31,BG,Bulgaria,
-1988-03-31,BR,Brazil,
 1988-03-31,CA,Canada,9.3599
-1988-03-31,CH,Switzerland,1.5152
-1988-03-31,CL,Chile,
-1988-03-31,CN,China,
-1988-03-31,CO,Colombia,
-1988-03-31,CY,Cyprus,
-1988-03-31,CZ,Czechia,
-1988-03-31,DE,Germany,-0.4259
+1988-03-31,CH,Switzerland,1.4522
+1988-03-31,DE,Germany,-0.5806
 1988-03-31,DK,Denmark,-4.9509
-1988-03-31,EE,Estonia,
 1988-03-31,ES,Spain,21.9496
 1988-03-31,FI,Finland,22.9105
 1988-03-31,FR,France,6.7356
 1988-03-31,GB,United Kingdom,17.7154
-1988-03-31,GR,Greece,
 1988-03-31,HK,Hong Kong SAR,7.5853
-1988-03-31,HR,Croatia,
-1988-03-31,HU,Hungary,
-1988-03-31,ID,Indonesia,
 1988-03-31,IE,Ireland,4.2946
-1988-03-31,IL,Israel,
-1988-03-31,IN,India,
-1988-03-31,IS,Iceland,
-1988-03-31,IT,Italy,4.1722
+1988-03-31,IS,Iceland,11.6814
+1988-03-31,IT,Italy,4.1663
 1988-03-31,JP,Japan,7.5075
-1988-03-31,KR,Korea,3.6482
-1988-03-31,LT,Lithuania,
-1988-03-31,LU,Luxembourg,
-1988-03-31,LV,Latvia,
-1988-03-31,MA,Morocco,
-1988-03-31,MK,North Macedonia,
-1988-03-31,MT,Malta,
-1988-03-31,MX,Mexico,
-1988-03-31,MY,Malaysia,
+1988-03-31,KR,Korea,3.7011
 1988-03-31,NL,Netherlands,2.2792
-1988-03-31,NO,Norway,
 1988-03-31,NZ,New Zealand,8.6983
-1988-03-31,PE,Peru,
-1988-03-31,PH,Philippines,
-1988-03-31,PL,Poland,
-1988-03-31,PT,Portugal,
-1988-03-31,RO,Romania,
-1988-03-31,RS,Serbia,
-1988-03-31,RU,Russia,
-1988-03-31,SE,Sweden,9.7024
-1988-03-31,SG,Singapore,
-1988-03-31,SI,Slovenia,
-1988-03-31,SK,Slovak Republic,
-1988-03-31,TH,Thailand,
-1988-03-31,TR,Türkiye,
-1988-03-31,US,United States,4.1251
-1988-03-31,XM,Euro area,4.7718
-1988-03-31,XW,World,
-1988-03-31,ZA,South Africa,3.1093
-1988-06-30,4T,Emerging market economies (aggregate),
-1988-06-30,5R,Advanced economies,
-1988-06-30,AE,United Arab Emirates,
-1988-06-30,AT,Austria,
-1988-06-30,AU,Australia,9.4357
+1988-03-31,SE,Sweden,9.7007
+1988-03-31,US,United States,4.0868
+1988-03-31,XM,Euro area,4.8222
+1988-03-31,ZA,South Africa,3.1378
+1988-06-30,AT,Austria,-2.6806
+1988-06-30,AU,Australia,9.4696
 1988-06-30,BE,Belgium,7.3789
-1988-06-30,BG,Bulgaria,
-1988-06-30,BR,Brazil,
 1988-06-30,CA,Canada,13.2203
-1988-06-30,CH,Switzerland,0.5627
-1988-06-30,CL,Chile,
-1988-06-30,CN,China,
-1988-06-30,CO,Colombia,
-1988-06-30,CY,Cyprus,
-1988-06-30,CZ,Czechia,
-1988-06-30,DE,Germany,0.4031
+1988-06-30,CH,Switzerland,0.4291
+1988-06-30,DE,Germany,0.5147
 1988-06-30,DK,Denmark,-4.9262
-1988-06-30,EE,Estonia,
 1988-06-30,ES,Spain,21.3778
 1988-06-30,FI,Finland,24.7448
 1988-06-30,FR,France,7.5926
 1988-06-30,GB,United Kingdom,18.6848
-1988-06-30,GR,Greece,
 1988-06-30,HK,Hong Kong SAR,9.3476
-1988-06-30,HR,Croatia,
-1988-06-30,HU,Hungary,
-1988-06-30,ID,Indonesia,
 1988-06-30,IE,Ireland,5.5237
-1988-06-30,IL,Israel,
-1988-06-30,IN,India,
-1988-06-30,IS,Iceland,
-1988-06-30,IT,Italy,6.6024
+1988-06-30,IS,Iceland,9.5716
+1988-06-30,IT,Italy,6.6192
 1988-06-30,JP,Japan,5.9713
-1988-06-30,KR,Korea,9.4564
-1988-06-30,LT,Lithuania,
-1988-06-30,LU,Luxembourg,
-1988-06-30,LV,Latvia,
-1988-06-30,MA,Morocco,
-1988-06-30,MK,North Macedonia,
-1988-06-30,MT,Malta,
-1988-06-30,MX,Mexico,
-1988-06-30,MY,Malaysia,
+1988-06-30,KR,Korea,9.6364
 1988-06-30,NL,Netherlands,3.6326
-1988-06-30,NO,Norway,
 1988-06-30,NZ,New Zealand,9.1562
-1988-06-30,PE,Peru,
-1988-06-30,PH,Philippines,
-1988-06-30,PL,Poland,
-1988-06-30,PT,Portugal,
-1988-06-30,RO,Romania,
-1988-06-30,RS,Serbia,
-1988-06-30,RU,Russia,
-1988-06-30,SE,Sweden,10.2028
-1988-06-30,SG,Singapore,
-1988-06-30,SI,Slovenia,
-1988-06-30,SK,Slovak Republic,
-1988-06-30,TH,Thailand,
-1988-06-30,TR,Türkiye,
-1988-06-30,US,United States,4.4459
-1988-06-30,XM,Euro area,5.7495
-1988-06-30,XW,World,
-1988-06-30,ZA,South Africa,1.7878
-1988-09-30,4T,Emerging market economies (aggregate),
-1988-09-30,5R,Advanced economies,
-1988-09-30,AE,United Arab Emirates,
-1988-09-30,AT,Austria,
-1988-09-30,AU,Australia,18.0151
+1988-06-30,SE,Sweden,10.2153
+1988-06-30,US,United States,4.4318
+1988-06-30,XM,Euro area,5.7949
+1988-06-30,ZA,South Africa,1.8028
+1988-09-30,AT,Austria,30.9521
+1988-09-30,AU,Australia,17.8762
 1988-09-30,BE,Belgium,7.4494
-1988-09-30,BG,Bulgaria,
-1988-09-30,BR,Brazil,
 1988-09-30,CA,Canada,14.3423
-1988-09-30,CH,Switzerland,3.7726
-1988-09-30,CL,Chile,
-1988-09-30,CN,China,
-1988-09-30,CO,Colombia,
-1988-09-30,CY,Cyprus,
-1988-09-30,CZ,Czechia,
-1988-09-30,DE,Germany,1.0128
+1988-09-30,CH,Switzerland,3.7589
+1988-09-30,DE,Germany,1.1183
 1988-09-30,DK,Denmark,-2.2344
-1988-09-30,EE,Estonia,
 1988-09-30,ES,Spain,18.0832
 1988-09-30,FI,Finland,30.4023
 1988-09-30,FR,France,8.2791
 1988-09-30,GB,United Kingdom,27.1985
-1988-09-30,GR,Greece,
 1988-09-30,HK,Hong Kong SAR,12.2888
-1988-09-30,HR,Croatia,
-1988-09-30,HU,Hungary,
-1988-09-30,ID,Indonesia,
 1988-09-30,IE,Ireland,5.3453
-1988-09-30,IL,Israel,
-1988-09-30,IN,India,
-1988-09-30,IS,Iceland,
-1988-09-30,IT,Italy,8.6417
+1988-09-30,IS,Iceland,-0.7308
+1988-09-30,IT,Italy,8.6305
 1988-09-30,JP,Japan,3.5167
-1988-09-30,KR,Korea,11.6061
-1988-09-30,LT,Lithuania,
-1988-09-30,LU,Luxembourg,
-1988-09-30,LV,Latvia,
-1988-09-30,MA,Morocco,
-1988-09-30,MK,North Macedonia,
-1988-09-30,MT,Malta,
-1988-09-30,MX,Mexico,
-1988-09-30,MY,Malaysia,
+1988-09-30,KR,Korea,11.6084
 1988-09-30,NL,Netherlands,4.812
-1988-09-30,NO,Norway,
 1988-09-30,NZ,New Zealand,5.4982
-1988-09-30,PE,Peru,
-1988-09-30,PH,Philippines,
-1988-09-30,PL,Poland,
-1988-09-30,PT,Portugal,
-1988-09-30,RO,Romania,
-1988-09-30,RS,Serbia,
-1988-09-30,RU,Russia,
-1988-09-30,SE,Sweden,13.9784
-1988-09-30,SG,Singapore,
-1988-09-30,SI,Slovenia,
-1988-09-30,SK,Slovak Republic,
-1988-09-30,TH,Thailand,
-1988-09-30,TR,Türkiye,
-1988-09-30,US,United States,4.8653
-1988-09-30,XM,Euro area,7.4489
-1988-09-30,XW,World,
-1988-09-30,ZA,South Africa,2.1873
-1988-12-31,4T,Emerging market economies (aggregate),
-1988-12-31,5R,Advanced economies,
-1988-12-31,AE,United Arab Emirates,
-1988-12-31,AT,Austria,
-1988-12-31,AU,Australia,23.5361
+1988-09-30,SE,Sweden,13.9801
+1988-09-30,US,United States,4.8412
+1988-09-30,XM,Euro area,7.4962
+1988-09-30,ZA,South Africa,2.2306
+1988-12-31,AT,Austria,11.9134
+1988-12-31,AU,Australia,23.4653
 1988-12-31,BE,Belgium,8.1296
-1988-12-31,BG,Bulgaria,
-1988-12-31,BR,Brazil,
 1988-12-31,CA,Canada,17.0895
-1988-12-31,CH,Switzerland,8.7999
-1988-12-31,CL,Chile,
-1988-12-31,CN,China,
-1988-12-31,CO,Colombia,
-1988-12-31,CY,Cyprus,
-1988-12-31,CZ,Czechia,
-1988-12-31,DE,Germany,0.6373
+1988-12-31,CH,Switzerland,9.0152
+1988-12-31,DE,Germany,0.5745
 1988-12-31,DK,Denmark,-0.7603
-1988-12-31,EE,Estonia,
 1988-12-31,ES,Spain,16.0855
 1988-12-31,FI,Finland,33.7761
 1988-12-31,FR,France,8.8321
 1988-12-31,GB,United Kingdom,27.2462
-1988-12-31,GR,Greece,
 1988-12-31,HK,Hong Kong SAR,19.2924
-1988-12-31,HR,Croatia,
-1988-12-31,HU,Hungary,
-1988-12-31,ID,Indonesia,
 1988-12-31,IE,Ireland,2.9148
-1988-12-31,IL,Israel,
-1988-12-31,IN,India,
-1988-12-31,IS,Iceland,
-1988-12-31,IT,Italy,10.1574
+1988-12-31,IS,Iceland,4.5368
+1988-12-31,IT,Italy,10.1642
 1988-12-31,JP,Japan,3.6797
-1988-12-31,KR,Korea,6.6657
-1988-12-31,LT,Lithuania,
-1988-12-31,LU,Luxembourg,
-1988-12-31,LV,Latvia,
-1988-12-31,MA,Morocco,
-1988-12-31,MK,North Macedonia,
-1988-12-31,MT,Malta,
-1988-12-31,MX,Mexico,
-1988-12-31,MY,Malaysia,
-1988-12-31,NL,Netherlands,4.5806
-1988-12-31,NO,Norway,
+1988-12-31,KR,Korea,6.5929
+1988-12-31,NL,Netherlands,4.5807
 1988-12-31,NZ,New Zealand,2.3668
-1988-12-31,PE,Peru,
-1988-12-31,PH,Philippines,
-1988-12-31,PL,Poland,
-1988-12-31,PT,Portugal,
-1988-12-31,RO,Romania,
-1988-12-31,RS,Serbia,
-1988-12-31,RU,Russia,
-1988-12-31,SE,Sweden,12.4906
-1988-12-31,SG,Singapore,
-1988-12-31,SI,Slovenia,
-1988-12-31,SK,Slovak Republic,
-1988-12-31,TH,Thailand,
-1988-12-31,TR,Türkiye,
-1988-12-31,US,United States,5.1884
-1988-12-31,XM,Euro area,6.4649
-1988-12-31,XW,World,
-1988-12-31,ZA,South Africa,1.1343
-1989-03-31,4T,Emerging market economies (aggregate),
-1989-03-31,5R,Advanced economies,
-1989-03-31,AE,United Arab Emirates,
-1989-03-31,AT,Austria,
-1989-03-31,AU,Australia,28.7848
+1988-12-31,SE,Sweden,12.491
+1988-12-31,US,United States,5.1746
+1988-12-31,XM,Euro area,6.5219
+1988-12-31,ZA,South Africa,1.1214
+1989-03-31,AT,Austria,20.117
+1989-03-31,AU,Australia,28.8311
 1989-03-31,BE,Belgium,10.5708
-1989-03-31,BG,Bulgaria,
-1989-03-31,BR,Brazil,
 1989-03-31,CA,Canada,17.4858
-1989-03-31,CH,Switzerland,7.9447
-1989-03-31,CL,Chile,
-1989-03-31,CN,China,
-1989-03-31,CO,Colombia,3.1463
-1989-03-31,CY,Cyprus,
-1989-03-31,CZ,Czechia,
-1989-03-31,DE,Germany,0.2755
+1989-03-31,CH,Switzerland,8.0911
+1989-03-31,CO,Colombia,3.0513
+1989-03-31,DE,Germany,0.3709
 1989-03-31,DK,Denmark,-3.0512
-1989-03-31,EE,Estonia,
 1989-03-31,ES,Spain,16.4518
 1989-03-31,FI,Finland,28.2776
 1989-03-31,FR,France,8.9983
 1989-03-31,GB,United Kingdom,24.0188
-1989-03-31,GR,Greece,
 1989-03-31,HK,Hong Kong SAR,26.6007
-1989-03-31,HR,Croatia,
-1989-03-31,HU,Hungary,
-1989-03-31,ID,Indonesia,
 1989-03-31,IE,Ireland,7.8273
-1989-03-31,IL,Israel,
-1989-03-31,IN,India,
-1989-03-31,IS,Iceland,
-1989-03-31,IT,Italy,10.3891
+1989-03-31,IS,Iceland,-1.8874
+1989-03-31,IT,Italy,10.3922
 1989-03-31,JP,Japan,4.3052
-1989-03-31,KR,Korea,7.6781
-1989-03-31,LT,Lithuania,
-1989-03-31,LU,Luxembourg,
-1989-03-31,LV,Latvia,
-1989-03-31,MA,Morocco,
-1989-03-31,MK,North Macedonia,
-1989-03-31,MT,Malta,
-1989-03-31,MX,Mexico,
+1989-03-31,KR,Korea,7.6861
 1989-03-31,MY,Malaysia,3.0612
 1989-03-31,NL,Netherlands,5.8141
-1989-03-31,NO,Norway,
 1989-03-31,NZ,New Zealand,2.7118
-1989-03-31,PE,Peru,
-1989-03-31,PH,Philippines,
-1989-03-31,PL,Poland,
-1989-03-31,PT,Portugal,
-1989-03-31,RO,Romania,
-1989-03-31,RS,Serbia,
-1989-03-31,RU,Russia,
-1989-03-31,SE,Sweden,12.9525
-1989-03-31,SG,Singapore,
-1989-03-31,SI,Slovenia,
-1989-03-31,SK,Slovak Republic,
-1989-03-31,TH,Thailand,
-1989-03-31,TR,Türkiye,
-1989-03-31,US,United States,5.2692
-1989-03-31,XM,Euro area,7.6774
-1989-03-31,XW,World,
-1989-03-31,ZA,South Africa,-0.441
-1989-06-30,4T,Emerging market economies (aggregate),
-1989-06-30,5R,Advanced economies,
-1989-06-30,AE,United Arab Emirates,
-1989-06-30,AT,Austria,
-1989-06-30,AU,Australia,23.8238
+1989-03-31,PT,Portugal,5.6991
+1989-03-31,SE,Sweden,12.9503
+1989-03-31,US,United States,5.2423
+1989-03-31,XM,Euro area,7.7074
+1989-03-31,ZA,South Africa,-0.4786
+1989-06-30,AT,Austria,16.6224
+1989-06-30,AU,Australia,23.7481
 1989-06-30,BE,Belgium,9.547
-1989-06-30,BG,Bulgaria,
-1989-06-30,BR,Brazil,
 1989-06-30,CA,Canada,4.6523
-1989-06-30,CH,Switzerland,5.4091
-1989-06-30,CL,Chile,
-1989-06-30,CN,China,
-1989-06-30,CO,Colombia,15.9816
-1989-06-30,CY,Cyprus,
-1989-06-30,CZ,Czechia,
-1989-06-30,DE,Germany,-0.2728
+1989-06-30,CH,Switzerland,5.4048
+1989-06-30,CO,Colombia,15.8689
+1989-06-30,DE,Germany,-0.24
 1989-06-30,DK,Denmark,-2.8362
-1989-06-30,EE,Estonia,
 1989-06-30,ES,Spain,15.2101
 1989-06-30,FI,Finland,23.1079
 1989-06-30,FR,France,8.6103
 1989-06-30,GB,United Kingdom,20.7683
-1989-06-30,GR,Greece,
 1989-06-30,HK,Hong Kong SAR,20.0127
-1989-06-30,HR,Croatia,
-1989-06-30,HU,Hungary,
-1989-06-30,ID,Indonesia,
 1989-06-30,IE,Ireland,5.5971
-1989-06-30,IL,Israel,
-1989-06-30,IN,India,
-1989-06-30,IS,Iceland,
-1989-06-30,IT,Italy,10.4337
+1989-06-30,IS,Iceland,-2.2507
+1989-06-30,IT,Italy,10.4302
 1989-06-30,JP,Japan,3.9522
-1989-06-30,KR,Korea,10.0937
-1989-06-30,LT,Lithuania,
-1989-06-30,LU,Luxembourg,
-1989-06-30,LV,Latvia,
-1989-06-30,MA,Morocco,
-1989-06-30,MK,North Macedonia,
-1989-06-30,MT,Malta,
-1989-06-30,MX,Mexico,
-1989-06-30,MY,Malaysia,2.8948
-1989-06-30,NL,Netherlands,5.1699
-1989-06-30,NO,Norway,
+1989-06-30,KR,Korea,10.0695
+1989-06-30,MY,Malaysia,2.8949
+1989-06-30,NL,Netherlands,5.17
 1989-06-30,NZ,New Zealand,0.3451
-1989-06-30,PE,Peru,
-1989-06-30,PH,Philippines,
-1989-06-30,PL,Poland,
-1989-06-30,PT,Portugal,
-1989-06-30,RO,Romania,
-1989-06-30,RS,Serbia,
-1989-06-30,RU,Russia,
-1989-06-30,SE,Sweden,13.427
-1989-06-30,SG,Singapore,
-1989-06-30,SI,Slovenia,
-1989-06-30,SK,Slovak Republic,
-1989-06-30,TH,Thailand,
-1989-06-30,TR,Türkiye,
-1989-06-30,US,United States,3.848
-1989-06-30,XM,Euro area,7.0399
-1989-06-30,XW,World,
-1989-06-30,ZA,South Africa,0.832
-1989-09-30,4T,Emerging market economies (aggregate),
-1989-09-30,5R,Advanced economies,
-1989-09-30,AE,United Arab Emirates,
-1989-09-30,AT,Austria,
-1989-09-30,AU,Australia,12.3033
+1989-06-30,PT,Portugal,3.8143
+1989-06-30,SE,Sweden,13.4212
+1989-06-30,US,United States,3.8319
+1989-06-30,XM,Euro area,7.0821
+1989-06-30,ZA,South Africa,0.8207
+1989-09-30,AT,Austria,8.1329
+1989-09-30,AU,Australia,12.2987
 1989-09-30,BE,Belgium,9.5087
-1989-09-30,BG,Bulgaria,
-1989-09-30,BR,Brazil,
 1989-09-30,CA,Canada,5.6924
-1989-09-30,CH,Switzerland,3.5633
-1989-09-30,CL,Chile,
-1989-09-30,CN,China,
-1989-09-30,CO,Colombia,-0.0524
-1989-09-30,CY,Cyprus,
-1989-09-30,CZ,Czechia,
-1989-09-30,DE,Germany,0.5133
+1989-09-30,CH,Switzerland,3.46
+1989-09-30,CO,Colombia,-0.0121
+1989-09-30,DE,Germany,0.4042
 1989-09-30,DK,Denmark,-6.4786
-1989-09-30,EE,Estonia,
 1989-09-30,ES,Spain,16.2746
 1989-09-30,FI,Finland,12.3789
 1989-09-30,FR,France,8.1568
 1989-09-30,GB,United Kingdom,10.5907
-1989-09-30,GR,Greece,
 1989-09-30,HK,Hong Kong SAR,7.7376
-1989-09-30,HR,Croatia,
-1989-09-30,HU,Hungary,
-1989-09-30,ID,Indonesia,
 1989-09-30,IE,Ireland,6.4638
-1989-09-30,IL,Israel,
-1989-09-30,IN,India,
-1989-09-30,IS,Iceland,
-1989-09-30,IT,Italy,11.1649
+1989-09-30,IS,Iceland,0.6118
+1989-09-30,IT,Italy,11.1695
 1989-09-30,JP,Japan,5.3103
-1989-09-30,KR,Korea,6.6245
-1989-09-30,LT,Lithuania,
-1989-09-30,LU,Luxembourg,
-1989-09-30,LV,Latvia,
-1989-09-30,MA,Morocco,
-1989-09-30,MK,North Macedonia,
-1989-09-30,MT,Malta,
-1989-09-30,MX,Mexico,
+1989-09-30,KR,Korea,6.6198
 1989-09-30,MY,Malaysia,0.6183
 1989-09-30,NL,Netherlands,5.6067
-1989-09-30,NO,Norway,
 1989-09-30,NZ,New Zealand,-0.9862
-1989-09-30,PE,Peru,
-1989-09-30,PH,Philippines,
-1989-09-30,PL,Poland,
-1989-09-30,PT,Portugal,
-1989-09-30,RO,Romania,
-1989-09-30,RS,Serbia,
-1989-09-30,RU,Russia,
-1989-09-30,SE,Sweden,11.372
-1989-09-30,SG,Singapore,
-1989-09-30,SI,Slovenia,
-1989-09-30,SK,Slovak Republic,
-1989-09-30,TH,Thailand,
-1989-09-30,TR,Türkiye,
-1989-09-30,US,United States,2.9447
-1989-09-30,XM,Euro area,6.9971
-1989-09-30,XW,World,
-1989-09-30,ZA,South Africa,0.2623
-1989-12-31,4T,Emerging market economies (aggregate),
-1989-12-31,5R,Advanced economies,
-1989-12-31,AE,United Arab Emirates,
-1989-12-31,AT,Austria,
-1989-12-31,AU,Australia,2.5416
+1989-09-30,PT,Portugal,5.7213
+1989-09-30,SE,Sweden,11.3627
+1989-09-30,US,United States,2.9184
+1989-09-30,XM,Euro area,7.0373
+1989-09-30,ZA,South Africa,0.2554
+1989-12-31,AT,Austria,17.4743
+1989-12-31,AU,Australia,2.5386
 1989-12-31,BE,Belgium,12.022
-1989-12-31,BG,Bulgaria,
-1989-12-31,BR,Brazil,
 1989-12-31,CA,Canada,3.4236
-1989-12-31,CH,Switzerland,3.316
-1989-12-31,CL,Chile,
-1989-12-31,CN,China,
-1989-12-31,CO,Colombia,5.2717
-1989-12-31,CY,Cyprus,
-1989-12-31,CZ,Czechia,
-1989-12-31,DE,Germany,1.5502
+1989-12-31,CH,Switzerland,3.2888
+1989-12-31,CO,Colombia,5.1586
+1989-12-31,DE,Germany,1.5349
 1989-12-31,DK,Denmark,-8.5373
-1989-12-31,EE,Estonia,
 1989-12-31,ES,Spain,13.9628
 1989-12-31,FI,Finland,-0.4329
 1989-12-31,FR,France,7.3965
 1989-12-31,GB,United Kingdom,1.659
-1989-12-31,GR,Greece,
 1989-12-31,HK,Hong Kong SAR,6.3661
-1989-12-31,HR,Croatia,
-1989-12-31,HU,Hungary,
-1989-12-31,ID,Indonesia,
 1989-12-31,IE,Ireland,9.6235
-1989-12-31,IL,Israel,
-1989-12-31,IN,India,
-1989-12-31,IS,Iceland,
-1989-12-31,IT,Italy,11.6466
+1989-12-31,IS,Iceland,-8.4197
+1989-12-31,IT,Italy,11.6462
 1989-12-31,JP,Japan,7.7378
-1989-12-31,KR,Korea,7.4707
-1989-12-31,LT,Lithuania,
-1989-12-31,LU,Luxembourg,
-1989-12-31,LV,Latvia,
-1989-12-31,MA,Morocco,
-1989-12-31,MK,North Macedonia,
-1989-12-31,MT,Malta,
-1989-12-31,MX,Mexico,
+1989-12-31,KR,Korea,7.5502
 1989-12-31,MY,Malaysia,-0.7856
-1989-12-31,NL,Netherlands,5.4149
-1989-12-31,NO,Norway,
+1989-12-31,NL,Netherlands,5.4147
 1989-12-31,NZ,New Zealand,0.1022
-1989-12-31,PE,Peru,
-1989-12-31,PH,Philippines,
-1989-12-31,PL,Poland,
-1989-12-31,PT,Portugal,
-1989-12-31,RO,Romania,
-1989-12-31,RS,Serbia,
-1989-12-31,RU,Russia,
-1989-12-31,SE,Sweden,8.9537
-1989-12-31,SG,Singapore,
-1989-12-31,SI,Slovenia,
-1989-12-31,SK,Slovak Republic,
-1989-12-31,TH,Thailand,
-1989-12-31,TR,Türkiye,
-1989-12-31,US,United States,1.7087
-1989-12-31,XM,Euro area,7.2367
-1989-12-31,XW,World,
-1989-12-31,ZA,South Africa,-0.7078
-1990-03-31,4T,Emerging market economies (aggregate),
-1990-03-31,5R,Advanced economies,
-1990-03-31,AE,United Arab Emirates,
-1990-03-31,AT,Austria,
-1990-03-31,AU,Australia,-5.4535
+1989-12-31,PT,Portugal,4.7372
+1989-12-31,SE,Sweden,8.9479
+1989-12-31,US,United States,1.7314
+1989-12-31,XM,Euro area,7.2483
+1989-12-31,ZA,South Africa,-0.6956
+1990-03-31,AT,Austria,15.5501
+1990-03-31,AU,Australia,-5.3913
 1990-03-31,BE,Belgium,10.4658
-1990-03-31,BG,Bulgaria,
-1990-03-31,BR,Brazil,
 1990-03-31,CA,Canada,-7.8783
-1990-03-31,CH,Switzerland,2.8613
-1990-03-31,CL,Chile,
-1990-03-31,CN,China,
-1990-03-31,CO,Colombia,1.8491
-1990-03-31,CY,Cyprus,
-1990-03-31,CZ,Czechia,
-1990-03-31,DE,Germany,3.8717
+1990-03-31,CH,Switzerland,2.8596
+1990-03-31,CO,Colombia,1.725
+1990-03-31,DE,Germany,3.8902
 1990-03-31,DK,Denmark,-10.6231
-1990-03-31,EE,Estonia,
 1990-03-31,ES,Spain,12.6713
 1990-03-31,FI,Finland,-10.1191
 1990-03-31,FR,France,6.2309
 1990-03-31,GB,United Kingdom,-2.7371
-1990-03-31,GR,Greece,
 1990-03-31,HK,Hong Kong SAR,-1.0585
-1990-03-31,HR,Croatia,
-1990-03-31,HU,Hungary,
-1990-03-31,ID,Indonesia,
-1990-03-31,IE,Ireland,10.3307
-1990-03-31,IL,Israel,
-1990-03-31,IN,India,
-1990-03-31,IS,Iceland,
-1990-03-31,IT,Italy,11.7696
+1990-03-31,IE,Ireland,10.334
+1990-03-31,IS,Iceland,-4.5974
+1990-03-31,IT,Italy,11.7725
 1990-03-31,JP,Japan,8.9402
-1990-03-31,KR,Korea,7.2756
-1990-03-31,LT,Lithuania,
-1990-03-31,LU,Luxembourg,
-1990-03-31,LV,Latvia,
-1990-03-31,MA,Morocco,
-1990-03-31,MK,North Macedonia,
-1990-03-31,MT,Malta,
-1990-03-31,MX,Mexico,
+1990-03-31,KR,Korea,7.2641
 1990-03-31,MY,Malaysia,-1.3772
-1990-03-31,NL,Netherlands,2.4761
-1990-03-31,NO,Norway,
+1990-03-31,NL,Netherlands,2.476
 1990-03-31,NZ,New Zealand,-0.121
-1990-03-31,PE,Peru,
-1990-03-31,PH,Philippines,
-1990-03-31,PL,Poland,
-1990-03-31,PT,Portugal,
-1990-03-31,RO,Romania,
-1990-03-31,RS,Serbia,
-1990-03-31,RU,Russia,
-1990-03-31,SE,Sweden,6.0679
-1990-03-31,SG,Singapore,
-1990-03-31,SI,Slovenia,
-1990-03-31,SK,Slovak Republic,
-1990-03-31,TH,Thailand,
-1990-03-31,TR,Türkiye,
-1990-03-31,US,United States,0.3457
-1990-03-31,XM,Euro area,7.5975
-1990-03-31,XW,World,
-1990-03-31,ZA,South Africa,0.328
-1990-06-30,4T,Emerging market economies (aggregate),
-1990-06-30,5R,Advanced economies,
-1990-06-30,AE,United Arab Emirates,
-1990-06-30,AT,Austria,
-1990-06-30,AU,Australia,-5.5904
+1990-03-31,PT,Portugal,2.946
+1990-03-31,SE,Sweden,6.0702
+1990-03-31,US,United States,0.3919
+1990-03-31,XM,Euro area,7.626
+1990-03-31,ZA,South Africa,0.3614
+1990-06-30,AT,Austria,24.5689
+1990-06-30,AU,Australia,-5.5503
 1990-06-30,BE,Belgium,7.761
-1990-06-30,BG,Bulgaria,
-1990-06-30,BR,Brazil,
 1990-06-30,CA,Canada,-5.2048
-1990-06-30,CH,Switzerland,5.3888
-1990-06-30,CL,Chile,
-1990-06-30,CN,China,
-1990-06-30,CO,Colombia,-5.4893
-1990-06-30,CY,Cyprus,
-1990-06-30,CZ,Czechia,
-1990-06-30,DE,Germany,6.1805
+1990-06-30,CH,Switzerland,5.5421
+1990-06-30,CO,Colombia,-5.5244
+1990-06-30,DE,Germany,6.1726
 1990-06-30,DK,Denmark,-9.5544
-1990-06-30,EE,Estonia,
 1990-06-30,ES,Spain,9.1928
 1990-06-30,FI,Finland,-10.6322
 1990-06-30,FR,France,5.8341
 1990-06-30,GB,United Kingdom,-7.69
-1990-06-30,GR,Greece,
 1990-06-30,HK,Hong Kong SAR,-2.567
-1990-06-30,HR,Croatia,
-1990-06-30,HU,Hungary,
-1990-06-30,ID,Indonesia,
-1990-06-30,IE,Ireland,11.7192
-1990-06-30,IL,Israel,
-1990-06-30,IN,India,
-1990-06-30,IS,Iceland,
-1990-06-30,IT,Italy,11.1987
+1990-06-30,IE,Ireland,11.7019
+1990-06-30,IS,Iceland,-4.3686
+1990-06-30,IT,Italy,11.1962
 1990-06-30,JP,Japan,11.1918
-1990-06-30,KR,Korea,5.6453
-1990-06-30,LT,Lithuania,
-1990-06-30,LU,Luxembourg,
-1990-06-30,LV,Latvia,
-1990-06-30,MA,Morocco,
-1990-06-30,MK,North Macedonia,
-1990-06-30,MT,Malta,
-1990-06-30,MX,Mexico,
+1990-06-30,KR,Korea,5.6582
 1990-06-30,MY,Malaysia,-2.1608
-1990-06-30,NL,Netherlands,2.2455
-1990-06-30,NO,Norway,
+1990-06-30,NL,Netherlands,2.2454
 1990-06-30,NZ,New Zealand,-0.5648
-1990-06-30,PE,Peru,
-1990-06-30,PH,Philippines,
-1990-06-30,PL,Poland,
-1990-06-30,PT,Portugal,
-1990-06-30,RO,Romania,
-1990-06-30,RS,Serbia,
-1990-06-30,RU,Russia,
-1990-06-30,SE,Sweden,2.5102
-1990-06-30,SG,Singapore,
-1990-06-30,SI,Slovenia,
-1990-06-30,SK,Slovak Republic,
-1990-06-30,TH,Thailand,
-1990-06-30,TR,Türkiye,
-1990-06-30,US,United States,-0.4294
-1990-06-30,XM,Euro area,8.2977
-1990-06-30,XW,World,
-1990-06-30,ZA,South Africa,1.2917
-1990-09-30,4T,Emerging market economies (aggregate),
-1990-09-30,5R,Advanced economies,
-1990-09-30,AE,United Arab Emirates,
-1990-09-30,AT,Austria,
-1990-09-30,AU,Australia,-4.9799
+1990-06-30,PT,Portugal,2.6862
+1990-06-30,SE,Sweden,2.503
+1990-06-30,US,United States,-0.3721
+1990-06-30,XM,Euro area,8.3105
+1990-06-30,ZA,South Africa,1.3287
+1990-09-30,AT,Austria,24.419
+1990-09-30,AU,Australia,-4.9743
 1990-09-30,BE,Belgium,6.5439
-1990-09-30,BG,Bulgaria,
-1990-09-30,BR,Brazil,
 1990-09-30,CA,Canada,-6.4789
-1990-09-30,CH,Switzerland,2.6643
-1990-09-30,CL,Chile,
-1990-09-30,CN,China,
-1990-09-30,CO,Colombia,-0.6633
-1990-09-30,CY,Cyprus,
-1990-09-30,CZ,Czechia,
-1990-09-30,DE,Germany,5.662
+1990-09-30,CH,Switzerland,2.7637
+1990-09-30,CO,Colombia,-0.747
+1990-09-30,DE,Germany,5.6665
 1990-09-30,DK,Denmark,-10.2584
-1990-09-30,EE,Estonia,
 1990-09-30,ES,Spain,6.7055
 1990-09-30,FI,Finland,-11.2274
 1990-09-30,FR,France,5.0255
 1990-09-30,GB,United Kingdom,-9.9198
-1990-09-30,GR,Greece,
 1990-09-30,HK,Hong Kong SAR,4.8997
-1990-09-30,HR,Croatia,
-1990-09-30,HU,Hungary,
-1990-09-30,ID,Indonesia,
-1990-09-30,IE,Ireland,10.8288
-1990-09-30,IL,Israel,
-1990-09-30,IN,India,
-1990-09-30,IS,Iceland,
-1990-09-30,IT,Italy,8.8844
+1990-09-30,IE,Ireland,10.7609
+1990-09-30,IS,Iceland,-0.4423
+1990-09-30,IT,Italy,8.8915
 1990-09-30,JP,Japan,12.3466
-1990-09-30,KR,Korea,7.463
-1990-09-30,LT,Lithuania,
-1990-09-30,LU,Luxembourg,
-1990-09-30,LV,Latvia,
-1990-09-30,MA,Morocco,
-1990-09-30,MK,North Macedonia,
-1990-09-30,MT,Malta,
-1990-09-30,MX,Mexico,
+1990-09-30,KR,Korea,7.5355
 1990-09-30,MY,Malaysia,-0.8795
 1990-09-30,NL,Netherlands,-2.4537
-1990-09-30,NO,Norway,
 1990-09-30,NZ,New Zealand,0.206
-1990-09-30,PE,Peru,
-1990-09-30,PH,Philippines,
-1990-09-30,PL,Poland,
-1990-09-30,PT,Portugal,
-1990-09-30,RO,Romania,
-1990-09-30,RS,Serbia,
-1990-09-30,RU,Russia,
-1990-09-30,SE,Sweden,-0.387
-1990-09-30,SG,Singapore,
-1990-09-30,SI,Slovenia,
-1990-09-30,SK,Slovak Republic,
-1990-09-30,TH,Thailand,
-1990-09-30,TR,Türkiye,
-1990-09-30,US,United States,-2.8758
-1990-09-30,XM,Euro area,7.9351
-1990-09-30,XW,World,
-1990-09-30,ZA,South Africa,0.321
-1990-12-31,4T,Emerging market economies (aggregate),
-1990-12-31,5R,Advanced economies,
-1990-12-31,AE,United Arab Emirates,
-1990-12-31,AT,Austria,
-1990-12-31,AU,Australia,-5.4143
+1990-09-30,PT,Portugal,0.0403
+1990-09-30,SE,Sweden,-0.3838
+1990-09-30,US,United States,-2.8319
+1990-09-30,XM,Euro area,7.9472
+1990-09-30,ZA,South Africa,0.3456
+1990-12-31,AT,Austria,23.4282
+1990-12-31,AU,Australia,-5.3911
 1990-12-31,BE,Belgium,3.288
-1990-12-31,BG,Bulgaria,
-1990-12-31,BR,Brazil,
 1990-12-31,CA,Canada,-11.515
-1990-12-31,CH,Switzerland,-4.6944
-1990-12-31,CL,Chile,
-1990-12-31,CN,China,
-1990-12-31,CO,Colombia,-3.3927
-1990-12-31,CY,Cyprus,
-1990-12-31,CZ,Czechia,
-1990-12-31,DE,Germany,4.1426
+1990-12-31,CH,Switzerland,-4.9193
+1990-12-31,CO,Colombia,-3.3694
+1990-12-31,DE,Germany,4.127
 1990-12-31,DK,Denmark,-9.187
-1990-12-31,EE,Estonia,
 1990-12-31,ES,Spain,5.328
 1990-12-31,FI,Finland,-11.6783
 1990-12-31,FR,France,3.9968
 1990-12-31,GB,United Kingdom,-9.8308
-1990-12-31,GR,Greece,
 1990-12-31,HK,Hong Kong SAR,2.6175
-1990-12-31,HR,Croatia,
-1990-12-31,HU,Hungary,
-1990-12-31,ID,Indonesia,
-1990-12-31,IE,Ireland,1.9991
-1990-12-31,IL,Israel,
-1990-12-31,IN,India,
-1990-12-31,IS,Iceland,
-1990-12-31,IT,Italy,8.9683
+1990-12-31,IE,Ireland,2.0727
+1990-12-31,IS,Iceland,2.8161
+1990-12-31,IT,Italy,8.9601
 1990-12-31,JP,Japan,8.4163
-1990-12-31,KR,Korea,10.9204
-1990-12-31,LT,Lithuania,
-1990-12-31,LU,Luxembourg,
-1990-12-31,LV,Latvia,
-1990-12-31,MA,Morocco,
-1990-12-31,MK,North Macedonia,
-1990-12-31,MT,Malta,
-1990-12-31,MX,Mexico,
+1990-12-31,KR,Korea,10.9559
 1990-12-31,MY,Malaysia,7.9558
-1990-12-31,NL,Netherlands,-3.7566
-1990-12-31,NO,Norway,
+1990-12-31,NL,Netherlands,-3.7565
 1990-12-31,NZ,New Zealand,-1.9551
-1990-12-31,PE,Peru,
-1990-12-31,PH,Philippines,
-1990-12-31,PL,Poland,
-1990-12-31,PT,Portugal,
-1990-12-31,RO,Romania,
-1990-12-31,RS,Serbia,
-1990-12-31,RU,Russia,
-1990-12-31,SE,Sweden,-2.413
-1990-12-31,SG,Singapore,
-1990-12-31,SI,Slovenia,
-1990-12-31,SK,Slovak Republic,
-1990-12-31,TH,Thailand,
-1990-12-31,TR,Türkiye,
-1990-12-31,US,United States,-5.1477
-1990-12-31,XM,Euro area,6.4642
-1990-12-31,XW,World,
-1990-12-31,ZA,South Africa,-0.6998
-1991-03-31,4T,Emerging market economies (aggregate),
-1991-03-31,5R,Advanced economies,
-1991-03-31,AE,United Arab Emirates,
-1991-03-31,AT,Austria,
-1991-03-31,AU,Australia,-4.1116
+1990-12-31,PT,Portugal,-0.3153
+1990-12-31,SE,Sweden,-2.4052
+1990-12-31,US,United States,-5.1182
+1990-12-31,XM,Euro area,6.5005
+1990-12-31,ZA,South Africa,-0.6813
+1991-03-31,AT,Austria,25.3145
+1991-03-31,AU,Australia,-4.1488
 1991-03-31,BE,Belgium,0.7372
-1991-03-31,BG,Bulgaria,
-1991-03-31,BR,Brazil,
 1991-03-31,CA,Canada,-6.8712
-1991-03-31,CH,Switzerland,-6.2467
-1991-03-31,CL,Chile,
-1991-03-31,CN,China,
-1991-03-31,CO,Colombia,-11.6535
-1991-03-31,CY,Cyprus,
-1991-03-31,CZ,Czechia,
-1991-03-31,DE,Germany,2.9136
+1991-03-31,CH,Switzerland,-6.4862
+1991-03-31,CO,Colombia,-11.5671
+1991-03-31,DE,Germany,2.7764
 1991-03-31,DK,Denmark,-3.0617
-1991-03-31,EE,Estonia,
 1991-03-31,ES,Spain,4.9536
 1991-03-31,FI,Finland,-15.356
 1991-03-31,FR,France,3.6627
 1991-03-31,GB,United Kingdom,-8.4224
-1991-03-31,GR,Greece,
 1991-03-31,HK,Hong Kong SAR,3.6484
-1991-03-31,HR,Croatia,
-1991-03-31,HU,Hungary,
-1991-03-31,ID,Indonesia,
-1991-03-31,IE,Ireland,0.0567
-1991-03-31,IL,Israel,
-1991-03-31,IN,India,
-1991-03-31,IS,Iceland,
-1991-03-31,IT,Italy,10.5791
+1991-03-31,IE,Ireland,-0.0791
+1991-03-31,IS,Iceland,4.0061
+1991-03-31,IT,Italy,10.5804
 1991-03-31,JP,Japan,5.6799
-1991-03-31,KR,Korea,7.045
-1991-03-31,LT,Lithuania,
-1991-03-31,LU,Luxembourg,
-1991-03-31,LV,Latvia,
-1991-03-31,MA,Morocco,
-1991-03-31,MK,North Macedonia,
-1991-03-31,MT,Malta,
-1991-03-31,MX,Mexico,
+1991-03-31,KR,Korea,7.0741
 1991-03-31,MY,Malaysia,15.1968
-1991-03-31,NL,Netherlands,-2.3285
-1991-03-31,NO,Norway,
+1991-03-31,NL,Netherlands,-2.3284
 1991-03-31,NZ,New Zealand,-5.4237
-1991-03-31,PE,Peru,
-1991-03-31,PH,Philippines,
-1991-03-31,PL,Poland,
-1991-03-31,PT,Portugal,
-1991-03-31,RO,Romania,
-1991-03-31,RS,Serbia,
-1991-03-31,RU,Russia,
-1991-03-31,SE,Sweden,-1.5752
-1991-03-31,SG,Singapore,
-1991-03-31,SI,Slovenia,
-1991-03-31,SK,Slovak Republic,
-1991-03-31,TH,Thailand,
-1991-03-31,TR,Türkiye,
-1991-03-31,US,United States,-6.3189
-1991-03-31,XM,Euro area,5.2168
-1991-03-31,XW,World,
-1991-03-31,ZA,South Africa,-1.6163
-1991-06-30,4T,Emerging market economies (aggregate),
-1991-06-30,5R,Advanced economies,
-1991-06-30,AE,United Arab Emirates,
-1991-06-30,AT,Austria,
-1991-06-30,AU,Australia,-2.454
+1991-03-31,PT,Portugal,4.5639
+1991-03-31,SE,Sweden,-1.5757
+1991-03-31,US,United States,-6.2786
+1991-03-31,XM,Euro area,5.2549
+1991-03-31,ZA,South Africa,-1.5962
+1991-06-30,AT,Austria,18.1025
+1991-06-30,AU,Australia,-2.5286
 1991-06-30,BE,Belgium,-0.0756
-1991-06-30,BG,Bulgaria,
-1991-06-30,BR,Brazil,
 1991-06-30,CA,Canada,3.5763
-1991-06-30,CH,Switzerland,-6.0004
-1991-06-30,CL,Chile,
-1991-06-30,CN,China,
-1991-06-30,CO,Colombia,-2.6164
-1991-06-30,CY,Cyprus,
-1991-06-30,CZ,Czechia,
-1991-06-30,DE,Germany,1.8345
+1991-06-30,CH,Switzerland,-6.1405
+1991-06-30,CO,Colombia,-2.7397
+1991-06-30,DE,Germany,1.861
 1991-06-30,DK,Denmark,-2.5384
-1991-06-30,EE,Estonia,
 1991-06-30,ES,Spain,7.438
 1991-06-30,FI,Finland,-16.5489
 1991-06-30,FR,France,2.8672
 1991-06-30,GB,United Kingdom,-9.1975
-1991-06-30,GR,Greece,
 1991-06-30,HK,Hong Kong SAR,14.5897
-1991-06-30,HR,Croatia,
-1991-06-30,HU,Hungary,
-1991-06-30,ID,Indonesia,
-1991-06-30,IE,Ireland,-2.59
-1991-06-30,IL,Israel,
-1991-06-30,IN,India,
-1991-06-30,IS,Iceland,
-1991-06-30,IT,Italy,9.9773
+1991-06-30,IE,Ireland,-2.5931
+1991-06-30,IS,Iceland,5.8198
+1991-06-30,IT,Italy,9.9821
 1991-06-30,JP,Japan,2.346
-1991-06-30,KR,Korea,4.2078
-1991-06-30,LT,Lithuania,
-1991-06-30,LU,Luxembourg,
-1991-06-30,LV,Latvia,
-1991-06-30,MA,Morocco,
-1991-06-30,MK,North Macedonia,
-1991-06-30,MT,Malta,
-1991-06-30,MX,Mexico,
+1991-06-30,KR,Korea,4.1732
 1991-06-30,MY,Malaysia,23.4974
-1991-06-30,NL,Netherlands,-2.7536
-1991-06-30,NO,Norway,
+1991-06-30,NL,Netherlands,-2.7535
 1991-06-30,NZ,New Zealand,-5.8215
-1991-06-30,PE,Peru,
-1991-06-30,PH,Philippines,
-1991-06-30,PL,Poland,
-1991-06-30,PT,Portugal,
-1991-06-30,RO,Romania,
-1991-06-30,RS,Serbia,
-1991-06-30,RU,Russia,
-1991-06-30,SE,Sweden,-3.0746
-1991-06-30,SG,Singapore,
-1991-06-30,SI,Slovenia,
-1991-06-30,SK,Slovak Republic,
-1991-06-30,TH,Thailand,
-1991-06-30,TR,Türkiye,
-1991-06-30,US,United States,-5.3377
-1991-06-30,XM,Euro area,4.3999
-1991-06-30,XW,World,
-1991-06-30,ZA,South Africa,-2.5023
-1991-09-30,4T,Emerging market economies (aggregate),
-1991-09-30,5R,Advanced economies,
-1991-09-30,AE,United Arab Emirates,
-1991-09-30,AT,Austria,
-1991-09-30,AU,Australia,1.6131
+1991-06-30,PT,Portugal,6.9689
+1991-06-30,SE,Sweden,-3.0723
+1991-06-30,US,United States,-5.3331
+1991-06-30,XM,Euro area,4.4494
+1991-06-30,ZA,South Africa,-2.5228
+1991-09-30,AT,Austria,11.1509
+1991-09-30,AU,Australia,1.5645
 1991-09-30,BE,Belgium,1.2596
-1991-09-30,BG,Bulgaria,
-1991-09-30,BR,Brazil,
 1991-09-30,CA,Canada,-2.4047
-1991-09-30,CH,Switzerland,-1.1146
-1991-09-30,CL,Chile,
-1991-09-30,CN,China,
-1991-09-30,CO,Colombia,-10.0359
-1991-09-30,CY,Cyprus,
-1991-09-30,CZ,Czechia,
-1991-09-30,DE,Germany,0.1909
+1991-09-30,CH,Switzerland,-0.942
+1991-09-30,CO,Colombia,-10.0333
+1991-09-30,DE,Germany,0.2254
 1991-09-30,DK,Denmark,-0.0754
-1991-09-30,EE,Estonia,
 1991-09-30,ES,Spain,7.9813
 1991-09-30,FI,Finland,-18.3094
 1991-09-30,FR,France,1.4897
 1991-09-30,GB,United Kingdom,-8.5643
-1991-09-30,GR,Greece,
 1991-09-30,HK,Hong Kong SAR,30.1426
-1991-09-30,HR,Croatia,
-1991-09-30,HU,Hungary,
-1991-09-30,ID,Indonesia,
-1991-09-30,IE,Ireland,-3.5383
-1991-09-30,IL,Israel,
-1991-09-30,IN,India,
-1991-09-30,IS,Iceland,
-1991-09-30,IT,Italy,8.5585
+1991-09-30,IE,Ireland,-3.5654
+1991-09-30,IS,Iceland,4.4884
+1991-09-30,IT,Italy,8.5558
 1991-09-30,JP,Japan,-0.9574
-1991-09-30,KR,Korea,0.2443
-1991-09-30,LT,Lithuania,
-1991-09-30,LU,Luxembourg,
-1991-09-30,LV,Latvia,
-1991-09-30,MA,Morocco,
-1991-09-30,MK,North Macedonia,
-1991-09-30,MT,Malta,
-1991-09-30,MX,Mexico,
+1991-09-30,KR,Korea,0.2646
 1991-09-30,MY,Malaysia,25.2161
-1991-09-30,NL,Netherlands,-0.1089
-1991-09-30,NO,Norway,
+1991-09-30,NL,Netherlands,-0.109
 1991-09-30,NZ,New Zealand,-4.5943
-1991-09-30,PE,Peru,
-1991-09-30,PH,Philippines,
-1991-09-30,PL,Poland,
-1991-09-30,PT,Portugal,
-1991-09-30,RO,Romania,
-1991-09-30,RS,Serbia,
-1991-09-30,RU,Russia,
-1991-09-30,SE,Sweden,-2.8782
-1991-09-30,SG,Singapore,
-1991-09-30,SI,Slovenia,
-1991-09-30,SK,Slovak Republic,
-1991-09-30,TH,Thailand,
-1991-09-30,TR,Türkiye,
-1991-09-30,US,United States,-4.5566
-1991-09-30,XM,Euro area,3.0748
-1991-09-30,XW,World,
-1991-09-30,ZA,South Africa,-1.4918
-1991-12-31,4T,Emerging market economies (aggregate),
-1991-12-31,5R,Advanced economies,
-1991-12-31,AE,United Arab Emirates,
-1991-12-31,AT,Austria,
-1991-12-31,AU,Australia,2.6075
+1991-09-30,PT,Portugal,6.9853
+1991-09-30,SE,Sweden,-2.8739
+1991-09-30,US,United States,-4.5141
+1991-09-30,XM,Euro area,3.1244
+1991-09-30,ZA,South Africa,-1.4995
+1991-12-31,AT,Austria,13.8052
+1991-12-31,AU,Australia,2.6202
 1991-12-31,BE,Belgium,2.0936
-1991-12-31,BG,Bulgaria,
-1991-12-31,BR,Brazil,
 1991-12-31,CA,Canada,-0.399
-1991-12-31,CH,Switzerland,-0.5658
-1991-12-31,CL,Chile,
-1991-12-31,CN,China,
-1991-12-31,CO,Colombia,-5.6737
-1991-12-31,CY,Cyprus,
-1991-12-31,CZ,Czechia,
-1991-12-31,DE,Germany,-0.2356
+1991-12-31,CH,Switzerland,-0.3535
+1991-12-31,CO,Colombia,-5.7493
+1991-12-31,DE,Germany,-0.1694
 1991-12-31,DK,Denmark,1.4285
-1991-12-31,EE,Estonia,
 1991-12-31,ES,Spain,11.1406
 1991-12-31,FI,Finland,-19.8268
 1991-12-31,FR,France,-0.1854
 1991-12-31,GB,United Kingdom,-7.1614
-1991-12-31,GR,Greece,
 1991-12-31,HK,Hong Kong SAR,40.5524
-1991-12-31,HR,Croatia,
-1991-12-31,HU,Hungary,
-1991-12-31,ID,Indonesia,
-1991-12-31,IE,Ireland,1.9671
-1991-12-31,IL,Israel,
-1991-12-31,IN,India,
-1991-12-31,IS,Iceland,
-1991-12-31,IT,Italy,7.14
+1991-12-31,IE,Ireland,1.9339
+1991-12-31,IS,Iceland,0.406
+1991-12-31,IT,Italy,7.1467
 1991-12-31,JP,Japan,-2.861
-1991-12-31,KR,Korea,-6.8463
-1991-12-31,LT,Lithuania,
-1991-12-31,LU,Luxembourg,
-1991-12-31,LV,Latvia,
-1991-12-31,MA,Morocco,
-1991-12-31,MK,North Macedonia,
-1991-12-31,MT,Malta,
-1991-12-31,MX,Mexico,
+1991-12-31,KR,Korea,-6.8399
 1991-12-31,MY,Malaysia,17.4115
-1991-12-31,NL,Netherlands,2.999
-1991-12-31,NO,Norway,
+1991-12-31,NL,Netherlands,2.9989
 1991-12-31,NZ,New Zealand,-3.4299
-1991-12-31,PE,Peru,
-1991-12-31,PH,Philippines,
-1991-12-31,PL,Poland,
-1991-12-31,PT,Portugal,
-1991-12-31,RO,Romania,
-1991-12-31,RS,Serbia,
-1991-12-31,RU,Russia,
-1991-12-31,SE,Sweden,-1.8541
-1991-12-31,SG,Singapore,
-1991-12-31,SI,Slovenia,
-1991-12-31,SK,Slovak Republic,
-1991-12-31,TH,Thailand,
-1991-12-31,TR,Türkiye,
-1991-12-31,US,United States,-3.5133
-1991-12-31,XM,Euro area,3.6772
-1991-12-31,XW,World,
-1991-12-31,ZA,South Africa,-1.0733
-1992-03-31,4T,Emerging market economies (aggregate),
-1992-03-31,5R,Advanced economies,
-1992-03-31,AE,United Arab Emirates,
-1992-03-31,AT,Austria,
-1992-03-31,AU,Australia,1.8542
+1991-12-31,PT,Portugal,8.5232
+1991-12-31,SE,Sweden,-1.8624
+1991-12-31,US,United States,-3.4968
+1991-12-31,XM,Euro area,3.7157
+1991-12-31,ZA,South Africa,-1.0798
+1992-03-31,AT,Austria,17.7033
+1992-03-31,AU,Australia,1.8405
 1992-03-31,BE,Belgium,3.1289
-1992-03-31,BG,Bulgaria,
-1992-03-31,BR,Brazil,
 1992-03-31,CA,Canada,-1.0235
-1992-03-31,CH,Switzerland,-0.7064
-1992-03-31,CL,Chile,
-1992-03-31,CN,China,
-1992-03-31,CO,Colombia,-2.824
-1992-03-31,CY,Cyprus,
-1992-03-31,CZ,Czechia,
-1992-03-31,DE,Germany,-0.4207
+1992-03-31,CH,Switzerland,-0.4838
+1992-03-31,CO,Colombia,-4.1586
+1992-03-31,DE,Germany,-0.2796
 1992-03-31,DK,Denmark,-1.4751
-1992-03-31,EE,Estonia,
 1992-03-31,ES,Spain,-0.4783
 1992-03-31,FI,Finland,-15.9818
 1992-03-31,FR,France,-2.7625
 1992-03-31,GB,United Kingdom,-7.3656
-1992-03-31,GR,Greece,
 1992-03-31,HK,Hong Kong SAR,45.9339
-1992-03-31,HR,Croatia,
-1992-03-31,HU,Hungary,
-1992-03-31,ID,Indonesia,
-1992-03-31,IE,Ireland,0.3288
-1992-03-31,IL,Israel,
-1992-03-31,IN,India,
-1992-03-31,IS,Iceland,
-1992-03-31,IT,Italy,8.5166
+1992-03-31,IE,Ireland,0.2949
+1992-03-31,IS,Iceland,0.1027
+1992-03-31,IT,Italy,8.5154
 1992-03-31,JP,Japan,-4.2843
-1992-03-31,KR,Korea,-9.5726
-1992-03-31,LT,Lithuania,
-1992-03-31,LU,Luxembourg,
-1992-03-31,LV,Latvia,
-1992-03-31,MA,Morocco,
-1992-03-31,MK,North Macedonia,
-1992-03-31,MT,Malta,
-1992-03-31,MX,Mexico,
+1992-03-31,KR,Korea,-9.5785
 1992-03-31,MY,Malaysia,12.0135
-1992-03-31,NL,Netherlands,5.8931
-1992-03-31,NO,Norway,
+1992-03-31,NL,Netherlands,5.893
 1992-03-31,NZ,New Zealand,-2.0001
-1992-03-31,PE,Peru,
-1992-03-31,PH,Philippines,
-1992-03-31,PL,Poland,
-1992-03-31,PT,Portugal,
-1992-03-31,RO,Romania,
-1992-03-31,RS,Serbia,
-1992-03-31,RU,Russia,
-1992-03-31,SE,Sweden,-8.5968
-1992-03-31,SG,Singapore,
-1992-03-31,SI,Slovenia,
-1992-03-31,SK,Slovak Republic,
-1992-03-31,TH,Thailand,18.2041
-1992-03-31,TR,Türkiye,
-1992-03-31,US,United States,-2.4472
-1992-03-31,XM,Euro area,2.2805
-1992-03-31,XW,World,
-1992-03-31,ZA,South Africa,-3.4162
-1992-06-30,4T,Emerging market economies (aggregate),
-1992-06-30,5R,Advanced economies,
-1992-06-30,AE,United Arab Emirates,
-1992-06-30,AT,Austria,
-1992-06-30,AU,Australia,1.4521
+1992-03-31,PT,Portugal,6.7893
+1992-03-31,SE,Sweden,-8.5938
+1992-03-31,TH,Thailand,18.2108
+1992-03-31,US,United States,-2.4523
+1992-03-31,XM,Euro area,2.3023
+1992-03-31,ZA,South Africa,-3.4585
+1992-06-30,AT,Austria,16.1346
+1992-06-30,AU,Australia,1.4184
 1992-06-30,BE,Belgium,6.926
-1992-06-30,BG,Bulgaria,
-1992-06-30,BR,Brazil,
 1992-06-30,CA,Canada,-3.4728
-1992-06-30,CH,Switzerland,-2.756
-1992-06-30,CL,Chile,
-1992-06-30,CN,China,
-1992-06-30,CO,Colombia,-7.6273
-1992-06-30,CY,Cyprus,
-1992-06-30,CZ,Czechia,
-1992-06-30,DE,Germany,-0.9346
+1992-06-30,CH,Switzerland,-2.6289
+1992-06-30,CO,Colombia,-7.9387
+1992-06-30,DE,Germany,-0.9972
 1992-06-30,DK,Denmark,-2.7273
-1992-06-30,EE,Estonia,
 1992-06-30,ES,Spain,-6.329
 1992-06-30,FI,Finland,-19.139
 1992-06-30,FR,France,-4.9639
 1992-06-30,GB,United Kingdom,-6.9862
-1992-06-30,GR,Greece,
 1992-06-30,HK,Hong Kong SAR,41.8216
-1992-06-30,HR,Croatia,
-1992-06-30,HU,Hungary,
-1992-06-30,ID,Indonesia,
-1992-06-30,IE,Ireland,2.286
-1992-06-30,IL,Israel,
-1992-06-30,IN,India,
-1992-06-30,IS,Iceland,
-1992-06-30,IT,Italy,9.1502
+1992-06-30,IE,Ireland,2.2564
+1992-06-30,IS,Iceland,-2.0209
+1992-06-30,IT,Italy,9.1468
 1992-06-30,JP,Japan,-5.6971
-1992-06-30,KR,Korea,-14.231
-1992-06-30,LT,Lithuania,
-1992-06-30,LU,Luxembourg,
-1992-06-30,LV,Latvia,
-1992-06-30,MA,Morocco,
-1992-06-30,MK,North Macedonia,
-1992-06-30,MT,Malta,
-1992-06-30,MX,Mexico,
+1992-06-30,KR,Korea,-14.2148
 1992-06-30,MY,Malaysia,7.3175
 1992-06-30,NL,Netherlands,0.8645
-1992-06-30,NO,Norway,
 1992-06-30,NZ,New Zealand,0.3033
-1992-06-30,PE,Peru,
-1992-06-30,PH,Philippines,
-1992-06-30,PL,Poland,
-1992-06-30,PT,Portugal,
-1992-06-30,RO,Romania,
-1992-06-30,RS,Serbia,
-1992-06-30,RU,Russia,
-1992-06-30,SE,Sweden,-8.8717
-1992-06-30,SG,Singapore,
-1992-06-30,SI,Slovenia,
-1992-06-30,SK,Slovak Republic,
-1992-06-30,TH,Thailand,7.5952
-1992-06-30,TR,Türkiye,
-1992-06-30,US,United States,-3.5505
-1992-06-30,XM,Euro area,1.1366
-1992-06-30,XW,World,
-1992-06-30,ZA,South Africa,-8.3927
-1992-09-30,4T,Emerging market economies (aggregate),
-1992-09-30,5R,Advanced economies,
-1992-09-30,AE,United Arab Emirates,
-1992-09-30,AT,Austria,
-1992-09-30,AU,Australia,-1.1236
+1992-06-30,PT,Portugal,4.5299
+1992-06-30,SE,Sweden,-8.8709
+1992-06-30,TH,Thailand,7.5894
+1992-06-30,US,United States,-3.5303
+1992-06-30,XM,Euro area,1.135
+1992-06-30,ZA,South Africa,-8.3791
+1992-09-30,AT,Austria,7.5132
+1992-09-30,AU,Australia,-1.0343
 1992-09-30,BE,Belgium,3.8758
-1992-09-30,BG,Bulgaria,
-1992-09-30,BR,Brazil,
 1992-09-30,CA,Canada,2.7026
-1992-09-30,CH,Switzerland,-8.7135
-1992-09-30,CL,Chile,
-1992-09-30,CN,China,
-1992-09-30,CO,Colombia,-4.7387
-1992-09-30,CY,Cyprus,
-1992-09-30,CZ,Czechia,
-1992-09-30,DE,Germany,0.3367
+1992-09-30,CH,Switzerland,-8.9265
+1992-09-30,CO,Colombia,-4.8514
+1992-09-30,DE,Germany,0.3603
 1992-09-30,DK,Denmark,-3.8853
-1992-09-30,EE,Estonia,
 1992-09-30,ES,Spain,-8.0462
 1992-09-30,FI,Finland,-21.3029
 1992-09-30,FR,France,-5.4789
 1992-09-30,GB,United Kingdom,-7.4288
-1992-09-30,GR,Greece,
 1992-09-30,HK,Hong Kong SAR,23.6708
-1992-09-30,HR,Croatia,
-1992-09-30,HU,Hungary,
-1992-09-30,ID,Indonesia,
-1992-09-30,IE,Ireland,1.0291
-1992-09-30,IL,Israel,
-1992-09-30,IN,India,
-1992-09-30,IS,Iceland,
-1992-09-30,IT,Italy,10.1079
+1992-09-30,IE,Ireland,1.0367
+1992-09-30,IS,Iceland,0.4868
+1992-09-30,IT,Italy,10.1095
 1992-09-30,JP,Japan,-6.3291
-1992-09-30,KR,Korea,-13.739
-1992-09-30,LT,Lithuania,
-1992-09-30,LU,Luxembourg,
-1992-09-30,LV,Latvia,
-1992-09-30,MA,Morocco,
-1992-09-30,MK,North Macedonia,
-1992-09-30,MT,Malta,
-1992-09-30,MX,Mexico,
+1992-09-30,KR,Korea,-13.7907
 1992-09-30,MY,Malaysia,5.2371
 1992-09-30,NL,Netherlands,7.618
-1992-09-30,NO,Norway,
 1992-09-30,NZ,New Zealand,0.0978
-1992-09-30,PE,Peru,
-1992-09-30,PH,Philippines,
-1992-09-30,PL,Poland,
-1992-09-30,PT,Portugal,
-1992-09-30,RO,Romania,
-1992-09-30,RS,Serbia,
-1992-09-30,RU,Russia,
-1992-09-30,SE,Sweden,-11.9974
-1992-09-30,SG,Singapore,
-1992-09-30,SI,Slovenia,
-1992-09-30,SK,Slovak Republic,
-1992-09-30,TH,Thailand,6.2325
-1992-09-30,TR,Türkiye,
-1992-09-30,US,United States,-3.3605
-1992-09-30,XM,Euro area,0.8747
-1992-09-30,XW,World,
-1992-09-30,ZA,South Africa,-11.7607
-1992-12-31,4T,Emerging market economies (aggregate),
-1992-12-31,5R,Advanced economies,
-1992-12-31,AE,United Arab Emirates,
-1992-12-31,AT,Austria,
-1992-12-31,AU,Australia,0.3308
+1992-09-30,PT,Portugal,1.3327
+1992-09-30,SE,Sweden,-11.9917
+1992-09-30,TH,Thailand,6.2386
+1992-09-30,US,United States,-3.3528
+1992-09-30,XM,Euro area,0.8734
+1992-09-30,ZA,South Africa,-11.7494
+1992-12-31,AT,Austria,5.6247
+1992-12-31,AU,Australia,0.4003
 1992-12-31,BE,Belgium,2.7223
-1992-12-31,BG,Bulgaria,
-1992-12-31,BR,Brazil,
 1992-12-31,CA,Canada,3.056
-1992-12-31,CH,Switzerland,-6.2543
-1992-12-31,CL,Chile,
-1992-12-31,CN,China,
-1992-12-31,CO,Colombia,-7.5197
-1992-12-31,CY,Cyprus,
-1992-12-31,CZ,Czechia,
-1992-12-31,DE,Germany,1.3901
+1992-12-31,CH,Switzerland,-6.3524
+1992-12-31,CO,Colombia,-7.0962
+1992-12-31,DE,Germany,1.2932
 1992-12-31,DK,Denmark,-6.5018
-1992-12-31,EE,Estonia,
 1992-12-31,ES,Spain,-12.0025
 1992-12-31,FI,Finland,-21.3383
 1992-12-31,FR,France,-5.2835
 1992-12-31,GB,United Kingdom,-9.8391
-1992-12-31,GR,Greece,
 1992-12-31,HK,Hong Kong SAR,6.8285
-1992-12-31,HR,Croatia,
-1992-12-31,HU,Hungary,
-1992-12-31,ID,Indonesia,
-1992-12-31,IE,Ireland,-1.8438
-1992-12-31,IL,Israel,
-1992-12-31,IN,India,
-1992-12-31,IS,Iceland,
-1992-12-31,IT,Italy,8.8929
+1992-12-31,IE,Ireland,-1.9712
+1992-12-31,IS,Iceland,2.0037
+1992-12-31,IT,Italy,8.8938
 1992-12-31,JP,Japan,-5.7063
-1992-12-31,KR,Korea,-10.2858
-1992-12-31,LT,Lithuania,
-1992-12-31,LU,Luxembourg,
-1992-12-31,LV,Latvia,
-1992-12-31,MA,Morocco,
-1992-12-31,MK,North Macedonia,
-1992-12-31,MT,Malta,
-1992-12-31,MX,Mexico,
+1992-12-31,KR,Korea,-10.3028
 1992-12-31,MY,Malaysia,4.2069
 1992-12-31,NL,Netherlands,5.7845
-1992-12-31,NO,Norway,
 1992-12-31,NZ,New Zealand,0.3944
-1992-12-31,PE,Peru,
-1992-12-31,PH,Philippines,
-1992-12-31,PL,Poland,
-1992-12-31,PT,Portugal,
-1992-12-31,RO,Romania,
-1992-12-31,RS,Serbia,
-1992-12-31,RU,Russia,
-1992-12-31,SE,Sweden,-16.7964
-1992-12-31,SG,Singapore,
-1992-12-31,SI,Slovenia,
-1992-12-31,SK,Slovak Republic,
-1992-12-31,TH,Thailand,5.642
-1992-12-31,TR,Türkiye,
-1992-12-31,US,United States,-2.7787
-1992-12-31,XM,Euro area,-0.2112
-1992-12-31,XW,World,
-1992-12-31,ZA,South Africa,-9.4335
-1993-03-31,4T,Emerging market economies (aggregate),
-1993-03-31,5R,Advanced economies,
-1993-03-31,AE,United Arab Emirates,
-1993-03-31,AT,Austria,
-1993-03-31,AU,Australia,1.121
+1992-12-31,PT,Portugal,-1.6636
+1992-12-31,SE,Sweden,-16.7962
+1992-12-31,TH,Thailand,5.646
+1992-12-31,US,United States,-2.7722
+1992-12-31,XM,Euro area,-0.2157
+1992-12-31,ZA,South Africa,-9.4442
+1993-03-31,AT,Austria,-4.0513
+1993-03-31,AU,Australia,1.0876
 1993-03-31,BE,Belgium,1.2731
-1993-03-31,BG,Bulgaria,
-1993-03-31,BR,Brazil,
 1993-03-31,CA,Canada,1.9326
-1993-03-31,CH,Switzerland,-6.0851
-1993-03-31,CL,Chile,
-1993-03-31,CN,China,
-1993-03-31,CO,Colombia,-4.8463
-1993-03-31,CY,Cyprus,
-1993-03-31,CZ,Czechia,
-1993-03-31,DE,Germany,0.008
+1993-03-31,CH,Switzerland,-6.1737
+1993-03-31,CO,Colombia,-3.4862
+1993-03-31,DE,Germany,0.0507
 1993-03-31,DK,Denmark,-6.8623
-1993-03-31,EE,Estonia,
 1993-03-31,ES,Spain,-7.7485
 1993-03-31,FI,Finland,-20.2156
 1993-03-31,FR,France,-4.4414
 1993-03-31,GB,United Kingdom,-7.6128
-1993-03-31,GR,Greece,
 1993-03-31,HK,Hong Kong SAR,-2.0381
-1993-03-31,HR,Croatia,
-1993-03-31,HU,Hungary,
-1993-03-31,ID,Indonesia,
-1993-03-31,IE,Ireland,-4.2161
-1993-03-31,IL,Israel,
-1993-03-31,IN,India,
-1993-03-31,IS,Iceland,
-1993-03-31,IT,Italy,3.7257
+1993-03-31,HU,Hungary,-14.5148
+1993-03-31,IE,Ireland,-4.1592
+1993-03-31,IS,Iceland,-1.8622
+1993-03-31,IT,Italy,3.7228
 1993-03-31,JP,Japan,-6.2022
-1993-03-31,KR,Korea,-8.4796
-1993-03-31,LT,Lithuania,
-1993-03-31,LU,Luxembourg,
-1993-03-31,LV,Latvia,
-1993-03-31,MA,Morocco,
-1993-03-31,MK,North Macedonia,
-1993-03-31,MT,Malta,
-1993-03-31,MX,Mexico,
+1993-03-31,KR,Korea,-8.4922
 1993-03-31,MY,Malaysia,2.6478
 1993-03-31,NL,Netherlands,3.309
-1993-03-31,NO,Norway,-7.723
+1993-03-31,NO,Norway,-7.6845
 1993-03-31,NZ,New Zealand,2.3146
-1993-03-31,PE,Peru,
-1993-03-31,PH,Philippines,
-1993-03-31,PL,Poland,
-1993-03-31,PT,Portugal,
-1993-03-31,RO,Romania,
-1993-03-31,RS,Serbia,
-1993-03-31,RU,Russia,
-1993-03-31,SE,Sweden,-19.0567
-1993-03-31,SG,Singapore,
-1993-03-31,SI,Slovenia,
-1993-03-31,SK,Slovak Republic,
-1993-03-31,TH,Thailand,4.6543
-1993-03-31,TR,Türkiye,
-1993-03-31,US,United States,-2.8558
-1993-03-31,XM,Euro area,-1.2218
-1993-03-31,XW,World,
-1993-03-31,ZA,South Africa,-7.2526
-1993-06-30,4T,Emerging market economies (aggregate),
-1993-06-30,5R,Advanced economies,
-1993-06-30,AE,United Arab Emirates,
-1993-06-30,AT,Austria,
-1993-06-30,AU,Australia,0.8157
+1993-03-31,PT,Portugal,-4.6944
+1993-03-31,SE,Sweden,-19.0533
+1993-03-31,TH,Thailand,4.6605
+1993-03-31,US,United States,-2.8325
+1993-03-31,XM,Euro area,-1.2169
+1993-03-31,ZA,South Africa,-7.2221
+1993-06-30,AT,Austria,-4.69
+1993-06-30,AU,Australia,0.8021
 1993-06-30,BE,Belgium,1.8486
-1993-06-30,BG,Bulgaria,
-1993-06-30,BR,Brazil,
 1993-06-30,CA,Canada,1.4751
-1993-06-30,CH,Switzerland,-3.5109
-1993-06-30,CL,Chile,
-1993-06-30,CN,China,
-1993-06-30,CO,Colombia,-1.3987
-1993-06-30,CY,Cyprus,
-1993-06-30,CZ,Czechia,
-1993-06-30,DE,Germany,-0.2831
+1993-06-30,CH,Switzerland,-3.4636
+1993-06-30,CO,Colombia,-0.9529
+1993-06-30,DE,Germany,-0.3181
 1993-06-30,DK,Denmark,-7.2421
-1993-06-30,EE,Estonia,
 1993-06-30,ES,Spain,-4.5972
 1993-06-30,FI,Finland,-14.9029
 1993-06-30,FR,France,-3.5938
 1993-06-30,GB,United Kingdom,-4.6303
-1993-06-30,GR,Greece,
 1993-06-30,HK,Hong Kong SAR,-3.5156
-1993-06-30,HR,Croatia,
-1993-06-30,HU,Hungary,
-1993-06-30,ID,Indonesia,
-1993-06-30,IE,Ireland,0.667
-1993-06-30,IL,Israel,
-1993-06-30,IN,India,
-1993-06-30,IS,Iceland,
-1993-06-30,IT,Italy,0.4896
+1993-06-30,HU,Hungary,-9.9505
+1993-06-30,IE,Ireland,0.7675
+1993-06-30,IS,Iceland,-1.5008
+1993-06-30,IT,Italy,0.4875
 1993-06-30,JP,Japan,-5.3833
-1993-06-30,KR,Korea,-7.588
-1993-06-30,LT,Lithuania,
-1993-06-30,LU,Luxembourg,
-1993-06-30,LV,Latvia,
-1993-06-30,MA,Morocco,
-1993-06-30,MK,North Macedonia,
-1993-06-30,MT,Malta,
-1993-06-30,MX,Mexico,
+1993-06-30,KR,Korea,-7.536
 1993-06-30,MY,Malaysia,0.868
 1993-06-30,NL,Netherlands,8.1389
-1993-06-30,NO,Norway,-3.3946
+1993-06-30,NO,Norway,-3.4356
 1993-06-30,NZ,New Zealand,1.4361
-1993-06-30,PE,Peru,
-1993-06-30,PH,Philippines,
-1993-06-30,PL,Poland,
-1993-06-30,PT,Portugal,
-1993-06-30,RO,Romania,
-1993-06-30,RS,Serbia,
-1993-06-30,RU,Russia,
-1993-06-30,SE,Sweden,-17.4666
-1993-06-30,SG,Singapore,
-1993-06-30,SI,Slovenia,
-1993-06-30,SK,Slovak Republic,
-1993-06-30,TH,Thailand,8.7379
-1993-06-30,TR,Türkiye,
-1993-06-30,US,United States,-2.147
-1993-06-30,XM,Euro area,-0.9498
-1993-06-30,XW,World,
-1993-06-30,ZA,South Africa,-5.7763
-1993-09-30,4T,Emerging market economies (aggregate),
-1993-09-30,5R,Advanced economies,
-1993-09-30,AE,United Arab Emirates,
-1993-09-30,AT,Austria,
-1993-09-30,AU,Australia,0.497
+1993-06-30,PT,Portugal,-5.3862
+1993-06-30,SE,Sweden,-17.4606
+1993-06-30,TH,Thailand,8.7363
+1993-06-30,US,United States,-2.1195
+1993-06-30,XM,Euro area,-0.9522
+1993-06-30,ZA,South Africa,-5.7813
+1993-09-30,AT,Austria,-2.2473
+1993-09-30,AU,Australia,0.4322
 1993-09-30,BE,Belgium,1.6645
-1993-09-30,BG,Bulgaria,
-1993-09-30,BR,Brazil,
 1993-09-30,CA,Canada,-0.9575
-1993-09-30,CH,Switzerland,-3.568
-1993-09-30,CL,Chile,
-1993-09-30,CN,China,
-1993-09-30,CO,Colombia,3.8865
-1993-09-30,CY,Cyprus,
-1993-09-30,CZ,Czechia,
-1993-09-30,DE,Germany,-0.5643
+1993-09-30,CH,Switzerland,-3.5299
+1993-09-30,CO,Colombia,3.8665
+1993-09-30,DE,Germany,-0.6247
 1993-09-30,DK,Denmark,-1.1723
-1993-09-30,EE,Estonia,
 1993-09-30,ES,Spain,-3.5038
 1993-09-30,FI,Finland,-7.3885
 1993-09-30,FR,France,-3.1124
 1993-09-30,GB,United Kingdom,-3.2724
-1993-09-30,GR,Greece,
 1993-09-30,HK,Hong Kong SAR,1.741
-1993-09-30,HR,Croatia,
-1993-09-30,HU,Hungary,
-1993-09-30,ID,Indonesia,
-1993-09-30,IE,Ireland,1.0489
-1993-09-30,IL,Israel,
-1993-09-30,IN,India,
-1993-09-30,IS,Iceland,
-1993-09-30,IT,Italy,-0.7242
+1993-09-30,HU,Hungary,-13.3885
+1993-09-30,IE,Ireland,1.1323
+1993-09-30,IS,Iceland,-7.2402
+1993-09-30,IT,Italy,-0.7295
 1993-09-30,JP,Japan,-5.8696
-1993-09-30,KR,Korea,-7.1286
-1993-09-30,LT,Lithuania,
-1993-09-30,LU,Luxembourg,
-1993-09-30,LV,Latvia,
-1993-09-30,MA,Morocco,
-1993-09-30,MK,North Macedonia,
-1993-09-30,MT,Malta,
-1993-09-30,MX,Mexico,
+1993-09-30,KR,Korea,-7.095
 1993-09-30,MY,Malaysia,0.5461
 1993-09-30,NL,Netherlands,4.3007
-1993-09-30,NO,Norway,-0.0438
+1993-09-30,NO,Norway,0.0097
 1993-09-30,NZ,New Zealand,2.5496
-1993-09-30,PE,Peru,
-1993-09-30,PH,Philippines,
-1993-09-30,PL,Poland,
-1993-09-30,PT,Portugal,
-1993-09-30,RO,Romania,
-1993-09-30,RS,Serbia,
-1993-09-30,RU,Russia,
-1993-09-30,SE,Sweden,-15.1089
-1993-09-30,SG,Singapore,
-1993-09-30,SI,Slovenia,
-1993-09-30,SK,Slovak Republic,
-1993-09-30,TH,Thailand,8.0989
-1993-09-30,TR,Türkiye,
-1993-09-30,US,United States,-0.9213
-1993-09-30,XM,Euro area,-0.9907
-1993-09-30,XW,World,
-1993-09-30,ZA,South Africa,-1.8665
-1993-12-31,4T,Emerging market economies (aggregate),
-1993-12-31,5R,Advanced economies,
-1993-12-31,AE,United Arab Emirates,
-1993-12-31,AT,Austria,
-1993-12-31,AU,Australia,0.8112
+1993-09-30,PT,Portugal,-5.2283
+1993-09-30,SE,Sweden,-15.1067
+1993-09-30,TH,Thailand,8.0915
+1993-09-30,US,United States,-0.9157
+1993-09-30,XM,Euro area,-0.9932
+1993-09-30,ZA,South Africa,-1.8853
+1993-12-31,AT,Austria,-1.4083
+1993-12-31,AU,Australia,0.677
 1993-12-31,BE,Belgium,5.1342
-1993-12-31,BG,Bulgaria,
-1993-12-31,BR,Brazil,
 1993-12-31,CA,Canada,-1.9265
-1993-12-31,CH,Switzerland,-3.2836
-1993-12-31,CL,Chile,
-1993-12-31,CN,China,
-1993-12-31,CO,Colombia,6.7947
-1993-12-31,CY,Cyprus,
-1993-12-31,CZ,Czechia,
-1993-12-31,DE,Germany,0.0015
+1993-12-31,CH,Switzerland,-3.279
+1993-12-31,CO,Colombia,5.8306
+1993-12-31,DE,Germany,0.0557
 1993-12-31,DK,Denmark,7.0684
-1993-12-31,EE,Estonia,
 1993-12-31,ES,Spain,-3.0484
 1993-12-31,FI,Finland,1.7559
 1993-12-31,FR,France,-2.7183
 1993-12-31,GB,United Kingdom,-0.8863
-1993-12-31,GR,Greece,
 1993-12-31,HK,Hong Kong SAR,5.0628
-1993-12-31,HR,Croatia,
-1993-12-31,HU,Hungary,
-1993-12-31,ID,Indonesia,
-1993-12-31,IE,Ireland,-0.9429
-1993-12-31,IL,Israel,
-1993-12-31,IN,India,
-1993-12-31,IS,Iceland,
-1993-12-31,IT,Italy,-2.6419
+1993-12-31,HU,Hungary,-4.414
+1993-12-31,IE,Ireland,-0.8695
+1993-12-31,IS,Iceland,-7.3031
+1993-12-31,IT,Italy,-2.6421
 1993-12-31,JP,Japan,-4.6279
-1993-12-31,KR,Korea,-8.26
-1993-12-31,LT,Lithuania,
-1993-12-31,LU,Luxembourg,
-1993-12-31,LV,Latvia,
-1993-12-31,MA,Morocco,
-1993-12-31,MK,North Macedonia,
-1993-12-31,MT,Malta,
-1993-12-31,MX,Mexico,
+1993-12-31,KR,Korea,-8.3089
 1993-12-31,MY,Malaysia,0.9759
-1993-12-31,NL,Netherlands,6.4068
-1993-12-31,NO,Norway,6.0035
+1993-12-31,NL,Netherlands,6.4069
+1993-12-31,NO,Norway,6.0482
 1993-12-31,NZ,New Zealand,4.8474
-1993-12-31,PE,Peru,
-1993-12-31,PH,Philippines,
-1993-12-31,PL,Poland,
-1993-12-31,PT,Portugal,
-1993-12-31,RO,Romania,
-1993-12-31,RS,Serbia,
-1993-12-31,RU,Russia,
-1993-12-31,SE,Sweden,-7.8982
-1993-12-31,SG,Singapore,
-1993-12-31,SI,Slovenia,
-1993-12-31,SK,Slovak Republic,
-1993-12-31,TH,Thailand,3.8669
-1993-12-31,TR,Türkiye,
-1993-12-31,US,United States,-0.2991
-1993-12-31,XM,Euro area,-0.8991
-1993-12-31,XW,World,
-1993-12-31,ZA,South Africa,-2.3347
-1994-03-31,4T,Emerging market economies (aggregate),
-1994-03-31,5R,Advanced economies,
-1994-03-31,AE,United Arab Emirates,
-1994-03-31,AT,Austria,
-1994-03-31,AU,Australia,1.3064
+1993-12-31,PT,Portugal,-5.3619
+1993-12-31,SE,Sweden,-7.8866
+1993-12-31,TH,Thailand,3.8657
+1993-12-31,US,United States,-0.2751
+1993-12-31,XM,Euro area,-0.8994
+1993-12-31,ZA,South Africa,-2.3284
+1994-03-31,AT,Austria,2.1132
+1994-03-31,AU,Australia,1.4139
 1994-03-31,BE,Belgium,4.9508
-1994-03-31,BG,Bulgaria,
-1994-03-31,BR,Brazil,
 1994-03-31,CA,Canada,2.8869
-1994-03-31,CH,Switzerland,-0.5533
-1994-03-31,CL,Chile,
-1994-03-31,CN,China,
-1994-03-31,CO,Colombia,8.6584
-1994-03-31,CY,Cyprus,
-1994-03-31,CZ,Czechia,
-1994-03-31,DE,Germany,0.9754
+1994-03-31,CH,Switzerland,-0.4566
+1994-03-31,CO,Colombia,8.9319
+1994-03-31,DE,Germany,0.8836
 1994-03-31,DK,Denmark,14.3217
-1994-03-31,EE,Estonia,
 1994-03-31,ES,Spain,-3.3485
 1994-03-31,FI,Finland,7.0226
 1994-03-31,FR,France,-2.2293
 1994-03-31,GB,United Kingdom,-0.3898
-1994-03-31,GR,Greece,
 1994-03-31,HK,Hong Kong SAR,22.8403
-1994-03-31,HR,Croatia,
-1994-03-31,HU,Hungary,
-1994-03-31,ID,Indonesia,
-1994-03-31,IE,Ireland,5.5004
-1994-03-31,IL,Israel,
-1994-03-31,IN,India,
-1994-03-31,IS,Iceland,
-1994-03-31,IT,Italy,-4.216
+1994-03-31,HU,Hungary,-2.0069
+1994-03-31,IE,Ireland,5.561
+1994-03-31,IS,Iceland,-3.0592
+1994-03-31,IT,Italy,-4.2109
 1994-03-31,JP,Japan,-4.1009
-1994-03-31,KR,Korea,-8.8238
-1994-03-31,LT,Lithuania,
-1994-03-31,LU,Luxembourg,
-1994-03-31,LV,Latvia,
-1994-03-31,MA,Morocco,
-1994-03-31,MK,North Macedonia,
-1994-03-31,MT,Malta,
-1994-03-31,MX,Mexico,
+1994-03-31,KR,Korea,-8.8453
 1994-03-31,MY,Malaysia,2.1977
-1994-03-31,NL,Netherlands,8.1248
-1994-03-31,NO,Norway,14.3089
+1994-03-31,NL,Netherlands,8.1249
+1994-03-31,NO,Norway,14.2623
 1994-03-31,NZ,New Zealand,9.7031
-1994-03-31,PE,Peru,
-1994-03-31,PH,Philippines,
-1994-03-31,PL,Poland,
-1994-03-31,PT,Portugal,
-1994-03-31,RO,Romania,
-1994-03-31,RS,Serbia,
-1994-03-31,RU,Russia,
-1994-03-31,SE,Sweden,0.6352
-1994-03-31,SG,Singapore,
-1994-03-31,SI,Slovenia,
-1994-03-31,SK,Slovak Republic,
-1994-03-31,TH,Thailand,-4.0551
-1994-03-31,TR,Türkiye,
-1994-03-31,US,United States,-0.0714
-1994-03-31,XM,Euro area,-0.508
-1994-03-31,XW,World,
-1994-03-31,ZA,South Africa,-1.4976
-1994-06-30,4T,Emerging market economies (aggregate),
-1994-06-30,5R,Advanced economies,
-1994-06-30,AE,United Arab Emirates,
-1994-06-30,AT,Austria,
-1994-06-30,AU,Australia,1.5228
+1994-03-31,PT,Portugal,-4.0701
+1994-03-31,SE,Sweden,0.6392
+1994-03-31,TH,Thailand,-4.0569
+1994-03-31,US,United States,-0.0698
+1994-03-31,XM,Euro area,-0.531
+1994-03-31,ZA,South Africa,-1.5159
+1994-06-30,AT,Austria,-3.3491
+1994-06-30,AU,Australia,1.5804
 1994-06-30,BE,Belgium,3.4628
-1994-06-30,BG,Bulgaria,
-1994-06-30,BR,Brazil,
 1994-06-30,CA,Canada,2.588
-1994-06-30,CH,Switzerland,-2.7989
-1994-06-30,CL,Chile,
-1994-06-30,CN,China,
-1994-06-30,CO,Colombia,5.697
-1994-06-30,CY,Cyprus,
-1994-06-30,CZ,Czechia,
-1994-06-30,DE,Germany,1.4271
+1994-06-30,CH,Switzerland,-2.8908
+1994-06-30,CO,Colombia,5.5621
+1994-06-30,DE,Germany,1.4018
 1994-06-30,DK,Denmark,14.9983
-1994-06-30,EE,Estonia,
 1994-06-30,ES,Spain,-4.3261
 1994-06-30,FI,Finland,7.8051
 1994-06-30,FR,France,-1.756
 1994-06-30,GB,United Kingdom,0.648
-1994-06-30,GR,Greece,
 1994-06-30,HK,Hong Kong SAR,18.1716
-1994-06-30,HR,Croatia,
-1994-06-30,HU,Hungary,
-1994-06-30,ID,Indonesia,
-1994-06-30,IE,Ireland,0.3114
-1994-06-30,IL,Israel,
-1994-06-30,IN,India,
-1994-06-30,IS,Iceland,
-1994-06-30,IT,Italy,-5.5366
+1994-06-30,HU,Hungary,0.1613
+1994-06-30,IE,Ireland,0.3149
+1994-06-30,IS,Iceland,-2.9848
+1994-06-30,IT,Italy,-5.5396
 1994-06-30,JP,Japan,-3.2646
-1994-06-30,KR,Korea,-7.5935
-1994-06-30,LT,Lithuania,
-1994-06-30,LU,Luxembourg,
-1994-06-30,LV,Latvia,
-1994-06-30,MA,Morocco,
-1994-06-30,MK,North Macedonia,
-1994-06-30,MT,Malta,
-1994-06-30,MX,Mexico,
-1994-06-30,MY,Malaysia,1.7234
+1994-06-30,KR,Korea,-7.637
+1994-06-30,MY,Malaysia,1.7233
 1994-06-30,NL,Netherlands,6.958
-1994-06-30,NO,Norway,12.2739
+1994-06-30,NO,Norway,12.3369
 1994-06-30,NZ,New Zealand,12.5563
-1994-06-30,PE,Peru,
-1994-06-30,PH,Philippines,
-1994-06-30,PL,Poland,
-1994-06-30,PT,Portugal,
-1994-06-30,RO,Romania,
-1994-06-30,RS,Serbia,
-1994-06-30,RU,Russia,
-1994-06-30,SE,Sweden,3.0539
-1994-06-30,SG,Singapore,
-1994-06-30,SI,Slovenia,
-1994-06-30,SK,Slovak Republic,
-1994-06-30,TH,Thailand,-5.9227
-1994-06-30,TR,Türkiye,
-1994-06-30,US,United States,0.1543
-1994-06-30,XM,Euro area,-0.9696
-1994-06-30,XW,World,
-1994-06-30,ZA,South Africa,3.8216
-1994-09-30,4T,Emerging market economies (aggregate),
-1994-09-30,5R,Advanced economies,
-1994-09-30,AE,United Arab Emirates,
-1994-09-30,AT,Austria,
-1994-09-30,AU,Australia,2.8263
+1994-06-30,PT,Portugal,-4.4809
+1994-06-30,SE,Sweden,3.0582
+1994-06-30,TH,Thailand,-5.9171
+1994-06-30,US,United States,0.1481
+1994-06-30,XM,Euro area,-0.9836
+1994-06-30,ZA,South Africa,3.8177
+1994-09-30,AT,Austria,-1.9729
+1994-09-30,AU,Australia,2.8827
 1994-09-30,BE,Belgium,5.2437
-1994-09-30,BG,Bulgaria,
-1994-09-30,BR,Brazil,
 1994-09-30,CA,Canada,3.0873
-1994-09-30,CH,Switzerland,-0.698
-1994-09-30,CL,Chile,
-1994-09-30,CN,China,
-1994-09-30,CO,Colombia,7.2611
-1994-09-30,CY,Cyprus,
-1994-09-30,CZ,Czechia,
-1994-09-30,DE,Germany,1.3835
+1994-09-30,CH,Switzerland,-0.6853
+1994-09-30,CO,Colombia,7.4637
+1994-09-30,DE,Germany,1.4779
 1994-09-30,DK,Denmark,8.074
-1994-09-30,EE,Estonia,
 1994-09-30,ES,Spain,-3.7806
 1994-09-30,FI,Finland,4.6535
 1994-09-30,FR,France,-1.6081
 1994-09-30,GB,United Kingdom,0.6217
-1994-09-30,GR,Greece,
 1994-09-30,HK,Hong Kong SAR,8.3433
-1994-09-30,HR,Croatia,
-1994-09-30,HU,Hungary,
-1994-09-30,ID,Indonesia,
-1994-09-30,IE,Ireland,-2.5099
-1994-09-30,IL,Israel,
-1994-09-30,IN,India,
-1994-09-30,IS,Iceland,
-1994-09-30,IT,Italy,-5.4287
+1994-09-30,HU,Hungary,9.1043
+1994-09-30,IE,Ireland,-2.4971
+1994-09-30,IS,Iceland,-1.2129
+1994-09-30,IT,Italy,-5.4338
 1994-09-30,JP,Japan,-2.0785
-1994-09-30,KR,Korea,-7.3582
-1994-09-30,LT,Lithuania,
-1994-09-30,LU,Luxembourg,
-1994-09-30,LV,Latvia,
-1994-09-30,MA,Morocco,
-1994-09-30,MK,North Macedonia,
-1994-09-30,MT,Malta,
-1994-09-30,MX,Mexico,
+1994-09-30,KR,Korea,-7.3901
 1994-09-30,MY,Malaysia,4.1954
-1994-09-30,NL,Netherlands,8.2721
-1994-09-30,NO,Norway,12.1898
+1994-09-30,NL,Netherlands,8.272
+1994-09-30,NO,Norway,12.0929
 1994-09-30,NZ,New Zealand,13.0022
-1994-09-30,PE,Peru,
-1994-09-30,PH,Philippines,
-1994-09-30,PL,Poland,
-1994-09-30,PT,Portugal,
-1994-09-30,RO,Romania,
-1994-09-30,RS,Serbia,
-1994-09-30,RU,Russia,
-1994-09-30,SE,Sweden,4.1964
-1994-09-30,SG,Singapore,
-1994-09-30,SI,Slovenia,
-1994-09-30,SK,Slovak Republic,
-1994-09-30,TH,Thailand,-6.496
-1994-09-30,TR,Türkiye,
-1994-09-30,US,United States,-0.5625
-1994-09-30,XM,Euro area,-0.9455
-1994-09-30,XW,World,
-1994-09-30,ZA,South Africa,2.5693
-1994-12-31,4T,Emerging market economies (aggregate),
-1994-12-31,5R,Advanced economies,
-1994-12-31,AE,United Arab Emirates,
-1994-12-31,AT,Austria,
-1994-12-31,AU,Australia,0.7739
+1994-09-30,PT,Portugal,-2.4916
+1994-09-30,SE,Sweden,4.1915
+1994-09-30,TH,Thailand,-6.4997
+1994-09-30,US,United States,-0.5532
+1994-09-30,XM,Euro area,-0.9504
+1994-09-30,ZA,South Africa,2.5683
+1994-12-31,AT,Austria,-6.5057
+1994-12-31,AU,Australia,0.8476
 1994-12-31,BE,Belgium,2.1949
-1994-12-31,BG,Bulgaria,
-1994-12-31,BR,Brazil,
 1994-12-31,CA,Canada,3.2482
-1994-12-31,CH,Switzerland,-1.1009
-1994-12-31,CL,Chile,
-1994-12-31,CN,China,
-1994-12-31,CO,Colombia,9.6623
-1994-12-31,CY,Cyprus,
-1994-12-31,CZ,Czechia,
-1994-12-31,DE,Germany,0.6938
+1994-12-31,CH,Switzerland,-1.114
+1994-12-31,CO,Colombia,9.9955
+1994-12-31,DE,Germany,0.7123
 1994-12-31,DK,Denmark,3.5894
-1994-12-31,EE,Estonia,
 1994-12-31,ES,Spain,-3.8792
 1994-12-31,FI,Finland,0.091
 1994-12-31,FR,France,-1.6367
 1994-12-31,GB,United Kingdom,1.7744
-1994-12-31,GR,Greece,
 1994-12-31,HK,Hong Kong SAR,6.3558
-1994-12-31,HR,Croatia,
-1994-12-31,HU,Hungary,
-1994-12-31,ID,Indonesia,
-1994-12-31,IE,Ireland,5.0123
-1994-12-31,IL,Israel,
-1994-12-31,IN,India,
-1994-12-31,IS,Iceland,
-1994-12-31,IT,Italy,-5.1361
+1994-12-31,HU,Hungary,-1.0704
+1994-12-31,IE,Ireland,5.0352
+1994-12-31,IS,Iceland,-0.7558
+1994-12-31,IT,Italy,-5.1396
 1994-12-31,JP,Japan,-2.5828
-1994-12-31,KR,Korea,-5.785
-1994-12-31,LT,Lithuania,
-1994-12-31,LU,Luxembourg,
-1994-12-31,LV,Latvia,
-1994-12-31,MA,Morocco,
-1994-12-31,MK,North Macedonia,
-1994-12-31,MT,Malta,
-1994-12-31,MX,Mexico,
+1994-12-31,KR,Korea,-5.7646
 1994-12-31,MY,Malaysia,8.4039
-1994-12-31,NL,Netherlands,4.8768
-1994-12-31,NO,Norway,8.1168
+1994-12-31,NL,Netherlands,4.8766
+1994-12-31,NO,Norway,8.018
 1994-12-31,NZ,New Zealand,11.4516
-1994-12-31,PE,Peru,
-1994-12-31,PH,Philippines,
-1994-12-31,PL,Poland,
-1994-12-31,PT,Portugal,
-1994-12-31,RO,Romania,
-1994-12-31,RS,Serbia,
-1994-12-31,RU,Russia,
-1994-12-31,SE,Sweden,1.5697
-1994-12-31,SG,Singapore,
-1994-12-31,SI,Slovenia,
-1994-12-31,SK,Slovak Republic,
-1994-12-31,TH,Thailand,-3.5713
-1994-12-31,TR,Türkiye,
-1994-12-31,US,United States,-0.8084
-1994-12-31,XM,Euro area,-1.1098
-1994-12-31,XW,World,
-1994-12-31,ZA,South Africa,1.5594
-1995-03-31,4T,Emerging market economies (aggregate),
-1995-03-31,5R,Advanced economies,
-1995-03-31,AE,United Arab Emirates,
-1995-03-31,AT,Austria,
-1995-03-31,AU,Australia,-0.4345
+1994-12-31,PT,Portugal,-0.8807
+1994-12-31,SE,Sweden,1.5706
+1994-12-31,TH,Thailand,-3.5763
+1994-12-31,US,United States,-0.8109
+1994-12-31,XM,Euro area,-1.1345
+1994-12-31,ZA,South Africa,1.5589
+1995-03-31,AT,Austria,-4.7013
+1995-03-31,AU,Australia,-0.5778
 1995-03-31,BE,Belgium,3.1031
-1995-03-31,BG,Bulgaria,
-1995-03-31,BR,Brazil,
 1995-03-31,CA,Canada,-5.3318
-1995-03-31,CH,Switzerland,-3.1013
-1995-03-31,CL,Chile,
-1995-03-31,CN,China,
-1995-03-31,CO,Colombia,5.9985
-1995-03-31,CY,Cyprus,
-1995-03-31,CZ,Czechia,
-1995-03-31,DE,Germany,0.138
+1995-03-31,CH,Switzerland,-3.1743
+1995-03-31,CO,Colombia,5.2768
+1995-03-31,DE,Germany,0.2015
 1995-03-31,DK,Denmark,0.0303
-1995-03-31,EE,Estonia,
 1995-03-31,ES,Spain,-1.8143
 1995-03-31,FI,Finland,-3.1741
 1995-03-31,FR,France,-2.5095
 1995-03-31,GB,United Kingdom,-0.9153
-1995-03-31,GR,Greece,
 1995-03-31,HK,Hong Kong SAR,-9.7792
-1995-03-31,HR,Croatia,
-1995-03-31,HU,Hungary,
-1995-03-31,ID,Indonesia,
-1995-03-31,IE,Ireland,3.8455
-1995-03-31,IL,Israel,4.0519
-1995-03-31,IN,India,
-1995-03-31,IS,Iceland,
-1995-03-31,IT,Italy,-5.3709
+1995-03-31,HU,Hungary,-5.4572
+1995-03-31,IE,Ireland,3.8603
+1995-03-31,IL,Israel,4.0523
+1995-03-31,IS,Iceland,-5.9706
+1995-03-31,IT,Italy,-5.3957
 1995-03-31,JP,Japan,-1.7259
-1995-03-31,KR,Korea,-4.7722
-1995-03-31,LT,Lithuania,
-1995-03-31,LU,Luxembourg,
-1995-03-31,LV,Latvia,
-1995-03-31,MA,Morocco,
-1995-03-31,MK,North Macedonia,
-1995-03-31,MT,Malta,
-1995-03-31,MX,Mexico,
+1995-03-31,KR,Korea,-4.7646
 1995-03-31,MY,Malaysia,11.5571
-1995-03-31,NL,Netherlands,2.7961
-1995-03-31,NO,Norway,4.5006
+1995-03-31,NL,Netherlands,2.858
+1995-03-31,NO,Norway,4.5553
 1995-03-31,NZ,New Zealand,6.313
-1995-03-31,PE,Peru,
-1995-03-31,PH,Philippines,
-1995-03-31,PL,Poland,
-1995-03-31,PT,Portugal,
-1995-03-31,RO,Romania,
-1995-03-31,RS,Serbia,
-1995-03-31,RU,Russia,
-1995-03-31,SE,Sweden,-0.333
-1995-03-31,SG,Singapore,
-1995-03-31,SI,Slovenia,
-1995-03-31,SK,Slovak Republic,
-1995-03-31,TH,Thailand,1.7104
-1995-03-31,TR,Türkiye,
-1995-03-31,US,United States,-0.9572
-1995-03-31,XM,Euro area,-1.0525
-1995-03-31,XW,World,
-1995-03-31,ZA,South Africa,0.8061
-1995-06-30,4T,Emerging market economies (aggregate),
-1995-06-30,5R,Advanced economies,
-1995-06-30,AE,United Arab Emirates,
-1995-06-30,AT,Austria,
-1995-06-30,AU,Australia,-3.0352
+1995-03-31,PT,Portugal,-2.0657
+1995-03-31,SE,Sweden,-0.3395
+1995-03-31,TH,Thailand,1.7046
+1995-03-31,US,United States,-0.9519
+1995-03-31,XM,Euro area,-1.0667
+1995-03-31,ZA,South Africa,0.8145
+1995-06-30,AT,Austria,-4.6112
+1995-06-30,AU,Australia,-3.0037
 1995-06-30,BE,Belgium,2.5321
-1995-06-30,BG,Bulgaria,
-1995-06-30,BR,Brazil,
 1995-06-30,CA,Canada,-8.0307
-1995-06-30,CH,Switzerland,-2.0424
-1995-06-30,CL,Chile,
-1995-06-30,CN,China,
-1995-06-30,CO,Colombia,10.3031
-1995-06-30,CY,Cyprus,
-1995-06-30,CZ,Czechia,
-1995-06-30,DE,Germany,-0.5336
+1995-06-30,CH,Switzerland,-2.0283
+1995-06-30,CO,Colombia,10.532
+1995-06-30,DE,Germany,-0.5057
 1995-06-30,DK,Denmark,3.6574
-1995-06-30,EE,Estonia,
 1995-06-30,ES,Spain,-1.2467
 1995-06-30,FI,Finland,-5.2763
 1995-06-30,FR,France,-2.5937
 1995-06-30,GB,United Kingdom,-1.0791
-1995-06-30,GR,Greece,
 1995-06-30,HK,Hong Kong SAR,-13.6908
-1995-06-30,HR,Croatia,
-1995-06-30,HU,Hungary,
-1995-06-30,ID,Indonesia,
-1995-06-30,IE,Ireland,3.4583
+1995-06-30,HU,Hungary,-14.7532
+1995-06-30,IE,Ireland,3.4533
 1995-06-30,IL,Israel,2.8616
-1995-06-30,IN,India,
-1995-06-30,IS,Iceland,
-1995-06-30,IT,Italy,-4.4153
+1995-06-30,IS,Iceland,-5.7762
+1995-06-30,IT,Italy,-4.4131
 1995-06-30,JP,Japan,-1.4633
-1995-06-30,KR,Korea,-4.68
-1995-06-30,LT,Lithuania,
-1995-06-30,LU,Luxembourg,
-1995-06-30,LV,Latvia,
-1995-06-30,MA,Morocco,
-1995-06-30,MK,North Macedonia,
-1995-06-30,MT,Malta,
-1995-06-30,MX,Mexico,
+1995-06-30,KR,Korea,-4.6669
 1995-06-30,MY,Malaysia,15.8414
-1995-06-30,NL,Netherlands,2.884
-1995-06-30,NO,Norway,5.644
+1995-06-30,NL,Netherlands,3.1253
+1995-06-30,NO,Norway,5.6064
 1995-06-30,NZ,New Zealand,4.0911
-1995-06-30,PE,Peru,
-1995-06-30,PH,Philippines,
-1995-06-30,PL,Poland,
-1995-06-30,PT,Portugal,
-1995-06-30,RO,Romania,
-1995-06-30,RS,Serbia,
-1995-06-30,RU,Russia,
-1995-06-30,SE,Sweden,-1.6147
-1995-06-30,SG,Singapore,
-1995-06-30,SI,Slovenia,
-1995-06-30,SK,Slovak Republic,
-1995-06-30,TH,Thailand,-0.5329
-1995-06-30,TR,Türkiye,
-1995-06-30,US,United States,-1.152
-1995-06-30,XM,Euro area,-1.1501
-1995-06-30,XW,World,
-1995-06-30,ZA,South Africa,-1.7836
-1995-09-30,4T,Emerging market economies (aggregate),
-1995-09-30,5R,Advanced economies,
-1995-09-30,AE,United Arab Emirates,
-1995-09-30,AT,Austria,
-1995-09-30,AU,Australia,-4.8855
+1995-06-30,PT,Portugal,-2.1627
+1995-06-30,SE,Sweden,-1.6173
+1995-06-30,TH,Thailand,-0.5391
+1995-06-30,US,United States,-1.1317
+1995-06-30,XM,Euro area,-1.1591
+1995-06-30,ZA,South Africa,-1.7819
+1995-09-30,AT,Austria,0.8827
+1995-09-30,AU,Australia,-4.8395
 1995-09-30,BE,Belgium,2.8985
-1995-09-30,BG,Bulgaria,
-1995-09-30,BR,Brazil,
 1995-09-30,CA,Canada,-5.3234
-1995-09-30,CH,Switzerland,-2.0681
-1995-09-30,CL,Chile,
-1995-09-30,CN,China,
-1995-09-30,CO,Colombia,7.0174
-1995-09-30,CY,Cyprus,
-1995-09-30,CZ,Czechia,
-1995-09-30,DE,Germany,-1.379
+1995-09-30,CH,Switzerland,-2.0343
+1995-09-30,CO,Colombia,6.7114
+1995-09-30,DE,Germany,-1.4854
 1995-09-30,DK,Denmark,8.2249
-1995-09-30,EE,Estonia,
 1995-09-30,ES,Spain,-1.127
 1995-09-30,FI,Finland,-5.4004
 1995-09-30,FR,France,-2.7084
 1995-09-30,GB,United Kingdom,-2.2715
-1995-09-30,GR,Greece,
 1995-09-30,HK,Hong Kong SAR,-17.3934
-1995-09-30,HR,Croatia,
-1995-09-30,HU,Hungary,
-1995-09-30,ID,Indonesia,
-1995-09-30,IE,Ireland,6.2175
-1995-09-30,IL,Israel,4.6812
-1995-09-30,IN,India,
-1995-09-30,IS,Iceland,
-1995-09-30,IT,Italy,-4.3514
+1995-09-30,HU,Hungary,-19.5471
+1995-09-30,IE,Ireland,6.2308
+1995-09-30,IL,Israel,4.679
+1995-09-30,IS,Iceland,-3.4215
+1995-09-30,IT,Italy,-4.347
 1995-09-30,JP,Japan,-1.5083
-1995-09-30,KR,Korea,-3.9117
-1995-09-30,LT,Lithuania,
-1995-09-30,LU,Luxembourg,
-1995-09-30,LV,Latvia,
-1995-09-30,MA,Morocco,
-1995-09-30,MK,North Macedonia,
-1995-09-30,MT,Malta,
-1995-09-30,MX,Mexico,
+1995-09-30,KR,Korea,-3.8532
 1995-09-30,MY,Malaysia,16.1984
-1995-09-30,NL,Netherlands,2.5801
-1995-09-30,NO,Norway,3.4759
+1995-09-30,NL,Netherlands,2.3462
+1995-09-30,NO,Norway,3.4334
 1995-09-30,NZ,New Zealand,4.9205
-1995-09-30,PE,Peru,
-1995-09-30,PH,Philippines,
-1995-09-30,PL,Poland,
-1995-09-30,PT,Portugal,
-1995-09-30,RO,Romania,
-1995-09-30,RS,Serbia,
-1995-09-30,RU,Russia,
-1995-09-30,SE,Sweden,-3.3096
-1995-09-30,SG,Singapore,
-1995-09-30,SI,Slovenia,
-1995-09-30,SK,Slovak Republic,
-1995-09-30,TH,Thailand,2.5255
-1995-09-30,TR,Türkiye,
-1995-09-30,US,United States,-0.282
-1995-09-30,XM,Euro area,-0.7468
-1995-09-30,XW,World,
-1995-09-30,ZA,South Africa,-1.4963
-1995-12-31,4T,Emerging market economies (aggregate),
-1995-12-31,5R,Advanced economies,
-1995-12-31,AE,United Arab Emirates,
-1995-12-31,AT,Austria,
-1995-12-31,AU,Australia,-4.5903
+1995-09-30,PT,Portugal,-2.7557
+1995-09-30,SE,Sweden,-3.3095
+1995-09-30,TH,Thailand,2.5296
+1995-09-30,US,United States,-0.2905
+1995-09-30,XM,Euro area,-0.7603
+1995-09-30,ZA,South Africa,-1.5025
+1995-12-31,AT,Austria,-4.148
+1995-12-31,AU,Australia,-4.5441
 1995-12-31,BE,Belgium,3.4884
-1995-12-31,BG,Bulgaria,
-1995-12-31,BR,Brazil,
 1995-12-31,CA,Canada,-6.0351
-1995-12-31,CH,Switzerland,-2.7741
-1995-12-31,CL,Chile,
-1995-12-31,CN,China,
-1995-12-31,CO,Colombia,4.2315
-1995-12-31,CY,Cyprus,
-1995-12-31,CZ,Czechia,
-1995-12-31,DE,Germany,-1.4885
+1995-12-31,CH,Switzerland,-2.7489
+1995-12-31,CO,Colombia,4.4069
+1995-12-31,DE,Germany,-1.4696
 1995-12-31,DK,Denmark,9.7433
-1995-12-31,EE,Estonia,
 1995-12-31,ES,Spain,-0.4768
 1995-12-31,FI,Finland,-4.4027
 1995-12-31,FR,France,-2.8359
 1995-12-31,GB,United Kingdom,-3.2057
-1995-12-31,GR,Greece,
 1995-12-31,HK,Hong Kong SAR,-16.6116
-1995-12-31,HR,Croatia,
-1995-12-31,HU,Hungary,
-1995-12-31,ID,Indonesia,
-1995-12-31,IE,Ireland,4.6362
-1995-12-31,IL,Israel,6.7124
-1995-12-31,IN,India,
-1995-12-31,IS,Iceland,
-1995-12-31,IT,Italy,-2.7786
+1995-12-31,HU,Hungary,-16.5064
+1995-12-31,IE,Ireland,4.5008
+1995-12-31,IL,Israel,6.7122
+1995-12-31,IS,Iceland,-7.6346
+1995-12-31,IT,Italy,-2.7801
 1995-12-31,JP,Japan,-1.0796
-1995-12-31,KR,Korea,-4.4902
-1995-12-31,LT,Lithuania,
-1995-12-31,LU,Luxembourg,
-1995-12-31,LV,Latvia,
-1995-12-31,MA,Morocco,
-1995-12-31,MK,North Macedonia,
-1995-12-31,MT,Malta,
-1995-12-31,MX,Mexico,
+1995-12-31,KR,Korea,-4.4507
 1995-12-31,MY,Malaysia,13.816
-1995-12-31,NL,Netherlands,5.2161
-1995-12-31,NO,Norway,5.4442
+1995-12-31,NL,Netherlands,5.156
+1995-12-31,NO,Norway,5.5332
 1995-12-31,NZ,New Zealand,5.8064
-1995-12-31,PE,Peru,
-1995-12-31,PH,Philippines,
-1995-12-31,PL,Poland,
-1995-12-31,PT,Portugal,
-1995-12-31,RO,Romania,
-1995-12-31,RS,Serbia,
-1995-12-31,RU,Russia,
-1995-12-31,SE,Sweden,-3.2144
-1995-12-31,SG,Singapore,
-1995-12-31,SI,Slovenia,
-1995-12-31,SK,Slovak Republic,
-1995-12-31,TH,Thailand,-1.3522
-1995-12-31,TR,Türkiye,
-1995-12-31,US,United States,-0.2295
-1995-12-31,XM,Euro area,-0.6084
-1995-12-31,XW,World,
-1995-12-31,ZA,South Africa,-1.5408
-1996-03-31,4T,Emerging market economies (aggregate),
-1996-03-31,5R,Advanced economies,
-1996-03-31,AE,United Arab Emirates,
-1996-03-31,AT,Austria,
-1996-03-31,AU,Australia,-4.4789
+1995-12-31,PT,Portugal,-3.3148
+1995-12-31,SE,Sweden,-3.2165
+1995-12-31,TH,Thailand,-1.3476
+1995-12-31,US,United States,-0.2182
+1995-12-31,XM,Euro area,-0.6124
+1995-12-31,ZA,South Africa,-1.544
+1996-03-31,AT,Austria,-0.0167
+1996-03-31,AU,Australia,-4.4624
 1996-03-31,BE,Belgium,-0.0185
-1996-03-31,BG,Bulgaria,
-1996-03-31,BR,Brazil,
 1996-03-31,CA,Canada,-4.0407
-1996-03-31,CH,Switzerland,-3.5526
-1996-03-31,CL,Chile,
-1996-03-31,CN,China,
-1996-03-31,CO,Colombia,4.8476
-1996-03-31,CY,Cyprus,
-1996-03-31,CZ,Czechia,
-1996-03-31,DE,Germany,-2.0156
+1996-03-31,CH,Switzerland,-3.5837
+1996-03-31,CO,Colombia,4.8182
+1996-03-31,DE,Germany,-1.9894
 1996-03-31,DK,Denmark,8.9366
-1996-03-31,EE,Estonia,
 1996-03-31,ES,Spain,-1.0004
 1996-03-31,FI,Finland,-2.2647
-1996-03-31,FR,France,-1.2389
+1996-03-31,FR,France,-1.2398
 1996-03-31,GB,United Kingdom,-0.639
-1996-03-31,GR,Greece,
 1996-03-31,HK,Hong Kong SAR,-8.9728
-1996-03-31,HR,Croatia,
-1996-03-31,HU,Hungary,
-1996-03-31,ID,Indonesia,
-1996-03-31,IE,Ireland,2.8544
-1996-03-31,IL,Israel,7.027
-1996-03-31,IN,India,
-1996-03-31,IS,Iceland,
-1996-03-31,IT,Italy,-0.8057
+1996-03-31,HU,Hungary,-13.6273
+1996-03-31,IE,Ireland,2.7393
+1996-03-31,IL,Israel,7.0268
+1996-03-31,IS,Iceland,-3.9693
+1996-03-31,IT,Italy,-0.8636
 1996-03-31,JP,Japan,-1.4388
-1996-03-31,KR,Korea,-4.2354
-1996-03-31,LT,Lithuania,
-1996-03-31,LU,Luxembourg,
-1996-03-31,LV,Latvia,
-1996-03-31,MA,Morocco,
-1996-03-31,MK,North Macedonia,
-1996-03-31,MT,Malta,
-1996-03-31,MX,Mexico,
-1996-03-31,MY,Malaysia,11.8048
-1996-03-31,NL,Netherlands,6.1247
-1996-03-31,NO,Norway,7.183
+1996-03-31,KR,Korea,-4.2748
+1996-03-31,MY,Malaysia,11.8049
+1996-03-31,NL,Netherlands,5.8755
+1996-03-31,NO,Norway,7.1878
 1996-03-31,NZ,New Zealand,9.3842
-1996-03-31,PE,Peru,
-1996-03-31,PH,Philippines,
-1996-03-31,PL,Poland,
-1996-03-31,PT,Portugal,
-1996-03-31,RO,Romania,
-1996-03-31,RS,Serbia,
-1996-03-31,RU,Russia,
-1996-03-31,SE,Sweden,-1.9594
-1996-03-31,SG,Singapore,
-1996-03-31,SI,Slovenia,
-1996-03-31,SK,Slovak Republic,
-1996-03-31,TH,Thailand,-2.2204
-1996-03-31,TR,Türkiye,
-1996-03-31,US,United States,0.1785
-1996-03-31,XM,Euro area,-0.0746
-1996-03-31,XW,World,
-1996-03-31,ZA,South Africa,-2.2345
-1996-06-30,4T,Emerging market economies (aggregate),
-1996-06-30,5R,Advanced economies,
-1996-06-30,AE,United Arab Emirates,
-1996-06-30,AT,Austria,
-1996-06-30,AU,Australia,-1.968
+1996-03-31,PT,Portugal,-1.7671
+1996-03-31,SE,Sweden,-1.9546
+1996-03-31,TH,Thailand,-2.2134
+1996-03-31,US,United States,0.1949
+1996-03-31,XM,Euro area,-0.0713
+1996-03-31,ZA,South Africa,-2.2435
+1996-06-30,AT,Austria,2.8144
+1996-06-30,AU,Australia,-1.9712
 1996-06-30,BE,Belgium,0.7283
-1996-06-30,BG,Bulgaria,
-1996-06-30,BR,Brazil,
 1996-06-30,CA,Canada,0.5898
-1996-06-30,CH,Switzerland,-3.4221
-1996-06-30,CL,Chile,
-1996-06-30,CN,China,
-1996-06-30,CO,Colombia,0.9928
-1996-06-30,CY,Cyprus,
-1996-06-30,CZ,Czechia,
-1996-06-30,DE,Germany,-2.7651
+1996-06-30,CH,Switzerland,-3.4274
+1996-06-30,CO,Colombia,0.3963
+1996-06-30,DE,Germany,-2.7713
 1996-06-30,DK,Denmark,7.6248
-1996-06-30,EE,Estonia,
 1996-06-30,ES,Spain,-1.4826
 1996-06-30,FI,Finland,2.0867
-1996-06-30,FR,France,-2.2326
+1996-06-30,FR,France,-2.2317
 1996-06-30,GB,United Kingdom,-1.2655
-1996-06-30,GR,Greece,
 1996-06-30,HK,Hong Kong SAR,-3.5004
-1996-06-30,HR,Croatia,
-1996-06-30,HU,Hungary,
-1996-06-30,ID,Indonesia,
-1996-06-30,IE,Ireland,8.9394
-1996-06-30,IL,Israel,7.3699
-1996-06-30,IN,India,
-1996-06-30,IS,Iceland,
-1996-06-30,IT,Italy,-0.6536
+1996-06-30,HU,Hungary,-11.0245
+1996-06-30,IE,Ireland,8.8513
+1996-06-30,IL,Israel,7.3696
+1996-06-30,IS,Iceland,-2.6945
+1996-06-30,IT,Italy,-0.7272
 1996-06-30,JP,Japan,-1.9861
-1996-06-30,KR,Korea,-4.1889
-1996-06-30,LT,Lithuania,
-1996-06-30,LU,Luxembourg,
-1996-06-30,LV,Latvia,
-1996-06-30,MA,Morocco,
-1996-06-30,MK,North Macedonia,
-1996-06-30,MT,Malta,
-1996-06-30,MX,Mexico,
+1996-06-30,KR,Korea,-4.1406
 1996-06-30,MY,Malaysia,10.2603
-1996-06-30,NL,Netherlands,8.3779
-1996-06-30,NO,Norway,7.63
+1996-06-30,NL,Netherlands,7.2196
+1996-06-30,NO,Norway,7.6681
 1996-06-30,NZ,New Zealand,9.3948
-1996-06-30,PE,Peru,
-1996-06-30,PH,Philippines,
-1996-06-30,PL,Poland,
-1996-06-30,PT,Portugal,
-1996-06-30,RO,Romania,
-1996-06-30,RS,Serbia,
-1996-06-30,RU,Russia,
-1996-06-30,SE,Sweden,-1.8493
-1996-06-30,SG,Singapore,
-1996-06-30,SI,Slovenia,
-1996-06-30,SK,Slovak Republic,
-1996-06-30,TH,Thailand,0.4154
-1996-06-30,TR,Türkiye,
-1996-06-30,US,United States,0.1519
-1996-06-30,XM,Euro area,-0.0775
-1996-06-30,XW,World,
-1996-06-30,ZA,South Africa,-2.7668
-1996-09-30,4T,Emerging market economies (aggregate),
-1996-09-30,5R,Advanced economies,
-1996-09-30,AE,United Arab Emirates,
-1996-09-30,AT,Austria,
-1996-09-30,AU,Australia,-0.8781
+1996-06-30,PT,Portugal,-1.3773
+1996-06-30,SE,Sweden,-1.8458
+1996-06-30,TH,Thailand,0.4151
+1996-06-30,US,United States,0.1494
+1996-06-30,XM,Euro area,-0.0865
+1996-06-30,ZA,South Africa,-2.7594
+1996-09-30,AT,Austria,-6.2345
+1996-09-30,AU,Australia,-0.8746
 1996-09-30,BE,Belgium,-0.0263
-1996-09-30,BG,Bulgaria,
-1996-09-30,BR,Brazil,
 1996-09-30,CA,Canada,-1.7015
-1996-09-30,CH,Switzerland,-2.3271
-1996-09-30,CL,Chile,
-1996-09-30,CN,China,
-1996-09-30,CO,Colombia,-3.9061
-1996-09-30,CY,Cyprus,
-1996-09-30,CZ,Czechia,
-1996-09-30,DE,Germany,-2.7276
+1996-09-30,CH,Switzerland,-2.2695
+1996-09-30,CO,Colombia,-3.7077
+1996-09-30,DE,Germany,-2.6849
 1996-09-30,DK,Denmark,7.8145
-1996-09-30,EE,Estonia,
 1996-09-30,ES,Spain,-2.1211
 1996-09-30,FI,Finland,7.6449
-1996-09-30,FR,France,-1.14
+1996-09-30,FR,France,-1.1347
 1996-09-30,GB,United Kingdom,1.7986
-1996-09-30,GR,Greece,
 1996-09-30,HK,Hong Kong SAR,5.83
-1996-09-30,HR,Croatia,
-1996-09-30,HU,Hungary,
-1996-09-30,ID,Indonesia,
-1996-09-30,IE,Ireland,16.0874
-1996-09-30,IL,Israel,1.7409
-1996-09-30,IN,India,
-1996-09-30,IS,Iceland,
-1996-09-30,IT,Italy,0.1334
+1996-09-30,HU,Hungary,-3.0998
+1996-09-30,IE,Ireland,15.9944
+1996-09-30,IL,Israel,1.7412
+1996-09-30,IS,Iceland,-3.4234
+1996-09-30,IT,Italy,0.0512
 1996-09-30,JP,Japan,-2.1192
-1996-09-30,KR,Korea,-4.055
-1996-09-30,LT,Lithuania,
-1996-09-30,LU,Luxembourg,
-1996-09-30,LV,Latvia,
-1996-09-30,MA,Morocco,
-1996-09-30,MK,North Macedonia,
-1996-09-30,MT,Malta,
-1996-09-30,MX,Mexico,
+1996-09-30,KR,Korea,-4.0913
 1996-09-30,MY,Malaysia,8.4157
-1996-09-30,NL,Netherlands,9.0873
-1996-09-30,NO,Norway,7.4874
+1996-09-30,NL,Netherlands,8.0729
+1996-09-30,NO,Norway,7.5116
 1996-09-30,NZ,New Zealand,6.156
-1996-09-30,PE,Peru,
-1996-09-30,PH,Philippines,
-1996-09-30,PL,Poland,
-1996-09-30,PT,Portugal,
-1996-09-30,RO,Romania,
-1996-09-30,RS,Serbia,
-1996-09-30,RU,Russia,
-1996-09-30,SE,Sweden,1.4662
-1996-09-30,SG,Singapore,
-1996-09-30,SI,Slovenia,
-1996-09-30,SK,Slovak Republic,
-1996-09-30,TH,Thailand,-6.3094
-1996-09-30,TR,Türkiye,
-1996-09-30,US,United States,-0.292
-1996-09-30,XM,Euro area,0.1582
-1996-09-30,XW,World,
-1996-09-30,ZA,South Africa,-4.0327
-1996-12-31,4T,Emerging market economies (aggregate),
-1996-12-31,5R,Advanced economies,
-1996-12-31,AE,United Arab Emirates,
-1996-12-31,AT,Austria,
-1996-12-31,AU,Australia,0.166
+1996-09-30,PT,Portugal,-1.5413
+1996-09-30,SE,Sweden,1.4702
+1996-09-30,TH,Thailand,-6.3124
+1996-09-30,US,United States,-0.2721
+1996-09-30,XM,Euro area,0.1303
+1996-09-30,ZA,South Africa,-4.0252
+1996-12-31,AT,Austria,-1.406
+1996-12-31,AU,Australia,0.1533
 1996-12-31,BE,Belgium,-0.2775
-1996-12-31,BG,Bulgaria,
-1996-12-31,BR,Brazil,
 1996-12-31,CA,Canada,-1.8469
-1996-12-31,CH,Switzerland,-3.7965
-1996-12-31,CL,Chile,
-1996-12-31,CN,China,
-1996-12-31,CO,Colombia,-7.4847
-1996-12-31,CY,Cyprus,
-1996-12-31,CZ,Czechia,
-1996-12-31,DE,Germany,-3.2163
+1996-12-31,CH,Switzerland,-3.8189
+1996-12-31,CO,Colombia,-8.0075
+1996-12-31,DE,Germany,-3.279
 1996-12-31,DK,Denmark,8.9984
-1996-12-31,EE,Estonia,
 1996-12-31,ES,Spain,-1.9166
 1996-12-31,FI,Finland,12.1486
-1996-12-31,FR,France,0.2874
+1996-12-31,FR,France,0.2816
 1996-12-31,GB,United Kingdom,4.9112
-1996-12-31,GR,Greece,
 1996-12-31,HK,Hong Kong SAR,18.0081
-1996-12-31,HR,Croatia,
-1996-12-31,HU,Hungary,
-1996-12-31,ID,Indonesia,
-1996-12-31,IE,Ireland,12.2721
-1996-12-31,IL,Israel,1.1619
-1996-12-31,IN,India,
-1996-12-31,IS,Iceland,
-1996-12-31,IT,Italy,0.8028
+1996-12-31,HU,Hungary,0.1157
+1996-12-31,IE,Ireland,12.4812
+1996-12-31,IL,Israel,1.1623
+1996-12-31,IS,Iceland,2.4394
+1996-12-31,IT,Italy,0.726
 1996-12-31,JP,Japan,-2.2584
-1996-12-31,KR,Korea,-3.4537
-1996-12-31,LT,Lithuania,
-1996-12-31,LU,Luxembourg,
-1996-12-31,LV,Latvia,
-1996-12-31,MA,Morocco,
-1996-12-31,MK,North Macedonia,
-1996-12-31,MT,Malta,
-1996-12-31,MX,Mexico,
+1996-12-31,KR,Korea,-3.5316
 1996-12-31,MY,Malaysia,6.217
-1996-12-31,NL,Netherlands,9.7585
-1996-12-31,NO,Norway,8.2067
+1996-12-31,NL,Netherlands,9.2279
+1996-12-31,NO,Norway,8.1443
 1996-12-31,NZ,New Zealand,5.3951
-1996-12-31,PE,Peru,
-1996-12-31,PH,Philippines,
-1996-12-31,PL,Poland,
-1996-12-31,PT,Portugal,
-1996-12-31,RO,Romania,
-1996-12-31,RS,Serbia,
-1996-12-31,RU,Russia,
-1996-12-31,SE,Sweden,3.5692
-1996-12-31,SG,Singapore,
-1996-12-31,SI,Slovenia,
-1996-12-31,SK,Slovak Republic,
-1996-12-31,TH,Thailand,-5.9118
-1996-12-31,TR,Türkiye,
-1996-12-31,US,United States,-0.404
-1996-12-31,XM,Euro area,0.5677
-1996-12-31,XW,World,
-1996-12-31,ZA,South Africa,-4.856
-1997-03-31,4T,Emerging market economies (aggregate),
-1997-03-31,5R,Advanced economies,
-1997-03-31,AE,United Arab Emirates,
-1997-03-31,AT,Austria,
-1997-03-31,AU,Australia,1.3827
+1996-12-31,PT,Portugal,-0.8973
+1996-12-31,SE,Sweden,3.5635
+1996-12-31,TH,Thailand,-5.9209
+1996-12-31,US,United States,-0.4005
+1996-12-31,XM,Euro area,0.5475
+1996-12-31,ZA,South Africa,-4.8487
+1997-03-31,AT,Austria,-2.4752
+1997-03-31,AU,Australia,1.4815
 1997-03-31,BE,Belgium,-1.6521
-1997-03-31,BG,Bulgaria,
-1997-03-31,BR,Brazil,
 1997-03-31,CA,Canada,0.3871
-1997-03-31,CH,Switzerland,-2.5286
-1997-03-31,CL,Chile,
-1997-03-31,CN,China,
-1997-03-31,CO,Colombia,-8.919
-1997-03-31,CY,Cyprus,
-1997-03-31,CZ,Czechia,
-1997-03-31,DE,Germany,-3.4581
+1997-03-31,CH,Switzerland,-2.4926
+1997-03-31,CO,Colombia,-8.9126
+1997-03-31,DE,Germany,-3.4681
 1997-03-31,DK,Denmark,10.3356
-1997-03-31,EE,Estonia,
 1997-03-31,ES,Spain,-1.3544
 1997-03-31,FI,Finland,18.4493
-1997-03-31,FR,France,-3.8375
+1997-03-31,FR,France,-3.8359
 1997-03-31,GB,United Kingdom,5.3745
-1997-03-31,GR,Greece,
 1997-03-31,HK,Hong Kong SAR,32.476
-1997-03-31,HR,Croatia,
-1997-03-31,HU,Hungary,
-1997-03-31,ID,Indonesia,
-1997-03-31,IE,Ireland,12.8119
-1997-03-31,IL,Israel,0.0867
-1997-03-31,IN,India,
-1997-03-31,IS,Iceland,
-1997-03-31,IT,Italy,1.8278
+1997-03-31,HU,Hungary,-1.9987
+1997-03-31,IE,Ireland,12.9192
+1997-03-31,IL,Israel,0.087
+1997-03-31,IS,Iceland,0.3538
+1997-03-31,IT,Italy,1.8249
 1997-03-31,JP,Japan,-2.0922
-1997-03-31,KR,Korea,-1.65
-1997-03-31,LT,Lithuania,
-1997-03-31,LU,Luxembourg,
-1997-03-31,LV,Latvia,
-1997-03-31,MA,Morocco,
-1997-03-31,MK,North Macedonia,
-1997-03-31,MT,Malta,
-1997-03-31,MX,Mexico,
+1997-03-31,KR,Korea,-1.6259
 1997-03-31,MY,Malaysia,4.19
-1997-03-31,NL,Netherlands,10.8296
+1997-03-31,NL,Netherlands,9.7626
 1997-03-31,NO,Norway,7.5831
 1997-03-31,NZ,New Zealand,4.9458
-1997-03-31,PE,Peru,
-1997-03-31,PH,Philippines,
-1997-03-31,PL,Poland,
-1997-03-31,PT,Portugal,
-1997-03-31,RO,Romania,
-1997-03-31,RS,Serbia,
-1997-03-31,RU,Russia,
-1997-03-31,SE,Sweden,4.5888
-1997-03-31,SG,Singapore,
-1997-03-31,SI,Slovenia,
-1997-03-31,SK,Slovak Republic,
-1997-03-31,TH,Thailand,-1.8368
-1997-03-31,TR,Türkiye,
-1997-03-31,US,United States,-0.1907
-1997-03-31,XM,Euro area,-0.398
-1997-03-31,XW,World,
-1997-03-31,ZA,South Africa,-5.387
-1997-06-30,4T,Emerging market economies (aggregate),
-1997-06-30,5R,Advanced economies,
-1997-06-30,AE,United Arab Emirates,
-1997-06-30,AT,Austria,
-1997-06-30,AU,Australia,2.509
+1997-03-31,PT,Portugal,-0.298
+1997-03-31,SE,Sweden,4.5876
+1997-03-31,TH,Thailand,-1.8403
+1997-03-31,US,United States,-0.1981
+1997-03-31,XM,Euro area,-0.406
+1997-03-31,ZA,South Africa,-5.3922
+1997-06-30,AT,Austria,-5.2535
+1997-06-30,AU,Australia,2.4625
 1997-06-30,BE,Belgium,1.0174
-1997-06-30,BG,Bulgaria,
-1997-06-30,BR,Brazil,
 1997-06-30,CA,Canada,1.2527
-1997-06-30,CH,Switzerland,-3.2926
-1997-06-30,CL,Chile,
-1997-06-30,CN,China,
-1997-06-30,CO,Colombia,-8.6444
-1997-06-30,CY,Cyprus,
-1997-06-30,CZ,Czechia,
-1997-06-30,DE,Germany,-3.3351
+1997-06-30,CH,Switzerland,-3.3188
+1997-06-30,CO,Colombia,-8.3457
+1997-06-30,DE,Germany,-3.373
 1997-06-30,DK,Denmark,10.59
-1997-06-30,EE,Estonia,
 1997-06-30,ES,Spain,-0.3421
 1997-06-30,FI,Finland,17.844
-1997-06-30,FR,France,1.5021
+1997-06-30,FR,France,1.5079
 1997-06-30,GB,United Kingdom,7.5163
-1997-06-30,GR,Greece,
 1997-06-30,HK,Hong Kong SAR,39.3098
-1997-06-30,HR,Croatia,
-1997-06-30,HU,Hungary,
-1997-06-30,ID,Indonesia,
-1997-06-30,IE,Ireland,17.05
-1997-06-30,IL,Israel,-0.6072
-1997-06-30,IN,India,
-1997-06-30,IS,Iceland,
-1997-06-30,IT,Italy,2.1419
+1997-06-30,HU,Hungary,0.2905
+1997-06-30,IE,Ireland,17.0176
+1997-06-30,IL,Israel,-0.6073
+1997-06-30,IS,Iceland,0.3639
+1997-06-30,IT,Italy,2.1388
 1997-06-30,JP,Japan,-3.245
-1997-06-30,KR,Korea,-0.6583
-1997-06-30,LT,Lithuania,
-1997-06-30,LU,Luxembourg,
-1997-06-30,LV,Latvia,
-1997-06-30,MA,Morocco,
-1997-06-30,MK,North Macedonia,
-1997-06-30,MT,Malta,
-1997-06-30,MX,Mexico,
+1997-06-30,KR,Korea,-0.7662
 1997-06-30,MY,Malaysia,2.046
-1997-06-30,NL,Netherlands,10.036
-1997-06-30,NO,Norway,10.6177
+1997-06-30,NL,Netherlands,9.8093
+1997-06-30,NO,Norway,10.6125
 1997-06-30,NZ,New Zealand,5.0265
-1997-06-30,PE,Peru,
-1997-06-30,PH,Philippines,
-1997-06-30,PL,Poland,
-1997-06-30,PT,Portugal,
-1997-06-30,RO,Romania,
-1997-06-30,RS,Serbia,
-1997-06-30,RU,Russia,
-1997-06-30,SE,Sweden,6.8617
-1997-06-30,SG,Singapore,
-1997-06-30,SI,Slovenia,
-1997-06-30,SK,Slovak Republic,
-1997-06-30,TH,Thailand,0.8022
-1997-06-30,TR,Türkiye,
-1997-06-30,US,United States,0.6885
-1997-06-30,XM,Euro area,1.1275
-1997-06-30,XW,World,
-1997-06-30,ZA,South Africa,-3.2148
-1997-09-30,4T,Emerging market economies (aggregate),
-1997-09-30,5R,Advanced economies,
-1997-09-30,AE,United Arab Emirates,
-1997-09-30,AT,Austria,
-1997-09-30,AU,Australia,4.7682
+1997-06-30,PT,Portugal,0.7724
+1997-06-30,SE,Sweden,6.856
+1997-06-30,TH,Thailand,0.8031
+1997-06-30,US,United States,0.7005
+1997-06-30,XM,Euro area,1.0964
+1997-06-30,ZA,South Africa,-3.2191
+1997-09-30,AT,Austria,3.8211
+1997-09-30,AU,Australia,4.6365
 1997-09-30,BE,Belgium,1.7956
-1997-09-30,BG,Bulgaria,
-1997-09-30,BR,Brazil,
 1997-09-30,CA,Canada,0.7678
-1997-09-30,CH,Switzerland,-3.1475
-1997-09-30,CL,Chile,
-1997-09-30,CN,China,
-1997-09-30,CO,Colombia,-6.4192
-1997-09-30,CY,Cyprus,
-1997-09-30,CZ,Czechia,
-1997-09-30,DE,Germany,-3.989
+1997-09-30,CH,Switzerland,-3.183
+1997-09-30,CO,Colombia,-6.6566
+1997-09-30,DE,Germany,-4.0221
 1997-09-30,DK,Denmark,9.3985
-1997-09-30,EE,Estonia,
 1997-09-30,ES,Spain,-0.1059
 1997-09-30,FI,Finland,15.3131
-1997-09-30,FR,France,-1.2651
+1997-09-30,FR,France,-1.2707
 1997-09-30,GB,United Kingdom,8.3847
-1997-09-30,GR,Greece,
 1997-09-30,HK,Hong Kong SAR,36.8587
-1997-09-30,HR,Croatia,
-1997-09-30,HU,Hungary,
-1997-09-30,ID,Indonesia,
-1997-09-30,IE,Ireland,13.1613
-1997-09-30,IL,Israel,2.0542
-1997-09-30,IN,India,
-1997-09-30,IS,Iceland,
-1997-09-30,IT,Italy,1.0453
+1997-09-30,HU,Hungary,-5.4605
+1997-09-30,IE,Ireland,13.1771
+1997-09-30,IL,Israel,2.0543
+1997-09-30,IS,Iceland,0.3386
+1997-09-30,IT,Italy,1.0505
 1997-09-30,JP,Japan,-3.2079
-1997-09-30,KR,Korea,-0.7473
-1997-09-30,LT,Lithuania,
-1997-09-30,LU,Luxembourg,
-1997-09-30,LV,Latvia,
-1997-09-30,MA,Morocco,
-1997-09-30,MK,North Macedonia,
-1997-09-30,MT,Malta,
-1997-09-30,MX,Mexico,
+1997-09-30,KR,Korea,-0.7962
 1997-09-30,MY,Malaysia,-1.6946
-1997-09-30,NL,Netherlands,8.9319
-1997-09-30,NO,Norway,9.6455
+1997-09-30,NL,Netherlands,8.9535
+1997-09-30,NO,Norway,9.7267
 1997-09-30,NZ,New Zealand,5.3222
-1997-09-30,PE,Peru,
-1997-09-30,PH,Philippines,
-1997-09-30,PL,Poland,
-1997-09-30,PT,Portugal,
-1997-09-30,RO,Romania,
-1997-09-30,RS,Serbia,
-1997-09-30,RU,Russia,
-1997-09-30,SE,Sweden,6.354
-1997-09-30,SG,Singapore,
-1997-09-30,SI,Slovenia,
-1997-09-30,SK,Slovak Republic,
-1997-09-30,TH,Thailand,3.9203
-1997-09-30,TR,Türkiye,
-1997-09-30,US,United States,1.5016
-1997-09-30,XM,Euro area,0.3775
-1997-09-30,XW,World,
-1997-09-30,ZA,South Africa,1.9165
-1997-12-31,4T,Emerging market economies (aggregate),
-1997-12-31,5R,Advanced economies,
-1997-12-31,AE,United Arab Emirates,
-1997-12-31,AT,Austria,
-1997-12-31,AU,Australia,6.3593
+1997-09-30,PT,Portugal,2.203
+1997-09-30,SE,Sweden,6.3412
+1997-09-30,TH,Thailand,3.9223
+1997-09-30,US,United States,1.511
+1997-09-30,XM,Euro area,0.3633
+1997-09-30,ZA,South Africa,1.9083
+1997-12-31,AT,Austria,1.9642
+1997-12-31,AU,Australia,6.316
 1997-12-31,BE,Belgium,1.8023
-1997-12-31,BG,Bulgaria,
-1997-12-31,BR,Brazil,
 1997-12-31,CA,Canada,0.7395
-1997-12-31,CH,Switzerland,-1.4951
-1997-12-31,CL,Chile,
-1997-12-31,CN,China,
-1997-12-31,CO,Colombia,-2.8953
-1997-12-31,CY,Cyprus,
-1997-12-31,CZ,Czechia,
-1997-12-31,DE,Germany,-3.7087
+1997-12-31,CH,Switzerland,-1.4672
+1997-12-31,CO,Colombia,-2.9824
+1997-12-31,DE,Germany,-3.6272
 1997-12-31,DK,Denmark,6.4906
-1997-12-31,EE,Estonia,
 1997-12-31,ES,Spain,0.2936
 1997-12-31,FI,Finland,13.0884
-1997-12-31,FR,France,-1.146
+1997-12-31,FR,France,-1.143
 1997-12-31,GB,United Kingdom,6.0035
-1997-12-31,GR,Greece,
 1997-12-31,HK,Hong Kong SAR,20.2214
-1997-12-31,HR,Croatia,
-1997-12-31,HU,Hungary,
-1997-12-31,ID,Indonesia,
-1997-12-31,IE,Ireland,19.9714
-1997-12-31,IL,Israel,-0.8439
-1997-12-31,IN,India,
-1997-12-31,IS,Iceland,
-1997-12-31,IT,Italy,0.3388
+1997-12-31,HU,Hungary,-10.1366
+1997-12-31,IE,Ireland,19.8519
+1997-12-31,IL,Israel,-0.845
+1997-12-31,IS,Iceland,-0.0535
+1997-12-31,IT,Italy,0.3375
 1997-12-31,JP,Japan,-3.2658
-1997-12-31,KR,Korea,-2.469
-1997-12-31,LT,Lithuania,
-1997-12-31,LU,Luxembourg,
-1997-12-31,LV,Latvia,
-1997-12-31,MA,Morocco,
-1997-12-31,MK,North Macedonia,
-1997-12-31,MT,Malta,
-1997-12-31,MX,Mexico,
+1997-12-31,KR,Korea,-2.4622
 1997-12-31,MY,Malaysia,-7.0282
-1997-12-31,NL,Netherlands,8.8631
-1997-12-31,NO,Norway,8.6899
+1997-12-31,NL,Netherlands,8.3294
+1997-12-31,NO,Norway,8.7193
 1997-12-31,NZ,New Zealand,3.9962
-1997-12-31,PE,Peru,
-1997-12-31,PH,Philippines,
-1997-12-31,PL,Poland,
-1997-12-31,PT,Portugal,
-1997-12-31,RO,Romania,
-1997-12-31,RS,Serbia,
-1997-12-31,RU,Russia,
-1997-12-31,SE,Sweden,5.8285
-1997-12-31,SG,Singapore,
-1997-12-31,SI,Slovenia,
-1997-12-31,SK,Slovak Republic,
-1997-12-31,TH,Thailand,0.6435
-1997-12-31,TR,Türkiye,
-1997-12-31,US,United States,2.7142
-1997-12-31,XM,Euro area,0.7
-1997-12-31,XW,World,
-1997-12-31,ZA,South Africa,7.8651
-1998-03-31,4T,Emerging market economies (aggregate),
-1998-03-31,5R,Advanced economies,
-1998-03-31,AE,United Arab Emirates,
-1998-03-31,AT,Austria,
-1998-03-31,AU,Australia,7.8794
+1997-12-31,PT,Portugal,2.3468
+1997-12-31,SE,Sweden,5.8338
+1997-12-31,TH,Thailand,0.6528
+1997-12-31,US,United States,2.7198
+1997-12-31,XM,Euro area,0.6641
+1997-12-31,ZA,South Africa,7.8615
+1998-03-31,AT,Austria,-3.6559
+1998-03-31,AU,Australia,7.8807
 1998-03-31,BE,Belgium,7.5818
-1998-03-31,BG,Bulgaria,
-1998-03-31,BR,Brazil,
 1998-03-31,CA,Canada,-1.3581
-1998-03-31,CH,Switzerland,-0.8115
-1998-03-31,CL,Chile,
-1998-03-31,CN,China,
-1998-03-31,CO,Colombia,-1.9375
-1998-03-31,CY,Cyprus,
-1998-03-31,CZ,Czechia,
-1998-03-31,DE,Germany,-2.7888
+1998-03-31,CH,Switzerland,-0.7861
+1998-03-31,CO,Colombia,-1.9613
+1998-03-31,DE,Germany,-2.8714
 1998-03-31,DK,Denmark,5.8981
-1998-03-31,EE,Estonia,
 1998-03-31,ES,Spain,0.5942
 1998-03-31,FI,Finland,8.6926
-1998-03-31,FR,France,1.738
+1998-03-31,FR,France,1.7372
 1998-03-31,GB,United Kingdom,7.4117
-1998-03-31,GR,Greece,
+1998-03-31,GR,Greece,9.5718
 1998-03-31,HK,Hong Kong SAR,-13.0482
-1998-03-31,HR,Croatia,
-1998-03-31,HU,Hungary,
-1998-03-31,ID,Indonesia,
-1998-03-31,IE,Ireland,23.9563
-1998-03-31,IL,Israel,-1.0151
-1998-03-31,IN,India,
-1998-03-31,IS,Iceland,
-1998-03-31,IT,Italy,-2.6435
+1998-03-31,HR,Croatia,4.8986
+1998-03-31,HU,Hungary,-11.8261
+1998-03-31,IE,Ireland,23.9245
+1998-03-31,IL,Israel,-1.0152
+1998-03-31,IS,Iceland,3.8772
+1998-03-31,IT,Italy,-2.6368
 1998-03-31,JP,Japan,-3.17
-1998-03-31,KR,Korea,-10.345
-1998-03-31,LT,Lithuania,
-1998-03-31,LU,Luxembourg,
-1998-03-31,LV,Latvia,
-1998-03-31,MA,Morocco,
-1998-03-31,MK,North Macedonia,
-1998-03-31,MT,Malta,
-1998-03-31,MX,Mexico,
+1998-03-31,KR,Korea,-10.3635
 1998-03-31,MY,Malaysia,-11.2612
-1998-03-31,NL,Netherlands,8.2184
-1998-03-31,NO,Norway,11.5557
+1998-03-31,NL,Netherlands,8.0626
+1998-03-31,NO,Norway,11.5313
 1998-03-31,NZ,New Zealand,-1.0579
-1998-03-31,PE,Peru,
-1998-03-31,PH,Philippines,
-1998-03-31,PL,Poland,
-1998-03-31,PT,Portugal,
-1998-03-31,RO,Romania,
-1998-03-31,RS,Serbia,
-1998-03-31,RU,Russia,
-1998-03-31,SE,Sweden,8.3528
-1998-03-31,SG,Singapore,
-1998-03-31,SI,Slovenia,
-1998-03-31,SK,Slovak Republic,
-1998-03-31,TH,Thailand,-0.7721
-1998-03-31,TR,Türkiye,
-1998-03-31,US,United States,4.338
-1998-03-31,XM,Euro area,1.3064
-1998-03-31,XW,World,
-1998-03-31,ZA,South Africa,11.503
-1998-06-30,4T,Emerging market economies (aggregate),
-1998-06-30,5R,Advanced economies,
-1998-06-30,AE,United Arab Emirates,
-1998-06-30,AT,Austria,
-1998-06-30,AU,Australia,7.8456
+1998-03-31,PT,Portugal,2.1587
+1998-03-31,SE,Sweden,8.3497
+1998-03-31,TH,Thailand,-0.7662
+1998-03-31,US,United States,4.3462
+1998-03-31,XM,Euro area,1.2441
+1998-03-31,ZA,South Africa,11.5137
+1998-06-30,AT,Austria,-5.6225
+1998-06-30,AU,Australia,7.9316
 1998-06-30,BE,Belgium,3.2697
-1998-06-30,BG,Bulgaria,
-1998-06-30,BR,Brazil,
 1998-06-30,CA,Canada,-2.9139
-1998-06-30,CH,Switzerland,-0.986
-1998-06-30,CL,Chile,
-1998-06-30,CN,China,
-1998-06-30,CO,Colombia,-4.5442
-1998-06-30,CY,Cyprus,
-1998-06-30,CZ,Czechia,
-1998-06-30,DE,Germany,-2.3187
+1998-06-30,CH,Switzerland,-0.9885
+1998-06-30,CO,Colombia,-5.098
+1998-06-30,DE,Germany,-2.2861
 1998-06-30,DK,Denmark,7.5266
-1998-06-30,EE,Estonia,
 1998-06-30,ES,Spain,1.8423
 1998-06-30,FI,Finland,7.9536
-1998-06-30,FR,France,-0.978
+1998-06-30,FR,France,-0.9772
 1998-06-30,GB,United Kingdom,10.7412
-1998-06-30,GR,Greece,
+1998-06-30,GR,Greece,10.1974
 1998-06-30,HK,Hong Kong SAR,-28.465
-1998-06-30,HR,Croatia,
-1998-06-30,HU,Hungary,
-1998-06-30,ID,Indonesia,
-1998-06-30,IE,Ireland,19.3894
+1998-06-30,HR,Croatia,3.4984
+1998-06-30,HU,Hungary,-14.0646
+1998-06-30,IE,Ireland,19.3622
 1998-06-30,IL,Israel,-2.1671
-1998-06-30,IN,India,
-1998-06-30,IS,Iceland,
-1998-06-30,IT,Italy,-1.7939
+1998-06-30,IS,Iceland,3.6653
+1998-06-30,IT,Italy,-1.7924
 1998-06-30,JP,Japan,-1.8404
-1998-06-30,KR,Korea,-16.6345
-1998-06-30,LT,Lithuania,
-1998-06-30,LU,Luxembourg,
-1998-06-30,LV,Latvia,
-1998-06-30,MA,Morocco,
-1998-06-30,MK,North Macedonia,
-1998-06-30,MT,Malta,
-1998-06-30,MX,Mexico,
+1998-06-30,KR,Korea,-16.5677
 1998-06-30,MY,Malaysia,-15.5969
-1998-06-30,NL,Netherlands,8.0148
-1998-06-30,NO,Norway,10.5481
+1998-06-30,NL,Netherlands,7.6657
+1998-06-30,NO,Norway,10.5568
 1998-06-30,NZ,New Zealand,-4.0746
-1998-06-30,PE,Peru,
-1998-06-30,PH,Philippines,
-1998-06-30,PL,Poland,
-1998-06-30,PT,Portugal,
-1998-06-30,RO,Romania,
-1998-06-30,RS,Serbia,
-1998-06-30,RU,Russia,
-1998-06-30,SE,Sweden,8.4836
-1998-06-30,SG,Singapore,
-1998-06-30,SI,Slovenia,
-1998-06-30,SK,Slovak Republic,
-1998-06-30,TH,Thailand,-16.7329
-1998-06-30,TR,Türkiye,
-1998-06-30,US,United States,4.5378
-1998-06-30,XM,Euro area,0.6618
-1998-06-30,XW,World,
-1998-06-30,ZA,South Africa,10.8418
-1998-09-30,4T,Emerging market economies (aggregate),
-1998-09-30,5R,Advanced economies,
-1998-09-30,AE,United Arab Emirates,
-1998-09-30,AT,Austria,
-1998-09-30,AU,Australia,5.3036
+1998-06-30,PT,Portugal,1.669
+1998-06-30,SE,Sweden,8.4881
+1998-06-30,TH,Thailand,-16.7339
+1998-06-30,US,United States,4.5347
+1998-06-30,XM,Euro area,0.6268
+1998-06-30,ZA,South Africa,10.8308
+1998-09-30,AT,Austria,-6.895
+1998-09-30,AU,Australia,5.2934
 1998-09-30,BE,Belgium,5.508
-1998-09-30,BG,Bulgaria,
-1998-09-30,BR,Brazil,
 1998-09-30,CA,Canada,-3.0082
-1998-09-30,CH,Switzerland,-1.0067
-1998-09-30,CL,Chile,
-1998-09-30,CN,China,
-1998-09-30,CO,Colombia,-7.129
-1998-09-30,CY,Cyprus,
-1998-09-30,CZ,Czechia,
-1998-09-30,DE,Germany,-1.4683
+1998-09-30,CH,Switzerland,-1.0325
+1998-09-30,CO,Colombia,-6.753
+1998-09-30,DE,Germany,-1.4813
 1998-09-30,DK,Denmark,7.1432
-1998-09-30,EE,Estonia,
 1998-09-30,ES,Spain,3.3841
 1998-09-30,FI,Finland,9.5724
-1998-09-30,FR,France,1.7613
+1998-09-30,FR,France,1.7634
 1998-09-30,GB,United Kingdom,10.4556
-1998-09-30,GR,Greece,
+1998-09-30,GR,Greece,9.2046
 1998-09-30,HK,Hong Kong SAR,-40.5393
-1998-09-30,HR,Croatia,
-1998-09-30,HU,Hungary,
-1998-09-30,ID,Indonesia,
-1998-09-30,IE,Ireland,16.1513
-1998-09-30,IL,Israel,-2.9531
-1998-09-30,IN,India,
-1998-09-30,IS,Iceland,
-1998-09-30,IT,Italy,-1.6398
+1998-09-30,HR,Croatia,-0.0911
+1998-09-30,HU,Hungary,-8.894
+1998-09-30,IE,Ireland,16.1765
+1998-09-30,IL,Israel,-2.9526
+1998-09-30,IS,Iceland,8.7886
+1998-09-30,IT,Italy,-1.6439
 1998-09-30,JP,Japan,-1.5276
-1998-09-30,KR,Korea,-17.6971
-1998-09-30,LT,Lithuania,
-1998-09-30,LU,Luxembourg,
-1998-09-30,LV,Latvia,
-1998-09-30,MA,Morocco,
-1998-09-30,MK,North Macedonia,
-1998-09-30,MT,Malta,
-1998-09-30,MX,Mexico,
+1998-09-30,KR,Korea,-17.6527
 1998-09-30,MY,Malaysia,-16.4192
-1998-09-30,NL,Netherlands,8.8871
-1998-09-30,NO,Norway,8.703
+1998-09-30,NL,Netherlands,8.6199
+1998-09-30,NO,Norway,8.5516
 1998-09-30,NZ,New Zealand,-4.2903
-1998-09-30,PE,Peru,
-1998-09-30,PH,Philippines,
-1998-09-30,PL,Poland,
-1998-09-30,PT,Portugal,
-1998-09-30,RO,Romania,
-1998-09-30,RS,Serbia,
-1998-09-30,RU,Russia,
-1998-09-30,SE,Sweden,10.1417
-1998-09-30,SG,Singapore,
-1998-09-30,SI,Slovenia,
-1998-09-30,SK,Slovak Republic,
-1998-09-30,TH,Thailand,-10.9538
-1998-09-30,TR,Türkiye,
-1998-09-30,US,United States,5.0959
-1998-09-30,XM,Euro area,1.5411
-1998-09-30,XW,World,
-1998-09-30,ZA,South Africa,5.5032
-1998-12-31,4T,Emerging market economies (aggregate),
-1998-12-31,5R,Advanced economies,
-1998-12-31,AE,United Arab Emirates,
-1998-12-31,AT,Austria,
-1998-12-31,AU,Australia,4.862
+1998-09-30,PT,Portugal,1.5224
+1998-09-30,SE,Sweden,10.1494
+1998-09-30,TH,Thailand,-10.9524
+1998-09-30,US,United States,5.0905
+1998-09-30,XM,Euro area,1.5042
+1998-09-30,ZA,South Africa,5.5197
+1998-12-31,AT,Austria,-6.7973
+1998-12-31,AU,Australia,4.8052
 1998-12-31,BE,Belgium,5.1693
-1998-12-31,BG,Bulgaria,
-1998-12-31,BR,Brazil,
 1998-12-31,CA,Canada,-1.7534
-1998-12-31,CH,Switzerland,0.2154
-1998-12-31,CL,Chile,
-1998-12-31,CN,China,
-1998-12-31,CO,Colombia,-10.8684
-1998-12-31,CY,Cyprus,
-1998-12-31,CZ,Czechia,
-1998-12-31,DE,Germany,-0.7497
+1998-12-31,CH,Switzerland,0.2192
+1998-12-31,CO,Colombia,-10.4839
+1998-12-31,DE,Germany,-0.6867
 1998-12-31,DK,Denmark,7.5396
-1998-12-31,EE,Estonia,
 1998-12-31,ES,Spain,5.1895
 1998-12-31,FI,Finland,8.531
-1998-12-31,FR,France,2.1146
+1998-12-31,FR,France,2.1169
 1998-12-31,GB,United Kingdom,10.4859
-1998-12-31,GR,Greece,
+1998-12-31,GR,Greece,7.7479
 1998-12-31,HK,Hong Kong SAR,-38.0108
-1998-12-31,HR,Croatia,
-1998-12-31,HU,Hungary,
-1998-12-31,ID,Indonesia,
-1998-12-31,IE,Ireland,18.6552
-1998-12-31,IL,Israel,-0.2331
-1998-12-31,IN,India,
-1998-12-31,IS,Iceland,
-1998-12-31,IT,Italy,-1.7844
+1998-12-31,HR,Croatia,-3.3228
+1998-12-31,HU,Hungary,-5.0854
+1998-12-31,IE,Ireland,18.7224
+1998-12-31,IL,Israel,-0.2319
+1998-12-31,IS,Iceland,6.6476
+1998-12-31,IT,Italy,-1.7502
 1998-12-31,JP,Japan,-2.7269
-1998-12-31,KR,Korea,-17.6879
-1998-12-31,LT,Lithuania,
-1998-12-31,LU,Luxembourg,
-1998-12-31,LV,Latvia,
-1998-12-31,MA,Morocco,
-1998-12-31,MK,North Macedonia,
-1998-12-31,MT,Malta,
-1998-12-31,MX,Mexico,
+1998-12-31,KR,Korea,-17.7161
 1998-12-31,MY,Malaysia,-12.4527
-1998-12-31,NL,Netherlands,9.7809
-1998-12-31,NO,Norway,4.1346
+1998-12-31,NL,Netherlands,9.21
+1998-12-31,NO,Norway,4.1733
 1998-12-31,NZ,New Zealand,-2.6363
-1998-12-31,PE,Peru,
-1998-12-31,PH,Philippines,
-1998-12-31,PL,Poland,
-1998-12-31,PT,Portugal,
-1998-12-31,RO,Romania,
-1998-12-31,RS,Serbia,
-1998-12-31,RU,Russia,
-1998-12-31,SE,Sweden,12.1926
-1998-12-31,SG,Singapore,
-1998-12-31,SI,Slovenia,
-1998-12-31,SK,Slovak Republic,
-1998-12-31,TH,Thailand,-8.2911
-1998-12-31,TR,Türkiye,
-1998-12-31,US,United States,5.5542
-1998-12-31,XM,Euro area,2.141
-1998-12-31,XW,World,
-1998-12-31,ZA,South Africa,-0.8835
-1999-03-31,4T,Emerging market economies (aggregate),
-1999-03-31,5R,Advanced economies,
-1999-03-31,AE,United Arab Emirates,
-1999-03-31,AT,Austria,
-1999-03-31,AU,Australia,4.4759
+1998-12-31,PT,Portugal,2.0034
+1998-12-31,SE,Sweden,12.192
+1998-12-31,TH,Thailand,-8.2918
+1998-12-31,US,United States,5.5453
+1998-12-31,XM,Euro area,2.1088
+1998-12-31,ZA,South Africa,-0.8705
+1999-03-31,AT,Austria,-4.8985
+1999-03-31,AU,Australia,4.4433
 1999-03-31,BE,Belgium,5.7484
-1999-03-31,BG,Bulgaria,
-1999-03-31,BR,Brazil,
+1999-03-31,BG,Bulgaria,2.6955
 1999-03-31,CA,Canada,0.0039
-1999-03-31,CH,Switzerland,0.5426
-1999-03-31,CL,Chile,
-1999-03-31,CN,China,
-1999-03-31,CO,Colombia,-12.6999
-1999-03-31,CY,Cyprus,
-1999-03-31,CZ,Czechia,
-1999-03-31,DE,Germany,-0.2388
+1999-03-31,CH,Switzerland,0.5559
+1999-03-31,CO,Colombia,-12.7587
+1999-03-31,DE,Germany,-0.1819
 1999-03-31,DK,Denmark,6.8227
-1999-03-31,EE,Estonia,
 1999-03-31,ES,Spain,7.5838
 1999-03-31,FI,Finland,7.145
-1999-03-31,FR,France,4.6099
+1999-03-31,FR,France,4.6078
 1999-03-31,GB,United Kingdom,8.3852
-1999-03-31,GR,Greece,
+1999-03-31,GR,Greece,5.5533
 1999-03-31,HK,Hong Kong SAR,-25.2761
-1999-03-31,HR,Croatia,
-1999-03-31,HU,Hungary,
-1999-03-31,ID,Indonesia,
-1999-03-31,IE,Ireland,19.0759
-1999-03-31,IL,Israel,-0.785
-1999-03-31,IN,India,
-1999-03-31,IS,Iceland,
-1999-03-31,IT,Italy,-0.2888
+1999-03-31,HR,Croatia,-5.741
+1999-03-31,HU,Hungary,3.1953
+1999-03-31,IE,Ireland,19.0612
+1999-03-31,IL,Israel,-0.7847
+1999-03-31,IS,Iceland,9.5369
+1999-03-31,IT,Italy,-0.2954
 1999-03-31,JP,Japan,-2.5747
-1999-03-31,KR,Korea,-9.5655
-1999-03-31,LT,Lithuania,
-1999-03-31,LU,Luxembourg,
-1999-03-31,LV,Latvia,
-1999-03-31,MA,Morocco,
-1999-03-31,MK,North Macedonia,
-1999-03-31,MT,Malta,
-1999-03-31,MX,Mexico,
+1999-03-31,KR,Korea,-9.4297
 1999-03-31,MY,Malaysia,-11.3722
-1999-03-31,NL,Netherlands,11.0352
-1999-03-31,NO,Norway,3.95
+1999-03-31,NL,Netherlands,10.36
+1999-03-31,NO,Norway,3.9398
 1999-03-31,NZ,New Zealand,0.5501
 1999-03-31,PE,Peru,15.4042
-1999-03-31,PH,Philippines,
-1999-03-31,PL,Poland,
-1999-03-31,PT,Portugal,
-1999-03-31,RO,Romania,
-1999-03-31,RS,Serbia,
-1999-03-31,RU,Russia,
-1999-03-31,SE,Sweden,9.2481
-1999-03-31,SG,Singapore,-22.7372
-1999-03-31,SI,Slovenia,
-1999-03-31,SK,Slovak Republic,
-1999-03-31,TH,Thailand,-9.8658
-1999-03-31,TR,Türkiye,
-1999-03-31,US,United States,4.9125
-1999-03-31,XM,Euro area,3.4253
-1999-03-31,XW,World,
-1999-03-31,ZA,South Africa,-3.6454
-1999-06-30,4T,Emerging market economies (aggregate),
-1999-06-30,5R,Advanced economies,
-1999-06-30,AE,United Arab Emirates,
-1999-06-30,AT,Austria,
-1999-06-30,AU,Australia,4.7444
+1999-03-31,PT,Portugal,5.2824
+1999-03-31,SE,Sweden,9.2501
+1999-03-31,SG,Singapore,-22.7373
+1999-03-31,TH,Thailand,-9.8717
+1999-03-31,US,United States,4.9477
+1999-03-31,XM,Euro area,3.4009
+1999-03-31,ZA,South Africa,-3.6484
+1999-06-30,AT,Austria,-0.6922
+1999-06-30,AU,Australia,4.6908
 1999-06-30,BE,Belgium,7.4146
-1999-06-30,BG,Bulgaria,
-1999-06-30,BR,Brazil,
+1999-06-30,BG,Bulgaria,0.3384
 1999-06-30,CA,Canada,2.1804
-1999-06-30,CH,Switzerland,0.8599
-1999-06-30,CL,Chile,
-1999-06-30,CN,China,
-1999-06-30,CO,Colombia,-11.2412
-1999-06-30,CY,Cyprus,
-1999-06-30,CZ,Czechia,
-1999-06-30,DE,Germany,-0.6455
+1999-06-30,CH,Switzerland,0.8798
+1999-06-30,CO,Colombia,-10.739
+1999-06-30,DE,Germany,-0.6355
 1999-06-30,DK,Denmark,3.8503
-1999-06-30,EE,Estonia,
 1999-06-30,ES,Spain,8.3712
 1999-06-30,FI,Finland,6.9277
-1999-06-30,FR,France,4.3625
+1999-06-30,FR,France,4.3593
 1999-06-30,GB,United Kingdom,7.285
-1999-06-30,GR,Greece,
+1999-06-30,GR,Greece,5.9266
 1999-06-30,HK,Hong Kong SAR,-14.5651
-1999-06-30,HR,Croatia,
-1999-06-30,HU,Hungary,
-1999-06-30,ID,Indonesia,
-1999-06-30,IE,Ireland,14.2909
+1999-06-30,HR,Croatia,-2.6122
+1999-06-30,HU,Hungary,12.2549
+1999-06-30,IE,Ireland,14.3533
 1999-06-30,IL,Israel,-0.9135
-1999-06-30,IN,India,
-1999-06-30,IS,Iceland,
-1999-06-30,IT,Italy,-0.7793
+1999-06-30,IS,Iceland,13.5002
+1999-06-30,IT,Italy,-0.7835
 1999-06-30,JP,Japan,-2.7348
-1999-06-30,KR,Korea,-1.8684
-1999-06-30,LT,Lithuania,
-1999-06-30,LU,Luxembourg,
-1999-06-30,LV,Latvia,
-1999-06-30,MA,Morocco,
-1999-06-30,MK,North Macedonia,
-1999-06-30,MT,Malta,
-1999-06-30,MX,Mexico,
+1999-06-30,KR,Korea,-1.932
 1999-06-30,MY,Malaysia,-6.6113
-1999-06-30,NL,Netherlands,12.6648
-1999-06-30,NO,Norway,5.4895
+1999-06-30,NL,Netherlands,12.2018
+1999-06-30,NO,Norway,5.521
 1999-06-30,NZ,New Zealand,3.3855
 1999-06-30,PE,Peru,13.1662
-1999-06-30,PH,Philippines,
-1999-06-30,PL,Poland,
-1999-06-30,PT,Portugal,
-1999-06-30,RO,Romania,
-1999-06-30,RS,Serbia,
-1999-06-30,RU,Russia,
-1999-06-30,SE,Sweden,9.605
-1999-06-30,SG,Singapore,-6.422
-1999-06-30,SI,Slovenia,
-1999-06-30,SK,Slovak Republic,
-1999-06-30,TH,Thailand,-18.3654
-1999-06-30,TR,Türkiye,
-1999-06-30,US,United States,5.1631
-1999-06-30,XM,Euro area,3.4593
-1999-06-30,XW,World,
-1999-06-30,ZA,South Africa,-2.2822
-1999-09-30,4T,Emerging market economies (aggregate),
-1999-09-30,5R,Advanced economies,
-1999-09-30,AE,United Arab Emirates,
-1999-09-30,AT,Austria,
-1999-09-30,AU,Australia,5.9199
+1999-06-30,PT,Portugal,6.0396
+1999-06-30,SE,Sweden,9.5992
+1999-06-30,SG,Singapore,-6.4224
+1999-06-30,TH,Thailand,-18.3664
+1999-06-30,US,United States,5.1569
+1999-06-30,XM,Euro area,3.4447
+1999-06-30,ZA,South Africa,-2.2891
+1999-09-30,AT,Austria,-4.3229
+1999-09-30,AU,Australia,5.9731
 1999-09-30,BE,Belgium,6.4206
-1999-09-30,BG,Bulgaria,
-1999-09-30,BR,Brazil,
+1999-09-30,BG,Bulgaria,-4.6876
 1999-09-30,CA,Canada,2.7534
-1999-09-30,CH,Switzerland,-0.5372
-1999-09-30,CL,Chile,
-1999-09-30,CN,China,
-1999-09-30,CO,Colombia,-11.2674
-1999-09-30,CY,Cyprus,
-1999-09-30,CZ,Czechia,
-1999-09-30,DE,Germany,-0.5114
+1999-09-30,CH,Switzerland,-0.5721
+1999-09-30,CO,Colombia,-12.2281
+1999-09-30,DE,Germany,-0.4825
 1999-09-30,DK,Denmark,3.9297
-1999-09-30,EE,Estonia,
 1999-09-30,ES,Spain,8.9803
 1999-09-30,FI,Finland,7.9066
-1999-09-30,FR,France,6.4233
+1999-09-30,FR,France,6.4226
 1999-09-30,GB,United Kingdom,9.039
-1999-09-30,GR,Greece,
+1999-09-30,GR,Greece,6.7395
 1999-09-30,HK,Hong Kong SAR,2.2931
-1999-09-30,HR,Croatia,
-1999-09-30,HU,Hungary,
-1999-09-30,ID,Indonesia,
-1999-09-30,IE,Ireland,19.9702
-1999-09-30,IL,Israel,0.1636
-1999-09-30,IN,India,
-1999-09-30,IS,Iceland,
-1999-09-30,IT,Italy,-0.7617
+1999-09-30,HR,Croatia,-3.1609
+1999-09-30,HU,Hungary,11.6887
+1999-09-30,IE,Ireland,19.9664
+1999-09-30,IL,Israel,0.1638
+1999-09-30,IS,Iceland,13.4742
+1999-09-30,IT,Italy,-0.7553
 1999-09-30,JP,Japan,-3.3291
-1999-09-30,KR,Korea,1.3592
-1999-09-30,LT,Lithuania,
-1999-09-30,LU,Luxembourg,
-1999-09-30,LV,Latvia,
-1999-09-30,MA,Morocco,
-1999-09-30,MK,North Macedonia,
-1999-09-30,MT,Malta,
-1999-09-30,MX,Mexico,
-1999-09-30,MY,Malaysia,-1.7619
-1999-09-30,NL,Netherlands,14.8336
-1999-09-30,NO,Norway,9.0852
+1999-09-30,KR,Korea,1.413
+1999-09-30,MY,Malaysia,-1.762
+1999-09-30,NL,Netherlands,14.1461
+1999-09-30,NO,Norway,9.1517
 1999-09-30,NZ,New Zealand,3.2125
 1999-09-30,PE,Peru,9.3762
-1999-09-30,PH,Philippines,
-1999-09-30,PL,Poland,
-1999-09-30,PT,Portugal,
-1999-09-30,RO,Romania,
-1999-09-30,RS,Serbia,
-1999-09-30,RU,Russia,
-1999-09-30,SE,Sweden,9.2739
+1999-09-30,PT,Portugal,7.6489
+1999-09-30,SE,Sweden,9.2759
 1999-09-30,SG,Singapore,15.9735
-1999-09-30,SI,Slovenia,
-1999-09-30,SK,Slovak Republic,
-1999-09-30,TH,Thailand,-4.5687
-1999-09-30,TR,Türkiye,
-1999-09-30,US,United States,5.1218
-1999-09-30,XM,Euro area,4.15
-1999-09-30,XW,World,
-1999-09-30,ZA,South Africa,0.2541
-1999-12-31,4T,Emerging market economies (aggregate),
-1999-12-31,5R,Advanced economies,
-1999-12-31,AE,United Arab Emirates,
-1999-12-31,AT,Austria,
-1999-12-31,AU,Australia,7.4755
+1999-09-30,TH,Thailand,-4.5701
+1999-09-30,US,United States,5.1202
+1999-09-30,XM,Euro area,4.1283
+1999-09-30,ZA,South Africa,0.238
+1999-12-31,AT,Austria,-2.1708
+1999-12-31,AU,Australia,7.5725
 1999-12-31,BE,Belgium,4.1405
-1999-12-31,BG,Bulgaria,
-1999-12-31,BR,Brazil,
+1999-12-31,BG,Bulgaria,-4.8032
 1999-12-31,CA,Canada,2.6026
-1999-12-31,CH,Switzerland,-0.8539
-1999-12-31,CL,Chile,
-1999-12-31,CN,China,
-1999-12-31,CO,Colombia,-9.1212
-1999-12-31,CY,Cyprus,
-1999-12-31,CZ,Czechia,
-1999-12-31,DE,Germany,-0.7186
+1999-12-31,CH,Switzerland,-0.8515
+1999-12-31,CO,Colombia,-9.0165
+1999-12-31,DE,Germany,-0.8125
 1999-12-31,DK,Denmark,2.1997
-1999-12-31,EE,Estonia,
 1999-12-31,ES,Spain,6.6226
 1999-12-31,FI,Finland,8.6696
-1999-12-31,FR,France,5.9286
+1999-12-31,FR,France,5.9222
 1999-12-31,GB,United Kingdom,12.7078
-1999-12-31,GR,Greece,
+1999-12-31,GR,Greece,6.1851
 1999-12-31,HK,Hong Kong SAR,-0.7738
-1999-12-31,HR,Croatia,
-1999-12-31,HU,Hungary,
-1999-12-31,ID,Indonesia,
-1999-12-31,IE,Ireland,13.7886
-1999-12-31,IL,Israel,-2.2902
-1999-12-31,IN,India,
-1999-12-31,IS,Iceland,
-1999-12-31,IT,Italy,-0.5552
+1999-12-31,HR,Croatia,-0.7771
+1999-12-31,HU,Hungary,14.3281
+1999-12-31,IE,Ireland,13.7531
+1999-12-31,IL,Israel,-2.2903
+1999-12-31,IS,Iceland,15.9036
+1999-12-31,IT,Italy,-0.5852
 1999-12-31,JP,Japan,-2.4665
-1999-12-31,KR,Korea,2.487
-1999-12-31,LT,Lithuania,-15.1746
-1999-12-31,LU,Luxembourg,
-1999-12-31,LV,Latvia,
-1999-12-31,MA,Morocco,
-1999-12-31,MK,North Macedonia,
-1999-12-31,MT,Malta,
-1999-12-31,MX,Mexico,
+1999-12-31,KR,Korea,2.4614
+1999-12-31,LT,Lithuania,-15.1745
 1999-12-31,MY,Malaysia,0.318
-1999-12-31,NL,Netherlands,16.6094
-1999-12-31,NO,Norway,15.6644
+1999-12-31,NL,Netherlands,16.2167
+1999-12-31,NO,Norway,15.6719
 1999-12-31,NZ,New Zealand,1.7713
 1999-12-31,PE,Peru,8.1672
-1999-12-31,PH,Philippines,
-1999-12-31,PL,Poland,
-1999-12-31,PT,Portugal,
-1999-12-31,RO,Romania,
-1999-12-31,RS,Serbia,
-1999-12-31,RU,Russia,
-1999-12-31,SE,Sweden,7.3826
-1999-12-31,SG,Singapore,33.4377
-1999-12-31,SI,Slovenia,
-1999-12-31,SK,Slovak Republic,
+1999-12-31,PT,Portugal,6.9376
+1999-12-31,SE,Sweden,7.3836
+1999-12-31,SG,Singapore,33.4366
 1999-12-31,TH,Thailand,-7.7586
-1999-12-31,TR,Türkiye,
-1999-12-31,US,United States,5.1055
-1999-12-31,XM,Euro area,3.6086
-1999-12-31,XW,World,
-1999-12-31,ZA,South Africa,4.6789
-2000-03-31,4T,Emerging market economies (aggregate),
-2000-03-31,5R,Advanced economies,
-2000-03-31,AE,United Arab Emirates,
-2000-03-31,AT,Austria,
-2000-03-31,AU,Australia,6.6042
+1999-12-31,US,United States,5.0987
+1999-12-31,XM,Euro area,3.5982
+1999-12-31,ZA,South Africa,4.6667
+2000-03-31,AT,Austria,0.1515
+2000-03-31,AU,Australia,6.6028
 2000-03-31,BE,Belgium,4.8421
-2000-03-31,BG,Bulgaria,
-2000-03-31,BR,Brazil,
+2000-03-31,BG,Bulgaria,-8.5791
 2000-03-31,CA,Canada,2.3021
-2000-03-31,CH,Switzerland,-1.8075
-2000-03-31,CL,Chile,
-2000-03-31,CN,China,
-2000-03-31,CO,Colombia,-7.4066
-2000-03-31,CY,Cyprus,
-2000-03-31,CZ,Czechia,
-2000-03-31,DE,Germany,-0.9306
+2000-03-31,CH,Switzerland,-1.8339
+2000-03-31,CO,Colombia,-8.6828
+2000-03-31,DE,Germany,-0.94
 2000-03-31,DK,Denmark,1.956
-2000-03-31,EE,Estonia,
 2000-03-31,ES,Spain,6.6347
 2000-03-31,FI,Finland,7.53
-2000-03-31,FR,France,8.1185
+2000-03-31,FR,France,8.1218
 2000-03-31,GB,United Kingdom,15.0928
-2000-03-31,GR,Greece,
+2000-03-31,GR,Greece,6.5946
 2000-03-31,HK,Hong Kong SAR,-0.6108
-2000-03-31,HR,Croatia,
-2000-03-31,HU,Hungary,
-2000-03-31,ID,Indonesia,
-2000-03-31,IE,Ireland,8.2097
-2000-03-31,IL,Israel,-5.6519
-2000-03-31,IN,India,
-2000-03-31,IS,Iceland,NaN
-2000-03-31,IT,Italy,0.7749
+2000-03-31,HR,Croatia,1.8677
+2000-03-31,HU,Hungary,21.5084
+2000-03-31,IE,Ireland,8.2809
+2000-03-31,IL,Israel,-5.652
+2000-03-31,IS,Iceland,13.7624
+2000-03-31,IT,Italy,0.7823
 2000-03-31,JP,Japan,-2.9835
-2000-03-31,KR,Korea,0.8586
-2000-03-31,LT,Lithuania,-17.9342
-2000-03-31,LU,Luxembourg,
-2000-03-31,LV,Latvia,
-2000-03-31,MA,Morocco,
-2000-03-31,MK,North Macedonia,
-2000-03-31,MT,Malta,
-2000-03-31,MX,Mexico,
+2000-03-31,KR,Korea,0.7414
+2000-03-31,LT,Lithuania,-17.9343
 2000-03-31,MY,Malaysia,3.1196
-2000-03-31,NL,Netherlands,17.5018
-2000-03-31,NO,Norway,17.7785
+2000-03-31,NL,Netherlands,17.1473
+2000-03-31,NO,Norway,17.7597
 2000-03-31,NZ,New Zealand,-0.6657
 2000-03-31,PE,Peru,-11.7883
-2000-03-31,PH,Philippines,
-2000-03-31,PL,Poland,
-2000-03-31,PT,Portugal,
-2000-03-31,RO,Romania,
-2000-03-31,RS,Serbia,
-2000-03-31,RU,Russia,
-2000-03-31,SE,Sweden,9.298
-2000-03-31,SG,Singapore,29.6942
-2000-03-31,SI,Slovenia,
-2000-03-31,SK,Slovak Republic,
-2000-03-31,TH,Thailand,-7.2779
-2000-03-31,TR,Türkiye,
-2000-03-31,US,United States,5.4703
-2000-03-31,XM,Euro area,4.1113
-2000-03-31,XW,World,
-2000-03-31,ZA,South Africa,19.713
-2000-06-30,4T,Emerging market economies (aggregate),
-2000-06-30,5R,Advanced economies,
-2000-06-30,AE,United Arab Emirates,
-2000-06-30,AT,Austria,
-2000-06-30,AU,Australia,6.3986
+2000-03-31,PT,Portugal,5.394
+2000-03-31,SE,Sweden,9.3008
+2000-03-31,SG,Singapore,29.695
+2000-03-31,TH,Thailand,-7.2738
+2000-03-31,US,United States,5.4162
+2000-03-31,XM,Euro area,4.1084
+2000-03-31,ZA,South Africa,19.7004
+2000-06-30,AT,Austria,-2.2311
+2000-06-30,AU,Australia,6.3512
 2000-06-30,BE,Belgium,2.9863
-2000-06-30,BG,Bulgaria,
-2000-06-30,BR,Brazil,
+2000-06-30,BG,Bulgaria,-11.7801
 2000-06-30,CA,Canada,0.5701
-2000-06-30,CH,Switzerland,-1.9238
-2000-06-30,CL,Chile,
-2000-06-30,CN,China,
-2000-06-30,CO,Colombia,-6.3651
-2000-06-30,CY,Cyprus,
-2000-06-30,CZ,Czechia,
-2000-06-30,DE,Germany,-0.3323
+2000-06-30,CH,Switzerland,-1.9276
+2000-06-30,CO,Colombia,-7.4303
+2000-06-30,DE,Germany,-0.3395
 2000-06-30,DK,Denmark,3.1014
-2000-06-30,EE,Estonia,
 2000-06-30,ES,Spain,5.8183
 2000-06-30,FI,Finland,6.0757
-2000-06-30,FR,France,8.8037
+2000-06-30,FR,France,8.8081
 2000-06-30,GB,United Kingdom,16.6902
-2000-06-30,GR,Greece,
+2000-06-30,GR,Greece,6.9558
 2000-06-30,HK,Hong Kong SAR,-7.9169
-2000-06-30,HR,Croatia,
-2000-06-30,HU,Hungary,
-2000-06-30,ID,Indonesia,
-2000-06-30,IE,Ireland,11.3705
-2000-06-30,IL,Israel,-4.3859
-2000-06-30,IN,India,
-2000-06-30,IS,Iceland,NaN
-2000-06-30,IT,Italy,0.8469
+2000-06-30,HR,Croatia,-3.1717
+2000-06-30,HU,Hungary,23.9316
+2000-06-30,IE,Ireland,11.3498
+2000-06-30,IL,Israel,-4.3856
+2000-06-30,IS,Iceland,12.5554
+2000-06-30,IT,Italy,0.8593
 2000-06-30,JP,Japan,-3.0505
-2000-06-30,KR,Korea,0.8325
+2000-06-30,KR,Korea,0.8846
 2000-06-30,LT,Lithuania,-10.122
-2000-06-30,LU,Luxembourg,
-2000-06-30,LV,Latvia,
-2000-06-30,MA,Morocco,
-2000-06-30,MK,North Macedonia,
-2000-06-30,MT,Malta,
-2000-06-30,MX,Mexico,
 2000-06-30,MY,Malaysia,5.7511
-2000-06-30,NL,Netherlands,16.8258
-2000-06-30,NO,Norway,16.2082
+2000-06-30,NL,Netherlands,16.2378
+2000-06-30,NO,Norway,16.1691
 2000-06-30,NZ,New Zealand,-2.1757
 2000-06-30,PE,Peru,-3.1316
-2000-06-30,PH,Philippines,
-2000-06-30,PL,Poland,
-2000-06-30,PT,Portugal,
-2000-06-30,RO,Romania,
-2000-06-30,RS,Serbia,
-2000-06-30,RU,Russia,
-2000-06-30,SE,Sweden,10.1201
-2000-06-30,SG,Singapore,18.1505
-2000-06-30,SI,Slovenia,
-2000-06-30,SK,Slovak Republic,
-2000-06-30,TH,Thailand,20.185
-2000-06-30,TR,Türkiye,
-2000-06-30,US,United States,5.9365
-2000-06-30,XM,Euro area,4.3036
-2000-06-30,XW,World,
-2000-06-30,ZA,South Africa,13.8617
-2000-09-30,4T,Emerging market economies (aggregate),
-2000-09-30,5R,Advanced economies,
-2000-09-30,AE,United Arab Emirates,
-2000-09-30,AT,Austria,
-2000-09-30,AU,Australia,1.3314
+2000-06-30,PT,Portugal,5.4478
+2000-06-30,SE,Sweden,10.1247
+2000-06-30,SG,Singapore,18.1511
+2000-06-30,TH,Thailand,20.1926
+2000-06-30,US,United States,5.9382
+2000-06-30,XM,Euro area,4.2915
+2000-06-30,ZA,South Africa,13.8775
+2000-09-30,AT,Austria,-3.9616
+2000-09-30,AU,Australia,1.4263
 2000-09-30,BE,Belgium,0.2351
-2000-09-30,BG,Bulgaria,
-2000-09-30,BR,Brazil,
+2000-09-30,BG,Bulgaria,-7.6074
 2000-09-30,CA,Canada,0.9739
-2000-09-30,CH,Switzerland,-1.0003
-2000-09-30,CL,Chile,
-2000-09-30,CN,China,
-2000-09-30,CO,Colombia,-6.9056
-2000-09-30,CY,Cyprus,
-2000-09-30,CZ,Czechia,
-2000-09-30,DE,Germany,-0.6995
+2000-09-30,CH,Switzerland,-0.9851
+2000-09-30,CO,Colombia,-6.776
+2000-09-30,DE,Germany,-0.7092
 2000-09-30,DK,Denmark,3.9958
-2000-09-30,EE,Estonia,
 2000-09-30,ES,Spain,3.9625
 2000-09-30,FI,Finland,-0.0456
-2000-09-30,FR,France,7.1686
+2000-09-30,FR,France,7.1752
 2000-09-30,GB,United Kingdom,12.2003
-2000-09-30,GR,Greece,
+2000-09-30,GR,Greece,7.6229
 2000-09-30,HK,Hong Kong SAR,-9.8285
-2000-09-30,HR,Croatia,
-2000-09-30,HU,Hungary,
-2000-09-30,ID,Indonesia,
-2000-09-30,IE,Ireland,5.3104
-2000-09-30,IL,Israel,-6.667
-2000-09-30,IN,India,
-2000-09-30,IS,Iceland,NaN
-2000-09-30,IT,Italy,1.589
+2000-09-30,HR,Croatia,-9.8569
+2000-09-30,HU,Hungary,23.1722
+2000-09-30,IE,Ireland,5.3564
+2000-09-30,IL,Israel,-6.6674
+2000-09-30,IS,Iceland,9.0836
+2000-09-30,IT,Italy,1.5841
 2000-09-30,JP,Japan,-3.2729
-2000-09-30,KR,Korea,-1.4748
+2000-09-30,KR,Korea,-1.5804
 2000-09-30,LT,Lithuania,-9.7927
-2000-09-30,LU,Luxembourg,
-2000-09-30,LV,Latvia,
-2000-09-30,MA,Morocco,
-2000-09-30,MK,North Macedonia,
-2000-09-30,MT,Malta,
-2000-09-30,MX,Mexico,
 2000-09-30,MY,Malaysia,4.7245
-2000-09-30,NL,Netherlands,15.3671
-2000-09-30,NO,Norway,10.0739
+2000-09-30,NL,Netherlands,14.7816
+2000-09-30,NO,Norway,10.0379
 2000-09-30,NZ,New Zealand,-3.7252
 2000-09-30,PE,Peru,-6.477
-2000-09-30,PH,Philippines,
-2000-09-30,PL,Poland,
-2000-09-30,PT,Portugal,
-2000-09-30,RO,Romania,
-2000-09-30,RS,Serbia,
-2000-09-30,RU,Russia,
-2000-09-30,SE,Sweden,10.6317
-2000-09-30,SG,Singapore,5.5629
-2000-09-30,SI,Slovenia,
-2000-09-30,SK,Slovak Republic,
-2000-09-30,TH,Thailand,-4.7819
-2000-09-30,TR,Türkiye,
-2000-09-30,US,United States,5.9711
-2000-09-30,XM,Euro area,3.3211
-2000-09-30,XW,World,
-2000-09-30,ZA,South Africa,8.4031
-2000-12-31,4T,Emerging market economies (aggregate),
-2000-12-31,5R,Advanced economies,
-2000-12-31,AE,United Arab Emirates,
-2000-12-31,AT,Austria,
-2000-12-31,AU,Australia,0.753
+2000-09-30,PT,Portugal,3.5936
+2000-09-30,SE,Sweden,10.6359
+2000-09-30,SG,Singapore,5.5633
+2000-09-30,TH,Thailand,-4.7807
+2000-09-30,US,United States,5.9577
+2000-09-30,XM,Euro area,3.3136
+2000-09-30,ZA,South Africa,8.4189
+2000-12-31,AT,Austria,-3.167
+2000-12-31,AU,Australia,0.7269
 2000-12-31,BE,Belgium,3.3023
-2000-12-31,BG,Bulgaria,
-2000-12-31,BR,Brazil,
+2000-12-31,BG,Bulgaria,-12.0578
 2000-12-31,CA,Canada,0.2361
-2000-12-31,CH,Switzerland,-2.9842
-2000-12-31,CL,Chile,
-2000-12-31,CN,China,
-2000-12-31,CO,Colombia,-9.1208
-2000-12-31,CY,Cyprus,
-2000-12-31,CZ,Czechia,
-2000-12-31,DE,Germany,-1.202
+2000-12-31,CH,Switzerland,-2.9703
+2000-12-31,CO,Colombia,-9.8453
+2000-12-31,DE,Germany,-1.1761
 2000-12-31,DK,Denmark,4.8114
-2000-12-31,EE,Estonia,
 2000-12-31,ES,Spain,3.5814
 2000-12-31,FI,Finland,-3.7808
-2000-12-31,FR,France,6.737
+2000-12-31,FR,France,6.7453
 2000-12-31,GB,United Kingdom,12.2217
-2000-12-31,GR,Greece,
+2000-12-31,GR,Greece,7.5102
 2000-12-31,HK,Hong Kong SAR,-9.4406
-2000-12-31,HR,Croatia,
-2000-12-31,HU,Hungary,
-2000-12-31,ID,Indonesia,
-2000-12-31,IE,Ireland,6.8159
-2000-12-31,IL,Israel,-6.7832
-2000-12-31,IN,India,
-2000-12-31,IS,Iceland,NaN
-2000-12-31,IT,Italy,2.1437
+2000-12-31,HR,Croatia,-13.8058
+2000-12-31,HU,Hungary,18.9473
+2000-12-31,IE,Ireland,6.8293
+2000-12-31,IL,Israel,-6.7836
+2000-12-31,IS,Iceland,8.2405
+2000-12-31,IT,Italy,2.1422
 2000-12-31,JP,Japan,-3.2449
-2000-12-31,KR,Korea,-1.8936
-2000-12-31,LT,Lithuania,-2.8065
-2000-12-31,LU,Luxembourg,
-2000-12-31,LV,Latvia,
-2000-12-31,MA,Morocco,
-2000-12-31,MK,North Macedonia,
-2000-12-31,MT,Malta,
-2000-12-31,MX,Mexico,
+2000-12-31,KR,Korea,-1.7856
+2000-12-31,LT,Lithuania,-2.8067
 2000-12-31,MY,Malaysia,2.8888
-2000-12-31,NL,Netherlands,12.731
-2000-12-31,NO,Norway,6.4963
+2000-12-31,NL,Netherlands,12.064
+2000-12-31,NO,Norway,6.5018
 2000-12-31,NZ,New Zealand,-4.9352
 2000-12-31,PE,Peru,-9.8896
-2000-12-31,PH,Philippines,
-2000-12-31,PL,Poland,
-2000-12-31,PT,Portugal,
-2000-12-31,RO,Romania,
-2000-12-31,RS,Serbia,
-2000-12-31,RU,Russia,
-2000-12-31,SE,Sweden,10.7809
-2000-12-31,SG,Singapore,-2.9499
-2000-12-31,SI,Slovenia,
-2000-12-31,SK,Slovak Republic,
-2000-12-31,TH,Thailand,1.4687
-2000-12-31,TR,Türkiye,
-2000-12-31,US,United States,6.1703
-2000-12-31,XM,Euro area,3.0985
-2000-12-31,XW,World,
-2000-12-31,ZA,South Africa,3.5932
-2001-03-31,4T,Emerging market economies (aggregate),
-2001-03-31,5R,Advanced economies,
-2001-03-31,AE,United Arab Emirates,
+2000-12-31,PT,Portugal,4.6156
+2000-12-31,SE,Sweden,10.785
+2000-12-31,SG,Singapore,-2.9495
+2000-12-31,TH,Thailand,1.4679
+2000-12-31,US,United States,6.1685
+2000-12-31,XM,Euro area,3.0909
+2000-12-31,ZA,South Africa,3.5891
 2001-03-31,AT,Austria,-1.7554
-2001-03-31,AU,Australia,0.8732
+2001-03-31,AU,Australia,0.9056
 2001-03-31,BE,Belgium,2.3773
-2001-03-31,BG,Bulgaria,
-2001-03-31,BR,Brazil,
+2001-03-31,BG,Bulgaria,-7.0118
 2001-03-31,CA,Canada,-0.2359
-2001-03-31,CH,Switzerland,-0.7241
-2001-03-31,CL,Chile,
-2001-03-31,CN,China,
-2001-03-31,CO,Colombia,-3.6493
-2001-03-31,CY,Cyprus,
-2001-03-31,CZ,Czechia,
-2001-03-31,DE,Germany,-1.5568
-2001-03-31,DK,Denmark,5.4377
-2001-03-31,EE,Estonia,
+2001-03-31,CH,Switzerland,-0.7236
+2001-03-31,CO,Colombia,-2.6599
+2001-03-31,DE,Germany,-1.5365
+2001-03-31,DK,Denmark,5.4597
 2001-03-31,ES,Spain,4.677
 2001-03-31,FI,Finland,-4.4158
-2001-03-31,FR,France,5.9535
+2001-03-31,FR,France,5.9542
 2001-03-31,GB,United Kingdom,9.2086
-2001-03-31,GR,Greece,
+2001-03-31,GR,Greece,10.2945
 2001-03-31,HK,Hong Kong SAR,-14.6185
-2001-03-31,HR,Croatia,
-2001-03-31,HU,Hungary,
-2001-03-31,ID,Indonesia,
-2001-03-31,IE,Ireland,8.113
-2001-03-31,IL,Israel,-3.6381
-2001-03-31,IN,India,
-2001-03-31,IS,Iceland,4.1252
-2001-03-31,IT,Italy,1.6596
+2001-03-31,HR,Croatia,-4.8966
+2001-03-31,HU,Hungary,13.6708
+2001-03-31,IE,Ireland,8.0909
+2001-03-31,IL,Israel,-3.6384
+2001-03-31,IS,Iceland,4.1445
+2001-03-31,IT,Italy,1.6592
 2001-03-31,JP,Japan,-3.7127
 2001-03-31,KR,Korea,-3.5619
-2001-03-31,LT,Lithuania,11.9419
-2001-03-31,LU,Luxembourg,
-2001-03-31,LV,Latvia,
-2001-03-31,MA,Morocco,
-2001-03-31,MK,North Macedonia,14.471
-2001-03-31,MT,Malta,
-2001-03-31,MX,Mexico,
+2001-03-31,LT,Lithuania,11.9418
+2001-03-31,MK,North Macedonia,14.4561
 2001-03-31,MY,Malaysia,1.2437
-2001-03-31,NL,Netherlands,9.2537
-2001-03-31,NO,Norway,3.5492
+2001-03-31,NL,Netherlands,9.3845
+2001-03-31,NO,Norway,3.5717
 2001-03-31,NZ,New Zealand,-2.941
 2001-03-31,PE,Peru,-13.4053
-2001-03-31,PH,Philippines,
-2001-03-31,PL,Poland,
-2001-03-31,PT,Portugal,
-2001-03-31,RO,Romania,
+2001-03-31,PT,Portugal,2.7766
 2001-03-31,RS,Serbia,-30.967
-2001-03-31,RU,Russia,
-2001-03-31,SE,Sweden,10.3723
-2001-03-31,SG,Singapore,-9.4399
-2001-03-31,SI,Slovenia,
-2001-03-31,SK,Slovak Republic,
-2001-03-31,TH,Thailand,2.8256
-2001-03-31,TR,Türkiye,
-2001-03-31,US,United States,6.1321
-2001-03-31,XM,Euro area,3.1185
-2001-03-31,XW,World,
-2001-03-31,ZA,South Africa,-8.9846
-2001-06-30,4T,Emerging market economies (aggregate),
-2001-06-30,5R,Advanced economies,
-2001-06-30,AE,United Arab Emirates,
+2001-03-31,SE,Sweden,10.3737
+2001-03-31,SG,Singapore,-9.4405
+2001-03-31,TH,Thailand,2.8274
+2001-03-31,US,United States,6.1312
+2001-03-31,XM,Euro area,3.1194
+2001-03-31,ZA,South Africa,-8.9761
 2001-06-30,AT,Austria,-4.651
-2001-06-30,AU,Australia,1.9676
+2001-06-30,AU,Australia,2.0216
 2001-06-30,BE,Belgium,2.1232
-2001-06-30,BG,Bulgaria,
-2001-06-30,BR,Brazil,
+2001-06-30,BG,Bulgaria,-9.298
 2001-06-30,CA,Canada,1.2536
-2001-06-30,CH,Switzerland,-1.3819
-2001-06-30,CL,Chile,
-2001-06-30,CN,China,
-2001-06-30,CO,Colombia,-6.0878
-2001-06-30,CY,Cyprus,
-2001-06-30,CZ,Czechia,
-2001-06-30,DE,Germany,-2.5084
-2001-06-30,DK,Denmark,3.8727
-2001-06-30,EE,Estonia,
+2001-06-30,CH,Switzerland,-1.3799
+2001-06-30,CO,Colombia,-5.555
+2001-06-30,DE,Germany,-2.494
+2001-06-30,DK,Denmark,3.8502
 2001-06-30,ES,Spain,4.9747
 2001-06-30,FI,Finland,-5.0768
-2001-06-30,FR,France,5.3748
+2001-06-30,FR,France,5.3692
 2001-06-30,GB,United Kingdom,6.6006
-2001-06-30,GR,Greece,
+2001-06-30,GR,Greece,10.8897
 2001-06-30,HK,Hong Kong SAR,-8.6007
-2001-06-30,HR,Croatia,
-2001-06-30,HU,Hungary,
-2001-06-30,ID,Indonesia,
-2001-06-30,IE,Ireland,6.3537
-2001-06-30,IL,Israel,-6.473
-2001-06-30,IN,India,
-2001-06-30,IS,Iceland,-0.1743
-2001-06-30,IT,Italy,1.9262
+2001-06-30,HR,Croatia,-2.012
+2001-06-30,HU,Hungary,6.8996
+2001-06-30,IE,Ireland,6.4401
+2001-06-30,IL,Israel,-6.4726
+2001-06-30,IS,Iceland,-0.1276
+2001-06-30,IT,Italy,1.9182
 2001-06-30,JP,Japan,-3.5853
-2001-06-30,KR,Korea,-3.3478
+2001-06-30,KR,Korea,-3.2954
 2001-06-30,LT,Lithuania,12.6044
-2001-06-30,LU,Luxembourg,
-2001-06-30,LV,Latvia,
-2001-06-30,MA,Morocco,
-2001-06-30,MK,North Macedonia,9.3439
-2001-06-30,MT,Malta,
-2001-06-30,MX,Mexico,
+2001-06-30,MK,North Macedonia,9.6637
 2001-06-30,MY,Malaysia,-0.8287
-2001-06-30,NL,Netherlands,7.4485
-2001-06-30,NO,Norway,0.8461
+2001-06-30,NL,Netherlands,7.5445
+2001-06-30,NO,Norway,0.8232
 2001-06-30,NZ,New Zealand,-2.4531
 2001-06-30,PE,Peru,-4.6177
-2001-06-30,PH,Philippines,
-2001-06-30,PL,Poland,
-2001-06-30,PT,Portugal,
-2001-06-30,RO,Romania,
+2001-06-30,PT,Portugal,1.8046
 2001-06-30,RS,Serbia,-44.1559
-2001-06-30,RU,Russia,
-2001-06-30,SE,Sweden,5.5535
-2001-06-30,SG,Singapore,-11.5689
-2001-06-30,SI,Slovenia,
-2001-06-30,SK,Slovak Republic,
-2001-06-30,TH,Thailand,-4.8069
-2001-06-30,TR,Türkiye,
-2001-06-30,US,United States,5.3154
-2001-06-30,XM,Euro area,2.1522
-2001-06-30,XW,World,
-2001-06-30,ZA,South Africa,-5.6246
-2001-09-30,4T,Emerging market economies (aggregate),
-2001-09-30,5R,Advanced economies,
-2001-09-30,AE,United Arab Emirates,
+2001-06-30,SE,Sweden,5.5478
+2001-06-30,SG,Singapore,-11.5685
+2001-06-30,TH,Thailand,-4.8123
+2001-06-30,US,United States,5.3103
+2001-06-30,XM,Euro area,2.15
+2001-06-30,ZA,South Africa,-5.6202
 2001-09-30,AT,Austria,1.3619
-2001-09-30,AU,Australia,11.2596
+2001-09-30,AU,Australia,11.1935
 2001-09-30,BE,Belgium,2.8981
-2001-09-30,BG,Bulgaria,
-2001-09-30,BR,Brazil,
+2001-09-30,BG,Bulgaria,-5.8967
 2001-09-30,CA,Canada,2.6125
-2001-09-30,CH,Switzerland,-1.5228
-2001-09-30,CL,Chile,
-2001-09-30,CN,China,
-2001-09-30,CO,Colombia,-3.6131
-2001-09-30,CY,Cyprus,
-2001-09-30,CZ,Czechia,
-2001-09-30,DE,Germany,-2.1335
-2001-09-30,DK,Denmark,2.846
-2001-09-30,EE,Estonia,
+2001-09-30,CH,Switzerland,-1.5217
+2001-09-30,CO,Colombia,-3.7263
+2001-09-30,DE,Germany,-2.1056
+2001-09-30,DK,Denmark,2.8595
 2001-09-30,ES,Spain,6.3308
 2001-09-30,FI,Finland,-3.0752
-2001-09-30,FR,France,5.0237
+2001-09-30,FR,France,5.0134
 2001-09-30,GB,United Kingdom,8.1641
-2001-09-30,GR,Greece,
+2001-09-30,GR,Greece,10.765
 2001-09-30,HK,Hong Kong SAR,-9.0168
-2001-09-30,HR,Croatia,
-2001-09-30,HU,Hungary,
-2001-09-30,ID,Indonesia,
-2001-09-30,IE,Ireland,0.9001
-2001-09-30,IL,Israel,-4.6133
-2001-09-30,IN,India,
-2001-09-30,IS,Iceland,-2.0579
-2001-09-30,IT,Italy,2.9559
+2001-09-30,HR,Croatia,-3.281
+2001-09-30,HU,Hungary,7.4162
+2001-09-30,IE,Ireland,0.8827
+2001-09-30,IL,Israel,-4.6135
+2001-09-30,IS,Iceland,-2.0398
+2001-09-30,IT,Italy,2.9677
 2001-09-30,JP,Japan,-3.7699
-2001-09-30,KR,Korea,1.2154
-2001-09-30,LT,Lithuania,33.2384
-2001-09-30,LU,Luxembourg,
-2001-09-30,LV,Latvia,
-2001-09-30,MA,Morocco,
-2001-09-30,MK,North Macedonia,2.3486
-2001-09-30,MT,Malta,
-2001-09-30,MX,Mexico,
+2001-09-30,KR,Korea,1.2898
+2001-09-30,LT,Lithuania,33.2385
+2001-09-30,MK,North Macedonia,1.6581
 2001-09-30,MY,Malaysia,-0.336
-2001-09-30,NL,Netherlands,5.8021
-2001-09-30,NO,Norway,5.2466
+2001-09-30,NL,Netherlands,5.83
+2001-09-30,NO,Norway,5.3171
 2001-09-30,NZ,New Zealand,-0.0412
 2001-09-30,PE,Peru,-11.0015
-2001-09-30,PH,Philippines,
-2001-09-30,PL,Poland,
-2001-09-30,PT,Portugal,
-2001-09-30,RO,Romania,
+2001-09-30,PT,Portugal,0.8773
 2001-09-30,RS,Serbia,-45.8416
-2001-09-30,RU,Russia,
-2001-09-30,SE,Sweden,3.7241
-2001-09-30,SG,Singapore,-11.0022
-2001-09-30,SI,Slovenia,
-2001-09-30,SK,Slovak Republic,
-2001-09-30,TH,Thailand,-3.0966
-2001-09-30,TR,Türkiye,
-2001-09-30,US,United States,5.7377
-2001-09-30,XM,Euro area,2.5834
-2001-09-30,XW,World,
-2001-09-30,ZA,South Africa,0.882
-2001-12-31,4T,Emerging market economies (aggregate),
-2001-12-31,5R,Advanced economies,
-2001-12-31,AE,United Arab Emirates,
+2001-09-30,SE,Sweden,3.7224
+2001-09-30,SG,Singapore,-11.0024
+2001-09-30,TH,Thailand,-3.1007
+2001-09-30,US,United States,5.742
+2001-09-30,XM,Euro area,2.6063
+2001-09-30,ZA,South Africa,0.8699
 2001-12-31,AT,Austria,-2.0609
-2001-12-31,AU,Australia,12.0116
+2001-12-31,AU,Australia,12.0269
 2001-12-31,BE,Belgium,1.8385
-2001-12-31,BG,Bulgaria,
-2001-12-31,BR,Brazil,
+2001-12-31,BG,Bulgaria,-4.0139
 2001-12-31,CA,Canada,4.5483
-2001-12-31,CH,Switzerland,2.6253
-2001-12-31,CL,Chile,
-2001-12-31,CN,China,
-2001-12-31,CO,Colombia,2.2181
-2001-12-31,CY,Cyprus,
-2001-12-31,CZ,Czechia,
-2001-12-31,DE,Germany,-2.1003
-2001-12-31,DK,Denmark,1.5357
-2001-12-31,EE,Estonia,
+2001-12-31,CH,Switzerland,2.6275
+2001-12-31,CO,Colombia,2.1011
+2001-12-31,DE,Germany,-2.1626
+2001-12-31,DK,Denmark,1.5219
 2001-12-31,ES,Spain,8.1583
 2001-12-31,FI,Finland,-0.5867
-2001-12-31,FR,France,6.2154
+2001-12-31,FR,France,6.2168
 2001-12-31,GB,United Kingdom,3.6102
-2001-12-31,GR,Greece,
+2001-12-31,GR,Greece,10.7115
 2001-12-31,HK,Hong Kong SAR,-10.4163
-2001-12-31,HR,Croatia,
-2001-12-31,HU,Hungary,
-2001-12-31,ID,Indonesia,
-2001-12-31,IE,Ireland,-3.3027
-2001-12-31,IL,Israel,-3.4028
-2001-12-31,IN,India,
-2001-12-31,IS,Iceland,-3.2512
-2001-12-31,IT,Italy,4.9184
+2001-12-31,HR,Croatia,3.1629
+2001-12-31,HU,Hungary,11.0653
+2001-12-31,IE,Ireland,-3.3222
+2001-12-31,IL,Israel,-3.4025
+2001-12-31,IS,Iceland,-3.2168
+2001-12-31,IT,Italy,4.9151
 2001-12-31,JP,Japan,-3.8252
-2001-12-31,KR,Korea,5.1977
-2001-12-31,LT,Lithuania,38.5246
-2001-12-31,LU,Luxembourg,
-2001-12-31,LV,Latvia,
-2001-12-31,MA,Morocco,
-2001-12-31,MK,North Macedonia,-3.873
-2001-12-31,MT,Malta,
-2001-12-31,MX,Mexico,
+2001-12-31,KR,Korea,5.1226
+2001-12-31,LT,Lithuania,38.5248
+2001-12-31,MK,North Macedonia,-3.9015
 2001-12-31,MY,Malaysia,-0.4442
-2001-12-31,NL,Netherlands,4.6025
-2001-12-31,NO,Norway,5.5689
+2001-12-31,NL,Netherlands,4.7101
+2001-12-31,NO,Norway,5.5932
 2001-12-31,NZ,New Zealand,2.5317
 2001-12-31,PE,Peru,-7.0754
-2001-12-31,PH,Philippines,
-2001-12-31,PL,Poland,
-2001-12-31,PT,Portugal,
-2001-12-31,RO,Romania,
+2001-12-31,PT,Portugal,-1.3083
 2001-12-31,RS,Serbia,-27.9544
-2001-12-31,RU,Russia,
-2001-12-31,SE,Sweden,2.2037
-2001-12-31,SG,Singapore,-11.5223
-2001-12-31,SI,Slovenia,
-2001-12-31,SK,Slovak Republic,
-2001-12-31,TH,Thailand,-2.1823
-2001-12-31,TR,Türkiye,
-2001-12-31,US,United States,5.9648
-2001-12-31,XM,Euro area,2.721
-2001-12-31,XW,World,
-2001-12-31,ZA,South Africa,6.1584
-2002-03-31,4T,Emerging market economies (aggregate),
-2002-03-31,5R,Advanced economies,
-2002-03-31,AE,United Arab Emirates,
+2001-12-31,SE,Sweden,2.1999
+2001-12-31,SG,Singapore,-11.5225
+2001-12-31,TH,Thailand,-2.1809
+2001-12-31,US,United States,5.9722
+2001-12-31,XM,Euro area,2.7521
+2001-12-31,ZA,South Africa,6.1554
 2002-03-31,AT,Austria,-3.3839
-2002-03-31,AU,Australia,13.955
+2002-03-31,AU,Australia,13.9705
 2002-03-31,BE,Belgium,2.0955
-2002-03-31,BG,Bulgaria,
-2002-03-31,BR,Brazil,-6.1761
+2002-03-31,BG,Bulgaria,-8.3642
+2002-03-31,BR,Brazil,-6.1759
 2002-03-31,CA,Canada,8.9186
-2002-03-31,CH,Switzerland,0.5856
-2002-03-31,CL,Chile,
-2002-03-31,CN,China,
-2002-03-31,CO,Colombia,-7.4521
-2002-03-31,CY,Cyprus,
-2002-03-31,CZ,Czechia,
-2002-03-31,DE,Germany,-2.4455
-2002-03-31,DK,Denmark,0.6738
-2002-03-31,EE,Estonia,
-2002-03-31,ES,Spain,10.3555
+2002-03-31,CH,Switzerland,0.5879
+2002-03-31,CO,Colombia,-7.6222
+2002-03-31,DE,Germany,-2.4762
+2002-03-31,DK,Denmark,0.6788
+2002-03-31,ES,Spain,10.3552
 2002-03-31,FI,Finland,2.8083
-2002-03-31,FR,France,5.159
+2002-03-31,FR,France,5.1595
 2002-03-31,GB,United Kingdom,6.9607
-2002-03-31,GR,Greece,
-2002-03-31,HK,Hong Kong SAR,-6.4372
-2002-03-31,HR,Croatia,
-2002-03-31,HU,Hungary,
-2002-03-31,ID,Indonesia,
-2002-03-31,IE,Ireland,-0.9683
-2002-03-31,IL,Israel,0.4399
-2002-03-31,IN,India,
-2002-03-31,IS,Iceland,-3.2747
-2002-03-31,IT,Italy,9.6567
+2002-03-31,GR,Greece,9.6338
+2002-03-31,HK,Hong Kong SAR,-6.4795
+2002-03-31,HR,Croatia,-2.3903
+2002-03-31,HU,Hungary,8.2974
+2002-03-31,IE,Ireland,-0.8853
+2002-03-31,IL,Israel,0.4394
+2002-03-31,IS,Iceland,-3.2926
+2002-03-31,IT,Italy,9.6516
 2002-03-31,JP,Japan,-3.6496
-2002-03-31,KR,Korea,12.313
-2002-03-31,LT,Lithuania,9.7916
-2002-03-31,LU,Luxembourg,
-2002-03-31,LV,Latvia,
-2002-03-31,MA,Morocco,
-2002-03-31,MK,North Macedonia,-1.6495
-2002-03-31,MT,Malta,
-2002-03-31,MX,Mexico,
+2002-03-31,KR,Korea,12.3312
+2002-03-31,LT,Lithuania,9.7917
+2002-03-31,MK,North Macedonia,-2.0575
 2002-03-31,MY,Malaysia,0.3111
-2002-03-31,NL,Netherlands,4.1875
-2002-03-31,NO,Norway,6.3345
+2002-03-31,NL,Netherlands,3.7244
+2002-03-31,NO,Norway,6.361
 2002-03-31,NZ,New Zealand,4.3645
 2002-03-31,PE,Peru,-0.0566
-2002-03-31,PH,Philippines,
-2002-03-31,PL,Poland,
-2002-03-31,PT,Portugal,
-2002-03-31,RO,Romania,
+2002-03-31,PT,Portugal,-1.5997
 2002-03-31,RS,Serbia,-22.7815
-2002-03-31,RU,Russia,13.8731
-2002-03-31,SE,Sweden,0.8898
-2002-03-31,SG,Singapore,-8.314
-2002-03-31,SI,Slovenia,
-2002-03-31,SK,Slovak Republic,
-2002-03-31,TH,Thailand,-3.3074
-2002-03-31,TR,Türkiye,
-2002-03-31,US,United States,5.9996
-2002-03-31,XM,Euro area,3.1528
-2002-03-31,XW,World,
-2002-03-31,ZA,South Africa,6.5972
-2002-06-30,4T,Emerging market economies (aggregate),
-2002-06-30,5R,Advanced economies,
-2002-06-30,AE,United Arab Emirates,
+2002-03-31,RU,Russia,13.8733
+2002-03-31,SE,Sweden,0.8909
+2002-03-31,SG,Singapore,-8.3131
+2002-03-31,TH,Thailand,-3.3107
+2002-03-31,US,United States,6.0022
+2002-03-31,XM,Euro area,3.1771
+2002-03-31,ZA,South Africa,6.5996
 2002-06-30,AT,Austria,-0.5168
-2002-06-30,AU,Australia,16.7514
+2002-06-30,AU,Australia,16.7253
 2002-06-30,BE,Belgium,4.4568
-2002-06-30,BG,Bulgaria,
-2002-06-30,BR,Brazil,-5.9158
+2002-06-30,BG,Bulgaria,-4.8462
+2002-06-30,BR,Brazil,-5.9156
 2002-06-30,CA,Canada,8.7493
-2002-06-30,CH,Switzerland,-0.3365
-2002-06-30,CL,Chile,
-2002-06-30,CN,China,
-2002-06-30,CO,Colombia,-3.1345
-2002-06-30,CY,Cyprus,
-2002-06-30,CZ,Czechia,
-2002-06-30,DE,Germany,-1.909
-2002-06-30,DK,Denmark,1.5262
-2002-06-30,EE,Estonia,
-2002-06-30,ES,Spain,12.2626
+2002-06-30,CH,Switzerland,-0.3349
+2002-06-30,CO,Colombia,-3.3745
+2002-06-30,DE,Germany,-1.9082
+2002-06-30,DK,Denmark,1.5357
+2002-06-30,ES,Spain,12.2623
 2002-06-30,FI,Finland,5.7614
-2002-06-30,FR,France,6.0423
+2002-06-30,FR,France,6.0383
 2002-06-30,GB,United Kingdom,12.352
-2002-06-30,GR,Greece,
-2002-06-30,HK,Hong Kong SAR,-8.2438
-2002-06-30,HR,Croatia,
-2002-06-30,HU,Hungary,
-2002-06-30,ID,Indonesia,
-2002-06-30,IE,Ireland,0.2752
-2002-06-30,IL,Israel,1.9341
-2002-06-30,IN,India,
-2002-06-30,IS,Iceland,-2.5496
-2002-06-30,IT,Italy,10.7103
+2002-06-30,GR,Greece,11.5938
+2002-06-30,HK,Hong Kong SAR,-8.2014
+2002-06-30,HR,Croatia,-3.0514
+2002-06-30,HU,Hungary,10.5191
+2002-06-30,IE,Ireland,0.2321
+2002-06-30,IL,Israel,1.9336
+2002-06-30,IS,Iceland,-2.5332
+2002-06-30,IT,Italy,10.7098
 2002-06-30,JP,Japan,-4.3503
-2002-06-30,KR,Korea,14.385
+2002-06-30,KR,Korea,14.3647
 2002-06-30,LT,Lithuania,20.2556
-2002-06-30,LU,Luxembourg,
-2002-06-30,LV,Latvia,
-2002-06-30,MA,Morocco,
-2002-06-30,MK,North Macedonia,7.1068
-2002-06-30,MT,Malta,
-2002-06-30,MX,Mexico,
+2002-06-30,MK,North Macedonia,7.0581
 2002-06-30,MY,Malaysia,0.6861
-2002-06-30,NL,Netherlands,3.3182
-2002-06-30,NO,Norway,6.1693
+2002-06-30,NL,Netherlands,3.1662
+2002-06-30,NO,Norway,6.1685
 2002-06-30,NZ,New Zealand,6.3047
 2002-06-30,PE,Peru,-8.9531
-2002-06-30,PH,Philippines,
-2002-06-30,PL,Poland,
-2002-06-30,PT,Portugal,
-2002-06-30,RO,Romania,
+2002-06-30,PT,Portugal,-2.6933
 2002-06-30,RS,Serbia,-13.4624
 2002-06-30,RU,Russia,17.5132
-2002-06-30,SE,Sweden,3.2555
+2002-06-30,SE,Sweden,3.2639
 2002-06-30,SG,Singapore,-8.585
-2002-06-30,SI,Slovenia,
-2002-06-30,SK,Slovak Republic,
-2002-06-30,TH,Thailand,1.2749
-2002-06-30,TR,Türkiye,
-2002-06-30,US,United States,6.8404
-2002-06-30,XM,Euro area,4.1552
-2002-06-30,XW,World,
-2002-06-30,ZA,South Africa,5.505
-2002-09-30,4T,Emerging market economies (aggregate),
-2002-09-30,5R,Advanced economies,
-2002-09-30,AE,United Arab Emirates,
+2002-06-30,TH,Thailand,1.2799
+2002-06-30,US,United States,6.8343
+2002-06-30,XM,Euro area,4.1807
+2002-06-30,ZA,South Africa,5.4937
 2002-09-30,AT,Austria,-1.0881
-2002-09-30,AU,Australia,15.1556
+2002-09-30,AU,Australia,15.1051
 2002-09-30,BE,Belgium,5.3707
-2002-09-30,BG,Bulgaria,
-2002-09-30,BR,Brazil,-4.9103
+2002-09-30,BG,Bulgaria,-2.4545
+2002-09-30,BR,Brazil,-4.9102
 2002-09-30,CA,Canada,6.5016
-2002-09-30,CH,Switzerland,0.5639
-2002-09-30,CL,Chile,
-2002-09-30,CN,China,
-2002-09-30,CO,Colombia,-4.2316
-2002-09-30,CY,Cyprus,
-2002-09-30,CZ,Czechia,
-2002-09-30,DE,Germany,-1.9891
-2002-09-30,DK,Denmark,0.9624
-2002-09-30,EE,Estonia,
-2002-09-30,ES,Spain,13.5635
+2002-09-30,CH,Switzerland,0.5661
+2002-09-30,CO,Colombia,-4.1644
+2002-09-30,DE,Germany,-1.9937
+2002-09-30,DK,Denmark,0.9011
+2002-09-30,ES,Spain,13.5637
 2002-09-30,FI,Finland,7.5119
-2002-09-30,FR,France,7.1232
+2002-09-30,FR,France,7.1327
 2002-09-30,GB,United Kingdom,15.7537
-2002-09-30,GR,Greece,
+2002-09-30,GR,Greece,9.4889
 2002-09-30,HK,Hong Kong SAR,-9.6125
-2002-09-30,HR,Croatia,
-2002-09-30,HU,Hungary,
-2002-09-30,ID,Indonesia,
-2002-09-30,IE,Ireland,6.792
-2002-09-30,IL,Israel,-1.2536
-2002-09-30,IN,India,
-2002-09-30,IS,Iceland,2.0301
-2002-09-30,IT,Italy,9.5491
+2002-09-30,HR,Croatia,12.2407
+2002-09-30,HU,Hungary,10.6366
+2002-09-30,IE,Ireland,6.6982
+2002-09-30,IL,Israel,-1.2529
+2002-09-30,IS,Iceland,2.0297
+2002-09-30,IT,Italy,9.5432
 2002-09-30,JP,Japan,-4.6214
-2002-09-30,KR,Korea,14.17
+2002-09-30,KR,Korea,14.0802
 2002-09-30,LT,Lithuania,14.5931
-2002-09-30,LU,Luxembourg,
-2002-09-30,LV,Latvia,
-2002-09-30,MA,Morocco,
-2002-09-30,MK,North Macedonia,15.954
-2002-09-30,MT,Malta,
-2002-09-30,MX,Mexico,
+2002-09-30,MK,North Macedonia,16.8849
 2002-09-30,MY,Malaysia,1.017
-2002-09-30,NL,Netherlands,2.5448
-2002-09-30,NO,Norway,1.7732
+2002-09-30,NL,Netherlands,2.6902
+2002-09-30,NO,Norway,1.7111
 2002-09-30,NZ,New Zealand,8.8123
 2002-09-30,PE,Peru,17.4078
-2002-09-30,PH,Philippines,
-2002-09-30,PL,Poland,
-2002-09-30,PT,Portugal,
-2002-09-30,RO,Romania,
+2002-09-30,PT,Portugal,-3.4417
 2002-09-30,RS,Serbia,-14.3888
 2002-09-30,RU,Russia,15.9438
-2002-09-30,SE,Sweden,5.352
-2002-09-30,SG,Singapore,-5.3022
-2002-09-30,SI,Slovenia,
-2002-09-30,SK,Slovak Republic,
-2002-09-30,TH,Thailand,3.0222
-2002-09-30,TR,Türkiye,
-2002-09-30,US,United States,7.2025
-2002-09-30,XM,Euro area,4.474
-2002-09-30,XW,World,
-2002-09-30,ZA,South Africa,2.8619
-2002-12-31,4T,Emerging market economies (aggregate),
-2002-12-31,5R,Advanced economies,
-2002-12-31,AE,United Arab Emirates,
-2002-12-31,AT,Austria,0.2997
-2002-12-31,AU,Australia,15.37
+2002-09-30,SE,Sweden,5.3515
+2002-09-30,SG,Singapore,-5.3026
+2002-09-30,TH,Thailand,3.0272
+2002-09-30,US,United States,7.1986
+2002-09-30,XM,Euro area,4.4882
+2002-09-30,ZA,South Africa,2.863
+2002-12-31,AT,Austria,0.2998
+2002-12-31,AU,Australia,15.279
 2002-12-31,BE,Belgium,6.7596
-2002-12-31,BG,Bulgaria,
-2002-12-31,BR,Brazil,-6.0557
+2002-12-31,BG,Bulgaria,0.8021
+2002-12-31,BR,Brazil,-6.0554
 2002-12-31,CA,Canada,6.9388
-2002-12-31,CH,Switzerland,-1.4856
-2002-12-31,CL,Chile,
-2002-12-31,CN,China,
-2002-12-31,CO,Colombia,-8.6157
-2002-12-31,CY,Cyprus,
-2002-12-31,CZ,Czechia,
-2002-12-31,DE,Germany,-2.0126
-2002-12-31,DK,Denmark,1.4652
-2002-12-31,EE,Estonia,
-2002-12-31,ES,Spain,12.8734
+2002-12-31,CH,Switzerland,-1.4829
+2002-12-31,CO,Colombia,-8.9055
+2002-12-31,DE,Germany,-1.9785
+2002-12-31,DK,Denmark,1.4711
+2002-12-31,ES,Spain,12.8736
 2002-12-31,FI,Finland,7.0241
-2002-12-31,FR,France,7.4201
+2002-12-31,FR,France,7.4204
 2002-12-31,GB,United Kingdom,23.3702
-2002-12-31,GR,Greece,
+2002-12-31,GR,Greece,8.8433
 2002-12-31,HK,Hong Kong SAR,-9.1113
-2002-12-31,HR,Croatia,
-2002-12-31,HU,Hungary,
-2002-12-31,ID,Indonesia,
-2002-12-31,IE,Ireland,8.967
-2002-12-31,IL,Israel,-2.6112
-2002-12-31,IN,India,
-2002-12-31,IS,Iceland,4.1087
-2002-12-31,IT,Italy,7.1085
+2002-12-31,HR,Croatia,9.3876
+2002-12-31,HU,Hungary,8.1947
+2002-12-31,IE,Ireland,8.9646
+2002-12-31,IL,Israel,-2.611
+2002-12-31,IS,Iceland,4.0976
+2002-12-31,IT,Italy,7.1083
 2002-12-31,JP,Japan,-5.1054
-2002-12-31,KR,Korea,13.2111
-2002-12-31,LT,Lithuania,3.9789
-2002-12-31,LU,Luxembourg,
-2002-12-31,LV,Latvia,
-2002-12-31,MA,Morocco,
-2002-12-31,MK,North Macedonia,11.5242
-2002-12-31,MT,Malta,
-2002-12-31,MX,Mexico,
+2002-12-31,KR,Korea,13.2609
+2002-12-31,LT,Lithuania,3.9788
+2002-12-31,MK,North Macedonia,11.4431
 2002-12-31,MY,Malaysia,2.9814
-2002-12-31,NL,Netherlands,1.9222
-2002-12-31,NO,Norway,0.5244
+2002-12-31,NL,Netherlands,1.9263
+2002-12-31,NO,Norway,0.509
 2002-12-31,NZ,New Zealand,10.9389
 2002-12-31,PE,Peru,-3.0245
-2002-12-31,PH,Philippines,
-2002-12-31,PL,Poland,
-2002-12-31,PT,Portugal,
-2002-12-31,RO,Romania,
+2002-12-31,PT,Portugal,-3.7188
 2002-12-31,RS,Serbia,-4.683
 2002-12-31,RU,Russia,10.7552
-2002-12-31,SE,Sweden,6.8559
-2002-12-31,SG,Singapore,-1.9433
-2002-12-31,SI,Slovenia,
-2002-12-31,SK,Slovak Republic,
-2002-12-31,TH,Thailand,-0.7739
-2002-12-31,TR,Türkiye,
-2002-12-31,US,United States,6.9752
-2002-12-31,XM,Euro area,4.3212
-2002-12-31,XW,World,
-2002-12-31,ZA,South Africa,0.8434
-2003-03-31,4T,Emerging market economies (aggregate),
-2003-03-31,5R,Advanced economies,
-2003-03-31,AE,United Arab Emirates,
+2002-12-31,SE,Sweden,6.8534
+2002-12-31,SG,Singapore,-1.943
+2002-12-31,TH,Thailand,-0.7736
+2002-12-31,US,United States,6.9516
+2002-12-31,XM,Euro area,4.329
+2002-12-31,ZA,South Africa,0.8481
 2003-03-31,AT,Austria,-1.2055
-2003-03-31,AU,Australia,13.7289
+2003-03-31,AU,Australia,13.594
 2003-03-31,BE,Belgium,5.7043
-2003-03-31,BG,Bulgaria,
-2003-03-31,BR,Brazil,-8.0893
+2003-03-31,BG,Bulgaria,4.4815
+2003-03-31,BR,Brazil,-8.0891
 2003-03-31,CA,Canada,3.9591
-2003-03-31,CH,Switzerland,-2.0128
-2003-03-31,CL,Chile,3.6558
-2003-03-31,CN,China,
-2003-03-31,CO,Colombia,-6.43
+2003-03-31,CH,Switzerland,-2.0104
+2003-03-31,CL,Chile,3.6557
+2003-03-31,CO,Colombia,-7.0533
 2003-03-31,CY,Cyprus,-0.2156
-2003-03-31,CZ,Czechia,
-2003-03-31,DE,Germany,-2.1466
-2003-03-31,DK,Denmark,-0.3669
-2003-03-31,EE,Estonia,
-2003-03-31,ES,Spain,12.6876
+2003-03-31,DE,Germany,-2.1136
+2003-03-31,DK,Denmark,-0.4028
+2003-03-31,ES,Spain,12.6878
 2003-03-31,FI,Finland,4.9251
 2003-03-31,FR,France,8.3454
 2003-03-31,GB,United Kingdom,21.5353
-2003-03-31,GR,Greece,
-2003-03-31,HK,Hong Kong SAR,-13.2988
-2003-03-31,HR,Croatia,12.5061
-2003-03-31,HU,Hungary,
+2003-03-31,GR,Greece,5.9255
+2003-03-31,HK,Hong Kong SAR,-13.2596
+2003-03-31,HR,Croatia,12.5782
+2003-03-31,HU,Hungary,14.9299
 2003-03-31,ID,Indonesia,-1.3361
-2003-03-31,IE,Ireland,7.3417
-2003-03-31,IL,Israel,-7.1566
-2003-03-31,IN,India,
-2003-03-31,IS,Iceland,7.5243
-2003-03-31,IT,Italy,3.6407
+2003-03-31,IE,Ireland,7.3007
+2003-03-31,IL,Israel,-7.1565
+2003-03-31,IS,Iceland,7.4984
+2003-03-31,IT,Italy,3.6411
 2003-03-31,JP,Japan,-5.6605
-2003-03-31,KR,Korea,6.8792
+2003-03-31,KR,Korea,6.9145
 2003-03-31,LT,Lithuania,25.9164
-2003-03-31,LU,Luxembourg,
-2003-03-31,LV,Latvia,
-2003-03-31,MA,Morocco,
-2003-03-31,MK,North Macedonia,11.7111
-2003-03-31,MT,Malta,
-2003-03-31,MX,Mexico,
+2003-03-31,MK,North Macedonia,12.0849
 2003-03-31,MY,Malaysia,3.3945
-2003-03-31,NL,Netherlands,1.5054
-2003-03-31,NO,Norway,-2.6957
+2003-03-31,NL,Netherlands,1.7874
+2003-03-31,NO,Norway,-2.7292
 2003-03-31,NZ,New Zealand,12.7917
 2003-03-31,PE,Peru,-14.6847
-2003-03-31,PH,Philippines,
-2003-03-31,PL,Poland,
-2003-03-31,PT,Portugal,
-2003-03-31,RO,Romania,
+2003-03-31,PT,Portugal,-3.2847
 2003-03-31,RS,Serbia,14.0151
 2003-03-31,RU,Russia,10.6197
-2003-03-31,SE,Sweden,4.8292
-2003-03-31,SG,Singapore,-2.1118
-2003-03-31,SI,Slovenia,
-2003-03-31,SK,Slovak Republic,
-2003-03-31,TH,Thailand,0.1372
-2003-03-31,TR,Türkiye,
-2003-03-31,US,United States,6.4801
-2003-03-31,XM,Euro area,3.7037
-2003-03-31,XW,World,
-2003-03-31,ZA,South Africa,3.7395
-2003-06-30,4T,Emerging market economies (aggregate),
-2003-06-30,5R,Advanced economies,
-2003-06-30,AE,United Arab Emirates,
-2003-06-30,AT,Austria,0.1425
-2003-06-30,AU,Australia,13.8759
+2003-03-31,SE,Sweden,4.8327
+2003-03-31,SG,Singapore,-2.1123
+2003-03-31,TH,Thailand,0.1327
+2003-03-31,US,United States,6.4857
+2003-03-31,XM,Euro area,3.7101
+2003-03-31,ZA,South Africa,3.744
+2003-06-30,AT,Austria,0.1426
+2003-06-30,AU,Australia,13.8114
 2003-06-30,BE,Belgium,4.9998
-2003-06-30,BG,Bulgaria,
-2003-06-30,BR,Brazil,-6.6055
+2003-06-30,BG,Bulgaria,7.0621
+2003-06-30,BR,Brazil,-6.6051
 2003-06-30,CA,Canada,5.0332
-2003-06-30,CH,Switzerland,2.0228
-2003-06-30,CL,Chile,0.9562
-2003-06-30,CN,China,
-2003-06-30,CO,Colombia,-6.1533
+2003-06-30,CH,Switzerland,2.0249
+2003-06-30,CL,Chile,0.9561
+2003-06-30,CO,Colombia,-6.5421
 2003-06-30,CY,Cyprus,1.4686
-2003-06-30,CZ,Czechia,
-2003-06-30,DE,Germany,-2.0819
-2003-06-30,DK,Denmark,0.2448
-2003-06-30,EE,Estonia,
-2003-06-30,ES,Spain,14.0208
+2003-06-30,DE,Germany,-2.0909
+2003-06-30,DK,Denmark,0.2564
+2003-06-30,ES,Spain,14.0202
 2003-06-30,FI,Finland,4.4054
-2003-06-30,FR,France,9.1597
+2003-06-30,FR,France,9.1688
 2003-06-30,GB,United Kingdom,16.1062
-2003-06-30,GR,Greece,
-2003-06-30,HK,Hong Kong SAR,-15.0454
-2003-06-30,HR,Croatia,17.4044
-2003-06-30,HU,Hungary,
+2003-06-30,GR,Greece,0.3197
+2003-06-30,HK,Hong Kong SAR,-15.0847
+2003-06-30,HR,Croatia,17.3766
+2003-06-30,HU,Hungary,15.2269
 2003-06-30,ID,Indonesia,-0.809
-2003-06-30,IE,Ireland,8.9166
-2003-06-30,IL,Israel,-9.59
-2003-06-30,IN,India,
-2003-06-30,IS,Iceland,9.5168
-2003-06-30,IT,Italy,2.8792
+2003-06-30,IE,Ireland,8.9052
+2003-06-30,IL,Israel,-9.5901
+2003-06-30,IS,Iceland,9.4527
+2003-06-30,IT,Italy,2.8796
 2003-06-30,JP,Japan,-5.9276
-2003-06-30,KR,Korea,6.7151
-2003-06-30,LT,Lithuania,11.9188
-2003-06-30,LU,Luxembourg,
-2003-06-30,LV,Latvia,
-2003-06-30,MA,Morocco,
-2003-06-30,MK,North Macedonia,5.3968
-2003-06-30,MT,Malta,
-2003-06-30,MX,Mexico,
+2003-06-30,KR,Korea,6.6408
+2003-06-30,LT,Lithuania,11.9189
+2003-06-30,MK,North Macedonia,5.1189
 2003-06-30,MY,Malaysia,1.9819
-2003-06-30,NL,Netherlands,1.5622
-2003-06-30,NO,Norway,-3.2513
+2003-06-30,NL,Netherlands,1.6885
+2003-06-30,NO,Norway,-3.1691
 2003-06-30,NZ,New Zealand,15.1217
 2003-06-30,PE,Peru,-9.104
-2003-06-30,PH,Philippines,
-2003-06-30,PL,Poland,
-2003-06-30,PT,Portugal,
-2003-06-30,RO,Romania,
+2003-06-30,PT,Portugal,-2.5647
 2003-06-30,RS,Serbia,24.671
 2003-06-30,RU,Russia,6.8947
-2003-06-30,SE,Sweden,5.0896
-2003-06-30,SG,Singapore,-1.4859
-2003-06-30,SI,Slovenia,
-2003-06-30,SK,Slovak Republic,
-2003-06-30,TH,Thailand,-0.4235
-2003-06-30,TR,Türkiye,
-2003-06-30,US,United States,6.7808
-2003-06-30,XM,Euro area,3.9001
-2003-06-30,XW,World,
-2003-06-30,ZA,South Africa,8.5789
-2003-09-30,4T,Emerging market economies (aggregate),
-2003-09-30,5R,Advanced economies,
-2003-09-30,AE,United Arab Emirates,
-2003-09-30,AT,Austria,-4.2797
-2003-09-30,AU,Australia,15.7716
+2003-06-30,SE,Sweden,5.0921
+2003-06-30,SG,Singapore,-1.4867
+2003-06-30,TH,Thailand,-0.4285
+2003-06-30,US,United States,6.7726
+2003-06-30,XM,Euro area,3.9132
+2003-06-30,ZA,South Africa,8.5878
+2003-09-30,AT,Austria,-4.2796
+2003-09-30,AU,Australia,15.8123
 2003-09-30,BE,Belgium,4.8334
-2003-09-30,BG,Bulgaria,
-2003-09-30,BR,Brazil,-2.7696
+2003-09-30,BG,Bulgaria,10.6753
+2003-09-30,BR,Brazil,-2.7691
 2003-09-30,CA,Canada,8.9039
-2003-09-30,CH,Switzerland,2.4631
-2003-09-30,CL,Chile,0.8091
-2003-09-30,CN,China,
-2003-09-30,CO,Colombia,-5.5417
+2003-09-30,CH,Switzerland,2.4656
+2003-09-30,CL,Chile,0.8093
+2003-09-30,CO,Colombia,-5.5323
 2003-09-30,CY,Cyprus,-0.7769
-2003-09-30,CZ,Czechia,
-2003-09-30,DE,Germany,-2.4817
-2003-09-30,DK,Denmark,1.828
-2003-09-30,EE,Estonia,
-2003-09-30,ES,Spain,14.3449
+2003-09-30,DE,Germany,-2.5024
+2003-09-30,DK,Denmark,1.8562
+2003-09-30,ES,Spain,14.3444
 2003-09-30,FI,Finland,5.6336
-2003-09-30,FR,France,9.3731
+2003-09-30,FR,France,9.3661
 2003-09-30,GB,United Kingdom,11.6633
-2003-09-30,GR,Greece,
+2003-09-30,GR,Greece,1.1059
 2003-09-30,HK,Hong Kong SAR,-10.2739
-2003-09-30,HR,Croatia,11.5551
-2003-09-30,HU,Hungary,
+2003-09-30,HR,Croatia,11.5744
+2003-09-30,HU,Hungary,12.2582
 2003-09-30,ID,Indonesia,0.0549
-2003-09-30,IE,Ireland,9.6691
-2003-09-30,IL,Israel,-4.671
-2003-09-30,IN,India,
-2003-09-30,IS,Iceland,11.8295
-2003-09-30,IT,Italy,3.496
+2003-09-30,IE,Ireland,9.7441
+2003-09-30,IL,Israel,-4.6715
+2003-09-30,IS,Iceland,11.7867
+2003-09-30,IT,Italy,3.4983
 2003-09-30,JP,Japan,-6.2039
-2003-09-30,KR,Korea,4.9855
-2003-09-30,LT,Lithuania,10.3539
-2003-09-30,LU,Luxembourg,
-2003-09-30,LV,Latvia,
-2003-09-30,MA,Morocco,
-2003-09-30,MK,North Macedonia,-4.0857
-2003-09-30,MT,Malta,
-2003-09-30,MX,Mexico,
+2003-09-30,KR,Korea,4.9998
+2003-09-30,LT,Lithuania,10.354
+2003-09-30,MK,North Macedonia,-4.9111
 2003-09-30,MY,Malaysia,3.7782
-2003-09-30,NL,Netherlands,0.7331
-2003-09-30,NO,Norway,0.0935
+2003-09-30,NL,Netherlands,0.8224
+2003-09-30,NO,Norway,0.0754
 2003-09-30,NZ,New Zealand,19.1265
 2003-09-30,PE,Peru,-25.9447
-2003-09-30,PH,Philippines,
-2003-09-30,PL,Poland,
-2003-09-30,PT,Portugal,
-2003-09-30,RO,Romania,
+2003-09-30,PT,Portugal,-1.3532
 2003-09-30,RS,Serbia,31.7259
 2003-09-30,RU,Russia,6.3642
-2003-09-30,SE,Sweden,3.8548
-2003-09-30,SG,Singapore,-2.7577
-2003-09-30,SI,Slovenia,
-2003-09-30,SK,Slovak Republic,
-2003-09-30,TH,Thailand,1.1018
-2003-09-30,TR,Türkiye,
-2003-09-30,US,United States,7.0731
-2003-09-30,XM,Euro area,3.6857
-2003-09-30,XW,World,
-2003-09-30,ZA,South Africa,14.8998
-2003-12-31,4T,Emerging market economies (aggregate),
-2003-12-31,5R,Advanced economies,
-2003-12-31,AE,United Arab Emirates,
-2003-12-31,AT,Austria,1.1235
-2003-12-31,AU,Australia,16.0676
+2003-09-30,SE,Sweden,3.862
+2003-09-30,SG,Singapore,-2.7583
+2003-09-30,TH,Thailand,1.0973
+2003-09-30,US,United States,7.0753
+2003-09-30,XM,Euro area,3.691
+2003-09-30,ZA,South Africa,14.8991
+2003-12-31,AT,Austria,1.1234
+2003-12-31,AU,Australia,16.1102
 2003-12-31,BE,Belgium,5.3459
-2003-12-31,BG,Bulgaria,
-2003-12-31,BR,Brazil,2.489
+2003-12-31,BG,Bulgaria,15.6353
+2003-12-31,BR,Brazil,2.4895
 2003-12-31,CA,Canada,9.0134
-2003-12-31,CH,Switzerland,2.6941
-2003-12-31,CL,Chile,3.5368
-2003-12-31,CN,China,
-2003-12-31,CO,Colombia,-0.5662
+2003-12-31,CH,Switzerland,2.6956
+2003-12-31,CL,Chile,3.5367
+2003-12-31,CO,Colombia,-0.1912
 2003-12-31,CY,Cyprus,0.3748
-2003-12-31,CZ,Czechia,
-2003-12-31,DE,Germany,-2.807
-2003-12-31,DK,Denmark,2.5374
-2003-12-31,EE,Estonia,
-2003-12-31,ES,Spain,15.3916
+2003-12-31,DE,Germany,-2.8097
+2003-12-31,DK,Denmark,2.5228
+2003-12-31,ES,Spain,15.3914
 2003-12-31,FI,Finland,6.9145
-2003-12-31,FR,France,9.8087
+2003-12-31,FR,France,9.8056
 2003-12-31,GB,United Kingdom,8.5702
-2003-12-31,GR,Greece,
+2003-12-31,GR,Greece,0.081
 2003-12-31,HK,Hong Kong SAR,1.1868
-2003-12-31,HR,Croatia,18.8509
-2003-12-31,HU,Hungary,
+2003-12-31,HR,Croatia,18.838
+2003-12-31,HU,Hungary,15.8174
 2003-12-31,ID,Indonesia,0.4311
-2003-12-31,IE,Ireland,11.4832
-2003-12-31,IL,Israel,-3.7464
-2003-12-31,IN,India,
-2003-12-31,IS,Iceland,9.5941
-2003-12-31,IT,Italy,3.5915
+2003-12-31,IE,Ireland,11.4524
+2003-12-31,IL,Israel,-3.7465
+2003-12-31,IS,Iceland,9.583
+2003-12-31,IT,Italy,3.5882
 2003-12-31,JP,Japan,-6.1291
-2003-12-31,KR,Korea,2.9262
-2003-12-31,LT,Lithuania,12.9055
-2003-12-31,LU,Luxembourg,
-2003-12-31,LV,Latvia,
-2003-12-31,MA,Morocco,
-2003-12-31,MK,North Macedonia,4.0567
-2003-12-31,MT,Malta,
-2003-12-31,MX,Mexico,
+2003-12-31,KR,Korea,2.9744
+2003-12-31,LT,Lithuania,12.9056
+2003-12-31,MK,North Macedonia,3.9925
 2003-12-31,MY,Malaysia,2.4454
-2003-12-31,NL,Netherlands,2.143
-2003-12-31,NO,Norway,2.7861
+2003-12-31,NL,Netherlands,2.0576
+2003-12-31,NO,Norway,2.6717
 2003-12-31,NZ,New Zealand,22.4597
 2003-12-31,PE,Peru,-12.1932
-2003-12-31,PH,Philippines,
-2003-12-31,PL,Poland,
-2003-12-31,PT,Portugal,
-2003-12-31,RO,Romania,
+2003-12-31,PT,Portugal,-1.0894
 2003-12-31,RS,Serbia,25.3007
 2003-12-31,RU,Russia,7.4018
-2003-12-31,SE,Sweden,4.7818
-2003-12-31,SG,Singapore,-2.6994
-2003-12-31,SI,Slovenia,
-2003-12-31,SK,Slovak Republic,
-2003-12-31,TH,Thailand,3.6879
-2003-12-31,TR,Türkiye,
-2003-12-31,US,United States,8.6976
-2003-12-31,XM,Euro area,4.1941
-2003-12-31,XW,World,
-2003-12-31,ZA,South Africa,24.2435
-2004-03-31,4T,Emerging market economies (aggregate),
-2004-03-31,5R,Advanced economies,
-2004-03-31,AE,United Arab Emirates,7.0992
-2004-03-31,AT,Austria,-8.2007
-2004-03-31,AU,Australia,13.0192
+2003-12-31,SE,Sweden,4.7939
+2003-12-31,SG,Singapore,-2.6992
+2003-12-31,TH,Thailand,3.6827
+2003-12-31,US,United States,8.6987
+2003-12-31,XM,Euro area,4.1989
+2003-12-31,ZA,South Africa,24.2496
+2004-03-31,AT,Austria,-8.2008
+2004-03-31,AU,Australia,13.0635
 2004-03-31,BE,Belgium,6.9486
-2004-03-31,BG,Bulgaria,
-2004-03-31,BR,Brazil,7.7185
+2004-03-31,BG,Bulgaria,26.4642
+2004-03-31,BR,Brazil,7.7182
 2004-03-31,CA,Canada,9.424
-2004-03-31,CH,Switzerland,5.0559
+2004-03-31,CH,Switzerland,5.0565
 2004-03-31,CL,Chile,5.0669
-2004-03-31,CN,China,
-2004-03-31,CO,Colombia,2.2554
+2004-03-31,CO,Colombia,2.1798
 2004-03-31,CY,Cyprus,17.6055
-2004-03-31,CZ,Czechia,
-2004-03-31,DE,Germany,-2.8357
-2004-03-31,DK,Denmark,6.7369
-2004-03-31,EE,Estonia,
-2004-03-31,ES,Spain,15.8384
+2004-03-31,DE,Germany,-2.9858
+2004-03-31,DK,Denmark,6.7316
+2004-03-31,ES,Spain,15.8381
 2004-03-31,FI,Finland,8.4307
-2004-03-31,FR,France,11.5977
+2004-03-31,FR,France,11.589
 2004-03-31,GB,United Kingdom,7.6882
-2004-03-31,GR,Greece,
+2004-03-31,GR,Greece,-1.628
 2004-03-31,HK,Hong Kong SAR,19.468
-2004-03-31,HR,Croatia,11.2089
-2004-03-31,HU,Hungary,
+2004-03-31,HR,Croatia,11.1802
+2004-03-31,HU,Hungary,2.8659
 2004-03-31,ID,Indonesia,-0.3788
-2004-03-31,IE,Ireland,9.5355
-2004-03-31,IL,Israel,-1.7153
-2004-03-31,IN,India,
-2004-03-31,IS,Iceland,6.2209
-2004-03-31,IT,Italy,2.5903
+2004-03-31,IE,Ireland,9.5276
+2004-03-31,IL,Israel,-1.7151
+2004-03-31,IS,Iceland,6.2308
+2004-03-31,IT,Italy,2.5919
 2004-03-31,JP,Japan,-6.2831
-2004-03-31,KR,Korea,1.7454
-2004-03-31,LT,Lithuania,7.8634
-2004-03-31,LU,Luxembourg,
-2004-03-31,LV,Latvia,
-2004-03-31,MA,Morocco,
-2004-03-31,MK,North Macedonia,-1.5664
-2004-03-31,MT,Malta,
-2004-03-31,MX,Mexico,
+2004-03-31,KR,Korea,1.6954
+2004-03-31,LT,Lithuania,7.8632
+2004-03-31,MK,North Macedonia,-1.6166
 2004-03-31,MY,Malaysia,4.2684
-2004-03-31,NL,Netherlands,2.9813
-2004-03-31,NO,Norway,10.7913
+2004-03-31,NL,Netherlands,2.8366
+2004-03-31,NO,Norway,10.7653
 2004-03-31,NZ,New Zealand,21.2513
 2004-03-31,PE,Peru,14.5475
-2004-03-31,PH,Philippines,
-2004-03-31,PL,Poland,
-2004-03-31,PT,Portugal,
-2004-03-31,RO,Romania,
+2004-03-31,PT,Portugal,-1.0837
 2004-03-31,RS,Serbia,12.4304
-2004-03-31,RU,Russia,13.327
-2004-03-31,SE,Sweden,7.6355
-2004-03-31,SG,Singapore,-2.7849
-2004-03-31,SI,Slovenia,
-2004-03-31,SK,Slovak Republic,
-2004-03-31,TH,Thailand,2.8048
-2004-03-31,TR,Türkiye,
-2004-03-31,US,United States,10.2909
-2004-03-31,XM,Euro area,4.1918
-2004-03-31,XW,World,
-2004-03-31,ZA,South Africa,30.0505
-2004-06-30,4T,Emerging market economies (aggregate),
-2004-06-30,5R,Advanced economies,
-2004-06-30,AE,United Arab Emirates,13.6252
-2004-06-30,AT,Austria,-3.0791
-2004-06-30,AU,Australia,5.6541
+2004-03-31,RU,Russia,13.3269
+2004-03-31,SE,Sweden,7.6316
+2004-03-31,SG,Singapore,-2.7864
+2004-03-31,TH,Thailand,2.8061
+2004-03-31,US,United States,10.2705
+2004-03-31,XM,Euro area,4.1998
+2004-03-31,ZA,South Africa,30.051
+2004-06-30,AT,Austria,-3.0792
+2004-06-30,AU,Australia,5.7292
 2004-06-30,BE,Belgium,5.4813
-2004-06-30,BG,Bulgaria,
-2004-06-30,BR,Brazil,8.4581
+2004-06-30,BG,Bulgaria,35.3411
+2004-06-30,BR,Brazil,8.4573
 2004-06-30,CA,Canada,9.4187
-2004-06-30,CH,Switzerland,2.669
-2004-06-30,CL,Chile,5.8758
-2004-06-30,CN,China,
-2004-06-30,CO,Colombia,2.0396
+2004-06-30,CH,Switzerland,2.6697
+2004-06-30,CL,Chile,5.8759
+2004-06-30,CO,Colombia,2.1315
 2004-06-30,CY,Cyprus,20.651
-2004-06-30,CZ,Czechia,
-2004-06-30,DE,Germany,-3.0931
-2004-06-30,DK,Denmark,8.9629
-2004-06-30,EE,Estonia,
-2004-06-30,ES,Spain,13.8336
+2004-06-30,DE,Germany,-3.0183
+2004-06-30,DK,Denmark,8.963
+2004-06-30,ES,Spain,13.834
 2004-06-30,FI,Finland,8.8136
-2004-06-30,FR,France,11.2426
+2004-06-30,FR,France,11.2331
 2004-06-30,GB,United Kingdom,10.4669
-2004-06-30,GR,Greece,
+2004-06-30,GR,Greece,-0.7011
 2004-06-30,HK,Hong Kong SAR,30.2046
-2004-06-30,HR,Croatia,11.1434
-2004-06-30,HU,Hungary,
+2004-06-30,HR,Croatia,11.1929
+2004-06-30,HU,Hungary,1.2362
 2004-06-30,ID,Indonesia,-2.1948
-2004-06-30,IE,Ireland,8.7269
-2004-06-30,IL,Israel,2.5978
-2004-06-30,IN,India,
-2004-06-30,IS,Iceland,8.6551
-2004-06-30,IT,Italy,3.2403
+2004-06-30,IE,Ireland,8.7259
+2004-06-30,IL,Israel,2.5982
+2004-06-30,IS,Iceland,8.6503
+2004-06-30,IT,Italy,3.2389
 2004-06-30,JP,Japan,-5.9616
-2004-06-30,KR,Korea,-1.1142
+2004-06-30,KR,Korea,-1.0731
 2004-06-30,LT,Lithuania,12.7077
-2004-06-30,LU,Luxembourg,
-2004-06-30,LV,Latvia,
-2004-06-30,MA,Morocco,
-2004-06-30,MK,North Macedonia,-0.8227
-2004-06-30,MT,Malta,
-2004-06-30,MX,Mexico,
+2004-06-30,MK,North Macedonia,-0.837
 2004-06-30,MY,Malaysia,4.4395
-2004-06-30,NL,Netherlands,2.8185
-2004-06-30,NO,Norway,9.3331
+2004-06-30,NL,Netherlands,2.7214
+2004-06-30,NO,Norway,9.2409
 2004-06-30,NZ,New Zealand,18.3216
 2004-06-30,PE,Peru,6.4738
-2004-06-30,PH,Philippines,
-2004-06-30,PL,Poland,
-2004-06-30,PT,Portugal,
-2004-06-30,RO,Romania,
+2004-06-30,PT,Portugal,-1.8767
 2004-06-30,RS,Serbia,5.3465
 2004-06-30,RU,Russia,16.7951
-2004-06-30,SE,Sweden,9.2743
-2004-06-30,SG,Singapore,-2.7036
-2004-06-30,SI,Slovenia,
-2004-06-30,SK,Slovak Republic,
-2004-06-30,TH,Thailand,3.2675
-2004-06-30,TR,Türkiye,
-2004-06-30,US,United States,11.0557
-2004-06-30,XM,Euro area,4.0634
-2004-06-30,XW,World,
-2004-06-30,ZA,South Africa,32.8322
-2004-09-30,4T,Emerging market economies (aggregate),
-2004-09-30,5R,Advanced economies,
-2004-09-30,AE,United Arab Emirates,18.5053
+2004-06-30,SE,Sweden,9.2783
+2004-06-30,SG,Singapore,-2.7034
+2004-06-30,TH,Thailand,3.2697
+2004-06-30,US,United States,11.0496
+2004-06-30,XM,Euro area,4.0718
+2004-06-30,ZA,South Africa,32.8191
 2004-09-30,AT,Austria,-1.662
-2004-09-30,AU,Australia,0.0446
+2004-09-30,AU,Australia,0.009
 2004-09-30,BE,Belgium,6.5885
-2004-09-30,BG,Bulgaria,
-2004-09-30,BR,Brazil,5.6428
+2004-09-30,BG,Bulgaria,41.6471
+2004-09-30,BR,Brazil,5.6417
 2004-09-30,CA,Canada,4.8368
-2004-09-30,CH,Switzerland,3.7213
+2004-09-30,CH,Switzerland,3.7226
 2004-09-30,CL,Chile,6.3204
-2004-09-30,CN,China,
-2004-09-30,CO,Colombia,3.9761
+2004-09-30,CO,Colombia,3.6147
 2004-09-30,CY,Cyprus,20.9762
-2004-09-30,CZ,Czechia,
-2004-09-30,DE,Germany,-2.8821
-2004-09-30,DK,Denmark,10.4172
-2004-09-30,EE,Estonia,
-2004-09-30,ES,Spain,13.0613
+2004-09-30,DE,Germany,-2.8634
+2004-09-30,DK,Denmark,10.388
+2004-09-30,ES,Spain,13.0604
 2004-09-30,FI,Finland,6.1181
-2004-09-30,FR,France,11.9857
+2004-09-30,FR,France,11.9885
 2004-09-30,GB,United Kingdom,12.4112
-2004-09-30,GR,Greece,
+2004-09-30,GR,Greece,-0.5114
 2004-09-30,HK,Hong Kong SAR,30.1953
-2004-09-30,HR,Croatia,14.5325
-2004-09-30,HU,Hungary,
+2004-09-30,HR,Croatia,14.5033
+2004-09-30,HU,Hungary,1.9859
 2004-09-30,ID,Indonesia,-2.9877
-2004-09-30,IE,Ireland,7.8216
-2004-09-30,IL,Israel,-0.1826
-2004-09-30,IN,India,
-2004-09-30,IS,Iceland,5.3541
-2004-09-30,IT,Italy,4.1114
+2004-09-30,IE,Ireland,7.8375
+2004-09-30,IL,Israel,-0.1822
+2004-09-30,IS,Iceland,5.3855
+2004-09-30,IT,Italy,4.1082
 2004-09-30,JP,Japan,-5.9768
-2004-09-30,KR,Korea,-4.3953
+2004-09-30,KR,Korea,-4.3801
 2004-09-30,LT,Lithuania,20.5087
-2004-09-30,LU,Luxembourg,
-2004-09-30,LV,Latvia,
-2004-09-30,MA,Morocco,
-2004-09-30,MK,North Macedonia,3.256
-2004-09-30,MT,Malta,
-2004-09-30,MX,Mexico,
+2004-09-30,MK,North Macedonia,3.5817
 2004-09-30,MY,Malaysia,1.0073
-2004-09-30,NL,Netherlands,3.6838
-2004-09-30,NO,Norway,9.3781
+2004-09-30,NL,Netherlands,3.4278
+2004-09-30,NO,Norway,9.4443
 2004-09-30,NZ,New Zealand,12.9542
 2004-09-30,PE,Peru,7.7706
-2004-09-30,PH,Philippines,
-2004-09-30,PL,Poland,
-2004-09-30,PT,Portugal,
-2004-09-30,RO,Romania,
+2004-09-30,PT,Portugal,-1.9027
 2004-09-30,RS,Serbia,1.8396
-2004-09-30,RU,Russia,16.2194
-2004-09-30,SE,Sweden,9.2057
-2004-09-30,SG,Singapore,-1.8698
-2004-09-30,SI,Slovenia,
-2004-09-30,SK,Slovak Republic,
-2004-09-30,TH,Thailand,1.6948
-2004-09-30,TR,Türkiye,
-2004-09-30,US,United States,11.7548
-2004-09-30,XM,Euro area,4.4766
-2004-09-30,XW,World,
-2004-09-30,ZA,South Africa,33.249
-2004-12-31,4T,Emerging market economies (aggregate),
-2004-12-31,5R,Advanced economies,
-2004-12-31,AE,United Arab Emirates,16.7637
+2004-09-30,RU,Russia,16.2193
+2004-09-30,SE,Sweden,9.2032
+2004-09-30,SG,Singapore,-1.8703
+2004-09-30,TH,Thailand,1.6986
+2004-09-30,US,United States,11.7337
+2004-09-30,XM,Euro area,4.4851
+2004-09-30,ZA,South Africa,33.2655
 2004-12-31,AT,Austria,-2.6991
-2004-12-31,AU,Australia,-2.1797
+2004-12-31,AU,Australia,-2.2157
 2004-12-31,BE,Belgium,6.7592
-2004-12-31,BG,Bulgaria,
-2004-12-31,BR,Brazil,3.7321
+2004-12-31,BG,Bulgaria,50.4214
+2004-12-31,BR,Brazil,3.7311
 2004-12-31,CA,Canada,5.4575
-2004-12-31,CH,Switzerland,3.6832
-2004-12-31,CL,Chile,5.9801
-2004-12-31,CN,China,
-2004-12-31,CO,Colombia,5.733
+2004-12-31,CH,Switzerland,3.6857
+2004-12-31,CL,Chile,5.9803
+2004-12-31,CO,Colombia,5.2781
 2004-12-31,CY,Cyprus,22.865
-2004-12-31,CZ,Czechia,
-2004-12-31,DE,Germany,-2.8733
-2004-12-31,DK,Denmark,12.4988
-2004-12-31,EE,Estonia,
-2004-12-31,ES,Spain,13.3482
+2004-12-31,DE,Germany,-2.8176
+2004-12-31,DK,Denmark,12.4818
+2004-12-31,ES,Spain,13.3481
 2004-12-31,FI,Finland,5.1659
-2004-12-31,FR,France,12.9879
+2004-12-31,FR,France,12.9853
 2004-12-31,GB,United Kingdom,10.7403
-2004-12-31,GR,Greece,
+2004-12-31,GR,Greece,0.5504
 2004-12-31,HK,Hong Kong SAR,28.8629
-2004-12-31,HR,Croatia,13.1557
-2004-12-31,HU,Hungary,
+2004-12-31,HR,Croatia,13.189
+2004-12-31,HU,Hungary,-2.9689
 2004-12-31,ID,Indonesia,-2.7541
-2004-12-31,IE,Ireland,8.2887
-2004-12-31,IL,Israel,-1.9398
-2004-12-31,IN,India,
-2004-12-31,IS,Iceland,9.3412
-2004-12-31,IT,Italy,5.3118
+2004-12-31,IE,Ireland,8.3703
+2004-12-31,IL,Israel,-1.9396
+2004-12-31,IS,Iceland,9.3179
+2004-12-31,IT,Italy,5.3134
 2004-12-31,JP,Japan,-6.2186
-2004-12-31,KR,Korea,-5.446
-2004-12-31,LT,Lithuania,26.7553
-2004-12-31,LU,Luxembourg,
-2004-12-31,LV,Latvia,
-2004-12-31,MA,Morocco,
-2004-12-31,MK,North Macedonia,-0.3157
-2004-12-31,MT,Malta,
-2004-12-31,MX,Mexico,
+2004-12-31,KR,Korea,-5.4944
+2004-12-31,LT,Lithuania,26.7551
+2004-12-31,MK,North Macedonia,-0.1018
 2004-12-31,MY,Malaysia,0.3342
-2004-12-31,NL,Netherlands,2.6929
-2004-12-31,NO,Norway,9.2032
+2004-12-31,NL,Netherlands,2.6599
+2004-12-31,NO,Norway,9.2523
 2004-12-31,NZ,New Zealand,9.4544
 2004-12-31,PE,Peru,-1.4572
-2004-12-31,PH,Philippines,
-2004-12-31,PL,Poland,
-2004-12-31,PT,Portugal,
-2004-12-31,RO,Romania,
+2004-12-31,PT,Portugal,-1.8783
 2004-12-31,RS,Serbia,0.5572
 2004-12-31,RU,Russia,14.9736
-2004-12-31,SE,Sweden,9.5076
-2004-12-31,SG,Singapore,-0.7809
-2004-12-31,SI,Slovenia,
-2004-12-31,SK,Slovak Republic,
-2004-12-31,TH,Thailand,2.3838
-2004-12-31,TR,Türkiye,
-2004-12-31,US,United States,11.6387
-2004-12-31,XM,Euro area,4.789
-2004-12-31,XW,World,
+2004-12-31,SE,Sweden,9.5066
+2004-12-31,SG,Singapore,-0.7817
+2004-12-31,TH,Thailand,2.3857
+2004-12-31,US,United States,11.6256
+2004-12-31,XM,Euro area,4.7959
 2004-12-31,ZA,South Africa,30.963
-2005-03-31,4T,Emerging market economies (aggregate),
-2005-03-31,5R,Advanced economies,
-2005-03-31,AE,United Arab Emirates,6.899
 2005-03-31,AT,Austria,5.5538
-2005-03-31,AU,Australia,-1.7662
-2005-03-31,BE,Belgium,8.609
-2005-03-31,BG,Bulgaria,
-2005-03-31,BR,Brazil,2.1902
-2005-03-31,CA,Canada,7.5302
-2005-03-31,CH,Switzerland,3.3235
+2005-03-31,AU,Australia,-1.732
+2005-03-31,BE,Belgium,8.6115
+2005-03-31,BG,Bulgaria,49.1761
+2005-03-31,BR,Brazil,2.1893
+2005-03-31,CA,Canada,7.6597
+2005-03-31,CH,Switzerland,3.3256
 2005-03-31,CL,Chile,3.0416
-2005-03-31,CN,China,
-2005-03-31,CO,Colombia,3.658
+2005-03-31,CO,Colombia,4.5118
 2005-03-31,CY,Cyprus,8.8958
-2005-03-31,CZ,Czechia,
-2005-03-31,DE,Germany,-2.1562
-2005-03-31,DK,Denmark,14.0542
-2005-03-31,EE,Estonia,
-2005-03-31,ES,Spain,12.0727
+2005-03-31,DE,Germany,-1.9786
+2005-03-31,DK,Denmark,14.0201
+2005-03-31,ES,Spain,12.0733
 2005-03-31,FI,Finland,4.6578
-2005-03-31,FR,France,13.2027
-2005-03-31,GB,United Kingdom,7.2145
-2005-03-31,GR,Greece,
+2005-03-31,FR,France,13.2104
+2005-03-31,GB,United Kingdom,7.2158
+2005-03-31,GR,Greece,4.182
 2005-03-31,HK,Hong Kong SAR,21.7139
-2005-03-31,HR,Croatia,10.1455
-2005-03-31,HU,Hungary,
+2005-03-31,HR,Croatia,10.1873
+2005-03-31,HU,Hungary,1.0326
 2005-03-31,ID,Indonesia,-3.599
-2005-03-31,IE,Ireland,8.8735
-2005-03-31,IL,Israel,-2.6227
-2005-03-31,IN,India,
-2005-03-31,IS,Iceland,18.8924
-2005-03-31,IT,Italy,6.2858
+2005-03-31,IE,Ireland,8.8527
+2005-03-31,IL,Israel,-2.6219
+2005-03-31,IS,Iceland,18.8817
+2005-03-31,IT,Italy,6.2843
 2005-03-31,JP,Japan,-5.4006
-2005-03-31,KR,Korea,-4.925
-2005-03-31,LT,Lithuania,36.052
-2005-03-31,LU,Luxembourg,
-2005-03-31,LV,Latvia,
-2005-03-31,MA,Morocco,
-2005-03-31,MK,North Macedonia,-1.9
-2005-03-31,MT,Malta,
-2005-03-31,MX,Mexico,
+2005-03-31,KR,Korea,-4.8933
+2005-03-31,LT,Lithuania,36.0522
+2005-03-31,MK,North Macedonia,-1.9767
 2005-03-31,MY,Malaysia,-0.5621
-2005-03-31,NL,Netherlands,2.1789
-2005-03-31,NO,Norway,6.1751
+2005-03-31,NL,Netherlands,2.1635
+2005-03-31,NO,Norway,6.2008
 2005-03-31,NZ,New Zealand,9.5535
 2005-03-31,PE,Peru,-2.714
-2005-03-31,PH,Philippines,
-2005-03-31,PL,Poland,
-2005-03-31,PT,Portugal,
-2005-03-31,RO,Romania,
+2005-03-31,PT,Portugal,-1.9338
 2005-03-31,RS,Serbia,-2.0099
-2005-03-31,RU,Russia,11.2055
-2005-03-31,SE,Sweden,8.14
-2005-03-31,SG,Singapore,1.7241
-2005-03-31,SI,Slovenia,
-2005-03-31,SK,Slovak Republic,
-2005-03-31,TH,Thailand,5.0974
-2005-03-31,TR,Türkiye,
-2005-03-31,US,United States,12.7194
-2005-03-31,XM,Euro area,5.4567
-2005-03-31,XW,World,
-2005-03-31,ZA,South Africa,29.8371
-2005-06-30,4T,Emerging market economies (aggregate),
-2005-06-30,5R,Advanced economies,
-2005-06-30,AE,United Arab Emirates,4.5375
-2005-06-30,AT,Austria,1.6784
-2005-06-30,AU,Australia,-0.2099
-2005-06-30,BE,Belgium,10.3915
-2005-06-30,BG,Bulgaria,
-2005-06-30,BR,Brazil,0.9769
-2005-06-30,CA,Canada,5.6428
-2005-06-30,CH,Switzerland,3.2581
+2005-03-31,RU,Russia,11.2056
+2005-03-31,SE,Sweden,8.1477
+2005-03-31,SG,Singapore,1.723
+2005-03-31,TH,Thailand,5.0981
+2005-03-31,US,United States,12.7137
+2005-03-31,XM,Euro area,5.4602
+2005-03-31,ZA,South Africa,29.8352
+2005-06-30,AT,Austria,1.6785
+2005-06-30,AU,Australia,-0.1945
+2005-06-30,BE,Belgium,10.382
+2005-06-30,BG,Bulgaria,37.5146
+2005-06-30,BR,Brazil,0.9761
+2005-06-30,CA,Canada,5.77
+2005-06-30,CH,Switzerland,3.2588
 2005-06-30,CL,Chile,4.3515
-2005-06-30,CN,China,
-2005-06-30,CO,Colombia,4.4209
+2005-06-30,CO,Colombia,4.1824
 2005-06-30,CY,Cyprus,8.0751
-2005-06-30,CZ,Czechia,
-2005-06-30,DE,Germany,-2.4216
-2005-06-30,DK,Denmark,14.4613
-2005-06-30,EE,Estonia,
-2005-06-30,ES,Spain,10.3548
+2005-06-30,DE,Germany,-2.5397
+2005-06-30,DK,Denmark,14.4719
+2005-06-30,ES,Spain,10.3549
 2005-06-30,FI,Finland,4.8673
-2005-06-30,FR,France,13.4642
-2005-06-30,GB,United Kingdom,3.957
-2005-06-30,GR,Greece,
+2005-06-30,FR,France,13.4726
+2005-06-30,GB,United Kingdom,3.8676
+2005-06-30,GR,Greece,6.9239
 2005-06-30,HK,Hong Kong SAR,21.588
-2005-06-30,HR,Croatia,11.2678
-2005-06-30,HU,Hungary,
+2005-06-30,HR,Croatia,11.2159
+2005-06-30,HU,Hungary,-0.7566
 2005-06-30,ID,Indonesia,-3.7152
-2005-06-30,IE,Ireland,9.912
-2005-06-30,IL,Israel,-1.9715
-2005-06-30,IN,India,
-2005-06-30,IS,Iceland,24.9159
-2005-06-30,IT,Italy,6.1752
+2005-06-30,IE,Ireland,9.8672
+2005-06-30,IL,Israel,-1.9719
+2005-06-30,IS,Iceland,24.9371
+2005-06-30,IT,Italy,6.1809
 2005-06-30,JP,Japan,-4.9237
-2005-06-30,KR,Korea,-3.4437
-2005-06-30,LT,Lithuania,35.876
-2005-06-30,LU,Luxembourg,
-2005-06-30,LV,Latvia,
-2005-06-30,MA,Morocco,
-2005-06-30,MK,North Macedonia,1.964
-2005-06-30,MT,Malta,
-2005-06-30,MX,Mexico,
+2005-06-30,KR,Korea,-3.3995
+2005-06-30,LT,Lithuania,35.8761
+2005-06-30,MK,North Macedonia,2.3153
 2005-06-30,MY,Malaysia,0.3605
-2005-06-30,NL,Netherlands,2.3389
-2005-06-30,NO,Norway,6.8721
+2005-06-30,NL,Netherlands,2.2578
+2005-06-30,NO,Norway,6.8642
 2005-06-30,NZ,New Zealand,10.5851
 2005-06-30,PE,Peru,-13.9667
-2005-06-30,PH,Philippines,
-2005-06-30,PL,Poland,
-2005-06-30,PT,Portugal,
-2005-06-30,RO,Romania,
+2005-06-30,PT,Portugal,-0.1831
 2005-06-30,RS,Serbia,-0.1436
 2005-06-30,RU,Russia,7.7639
-2005-06-30,SE,Sweden,7.2526
-2005-06-30,SG,Singapore,2.3074
-2005-06-30,SI,Slovenia,
-2005-06-30,SK,Slovak Republic,
-2005-06-30,TH,Thailand,3.9931
-2005-06-30,TR,Türkiye,
-2005-06-30,US,United States,12.8207
-2005-06-30,XM,Euro area,5.1022
-2005-06-30,XW,World,
-2005-06-30,ZA,South Africa,26.7629
-2005-09-30,4T,Emerging market economies (aggregate),
-2005-09-30,5R,Advanced economies,
-2005-09-30,AE,United Arab Emirates,2.4729
+2005-06-30,SE,Sweden,7.2519
+2005-06-30,SG,Singapore,2.3009
+2005-06-30,TH,Thailand,3.993
+2005-06-30,US,United States,12.816
+2005-06-30,XM,Euro area,5.098
+2005-06-30,ZA,South Africa,26.7793
 2005-09-30,AT,Austria,1.4116
-2005-09-30,AU,Australia,-0.9366
-2005-09-30,BE,Belgium,9.7236
-2005-09-30,BG,Bulgaria,
-2005-09-30,BR,Brazil,2.1223
-2005-09-30,CA,Canada,9.5227
-2005-09-30,CH,Switzerland,2.8506
+2005-09-30,AU,Australia,-0.9081
+2005-09-30,BE,Belgium,9.6809
+2005-09-30,BG,Bulgaria,26.015
+2005-09-30,BR,Brazil,2.122
+2005-09-30,CA,Canada,9.4474
+2005-09-30,CH,Switzerland,2.8472
 2005-09-30,CL,Chile,3.4185
-2005-09-30,CN,China,
-2005-09-30,CO,Colombia,4.6612
+2005-09-30,CO,Colombia,4.8618
 2005-09-30,CY,Cyprus,5.9923
-2005-09-30,CZ,Czechia,
-2005-09-30,DE,Germany,-2.8063
-2005-09-30,DK,Denmark,18.7299
-2005-09-30,EE,Estonia,
-2005-09-30,ES,Spain,9.6621
+2005-09-30,DE,Germany,-2.8388
+2005-09-30,DK,Denmark,18.7683
+2005-09-30,ES,Spain,9.6632
 2005-09-30,FI,Finland,6.7469
-2005-09-30,FR,France,13.0854
-2005-09-30,GB,United Kingdom,1.5225
-2005-09-30,GR,Greece,
-2005-09-30,HK,Hong Kong SAR,18.4829
-2005-09-30,HR,Croatia,8.881
-2005-09-30,HU,Hungary,
+2005-09-30,FR,France,13.0878
+2005-09-30,GB,United Kingdom,1.5349
+2005-09-30,GR,Greece,8.0212
+2005-09-30,HK,Hong Kong SAR,18.6942
+2005-09-30,HR,Croatia,8.7995
+2005-09-30,HU,Hungary,-1.4054
 2005-09-30,ID,Indonesia,-4.6463
-2005-09-30,IE,Ireland,8.7041
-2005-09-30,IL,Israel,-1.1472
-2005-09-30,IN,India,
-2005-09-30,IS,Iceland,28.3481
-2005-09-30,IT,Italy,5.3048
+2005-09-30,IE,Ireland,8.7067
+2005-09-30,IL,Israel,-1.1479
+2005-09-30,IS,Iceland,28.3284
+2005-09-30,IT,Italy,5.2986
 2005-09-30,JP,Japan,-4.3804
-2005-09-30,KR,Korea,-0.1703
-2005-09-30,LT,Lithuania,34.591
-2005-09-30,LU,Luxembourg,
-2005-09-30,LV,Latvia,
-2005-09-30,MA,Morocco,
-2005-09-30,MK,North Macedonia,-2.523
-2005-09-30,MT,Malta,
-2005-09-30,MX,Mexico,
+2005-09-30,KR,Korea,-0.1857
+2005-09-30,LT,Lithuania,34.5909
+2005-09-30,MK,North Macedonia,-2.459
 2005-09-30,MY,Malaysia,-0.6957
-2005-09-30,NL,Netherlands,1.9788
-2005-09-30,NO,Norway,7.371
+2005-09-30,NL,Netherlands,2.0755
+2005-09-30,NO,Norway,7.3244
 2005-09-30,NZ,New Zealand,11.223
 2005-09-30,PE,Peru,-10.6419
-2005-09-30,PH,Philippines,
-2005-09-30,PL,Poland,
-2005-09-30,PT,Portugal,
-2005-09-30,RO,Romania,
+2005-09-30,PT,Portugal,1.049
 2005-09-30,RS,Serbia,5.3754
-2005-09-30,RU,Russia,8.0542
-2005-09-30,SE,Sweden,8.6502
-2005-09-30,SG,Singapore,2.7518
-2005-09-30,SI,Slovenia,
-2005-09-30,SK,Slovak Republic,
-2005-09-30,TH,Thailand,3.2742
-2005-09-30,TR,Türkiye,
-2005-09-30,US,United States,11.9324
-2005-09-30,XM,Euro area,4.6916
-2005-09-30,XW,World,
-2005-09-30,ZA,South Africa,22.9943
-2005-12-31,4T,Emerging market economies (aggregate),
-2005-12-31,5R,Advanced economies,
-2005-12-31,AE,United Arab Emirates,-0.1985
+2005-09-30,RU,Russia,8.0543
+2005-09-30,SE,Sweden,8.6488
+2005-09-30,SG,Singapore,2.7469
+2005-09-30,TH,Thailand,3.2704
+2005-09-30,US,United States,11.9156
+2005-09-30,XM,Euro area,4.6878
+2005-09-30,ZA,South Africa,22.9731
 2005-12-31,AT,Austria,2.0805
-2005-12-31,AU,Australia,-0.4419
-2005-12-31,BE,Belgium,9.9793
-2005-12-31,BG,Bulgaria,
-2005-12-31,BR,Brazil,2.4069
-2005-12-31,CA,Canada,7.3813
-2005-12-31,CH,Switzerland,3.0866
-2005-12-31,CL,Chile,3.4174
-2005-12-31,CN,China,
-2005-12-31,CO,Colombia,-0.237
+2005-12-31,AU,Australia,-0.428
+2005-12-31,BE,Belgium,10.0285
+2005-12-31,BG,Bulgaria,14.0706
+2005-12-31,BR,Brazil,2.4064
+2005-12-31,CA,Canada,7.21
+2005-12-31,CH,Switzerland,3.08
+2005-12-31,CL,Chile,3.4172
+2005-12-31,CO,Colombia,0.2867
 2005-12-31,CY,Cyprus,3.6498
-2005-12-31,CZ,Czechia,
-2005-12-31,DE,Germany,-2.3266
-2005-12-31,DK,Denmark,23.7257
-2005-12-31,EE,Estonia,
-2005-12-31,ES,Spain,8.8618
+2005-12-31,DE,Germany,-2.3519
+2005-12-31,DK,Denmark,23.7533
+2005-12-31,ES,Spain,8.8621
 2005-12-31,FI,Finland,8.5955
-2005-12-31,FR,France,12.8333
-2005-12-31,GB,United Kingdom,1.1956
-2005-12-31,GR,Greece,
+2005-12-31,FR,France,12.8341
+2005-12-31,GB,United Kingdom,1.2667
+2005-12-31,GR,Greece,9.1599
 2005-12-31,HK,Hong Kong SAR,6.7661
-2005-12-31,HR,Croatia,7.2641
-2005-12-31,HU,Hungary,
+2005-12-31,HR,Croatia,7.2686
+2005-12-31,HU,Hungary,-0.5769
 2005-12-31,ID,Indonesia,-10.9407
-2005-12-31,IE,Ireland,7.7618
-2005-12-31,IL,Israel,1.4063
-2005-12-31,IN,India,
-2005-12-31,IS,Iceland,26.3495
-2005-12-31,IT,Italy,4.5103
+2005-12-31,IE,Ireland,7.7082
+2005-12-31,IL,Israel,1.4059
+2005-12-31,IS,Iceland,26.3703
+2005-12-31,IT,Italy,4.5121
 2005-12-31,JP,Japan,-3.5277
-2005-12-31,KR,Korea,0.98
-2005-12-31,LT,Lithuania,51.1896
-2005-12-31,LU,Luxembourg,
-2005-12-31,LV,Latvia,
-2005-12-31,MA,Morocco,
-2005-12-31,MK,North Macedonia,-2.2254
-2005-12-31,MT,Malta,
-2005-12-31,MX,Mexico,
+2005-12-31,KR,Korea,0.9553
+2005-12-31,LT,Lithuania,51.1897
+2005-12-31,MK,North Macedonia,-2.2362
 2005-12-31,MY,Malaysia,-0.6498
-2005-12-31,NL,Netherlands,2.0946
-2005-12-31,NO,Norway,6.0398
+2005-12-31,NL,Netherlands,2.1957
+2005-12-31,NO,Norway,6.1385
 2005-12-31,NZ,New Zealand,11.7142
 2005-12-31,PE,Peru,4.154
-2005-12-31,PH,Philippines,
-2005-12-31,PL,Poland,
-2005-12-31,PT,Portugal,
-2005-12-31,RO,Romania,
+2005-12-31,PT,Portugal,1.0255
 2005-12-31,RS,Serbia,1.606
 2005-12-31,RU,Russia,11.0725
-2005-12-31,SE,Sweden,10.0308
-2005-12-31,SG,Singapore,2.8089
-2005-12-31,SI,Slovenia,
-2005-12-31,SK,Slovak Republic,
-2005-12-31,TH,Thailand,1.1775
-2005-12-31,TR,Türkiye,
-2005-12-31,US,United States,10.9434
-2005-12-31,XM,Euro area,4.5701
-2005-12-31,XW,World,
-2005-12-31,ZA,South Africa,19.117
-2006-03-31,4T,Emerging market economies (aggregate),
-2006-03-31,5R,Advanced economies,
-2006-03-31,AE,United Arab Emirates,2.4666
+2005-12-31,SE,Sweden,10.029
+2005-12-31,SG,Singapore,2.8024
+2005-12-31,TH,Thailand,1.1809
+2005-12-31,US,United States,10.9492
+2005-12-31,XM,Euro area,4.5676
+2005-12-31,ZA,South Africa,19.113
 2006-03-31,AT,Austria,3.3755
-2006-03-31,AU,Australia,0.683
-2006-03-31,BE,Belgium,7.6682
-2006-03-31,BG,Bulgaria,6.5348
-2006-03-31,BR,Brazil,3.6606
-2006-03-31,CA,Canada,7.7303
-2006-03-31,CH,Switzerland,3.8371
-2006-03-31,CL,Chile,3.3974
-2006-03-31,CN,China,
-2006-03-31,CO,Colombia,5.6011
+2006-03-31,AU,Australia,0.6085
+2006-03-31,BE,Belgium,7.6888
+2006-03-31,BG,Bulgaria,6.5468
+2006-03-31,BR,Brazil,3.6604
+2006-03-31,CA,Canada,7.1511
+2006-03-31,CH,Switzerland,3.8306
+2006-03-31,CL,Chile,3.3975
+2006-03-31,CO,Colombia,4.2603
 2006-03-31,CY,Cyprus,8.0965
-2006-03-31,CZ,Czechia,
-2006-03-31,DE,Germany,-3.2566
-2006-03-31,DK,Denmark,26.76
+2006-03-31,DE,Germany,-3.2973
+2006-03-31,DK,Denmark,26.8366
 2006-03-31,EE,Estonia,45.8701
-2006-03-31,ES,Spain,5.0367
+2006-03-31,ES,Spain,5.036
 2006-03-31,FI,Finland,7.2201
-2006-03-31,FR,France,11.7898
-2006-03-31,GB,United Kingdom,4.2877
-2006-03-31,GR,Greece,
+2006-03-31,FR,France,11.7912
+2006-03-31,GB,United Kingdom,4.3523
+2006-03-31,GR,Greece,9.8659
 2006-03-31,HK,Hong Kong SAR,0.2068
-2006-03-31,HR,Croatia,11.902
-2006-03-31,HU,Hungary,
+2006-03-31,HR,Croatia,11.7866
+2006-03-31,HU,Hungary,2.0654
 2006-03-31,ID,Indonesia,-9.1608
-2006-03-31,IE,Ireland,9.2916
-2006-03-31,IL,Israel,1.8448
-2006-03-31,IN,India,
-2006-03-31,IS,Iceland,19.4416
-2006-03-31,IT,Italy,3.6726
+2006-03-31,IE,Ireland,9.2585
+2006-03-31,IL,Israel,1.8445
+2006-03-31,IS,Iceland,19.4701
+2006-03-31,IT,Italy,3.6792
 2006-03-31,JP,Japan,-3.7046
-2006-03-31,KR,Korea,2.759
+2006-03-31,KR,Korea,2.6938
 2006-03-31,LT,Lithuania,36.1789
-2006-03-31,LU,Luxembourg,
-2006-03-31,LV,Latvia,
-2006-03-31,MA,Morocco,
-2006-03-31,MK,North Macedonia,-0.4654
+2006-03-31,MK,North Macedonia,-0.2092
 2006-03-31,MT,Malta,7.1736
 2006-03-31,MX,Mexico,3.6363
 2006-03-31,MY,Malaysia,-1.3373
-2006-03-31,NL,Netherlands,2.9897
-2006-03-31,NO,Norway,7.8701
+2006-03-31,NL,Netherlands,3.0017
+2006-03-31,NO,Norway,7.9256
 2006-03-31,NZ,New Zealand,8.6497
 2006-03-31,PE,Peru,-4.7861
-2006-03-31,PH,Philippines,
-2006-03-31,PL,Poland,
-2006-03-31,PT,Portugal,
-2006-03-31,RO,Romania,
+2006-03-31,PT,Portugal,0.7033
 2006-03-31,RS,Serbia,-5.748
 2006-03-31,RU,Russia,18.3972
-2006-03-31,SE,Sweden,13.1085
-2006-03-31,SG,Singapore,3.3592
-2006-03-31,SI,Slovenia,
-2006-03-31,SK,Slovak Republic,
-2006-03-31,TH,Thailand,-0.7158
-2006-03-31,TR,Türkiye,
-2006-03-31,US,United States,8.6362
-2006-03-31,XM,Euro area,3.9259
-2006-03-31,XW,World,
-2006-03-31,ZA,South Africa,14.861
-2006-06-30,4T,Emerging market economies (aggregate),
-2006-06-30,5R,Advanced economies,
-2006-06-30,AE,United Arab Emirates,3.9297
+2006-03-31,SE,Sweden,13.107
+2006-03-31,SG,Singapore,3.3545
+2006-03-31,TH,Thailand,-0.7142
+2006-03-31,US,United States,8.6456
+2006-03-31,XM,Euro area,3.9135
+2006-03-31,ZA,South Africa,14.8568
 2006-06-30,AT,Austria,2.7532
-2006-06-30,AU,Australia,2.5511
-2006-06-30,BE,Belgium,8.4248
-2006-06-30,BG,Bulgaria,3.5981
-2006-06-30,BR,Brazil,6.0131
-2006-06-30,CA,Canada,10.0901
-2006-06-30,CH,Switzerland,4.8693
+2006-06-30,AU,Australia,2.5361
+2006-06-30,BE,Belgium,8.4288
+2006-06-30,BG,Bulgaria,3.4866
+2006-06-30,BR,Brazil,6.0132
+2006-06-30,CA,Canada,9.2447
+2006-06-30,CH,Switzerland,4.8641
 2006-06-30,CL,Chile,2.4758
 2006-06-30,CN,China,3.1256
-2006-06-30,CO,Colombia,7.3848
+2006-06-30,CO,Colombia,7.8304
 2006-06-30,CY,Cyprus,11.1081
-2006-06-30,CZ,Czechia,
-2006-06-30,DE,Germany,-1.541
-2006-06-30,DK,Denmark,27.7335
+2006-06-30,DE,Germany,-1.5102
+2006-06-30,DK,Denmark,27.7408
 2006-06-30,EE,Estonia,42.2975
-2006-06-30,ES,Spain,5.3535
+2006-06-30,ES,Spain,5.3536
 2006-06-30,FI,Finland,5.8738
-2006-06-30,FR,France,10.3888
-2006-06-30,GB,United Kingdom,4.8203
-2006-06-30,GR,Greece,
+2006-06-30,FR,France,10.3872
+2006-06-30,GB,United Kingdom,4.879
+2006-06-30,GR,Greece,9.6586
 2006-06-30,HK,Hong Kong SAR,-3.3253
-2006-06-30,HR,Croatia,8.4785
-2006-06-30,HU,Hungary,
+2006-06-30,HR,Croatia,8.5135
+2006-06-30,HU,Hungary,0.8429
 2006-06-30,ID,Indonesia,-8.7121
-2006-06-30,IE,Ireland,10.5444
-2006-06-30,IL,Israel,-2.2521
-2006-06-30,IN,India,
-2006-06-30,IS,Iceland,9.4518
-2006-06-30,IT,Italy,3.6779
+2006-06-30,IE,Ireland,10.5541
+2006-06-30,IL,Israel,-2.2528
+2006-06-30,IS,Iceland,9.4587
+2006-06-30,IT,Italy,3.6765
 2006-06-30,JP,Japan,-3.4377
-2006-06-30,KR,Korea,3.334
+2006-06-30,KR,Korea,3.2831
 2006-06-30,LT,Lithuania,43.8169
-2006-06-30,LU,Luxembourg,
-2006-06-30,LV,Latvia,
-2006-06-30,MA,Morocco,
-2006-06-30,MK,North Macedonia,-7.5012
+2006-06-30,MK,North Macedonia,-7.6258
 2006-06-30,MT,Malta,18.1711
 2006-06-30,MX,Mexico,3.3601
 2006-06-30,MY,Malaysia,-2.6459
-2006-06-30,NL,Netherlands,2.9616
-2006-06-30,NO,Norway,9.9411
+2006-06-30,NL,Netherlands,2.9505
+2006-06-30,NO,Norway,9.9918
 2006-06-30,NZ,New Zealand,5.9407
 2006-06-30,PE,Peru,2.3963
-2006-06-30,PH,Philippines,
-2006-06-30,PL,Poland,
-2006-06-30,PT,Portugal,
-2006-06-30,RO,Romania,
+2006-06-30,PT,Portugal,-0.739
 2006-06-30,RS,Serbia,-10.0998
 2006-06-30,RU,Russia,27.7724
-2006-06-30,SE,Sweden,11.7409
-2006-06-30,SG,Singapore,4.8355
-2006-06-30,SI,Slovenia,
-2006-06-30,SK,Slovak Republic,
-2006-06-30,TH,Thailand,-1.0488
-2006-06-30,TR,Türkiye,
-2006-06-30,US,United States,3.4057
-2006-06-30,XM,Euro area,4.2894
-2006-06-30,XW,World,
-2006-06-30,ZA,South Africa,12.7999
-2006-09-30,4T,Emerging market economies (aggregate),
-2006-09-30,5R,Advanced economies,
-2006-09-30,AE,United Arab Emirates,12.9679
+2006-06-30,SE,Sweden,11.7411
+2006-06-30,SG,Singapore,4.8342
+2006-06-30,TH,Thailand,-1.047
+2006-06-30,US,United States,3.4031
+2006-06-30,XM,Euro area,4.2731
+2006-06-30,ZA,South Africa,12.7987
 2006-09-30,AT,Austria,3.451
-2006-09-30,AU,Australia,4.5991
-2006-09-30,BE,Belgium,8.2686
-2006-09-30,BG,Bulgaria,6.8577
-2006-09-30,BR,Brazil,7.9216
-2006-09-30,CA,Canada,11.8602
-2006-09-30,CH,Switzerland,4.2363
-2006-09-30,CL,Chile,2.675
+2006-09-30,AU,Australia,4.6542
+2006-09-30,BE,Belgium,8.3968
+2006-09-30,BG,Bulgaria,6.8619
+2006-09-30,BR,Brazil,7.9215
+2006-09-30,CA,Canada,11.0482
+2006-09-30,CH,Switzerland,4.2331
+2006-09-30,CL,Chile,2.6748
 2006-09-30,CN,China,3.2769
-2006-09-30,CO,Colombia,9.6915
+2006-09-30,CO,Colombia,9.3446
 2006-09-30,CY,Cyprus,11.7878
-2006-09-30,CZ,Czechia,
-2006-09-30,DE,Germany,-0.0422
-2006-09-30,DK,Denmark,21.1813
+2006-09-30,DE,Germany,-0.0271
+2006-09-30,DK,Denmark,21.2356
 2006-09-30,EE,Estonia,44.2169
 2006-09-30,ES,Spain,7.4525
 2006-09-30,FI,Finland,4.6465
-2006-09-30,FR,France,8.9463
-2006-09-30,GB,United Kingdom,5.351
-2006-09-30,GR,Greece,
-2006-09-30,HK,Hong Kong SAR,-2.9093
-2006-09-30,HR,Croatia,9.9163
-2006-09-30,HU,Hungary,
+2006-09-30,FR,France,8.9433
+2006-09-30,GB,United Kingdom,5.2778
+2006-09-30,GR,Greece,8.4628
+2006-09-30,HK,Hong Kong SAR,-3.0822
+2006-09-30,HR,Croatia,9.9879
+2006-09-30,HU,Hungary,0.2191
 2006-09-30,ID,Indonesia,-8.2296
-2006-09-30,IE,Ireland,12.3956
-2006-09-30,IL,Israel,-2.316
-2006-09-30,IN,India,
-2006-09-30,IS,Iceland,3.0828
-2006-09-30,IT,Italy,3.6031
+2006-09-30,IE,Ireland,12.3726
+2006-09-30,IL,Israel,-2.3159
+2006-09-30,IS,Iceland,3.0892
+2006-09-30,IT,Italy,3.6077
 2006-09-30,JP,Japan,-3.2883
-2006-09-30,KR,Korea,2.2725
-2006-09-30,LT,Lithuania,42.8449
-2006-09-30,LU,Luxembourg,
-2006-09-30,LV,Latvia,
-2006-09-30,MA,Morocco,
-2006-09-30,MK,North Macedonia,-2.3038
+2006-09-30,KR,Korea,2.3008
+2006-09-30,LT,Lithuania,42.845
+2006-09-30,MK,North Macedonia,-2.5067
 2006-09-30,MT,Malta,12.9247
 2006-09-30,MX,Mexico,2.5491
 2006-09-30,MY,Malaysia,-1.4447
-2006-09-30,NL,Netherlands,2.9054
-2006-09-30,NO,Norway,12.6579
+2006-09-30,NL,Netherlands,2.9001
+2006-09-30,NO,Norway,12.7162
 2006-09-30,NZ,New Zealand,5.5379
 2006-09-30,PE,Peru,-5.658
-2006-09-30,PH,Philippines,
-2006-09-30,PL,Poland,
-2006-09-30,PT,Portugal,
-2006-09-30,RO,Romania,
+2006-09-30,PT,Portugal,-2.1844
 2006-09-30,RS,Serbia,-9.1541
-2006-09-30,RU,Russia,40.78
-2006-09-30,SE,Sweden,10.3869
-2006-09-30,SG,Singapore,6.7846
-2006-09-30,SI,Slovenia,
-2006-09-30,SK,Slovak Republic,
-2006-09-30,TH,Thailand,-1.1849
-2006-09-30,TR,Türkiye,
-2006-09-30,US,United States,-0.1808
-2006-09-30,XM,Euro area,4.7216
-2006-09-30,XW,World,
-2006-09-30,ZA,South Africa,10.404
-2006-12-31,4T,Emerging market economies (aggregate),
-2006-12-31,5R,Advanced economies,
-2006-12-31,AE,United Arab Emirates,9.4259
-2006-12-31,AT,Austria,0.9285
-2006-12-31,AU,Australia,5.061
-2006-12-31,BE,Belgium,7.0238
-2006-12-31,BG,Bulgaria,10.6776
-2006-12-31,BR,Brazil,10.1946
-2006-12-31,CA,Canada,11.4372
-2006-12-31,CH,Switzerland,8.652
+2006-09-30,RU,Russia,40.7799
+2006-09-30,SE,Sweden,10.3883
+2006-09-30,SG,Singapore,6.7822
+2006-09-30,TH,Thailand,-1.1883
+2006-09-30,US,United States,-0.1519
+2006-09-30,XM,Euro area,4.7055
+2006-09-30,ZA,South Africa,10.4094
+2006-12-31,AT,Austria,0.9286
+2006-12-31,AU,Australia,5.1577
+2006-12-31,BE,Belgium,7.0562
+2006-12-31,BG,Bulgaria,10.6167
+2006-12-31,BR,Brazil,10.1943
+2006-12-31,CA,Canada,10.6433
+2006-12-31,CH,Switzerland,8.6499
 2006-12-31,CL,Chile,2.2843
 2006-12-31,CN,China,3.0445
-2006-12-31,CO,Colombia,10.0143
+2006-12-31,CO,Colombia,9.5988
 2006-12-31,CY,Cyprus,17.9809
-2006-12-31,CZ,Czechia,
-2006-12-31,DE,Germany,-0.9914
-2006-12-31,DK,Denmark,12.7807
+2006-12-31,DE,Germany,-0.9961
+2006-12-31,DK,Denmark,12.7978
 2006-12-31,EE,Estonia,40.8674
-2006-12-31,ES,Spain,8.6858
+2006-12-31,ES,Spain,8.6854
 2006-12-31,FI,Finland,3.5879
-2006-12-31,FR,France,8.1525
-2006-12-31,GB,United Kingdom,6.913
-2006-12-31,GR,Greece,
+2006-12-31,FR,France,8.1512
+2006-12-31,GB,United Kingdom,6.8745
+2006-12-31,GR,Greece,9.9744
 2006-12-31,HK,Hong Kong SAR,1.3357
-2006-12-31,HR,Croatia,12.7363
-2006-12-31,HU,Hungary,
+2006-12-31,HR,Croatia,12.7512
+2006-12-31,HU,Hungary,-0.5324
 2006-12-31,ID,Indonesia,-1.8813
-2006-12-31,IE,Ireland,9.8058
-2006-12-31,IL,Israel,-3.6851
-2006-12-31,IN,India,
-2006-12-31,IS,Iceland,0.6346
-2006-12-31,IT,Italy,3.7225
+2006-12-31,IE,Ireland,9.8022
+2006-12-31,IL,Israel,-3.6849
+2006-12-31,IS,Iceland,0.62
+2006-12-31,IT,Italy,3.7273
 2006-12-31,JP,Japan,-2.4569
-2006-12-31,KR,Korea,6.9702
+2006-12-31,KR,Korea,7.0012
 2006-12-31,LT,Lithuania,24.532
-2006-12-31,LU,Luxembourg,
-2006-12-31,LV,Latvia,
-2006-12-31,MA,Morocco,
-2006-12-31,MK,North Macedonia,-7.7742
+2006-12-31,MK,North Macedonia,-7.9919
 2006-12-31,MT,Malta,27.9136
 2006-12-31,MX,Mexico,2.714
 2006-12-31,MY,Malaysia,1.5794
-2006-12-31,NL,Netherlands,3.687
-2006-12-31,NO,Norway,13.8171
+2006-12-31,NL,Netherlands,3.6784
+2006-12-31,NO,Norway,13.7717
 2006-12-31,NZ,New Zealand,6.1278
 2006-12-31,PE,Peru,-7.726
-2006-12-31,PH,Philippines,
-2006-12-31,PL,Poland,
-2006-12-31,PT,Portugal,
-2006-12-31,RO,Romania,
+2006-12-31,PT,Portugal,-1.5973
 2006-12-31,RS,Serbia,-6.2585
 2006-12-31,RU,Russia,51.4479
-2006-12-31,SE,Sweden,8.2761
-2006-12-31,SG,Singapore,9.5307
-2006-12-31,SI,Slovenia,
-2006-12-31,SK,Slovak Republic,
-2006-12-31,TH,Thailand,-0.7843
-2006-12-31,TR,Türkiye,
-2006-12-31,US,United States,-1.5357
-2006-12-31,XM,Euro area,4.4599
-2006-12-31,XW,World,
-2006-12-31,ZA,South Africa,8.5876
-2007-03-31,4T,Emerging market economies (aggregate),
-2007-03-31,5R,Advanced economies,
-2007-03-31,AE,United Arab Emirates,12.4944
-2007-03-31,AT,Austria,2.3825
-2007-03-31,AU,Australia,5.7173
-2007-03-31,BE,Belgium,7.1474
-2007-03-31,BG,Bulgaria,16.4955
-2007-03-31,BR,Brazil,11.8669
-2007-03-31,CA,Canada,10.0969
-2007-03-31,CH,Switzerland,8.3691
+2006-12-31,SE,Sweden,8.2739
+2006-12-31,SG,Singapore,9.5277
+2006-12-31,TH,Thailand,-0.792
+2006-12-31,US,United States,-1.5315
+2006-12-31,XM,Euro area,4.4507
+2006-12-31,ZA,South Africa,8.5868
+2007-03-31,AT,Austria,2.3824
+2007-03-31,AU,Australia,5.7511
+2007-03-31,BE,Belgium,7.1396
+2007-03-31,BG,Bulgaria,16.4814
+2007-03-31,BR,Brazil,11.8668
+2007-03-31,CA,Canada,9.4532
+2007-03-31,CH,Switzerland,8.3678
 2007-03-31,CL,Chile,4.9337
 2007-03-31,CN,China,2.4798
-2007-03-31,CO,Colombia,12.3192
+2007-03-31,CO,Colombia,13.0521
 2007-03-31,CY,Cyprus,19.7624
-2007-03-31,CZ,Czechia,
 2007-03-31,DE,Germany,-0.9706
-2007-03-31,DK,Denmark,5.4824
+2007-03-31,DK,Denmark,5.4696
 2007-03-31,EE,Estonia,27.7097
-2007-03-31,ES,Spain,10.4497
+2007-03-31,ES,Spain,10.4498
 2007-03-31,FI,Finland,4.4485
-2007-03-31,FR,France,6.6894
-2007-03-31,GB,United Kingdom,7.4759
+2007-03-31,FR,France,6.6916
+2007-03-31,GB,United Kingdom,7.4875
 2007-03-31,GR,Greece,5.8401
 2007-03-31,HK,Hong Kong SAR,3.7276
-2007-03-31,HR,Croatia,12.3651
-2007-03-31,HU,Hungary,
+2007-03-31,HR,Croatia,12.4757
+2007-03-31,HU,Hungary,-2.4578
 2007-03-31,ID,Indonesia,-4.277
-2007-03-31,IE,Ireland,9.0907
-2007-03-31,IL,Israel,-4.6831
-2007-03-31,IN,India,
-2007-03-31,IS,Iceland,-0.5634
-2007-03-31,IT,Italy,4.0599
+2007-03-31,IE,Ireland,9.1283
+2007-03-31,IL,Israel,-4.6833
+2007-03-31,IS,Iceland,-0.5814
+2007-03-31,IT,Italy,4.0543
 2007-03-31,JP,Japan,-1.439
-2007-03-31,KR,Korea,9.7176
+2007-03-31,KR,Korea,9.7639
 2007-03-31,LT,Lithuania,23.1515
-2007-03-31,LU,Luxembourg,
-2007-03-31,LV,Latvia,38.9971
-2007-03-31,MA,Morocco,
-2007-03-31,MK,North Macedonia,-1.6436
+2007-03-31,LV,Latvia,38.9988
+2007-03-31,MK,North Macedonia,-1.7815
 2007-03-31,MT,Malta,28.6603
 2007-03-31,MX,Mexico,3.222
 2007-03-31,MY,Malaysia,2.1507
-2007-03-31,NL,Netherlands,3.1293
-2007-03-31,NO,Norway,15.3141
+2007-03-31,NL,Netherlands,3.1135
+2007-03-31,NO,Norway,15.26
 2007-03-31,NZ,New Zealand,8.5713
 2007-03-31,PE,Peru,-10.4941
-2007-03-31,PH,Philippines,
-2007-03-31,PL,Poland,
-2007-03-31,PT,Portugal,
-2007-03-31,RO,Romania,
+2007-03-31,PT,Portugal,-1.0377
 2007-03-31,RS,Serbia,-4.7787
-2007-03-31,RU,Russia,51.3046
-2007-03-31,SE,Sweden,8.1803
-2007-03-31,SG,Singapore,13.9016
-2007-03-31,SI,Slovenia,
-2007-03-31,SK,Slovak Republic,18.5351
-2007-03-31,TH,Thailand,-2.1204
-2007-03-31,TR,Türkiye,
-2007-03-31,US,United States,-4.7299
-2007-03-31,XM,Euro area,4.3938
-2007-03-31,XW,World,
-2007-03-31,ZA,South Africa,8.1707
-2007-06-30,4T,Emerging market economies (aggregate),
-2007-06-30,5R,Advanced economies,
-2007-06-30,AE,United Arab Emirates,15.1276
-2007-06-30,AT,Austria,3.3214
-2007-06-30,AU,Australia,6.9791
-2007-06-30,BE,Belgium,6.6898
-2007-06-30,BG,Bulgaria,21.3795
-2007-06-30,BR,Brazil,12.9503
-2007-06-30,CA,Canada,9.0427
-2007-06-30,CH,Switzerland,7.9795
-2007-06-30,CL,Chile,5.4431
+2007-03-31,RU,Russia,51.3045
+2007-03-31,SE,Sweden,8.1824
+2007-03-31,SG,Singapore,13.8939
+2007-03-31,SK,Slovakia,18.5351
+2007-03-31,TH,Thailand,-2.1217
+2007-03-31,US,United States,-4.7289
+2007-03-31,XM,Euro area,4.3881
+2007-03-31,ZA,South Africa,8.1734
+2007-06-30,AT,Austria,3.3213
+2007-06-30,AU,Australia,6.9789
+2007-06-30,BE,Belgium,6.7494
+2007-06-30,BG,Bulgaria,21.4344
+2007-06-30,BR,Brazil,12.95
+2007-06-30,CA,Canada,8.6245
+2007-06-30,CH,Switzerland,7.9768
+2007-06-30,CL,Chile,5.443
 2007-06-30,CN,China,2.1859
-2007-06-30,CO,Colombia,10.9345
+2007-06-30,CO,Colombia,9.9494
 2007-06-30,CY,Cyprus,21.6963
-2007-06-30,CZ,Czechia,
 2007-06-30,DE,Germany,-2.7799
-2007-06-30,DK,Denmark,1.0931
+2007-06-30,DK,Denmark,1.0631
 2007-06-30,EE,Estonia,22.9346
-2007-06-30,ES,Spain,8.9836
+2007-06-30,ES,Spain,8.9845
 2007-06-30,FI,Finland,3.8328
-2007-06-30,FR,France,5.2823
-2007-06-30,GB,United Kingdom,7.9356
+2007-06-30,FR,France,5.2749
+2007-06-30,GB,United Kingdom,8.0073
 2007-06-30,GR,Greece,4.0938
 2007-06-30,HK,Hong Kong SAR,6.1792
-2007-06-30,HR,Croatia,14.5434
-2007-06-30,HU,Hungary,
+2007-06-30,HR,Croatia,14.5585
+2007-06-30,HU,Hungary,-1.4645
 2007-06-30,ID,Indonesia,-3.6564
-2007-06-30,IE,Ireland,5.3687
-2007-06-30,IL,Israel,-1.8401
-2007-06-30,IN,India,
-2007-06-30,IS,Iceland,2.8879
-2007-06-30,IT,Italy,3.3933
+2007-06-30,IE,Ireland,5.3104
+2007-06-30,IL,Israel,-1.8389
+2007-06-30,IS,Iceland,2.8925
+2007-06-30,IT,Italy,3.3883
 2007-06-30,JP,Japan,-1.0737
-2007-06-30,KR,Korea,7.3417
-2007-06-30,LT,Lithuania,26.4601
-2007-06-30,LU,Luxembourg,
-2007-06-30,LV,Latvia,28.6069
-2007-06-30,MA,Morocco,
-2007-06-30,MK,North Macedonia,2.0618
+2007-06-30,KR,Korea,7.28
+2007-06-30,LT,Lithuania,26.4602
+2007-06-30,LV,Latvia,28.6427
+2007-06-30,MK,North Macedonia,1.8238
 2007-06-30,MT,Malta,22.5918
 2007-06-30,MX,Mexico,3.5839
 2007-06-30,MY,Malaysia,2.8791
-2007-06-30,NL,Netherlands,2.4571
-2007-06-30,NO,Norway,14.8469
+2007-06-30,NL,Netherlands,2.4624
+2007-06-30,NO,Norway,14.7725
 2007-06-30,NZ,New Zealand,11.2152
 2007-06-30,PE,Peru,-0.8704
-2007-06-30,PH,Philippines,
-2007-06-30,PL,Poland,
-2007-06-30,PT,Portugal,
-2007-06-30,RO,Romania,
+2007-06-30,PT,Portugal,-2.1354
 2007-06-30,RS,Serbia,-3.1994
-2007-06-30,RU,Russia,42.3552
-2007-06-30,SE,Sweden,11.747
-2007-06-30,SG,Singapore,19.599
-2007-06-30,SI,Slovenia,
-2007-06-30,SK,Slovak Republic,22.3942
-2007-06-30,TH,Thailand,-1.6104
-2007-06-30,TR,Türkiye,
-2007-06-30,US,United States,-7.1275
-2007-06-30,XM,Euro area,3.1696
-2007-06-30,XW,World,
-2007-06-30,ZA,South Africa,8.2579
-2007-09-30,4T,Emerging market economies (aggregate),
-2007-09-30,5R,Advanced economies,
-2007-09-30,AE,United Arab Emirates,13.279
-2007-09-30,AT,Austria,3.2898
-2007-09-30,AU,Australia,9.0839
-2007-09-30,BE,Belgium,5.783
-2007-09-30,BG,Bulgaria,17.4737
-2007-09-30,BR,Brazil,13.4869
-2007-09-30,CA,Canada,8.5676
-2007-09-30,CH,Switzerland,6.4013
+2007-06-30,RU,Russia,42.3553
+2007-06-30,SE,Sweden,11.7479
+2007-06-30,SG,Singapore,19.5954
+2007-06-30,SK,Slovakia,22.3942
+2007-06-30,TH,Thailand,-1.6094
+2007-06-30,US,United States,-7.1068
+2007-06-30,XM,Euro area,3.1746
+2007-06-30,ZA,South Africa,8.2446
+2007-09-30,AT,Austria,3.2897
+2007-09-30,AU,Australia,9.0316
+2007-09-30,BE,Belgium,5.6574
+2007-09-30,BG,Bulgaria,17.562
+2007-09-30,BR,Brazil,13.4868
+2007-09-30,CA,Canada,8.1734
+2007-09-30,CH,Switzerland,6.4009
 2007-09-30,CL,Chile,4.7117
 2007-09-30,CN,China,0.7457
-2007-09-30,CO,Colombia,8.5676
+2007-09-30,CO,Colombia,8.3382
 2007-09-30,CY,Cyprus,22.2727
-2007-09-30,CZ,Czechia,
 2007-09-30,DE,Germany,-3.2354
-2007-09-30,DK,Denmark,-0.2708
+2007-09-30,DK,Denmark,-0.3104
 2007-09-30,EE,Estonia,10.7714
-2007-09-30,ES,Spain,6.6973
+2007-09-30,ES,Spain,6.6971
 2007-09-30,FI,Finland,3.2834
-2007-09-30,FR,France,4.3759
-2007-09-30,GB,United Kingdom,8.3872
+2007-09-30,FR,France,4.3755
+2007-09-30,GB,United Kingdom,8.4601
 2007-09-30,GR,Greece,3.4366
 2007-09-30,HK,Hong Kong SAR,10.3953
-2007-09-30,HR,Croatia,13.0141
-2007-09-30,HU,Hungary,
+2007-09-30,HR,Croatia,13.0105
+2007-09-30,HU,Hungary,0.6015
 2007-09-30,ID,Indonesia,-4.3549
-2007-09-30,IE,Ireland,-0.5091
-2007-09-30,IL,Israel,-0.6061
-2007-09-30,IN,India,
-2007-09-30,IS,Iceland,8.4508
-2007-09-30,IT,Italy,2.9042
+2007-09-30,IE,Ireland,-0.524
+2007-09-30,IL,Israel,-0.6057
+2007-09-30,IS,Iceland,8.474
+2007-09-30,IT,Italy,2.8972
 2007-09-30,JP,Japan,-0.5955
-2007-09-30,KR,Korea,6.743
-2007-09-30,LT,Lithuania,21.158
-2007-09-30,LU,Luxembourg,
-2007-09-30,LV,Latvia,23.7451
-2007-09-30,MA,Morocco,
-2007-09-30,MK,North Macedonia,-3.1702
+2007-09-30,KR,Korea,6.7754
+2007-09-30,LT,Lithuania,21.1579
+2007-09-30,LV,Latvia,23.6984
+2007-09-30,MK,North Macedonia,-3.1586
 2007-09-30,MT,Malta,18.876
 2007-09-30,MX,Mexico,3.9982
 2007-09-30,MY,Malaysia,3.4958
-2007-09-30,NL,Netherlands,3.7839
-2007-09-30,NO,Norway,11.266
+2007-09-30,NL,Netherlands,3.7877
+2007-09-30,NO,Norway,11.1997
 2007-09-30,NZ,New Zealand,9.3377
 2007-09-30,PE,Peru,9.4252
-2007-09-30,PH,Philippines,
-2007-09-30,PL,Poland,
-2007-09-30,PT,Portugal,
-2007-09-30,RO,Romania,
+2007-09-30,PT,Portugal,-1.0693
 2007-09-30,RS,Serbia,-4.7774
 2007-09-30,RU,Russia,27.954
-2007-09-30,SE,Sweden,12.6273
-2007-09-30,SG,Singapore,23.7876
-2007-09-30,SI,Slovenia,
-2007-09-30,SK,Slovak Republic,29.4072
-2007-09-30,TH,Thailand,1.0215
-2007-09-30,TR,Türkiye,
-2007-09-30,US,United States,-8.7783
-2007-09-30,XM,Euro area,2.45
-2007-09-30,XW,World,
-2007-09-30,ZA,South Africa,7.7371
-2007-12-31,4T,Emerging market economies (aggregate),
-2007-12-31,5R,Advanced economies,
-2007-12-31,AE,United Arab Emirates,26.8199
+2007-09-30,SE,Sweden,12.6311
+2007-09-30,SG,Singapore,23.7847
+2007-09-30,SK,Slovakia,29.4072
+2007-09-30,TH,Thailand,1.0273
+2007-09-30,US,United States,-8.7288
+2007-09-30,XM,Euro area,2.4724
+2007-09-30,ZA,South Africa,7.7466
 2007-12-31,AT,Austria,0.8655
-2007-12-31,AU,Australia,10.1047
-2007-12-31,BE,Belgium,3.926
-2007-12-31,BG,Bulgaria,19.6988
-2007-12-31,BR,Brazil,14.555
-2007-12-31,CA,Canada,7.8771
-2007-12-31,CH,Switzerland,1.8025
-2007-12-31,CL,Chile,1.7999
+2007-12-31,AU,Australia,10.0251
+2007-12-31,BE,Belgium,3.8763
+2007-12-31,BG,Bulgaria,19.727
+2007-12-31,BR,Brazil,14.5552
+2007-12-31,CA,Canada,7.5726
+2007-12-31,CH,Switzerland,1.8026
+2007-12-31,CL,Chile,1.8
 2007-12-31,CN,China,2.0936
-2007-12-31,CO,Colombia,10.2087
+2007-12-31,CO,Colombia,9.3892
 2007-12-31,CY,Cyprus,17.9573
-2007-12-31,CZ,Czechia,
 2007-12-31,DE,Germany,-2.7986
-2007-12-31,DK,Denmark,-2.1252
+2007-12-31,DK,Denmark,-2.1183
 2007-12-31,EE,Estonia,-3.5562
-2007-12-31,ES,Spain,1.6754
+2007-12-31,ES,Spain,1.6756
 2007-12-31,FI,Finland,1.7786
-2007-12-31,FR,France,3.0306
-2007-12-31,GB,United Kingdom,5.9437
-2007-12-31,GR,Greece,-1.1737
+2007-12-31,FR,France,3.0346
+2007-12-31,GB,United Kingdom,6.0245
+2007-12-31,GR,Greece,-1.1738
 2007-12-31,HK,Hong Kong SAR,17.2906
-2007-12-31,HR,Croatia,3.2747
-2007-12-31,HU,Hungary,
+2007-12-31,HR,Croatia,3.2166
+2007-12-31,HU,Hungary,1.4956
 2007-12-31,ID,Indonesia,-4.6656
-2007-12-31,IE,Ireland,-3.277
-2007-12-31,IL,Israel,-1.0086
-2007-12-31,IN,India,
-2007-12-31,IS,Iceland,9.4383
-2007-12-31,IT,Italy,2.0347
+2007-12-31,IE,Ireland,-3.2415
+2007-12-31,IL,Israel,-1.009
+2007-12-31,IS,Iceland,9.4651
+2007-12-31,IT,Italy,2.0301
 2007-12-31,JP,Japan,-1.2183
-2007-12-31,KR,Korea,1.8394
+2007-12-31,KR,Korea,1.8331
 2007-12-31,LT,Lithuania,9.1289
-2007-12-31,LU,Luxembourg,
-2007-12-31,LV,Latvia,8.3509
-2007-12-31,MA,Morocco,
-2007-12-31,MK,North Macedonia,6.0642
+2007-12-31,LV,Latvia,8.3746
+2007-12-31,MK,North Macedonia,6.1918
 2007-12-31,MT,Malta,9.99
 2007-12-31,MX,Mexico,3.5075
 2007-12-31,MY,Malaysia,0.6608
-2007-12-31,NL,Netherlands,3.332
-2007-12-31,NO,Norway,6.1285
+2007-12-31,NL,Netherlands,3.3356
+2007-12-31,NO,Norway,6.0949
 2007-12-31,NZ,New Zealand,4.3321
 2007-12-31,PE,Peru,12.7146
-2007-12-31,PH,Philippines,
-2007-12-31,PL,Poland,
-2007-12-31,PT,Portugal,
-2007-12-31,RO,Romania,
+2007-12-31,PT,Portugal,-3.5504
 2007-12-31,RS,Serbia,-3.9893
 2007-12-31,RU,Russia,15.7364
-2007-12-31,SE,Sweden,7.4973
-2007-12-31,SG,Singapore,25.8072
-2007-12-31,SI,Slovenia,
-2007-12-31,SK,Slovak Republic,30.8109
-2007-12-31,TH,Thailand,-1.4868
-2007-12-31,TR,Türkiye,
-2007-12-31,US,United States,-13.0734
-2007-12-31,XM,Euro area,0.9818
-2007-12-31,XW,World,
-2007-12-31,ZA,South Africa,3.5967
-2008-03-31,4T,Emerging market economies (aggregate),
-2008-03-31,5R,Advanced economies,
-2008-03-31,AE,United Arab Emirates,24.0967
+2007-12-31,SE,Sweden,7.4992
+2007-12-31,SG,Singapore,25.7982
+2007-12-31,SK,Slovakia,30.8109
+2007-12-31,TH,Thailand,-1.4797
+2007-12-31,US,United States,-13.0021
+2007-12-31,XM,Euro area,0.9987
+2007-12-31,ZA,South Africa,3.5951
 2008-03-31,AT,Austria,-1.4606
-2008-03-31,AU,Australia,8.1733
-2008-03-31,BE,Belgium,1.4602
-2008-03-31,BG,Bulgaria,16.1417
-2008-03-31,BR,Brazil,15.4471
-2008-03-31,CA,Canada,6.7289
-2008-03-31,CH,Switzerland,0.9804
+2008-03-31,AU,Australia,8.1912
+2008-03-31,BE,Belgium,1.4224
+2008-03-31,BG,Bulgaria,16.0664
+2008-03-31,BR,Brazil,15.4473
+2008-03-31,CA,Canada,6.5867
+2008-03-31,CH,Switzerland,0.9807
 2008-03-31,CL,Chile,2.1761
 2008-03-31,CN,China,1.2105
-2008-03-31,CO,Colombia,9.0622
+2008-03-31,CO,Colombia,9.3157
 2008-03-31,CY,Cyprus,19.6075
-2008-03-31,CZ,Czechia,
 2008-03-31,DE,Germany,-0.0062
-2008-03-31,DK,Denmark,-4.6202
+2008-03-31,DK,Denmark,-4.6137
 2008-03-31,EE,Estonia,-11.0745
-2008-03-31,ES,Spain,-1.472
+2008-03-31,ES,Spain,-1.4717
 2008-03-31,FI,Finland,-0.5127
-2008-03-31,FR,France,1.1004
-2008-03-31,GB,United Kingdom,1.3406
+2008-03-31,FR,France,1.0986
+2008-03-31,GB,United Kingdom,1.2516
 2008-03-31,GR,Greece,-1.3069
 2008-03-31,HK,Hong Kong SAR,23.836
-2008-03-31,HR,Croatia,-1.6699
-2008-03-31,HU,Hungary,-0.9483
+2008-03-31,HR,Croatia,-1.6554
+2008-03-31,HU,Hungary,-0.9482
 2008-03-31,ID,Indonesia,-5.0132
-2008-03-31,IE,Ireland,-6.8336
-2008-03-31,IL,Israel,0.8996
-2008-03-31,IN,India,
-2008-03-31,IS,Iceland,6.372
-2008-03-31,IT,Italy,0.6583
+2008-03-31,IE,Ireland,-6.7856
+2008-03-31,IL,Israel,0.8991
+2008-03-31,IS,Iceland,6.4123
+2008-03-31,IT,Italy,0.6607
 2008-03-31,JP,Japan,-1.7034
-2008-03-31,KR,Korea,-1.0716
-2008-03-31,LT,Lithuania,5.5324
-2008-03-31,LU,Luxembourg,0.4162
-2008-03-31,LV,Latvia,0.2387
-2008-03-31,MA,Morocco,0.3983
-2008-03-31,MK,North Macedonia,2.2351
+2008-03-31,KR,Korea,-1.0712
+2008-03-31,LT,Lithuania,5.5323
+2008-03-31,LU,Luxembourg,0.4138
+2008-03-31,LV,Latvia,0.2222
+2008-03-31,MA,Morocco,-0.0771
+2008-03-31,MK,North Macedonia,2.0061
 2008-03-31,MT,Malta,12.5035
 2008-03-31,MX,Mexico,2.2956
 2008-03-31,MY,Malaysia,1.7198
-2008-03-31,NL,Netherlands,1.6943
-2008-03-31,NO,Norway,0.1114
+2008-03-31,NL,Netherlands,1.7022
+2008-03-31,NO,Norway,0.0911
 2008-03-31,NZ,New Zealand,-0.6106
 2008-03-31,PE,Peru,11.9445
-2008-03-31,PH,Philippines,
-2008-03-31,PL,Poland,
-2008-03-31,PT,Portugal,
-2008-03-31,RO,Romania,
+2008-03-31,PT,Portugal,-7.8924
 2008-03-31,RS,Serbia,0.9496
 2008-03-31,RU,Russia,10.5272
-2008-03-31,SE,Sweden,3.7419
-2008-03-31,SG,Singapore,21.7391
-2008-03-31,SI,Slovenia,4.9438
-2008-03-31,SK,Slovak Republic,28.2113
-2008-03-31,TH,Thailand,-9.9519
-2008-03-31,TR,Türkiye,
-2008-03-31,US,United States,-15.751
-2008-03-31,XM,Euro area,0.3112
-2008-03-31,XW,World,
-2008-03-31,ZA,South Africa,-3.318
-2008-06-30,4T,Emerging market economies (aggregate),
-2008-06-30,5R,Advanced economies,
-2008-06-30,AE,United Arab Emirates,23.1531
+2008-03-31,SE,Sweden,3.7357
+2008-03-31,SG,Singapore,21.7258
+2008-03-31,SI,Slovenia,4.9103
+2008-03-31,SK,Slovakia,28.2113
+2008-03-31,TH,Thailand,-9.9493
+2008-03-31,US,United States,-15.6747
+2008-03-31,XM,Euro area,0.3368
+2008-03-31,ZA,South Africa,-3.3389
 2008-06-30,AT,Austria,-4.4263
-2008-06-30,AU,Australia,2.4591
-2008-06-30,BE,Belgium,-0.2822
-2008-06-30,BG,Bulgaria,14.9997
-2008-06-30,BR,Brazil,15.6065
-2008-06-30,CA,Canada,2.2635
-2008-06-30,CH,Switzerland,0.5064
-2008-06-30,CL,Chile,0.9633
+2008-06-30,AU,Australia,2.424
+2008-06-30,BE,Belgium,-0.4402
+2008-06-30,BG,Bulgaria,15.0298
+2008-06-30,BR,Brazil,15.6069
+2008-06-30,CA,Canada,2.3165
+2008-06-30,CH,Switzerland,0.5108
+2008-06-30,CL,Chile,0.9634
 2008-06-30,CN,China,-0.0095
-2008-06-30,CO,Colombia,9.1007
+2008-06-30,CO,Colombia,8.5764
 2008-06-30,CY,Cyprus,13.7677
-2008-06-30,CZ,Czechia,
 2008-06-30,DE,Germany,1.0651
-2008-06-30,DK,Denmark,-5.9395
+2008-06-30,DK,Denmark,-5.9184
 2008-06-30,EE,Estonia,-19.1751
-2008-06-30,ES,Spain,-4.6609
+2008-06-30,ES,Spain,-4.6619
 2008-06-30,FI,Finland,-1.5774
-2008-06-30,FR,France,-0.5777
-2008-06-30,GB,United Kingdom,-4.0096
+2008-06-30,FR,France,-0.5756
+2008-06-30,GB,United Kingdom,-4.0523
 2008-06-30,GR,Greece,-2.8767
 2008-06-30,HK,Hong Kong SAR,18.7277
-2008-06-30,HR,Croatia,-5.3714
+2008-06-30,HR,Croatia,-5.3847
 2008-06-30,HU,Hungary,-1.8919
 2008-06-30,ID,Indonesia,-7.4992
-2008-06-30,IE,Ireland,-9.6262
-2008-06-30,IL,Israel,1.4041
-2008-06-30,IN,India,
-2008-06-30,IS,Iceland,-4.5331
-2008-06-30,IT,Italy,0.0141
+2008-06-30,IE,Ireland,-9.5713
+2008-06-30,IL,Israel,1.4038
+2008-06-30,IS,Iceland,-4.5292
+2008-06-30,IT,Italy,0.0218
 2008-06-30,JP,Japan,-2.5403
-2008-06-30,KR,Korea,-0.4539
+2008-06-30,KR,Korea,-0.4323
 2008-06-30,LT,Lithuania,3.5744
-2008-06-30,LU,Luxembourg,2.0046
-2008-06-30,LV,Latvia,-5.4664
-2008-06-30,MA,Morocco,-2.4898
-2008-06-30,MK,North Macedonia,8.9758
+2008-06-30,LU,Luxembourg,1.9981
+2008-06-30,LV,Latvia,-5.5105
+2008-06-30,MA,Morocco,-2.54
+2008-06-30,MK,North Macedonia,9.0711
 2008-06-30,MT,Malta,2.8361
 2008-06-30,MX,Mexico,1.2857
 2008-06-30,MY,Malaysia,-0.6096
-2008-06-30,NL,Netherlands,0.7977
-2008-06-30,NO,Norway,-2.0438
+2008-06-30,NL,Netherlands,0.805
+2008-06-30,NO,Norway,-1.9633
 2008-06-30,NZ,New Zealand,-8.1464
 2008-06-30,PE,Peru,19.5667
-2008-06-30,PH,Philippines,
-2008-06-30,PL,Poland,
-2008-06-30,PT,Portugal,
-2008-06-30,RO,Romania,
+2008-06-30,PT,Portugal,-7.1851
 2008-06-30,RS,Serbia,4.903
-2008-06-30,RU,Russia,10.1515
-2008-06-30,SE,Sweden,-0.8618
-2008-06-30,SG,Singapore,11.7364
-2008-06-30,SI,Slovenia,2.4684
-2008-06-30,SK,Slovak Republic,23.0563
-2008-06-30,TH,Thailand,-9.4313
-2008-06-30,TR,Türkiye,
-2008-06-30,US,United States,-17.34
-2008-06-30,XM,Euro area,-0.6638
-2008-06-30,XW,World,
-2008-06-30,ZA,South Africa,-9.9987
-2008-09-30,4T,Emerging market economies (aggregate),
-2008-09-30,5R,Advanced economies,
-2008-09-30,AE,United Arab Emirates,10.9067
+2008-06-30,RU,Russia,10.1514
+2008-06-30,SE,Sweden,-0.8664
+2008-06-30,SG,Singapore,11.7244
+2008-06-30,SI,Slovenia,2.5004
+2008-06-30,SK,Slovakia,23.0563
+2008-06-30,TH,Thailand,-9.4344
+2008-06-30,US,United States,-17.2422
+2008-06-30,XM,Euro area,-0.6411
+2008-06-30,ZA,South Africa,-9.9725
 2008-09-30,AT,Austria,-3.3661
-2008-09-30,AU,Australia,-3.7622
-2008-09-30,BE,Belgium,-1.2385
-2008-09-30,BG,Bulgaria,13.0122
-2008-09-30,BR,Brazil,15.7662
-2008-09-30,CA,Canada,-3.0235
-2008-09-30,CH,Switzerland,1.8102
+2008-09-30,AU,Australia,-3.754
+2008-09-30,BE,Belgium,-1.2029
+2008-09-30,BG,Bulgaria,12.9115
+2008-09-30,BR,Brazil,15.7664
+2008-09-30,CA,Canada,-2.7997
+2008-09-30,CH,Switzerland,1.8115
 2008-09-30,CL,Chile,0.125
 2008-09-30,CN,China,0.1799
-2008-09-30,CO,Colombia,8.5744
+2008-09-30,CO,Colombia,7.986
 2008-09-30,CY,Cyprus,10.9857
-2008-09-30,CZ,Czechia,
 2008-09-30,DE,Germany,-0.2127
-2008-09-30,DK,Denmark,-9.1472
+2008-09-30,DK,Denmark,-9.1455
 2008-09-30,EE,Estonia,-16.4789
-2008-09-30,ES,Spain,-7.4487
+2008-09-30,ES,Spain,-7.4488
 2008-09-30,FI,Finland,-3.598
-2008-09-30,FR,France,-2.578
-2008-09-30,GB,United Kingdom,-11.4679
+2008-09-30,FR,France,-2.5792
+2008-09-30,GB,United Kingdom,-11.4024
 2008-09-30,GR,Greece,-3.0257
 2008-09-30,HK,Hong Kong SAR,13.2007
-2008-09-30,HR,Croatia,-6.0328
+2008-09-30,HR,Croatia,-5.9898
 2008-09-30,HU,Hungary,-4.9094
 2008-09-30,ID,Indonesia,-9.5674
-2008-09-30,IE,Ireland,-11.7185
-2008-09-30,IL,Israel,3.1082
-2008-09-30,IN,India,
-2008-09-30,IS,Iceland,-11.3447
-2008-09-30,IT,Italy,-1.309
+2008-09-30,IE,Ireland,-11.73
+2008-09-30,IL,Israel,3.1079
+2008-09-30,IS,Iceland,-11.3662
+2008-09-30,IT,Italy,-1.3052
 2008-09-30,JP,Japan,-3.8342
-2008-09-30,KR,Korea,-0.461
+2008-09-30,KR,Korea,-0.4667
 2008-09-30,LT,Lithuania,-4.2101
-2008-09-30,LU,Luxembourg,-2.6825
-2008-09-30,LV,Latvia,-16.9046
-2008-09-30,MA,Morocco,-0.8435
-2008-09-30,MK,North Macedonia,14.8758
+2008-09-30,LU,Luxembourg,-2.6823
+2008-09-30,LV,Latvia,-16.8813
+2008-09-30,MA,Morocco,-2.1483
+2008-09-30,MK,North Macedonia,14.694
 2008-09-30,MT,Malta,7.068
 2008-09-30,MX,Mexico,1.3182
 2008-09-30,MY,Malaysia,-3.18
-2008-09-30,NL,Netherlands,-0.6978
-2008-09-30,NO,Norway,-6.5022
+2008-09-30,NL,Netherlands,-0.7026
+2008-09-30,NO,Norway,-6.5292
 2008-09-30,NZ,New Zealand,-11.1718
 2008-09-30,PE,Peru,30.8975
-2008-09-30,PH,Philippines,
-2008-09-30,PL,Poland,
-2008-09-30,PT,Portugal,
-2008-09-30,RO,Romania,
+2008-09-30,PT,Portugal,-10.5392
 2008-09-30,RS,Serbia,12.0123
 2008-09-30,RU,Russia,10.4527
-2008-09-30,SE,Sweden,-5.436
-2008-09-30,SG,Singapore,1.6119
-2008-09-30,SI,Slovenia,1.5157
-2008-09-30,SK,Slovak Republic,7.5688
-2008-09-30,TH,Thailand,-6.5718
-2008-09-30,TR,Türkiye,
-2008-09-30,US,United States,-19.4354
-2008-09-30,XM,Euro area,-2.4025
-2008-09-30,XW,World,
-2008-09-30,ZA,South Africa,-15.0837
-2008-12-31,4T,Emerging market economies (aggregate),-0.5908
-2008-12-31,5R,Advanced economies,-10.2541
-2008-12-31,AE,United Arab Emirates,-6.3591
+2008-09-30,SE,Sweden,-5.4362
+2008-09-30,SG,Singapore,1.6042
+2008-09-30,SI,Slovenia,1.5126
+2008-09-30,SK,Slovakia,7.5687
+2008-09-30,TH,Thailand,-6.5726
+2008-09-30,US,United States,-19.3848
+2008-09-30,XM,Euro area,-2.3847
+2008-09-30,ZA,South Africa,-15.0462
+2008-12-31,4T,Emerging market economies (aggregate),-0.4183
+2008-12-31,5R,Advanced economies,-9.5455
 2008-12-31,AT,Austria,1.026
-2008-12-31,AU,Australia,-7.4115
-2008-12-31,BE,Belgium,-0.1835
-2008-12-31,BG,Bulgaria,2.2511
-2008-12-31,BR,Brazil,16.4664
-2008-12-31,CA,Canada,-5.8293
-2008-12-31,CH,Switzerland,3.5478
+2008-12-31,AU,Australia,-7.3794
+2008-12-31,BE,Belgium,-0.2664
+2008-12-31,BG,Bulgaria,2.2597
+2008-12-31,BR,Brazil,16.4668
+2008-12-31,CA,Canada,-5.509
+2008-12-31,CH,Switzerland,3.5488
 2008-12-31,CL,Chile,1.7166
 2008-12-31,CN,China,-0.77
-2008-12-31,CO,Colombia,6.6586
+2008-12-31,CO,Colombia,6.978
 2008-12-31,CY,Cyprus,5.9296
-2008-12-31,CZ,Czechia,
 2008-12-31,DE,Germany,1.7278
-2008-12-31,DK,Denmark,-13.6142
+2008-12-31,DK,Denmark,-13.6182
 2008-12-31,EE,Estonia,-25.7719
-2008-12-31,ES,Spain,-7.4957
+2008-12-31,ES,Spain,-7.4959
 2008-12-31,FI,Finland,-6.765
-2008-12-31,FR,France,-4.9866
-2008-12-31,GB,United Kingdom,-16.462
-2008-12-31,GR,Greece,-2.2439
+2008-12-31,FR,France,-4.986
+2008-12-31,GB,United Kingdom,-16.472
+2008-12-31,GR,Greece,-2.2438
 2008-12-31,HK,Hong Kong SAR,-6.7814
-2008-12-31,HR,Croatia,-5.4213
+2008-12-31,HR,Croatia,-5.3518
 2008-12-31,HU,Hungary,-5.7013
 2008-12-31,ID,Indonesia,-8.9143
-2008-12-31,IE,Ireland,-14.2445
-2008-12-31,IL,Israel,5.8875
-2008-12-31,IN,India,
-2008-12-31,IS,Iceland,-16.8924
-2008-12-31,IT,Italy,-2.211
+2008-12-31,IE,Ireland,-14.2475
+2008-12-31,IL,Israel,5.8879
+2008-12-31,IS,Iceland,-16.8988
+2008-12-31,IT,Italy,-2.2088
 2008-12-31,JP,Japan,-3.5525
-2008-12-31,KR,Korea,-0.534
+2008-12-31,KR,Korea,-0.5344
 2008-12-31,LT,Lithuania,-10.8209
-2008-12-31,LU,Luxembourg,0.1413
-2008-12-31,LV,Latvia,-26.5869
-2008-12-31,MA,Morocco,-4.2024
-2008-12-31,MK,North Macedonia,17.3983
+2008-12-31,LU,Luxembourg,0.1427
+2008-12-31,LV,Latvia,-26.6053
+2008-12-31,MA,Morocco,-5.8906
+2008-12-31,MK,North Macedonia,17.1435
 2008-12-31,MT,Malta,4.0389
 2008-12-31,MX,Mexico,1.8137
 2008-12-31,MY,Malaysia,-3.2588
-2008-12-31,NL,Netherlands,-2.8459
-2008-12-31,NO,Norway,-10.1058
+2008-12-31,NL,Netherlands,-2.8467
+2008-12-31,NO,Norway,-10.1149
 2008-12-31,NZ,New Zealand,-11.9004
 2008-12-31,PE,Peru,20.3234
-2008-12-31,PH,Philippines,
-2008-12-31,PL,Poland,
-2008-12-31,PT,Portugal,
-2008-12-31,RO,Romania,
+2008-12-31,PT,Portugal,-9.0989
 2008-12-31,RS,Serbia,16.1154
 2008-12-31,RU,Russia,5.2187
-2008-12-31,SE,Sweden,-5.9873
-2008-12-31,SG,Singapore,-9.8744
-2008-12-31,SI,Slovenia,-3.4143
-2008-12-31,SK,Slovak Republic,-3.6489
-2008-12-31,TH,Thailand,1.0248
-2008-12-31,TR,Türkiye,
-2008-12-31,US,United States,-18.1758
-2008-12-31,XM,Euro area,-2.6278
-2008-12-31,XW,World,-5.8167
-2008-12-31,ZA,South Africa,-14.4496
-2009-03-31,4T,Emerging market economies (aggregate),-1.2326
-2009-03-31,5R,Advanced economies,-9.8971
-2009-03-31,AE,United Arab Emirates,-18.2803
+2008-12-31,SE,Sweden,-5.9849
+2008-12-31,SG,Singapore,-9.8742
+2008-12-31,SI,Slovenia,-3.4028
+2008-12-31,SK,Slovakia,-3.6489
+2008-12-31,TH,Thailand,1.0249
+2008-12-31,US,United States,-18.1294
+2008-12-31,XM,Euro area,-2.6004
+2008-12-31,XW,World,-5.878
+2008-12-31,ZA,South Africa,-14.3661
+2009-03-31,4T,Emerging market economies (aggregate),-0.6141
+2009-03-31,5R,Advanced economies,-9.4897
 2009-03-31,AT,Austria,3.3457
-2009-03-31,AU,Australia,-6.8939
-2009-03-31,BE,Belgium,-0.6325
-2009-03-31,BG,Bulgaria,-12.5436
-2009-03-31,BR,Brazil,17.4828
-2009-03-31,CA,Canada,-9.5902
-2009-03-31,CH,Switzerland,4.1685
-2009-03-31,CL,Chile,-2.8924
+2009-03-31,AU,Australia,-6.8677
+2009-03-31,BE,Belgium,-0.637
+2009-03-31,BG,Bulgaria,-12.5372
+2009-03-31,BR,Brazil,17.4829
+2009-03-31,CA,Canada,-9.2545
+2009-03-31,CH,Switzerland,4.1738
+2009-03-31,CL,Chile,-2.8925
 2009-03-31,CN,China,0.4391
-2009-03-31,CO,Colombia,4.8714
+2009-03-31,CO,Colombia,4.6242
 2009-03-31,CY,Cyprus,-5.0178
-2009-03-31,CZ,Czechia,0.6544
+2009-03-31,CZ,Czechia,0.6572
 2009-03-31,DE,Germany,0.0926
-2009-03-31,DK,Denmark,-17.0597
+2009-03-31,DK,Denmark,-17.0886
 2009-03-31,EE,Estonia,-36.9223
-2009-03-31,ES,Spain,-7.8468
+2009-03-31,ES,Spain,-7.8465
 2009-03-31,FI,Finland,-3.5024
-2009-03-31,FR,France,-6.954
-2009-03-31,GB,United Kingdom,-17.8993
+2009-03-31,FR,France,-6.9539
+2009-03-31,GB,United Kingdom,-17.8607
 2009-03-31,GR,Greece,-4.7667
 2009-03-31,HK,Hong Kong SAR,-15.0298
-2009-03-31,HR,Croatia,-4.1379
-2009-03-31,HU,Hungary,-3.7987
+2009-03-31,HR,Croatia,-4.1727
+2009-03-31,HU,Hungary,-3.7986
 2009-03-31,ID,Indonesia,-6.2742
-2009-03-31,IE,Ireland,-15.2368
-2009-03-31,IL,Israel,6.8311
-2009-03-31,IN,India,
-2009-03-31,IS,Iceland,-24.0598
-2009-03-31,IT,Italy,-1.2254
+2009-03-31,IE,Ireland,-15.2948
+2009-03-31,IL,Israel,6.8317
+2009-03-31,IS,Iceland,-24.0715
+2009-03-31,IT,Italy,-1.2283
 2009-03-31,JP,Japan,-4.1
-2009-03-31,KR,Korea,-2.2722
-2009-03-31,LT,Lithuania,-30.5939
-2009-03-31,LU,Luxembourg,-0.3887
-2009-03-31,LV,Latvia,-42.2918
-2009-03-31,MA,Morocco,3.1756
-2009-03-31,MK,North Macedonia,12.6838
+2009-03-31,KR,Korea,-2.2661
+2009-03-31,LT,Lithuania,-30.5938
+2009-03-31,LU,Luxembourg,-0.3832
+2009-03-31,LV,Latvia,-42.2919
+2009-03-31,MA,Morocco,-1.1939
+2009-03-31,MK,North Macedonia,12.7988
 2009-03-31,MT,Malta,-6.5927
 2009-03-31,MX,Mexico,1.6962
 2009-03-31,MY,Malaysia,-3.0339
-2009-03-31,NL,Netherlands,-3.5585
-2009-03-31,NO,Norway,-7.472
+2009-03-31,NL,Netherlands,-3.5518
+2009-03-31,NO,Norway,-7.4494
 2009-03-31,NZ,New Zealand,-11.6247
 2009-03-31,PE,Peru,21.7241
 2009-03-31,PH,Philippines,-2.2477
-2009-03-31,PL,Poland,
 2009-03-31,PT,Portugal,-3.2484
-2009-03-31,RO,Romania,
 2009-03-31,RS,Serbia,17.3852
 2009-03-31,RU,Russia,-2.757
-2009-03-31,SE,Sweden,-2.1059
-2009-03-31,SG,Singapore,-23.6381
-2009-03-31,SI,Slovenia,-9.3376
-2009-03-31,SK,Slovak Republic,-13.881
-2009-03-31,TH,Thailand,9.9452
-2009-03-31,TR,Türkiye,
-2009-03-31,US,United States,-15.956
-2009-03-31,XM,Euro area,-3.7143
-2009-03-31,XW,World,-5.8979
-2009-03-31,ZA,South Africa,-12.0362
-2009-06-30,4T,Emerging market economies (aggregate),-1.148
-2009-06-30,5R,Advanced economies,-7.6988
-2009-06-30,AE,United Arab Emirates,-24.9428
+2009-03-31,SE,Sweden,-2.0997
+2009-03-31,SG,Singapore,-23.6296
+2009-03-31,SI,Slovenia,-9.3419
+2009-03-31,SK,Slovakia,-13.881
+2009-03-31,TH,Thailand,9.9408
+2009-03-31,US,United States,-15.9195
+2009-03-31,XM,Euro area,-3.6841
+2009-03-31,XW,World,-5.9082
+2009-03-31,ZA,South Africa,-11.974
+2009-06-30,4T,Emerging market economies (aggregate),-0.4242
+2009-06-30,5R,Advanced economies,-7.521
 2009-06-30,AT,Austria,5.4592
-2009-06-30,AU,Australia,-1.1802
-2009-06-30,BE,Belgium,-1.1061
-2009-06-30,BG,Bulgaria,-24.0246
+2009-06-30,AU,Australia,-1.2062
+2009-06-30,BE,Belgium,-0.9665
+2009-06-30,BG,Bulgaria,-24.0698
 2009-06-30,BR,Brazil,18.6854
-2009-06-30,CA,Canada,-7.0037
-2009-06-30,CH,Switzerland,2.8788
+2009-06-30,CA,Canada,-6.785
+2009-06-30,CH,Switzerland,2.8808
 2009-06-30,CL,Chile,-1.7073
 2009-06-30,CN,China,1.0781
-2009-06-30,CO,Colombia,4.1484
+2009-06-30,CO,Colombia,5.3348
 2009-06-30,CY,Cyprus,-6.8503
-2009-06-30,CZ,Czechia,-5.7622
+2009-06-30,CZ,Czechia,-5.7675
 2009-06-30,DE,Germany,-1.5983
-2009-06-30,DK,Denmark,-15.8898
+2009-06-30,DK,Denmark,-15.9398
 2009-06-30,EE,Estonia,-37.4405
-2009-06-30,ES,Spain,-6.962
+2009-06-30,ES,Spain,-6.9616
 2009-06-30,FI,Finland,-1.5655
-2009-06-30,FR,France,-7.8173
-2009-06-30,GB,United Kingdom,-15.5143
+2009-06-30,FR,France,-7.8172
+2009-06-30,GB,United Kingdom,-15.5408
 2009-06-30,GR,Greece,-3.1195
 2009-06-30,HK,Hong Kong SAR,-6.9732
-2009-06-30,HR,Croatia,-7.1129
+2009-06-30,HR,Croatia,-7.1514
 2009-06-30,HU,Hungary,-8.5171
 2009-06-30,ID,Indonesia,-3.3746
-2009-06-30,IE,Ireland,-16.2832
-2009-06-30,IL,Israel,8.9875
-2009-06-30,IN,India,
-2009-06-30,IS,Iceland,-20.0316
-2009-06-30,IT,Italy,-1.6976
+2009-06-30,IE,Ireland,-16.2681
+2009-06-30,IL,Israel,8.9876
+2009-06-30,IS,Iceland,-20.0349
+2009-06-30,IT,Italy,-1.702
 2009-06-30,JP,Japan,-4.1392
-2009-06-30,KR,Korea,-3.3024
+2009-06-30,KR,Korea,-3.2195
 2009-06-30,LT,Lithuania,-34.4381
-2009-06-30,LU,Luxembourg,-1.8372
-2009-06-30,LV,Latvia,-44.8649
-2009-06-30,MA,Morocco,4.8488
-2009-06-30,MK,North Macedonia,7.9413
+2009-06-30,LU,Luxembourg,-1.8354
+2009-06-30,LV,Latvia,-44.8497
+2009-06-30,MA,Morocco,0.6569
+2009-06-30,MK,North Macedonia,7.7622
 2009-06-30,MT,Malta,-4.0665
 2009-06-30,MX,Mexico,0.3299
 2009-06-30,MY,Malaysia,1.2099
-2009-06-30,NL,Netherlands,-6.1602
-2009-06-30,NO,Norway,-4.5184
+2009-06-30,NL,Netherlands,-6.1623
+2009-06-30,NO,Norway,-4.5422
 2009-06-30,NZ,New Zealand,-4.8893
 2009-06-30,PE,Peru,7.7996
 2009-06-30,PH,Philippines,-4.7484
-2009-06-30,PL,Poland,
 2009-06-30,PT,Portugal,-1.597
-2009-06-30,RO,Romania,
 2009-06-30,RS,Serbia,14.713
 2009-06-30,RU,Russia,-10.6611
 2009-06-30,SE,Sweden,0.2254
-2009-06-30,SG,Singapore,-25.0395
-2009-06-30,SI,Slovenia,-10.0285
-2009-06-30,SK,Slovak Republic,-19.6445
-2009-06-30,TH,Thailand,9.282
-2009-06-30,TR,Türkiye,
-2009-06-30,US,United States,-10.9619
-2009-06-30,XM,Euro area,-4.6503
-2009-06-30,XW,World,-4.6374
-2009-06-30,ZA,South Africa,-9.7634
-2009-09-30,4T,Emerging market economies (aggregate),-0.028
-2009-09-30,5R,Advanced economies,-4.1845
-2009-09-30,AE,United Arab Emirates,-24.2921
+2009-06-30,SG,Singapore,-25.0317
+2009-06-30,SI,Slovenia,-10.0421
+2009-06-30,SK,Slovakia,-19.6445
+2009-06-30,TH,Thailand,9.2851
+2009-06-30,US,United States,-10.9556
+2009-06-30,XM,Euro area,-4.6135
+2009-06-30,XW,World,-4.6207
+2009-06-30,ZA,South Africa,-9.7871
+2009-09-30,4T,Emerging market economies (aggregate),0.4008
+2009-09-30,5R,Advanced economies,-4.0652
 2009-09-30,AT,Austria,3.1952
-2009-09-30,AU,Australia,5.5655
-2009-09-30,BE,Belgium,0.7089
-2009-09-30,BG,Bulgaria,-27.5635
-2009-09-30,BR,Brazil,20.1594
-2009-09-30,CA,Canada,-0.7855
-2009-09-30,CH,Switzerland,2.1056
-2009-09-30,CL,Chile,4.2864
+2009-09-30,AU,Australia,5.5231
+2009-09-30,BE,Belgium,0.7226
+2009-09-30,BG,Bulgaria,-27.5262
+2009-09-30,BR,Brazil,20.1593
+2009-09-30,CA,Canada,-0.6508
+2009-09-30,CH,Switzerland,2.1088
+2009-09-30,CL,Chile,4.2865
 2009-09-30,CN,China,2.4894
-2009-09-30,CO,Colombia,5.8635
+2009-09-30,CO,Colombia,6.3755
 2009-09-30,CY,Cyprus,-5.5476
-2009-09-30,CZ,Czechia,-6.7233
+2009-09-30,CZ,Czechia,-6.7215
 2009-09-30,DE,Germany,-0.6739
-2009-09-30,DK,Denmark,-12.7605
+2009-09-30,DK,Denmark,-12.7373
 2009-09-30,EE,Estonia,-41.5677
-2009-09-30,ES,Spain,-5.9432
+2009-09-30,ES,Spain,-5.9435
 2009-09-30,FI,Finland,2.3821
-2009-09-30,FR,France,-6.3287
-2009-09-30,GB,United Kingdom,-8.1194
+2009-09-30,FR,France,-6.3303
+2009-09-30,GB,United Kingdom,-8.1575
 2009-09-30,GR,Greece,-5.7561
 2009-09-30,HK,Hong Kong SAR,4.127
-2009-09-30,HR,Croatia,-8.9396
-2009-09-30,HU,Hungary,-11.4616
+2009-09-30,HR,Croatia,-8.9575
+2009-09-30,HU,Hungary,-11.4615
 2009-09-30,ID,Indonesia,-0.6482
-2009-09-30,IE,Ireland,-16.1245
-2009-09-30,IL,Israel,9.8724
-2009-09-30,IN,India,
-2009-09-30,IS,Iceland,-20.1203
-2009-09-30,IT,Italy,-1.2491
+2009-09-30,IE,Ireland,-16.1499
+2009-09-30,IL,Israel,9.8727
+2009-09-30,IS,Iceland,-20.1215
+2009-09-30,IT,Italy,-1.2495
 2009-09-30,JP,Japan,-0.7691
-2009-09-30,KR,Korea,-2.7533
-2009-09-30,LT,Lithuania,-34.7989
-2009-09-30,LU,Luxembourg,-2.3258
-2009-09-30,LV,Latvia,-40.0539
-2009-09-30,MA,Morocco,0.377
-2009-09-30,MK,North Macedonia,3.6436
+2009-09-30,KR,Korea,-2.7814
+2009-09-30,LT,Lithuania,-34.799
+2009-09-30,LU,Luxembourg,-2.3157
+2009-09-30,LV,Latvia,-40.0476
+2009-09-30,MA,Morocco,-0.4933
+2009-09-30,MK,North Macedonia,3.8204
 2009-09-30,MT,Malta,-7.013
 2009-09-30,MX,Mexico,-1.1009
 2009-09-30,MY,Malaysia,4.3558
-2009-09-30,NL,Netherlands,-6.942
-2009-09-30,NO,Norway,1.8914
+2009-09-30,NL,Netherlands,-6.9399
+2009-09-30,NO,Norway,1.9891
 2009-09-30,NZ,New Zealand,-0.6086
 2009-09-30,PE,Peru,6.07
 2009-09-30,PH,Philippines,-4.1524
-2009-09-30,PL,Poland,
 2009-09-30,PT,Portugal,1.6696
-2009-09-30,RO,Romania,
 2009-09-30,RS,Serbia,7.5833
 2009-09-30,RU,Russia,-15.7354
-2009-09-30,SE,Sweden,4.5817
-2009-09-30,SG,Singapore,-10.6966
-2009-09-30,SI,Slovenia,-12.4105
-2009-09-30,SK,Slovak Republic,-11.1568
-2009-09-30,TH,Thailand,5.4107
-2009-09-30,TR,Türkiye,
-2009-09-30,US,United States,-6.0967
-2009-09-30,XM,Euro area,-3.9659
-2009-09-30,XW,World,-2.211
-2009-09-30,ZA,South Africa,-6.2453
-2009-12-31,4T,Emerging market economies (aggregate),1.6346
-2009-12-31,5R,Advanced economies,-1.9234
-2009-12-31,AE,United Arab Emirates,-17.2854
-2009-12-31,AT,Austria,1.553
-2009-12-31,AU,Australia,11.983
-2009-12-31,BE,Belgium,-0.6339
-2009-12-31,BG,Bulgaria,-25.7741
-2009-12-31,BR,Brazil,20.8792
-2009-12-31,CA,Canada,4.6213
-2009-12-31,CH,Switzerland,0.5018
+2009-09-30,SE,Sweden,4.5812
+2009-09-30,SG,Singapore,-10.6917
+2009-09-30,SI,Slovenia,-12.386
+2009-09-30,SK,Slovakia,-11.1568
+2009-09-30,TH,Thailand,5.4101
+2009-09-30,US,United States,-6.1126
+2009-09-30,XM,Euro area,-3.9302
+2009-09-30,XW,World,-2.2102
+2009-09-30,ZA,South Africa,-6.2392
+2009-12-31,4T,Emerging market economies (aggregate),1.7088
+2009-12-31,5R,Advanced economies,-1.7115
+2009-12-31,AT,Austria,1.5531
+2009-12-31,AU,Australia,11.9305
+2009-12-31,BE,Belgium,-0.5523
+2009-12-31,BG,Bulgaria,-25.7649
+2009-12-31,BR,Brazil,20.879
+2009-12-31,CA,Canada,4.5943
+2009-12-31,CH,Switzerland,0.505
 2009-12-31,CL,Chile,9.4105
 2009-12-31,CN,China,3.8818
-2009-12-31,CO,Colombia,6.2556
+2009-12-31,CO,Colombia,6.5393
 2009-12-31,CY,Cyprus,-2.7002
-2009-12-31,CZ,Czechia,-7.201
+2009-12-31,CZ,Czechia,-7.202
 2009-12-31,DE,Germany,-1.6075
-2009-12-31,DK,Denmark,-6.017
+2009-12-31,DK,Denmark,-6.0135
 2009-12-31,EE,Estonia,-32.2135
 2009-12-31,ES,Spain,-4.5104
 2009-12-31,FI,Finland,8.85
-2009-12-31,FR,France,-3.5774
-2009-12-31,GB,United Kingdom,-0.2742
-2009-12-31,GR,Greece,-5.8375
+2009-12-31,FR,France,-3.576
+2009-12-31,GB,United Kingdom,-0.4056
+2009-12-31,GR,Greece,-5.8376
 2009-12-31,HK,Hong Kong SAR,21.097
-2009-12-31,HR,Croatia,-8.5867
+2009-12-31,HR,Croatia,-8.652
 2009-12-31,HU,Hungary,-12.4006
 2009-12-31,ID,Indonesia,-0.2729
-2009-12-31,IE,Ireland,-13.9865
-2009-12-31,IL,Israel,14.1534
-2009-12-31,IN,India,
-2009-12-31,IS,Iceland,-15.584
-2009-12-31,IT,Italy,-0.9106
+2009-12-31,IE,Ireland,-13.9942
+2009-12-31,IL,Israel,14.1531
+2009-12-31,IS,Iceland,-15.6095
+2009-12-31,IT,Italy,-0.9079
 2009-12-31,JP,Japan,-0.8349
-2009-12-31,KR,Korea,-1.6914
+2009-12-31,KR,Korea,-1.7069
 2009-12-31,LT,Lithuania,-32.0403
-2009-12-31,LU,Luxembourg,-1.4847
-2009-12-31,LV,Latvia,-28.5387
-2009-12-31,MA,Morocco,-0.0817
-2009-12-31,MK,North Macedonia,-5.9368
+2009-12-31,LU,Luxembourg,-1.485
+2009-12-31,LV,Latvia,-28.5681
+2009-12-31,MA,Morocco,1.168
+2009-12-31,MK,North Macedonia,-6.0732
 2009-12-31,MT,Malta,-7.3312
 2009-12-31,MX,Mexico,-1.1025
 2009-12-31,MY,Malaysia,5.2762
-2009-12-31,NL,Netherlands,-5.6779
-2009-12-31,NO,Norway,10.0301
+2009-12-31,NL,Netherlands,-5.6716
+2009-12-31,NO,Norway,10.0633
 2009-12-31,NZ,New Zealand,3.3676
 2009-12-31,PE,Peru,6.642
 2009-12-31,PH,Philippines,-5.9135
-2009-12-31,PL,Poland,
 2009-12-31,PT,Portugal,3.0039
-2009-12-31,RO,Romania,
 2009-12-31,RS,Serbia,4.3861
-2009-12-31,RU,Russia,-14.2639
-2009-12-31,SE,Sweden,12.429
-2009-12-31,SG,Singapore,2.4779
-2009-12-31,SI,Slovenia,-9.1405
-2009-12-31,SK,Slovak Republic,-11.5856
-2009-12-31,TH,Thailand,0.606
-2009-12-31,TR,Türkiye,
-2009-12-31,US,United States,-3.4389
-2009-12-31,XM,Euro area,-3.27
-2009-12-31,XW,World,-0.2117
-2009-12-31,ZA,South Africa,-4.3272
-2010-03-31,4T,Emerging market economies (aggregate),4.237
-2010-03-31,5R,Advanced economies,-0.5173
-2010-03-31,AE,United Arab Emirates,-14.8079
+2009-12-31,RU,Russia,-14.264
+2009-12-31,SE,Sweden,12.4276
+2009-12-31,SG,Singapore,2.4814
+2009-12-31,SI,Slovenia,-9.1455
+2009-12-31,SK,Slovakia,-11.5856
+2009-12-31,TH,Thailand,0.6033
+2009-12-31,US,United States,-3.4585
+2009-12-31,XM,Euro area,-3.2405
+2009-12-31,XW,World,-0.2671
+2009-12-31,ZA,South Africa,-4.4386
+2010-03-31,4T,Emerging market economies (aggregate),4.1776
+2010-03-31,5R,Advanced economies,-0.1322
 2010-03-31,AT,Austria,4.1508
-2010-03-31,AU,Australia,14.779
-2010-03-31,BE,Belgium,0.5014
-2010-03-31,BG,Bulgaria,-18.774
-2010-03-31,BR,Brazil,20.3147
-2010-03-31,CA,Canada,10.5946
-2010-03-31,CH,Switzerland,0.9072
+2010-03-31,AU,Australia,14.7527
+2010-03-31,BE,Belgium,-0.1593
+2010-03-31,BG,Bulgaria,-18.7583
+2010-03-31,BR,Brazil,20.3143
+2010-03-31,CA,Canada,10.5436
+2010-03-31,CH,Switzerland,0.9058
 2010-03-31,CL,Chile,9.5759
 2010-03-31,CN,China,6.7782
-2010-03-31,CO,Colombia,5.7628
+2010-03-31,CO,Colombia,5.5607
 2010-03-31,CY,Cyprus,-1.827
-2010-03-31,CZ,Czechia,-5.3224
+2010-03-31,CZ,Czechia,-5.3274
 2010-03-31,DE,Germany,-2.5546
-2010-03-31,DK,Denmark,0.1957
+2010-03-31,DK,Denmark,0.2173
 2010-03-31,EE,Estonia,-5.7256
-2010-03-31,ES,Spain,-4.0297
+2010-03-31,ES,Spain,-4.0302
 2010-03-31,FI,Finland,7.4576
-2010-03-31,FR,France,-0.0671
-2010-03-31,GB,United Kingdom,4.293
+2010-03-31,FR,France,-0.0711
+2010-03-31,GB,United Kingdom,4.2206
 2010-03-31,GR,Greece,-4.6619
 2010-03-31,HK,Hong Kong SAR,27.6248
-2010-03-31,HR,Croatia,-9.3547
+2010-03-31,HR,Croatia,-9.4033
 2010-03-31,HU,Hungary,-10.4229
 2010-03-31,ID,Indonesia,-1.0717
-2010-03-31,IE,Ireland,-12.8525
-2010-03-31,IL,Israel,16.4245
+2010-03-31,IE,Ireland,-12.8685
+2010-03-31,IL,Israel,16.4243
 2010-03-31,IN,India,8.2404
-2010-03-31,IS,Iceland,-11.1021
-2010-03-31,IT,Italy,-3.3484
+2010-03-31,IS,Iceland,-11.1019
+2010-03-31,IT,Italy,-3.3482
 2010-03-31,JP,Japan,1.2843
-2010-03-31,KR,Korea,-0.2914
+2010-03-31,KR,Korea,-0.2997
 2010-03-31,LT,Lithuania,-15.3054
-2010-03-31,LU,Luxembourg,3.9218
-2010-03-31,LV,Latvia,-17.5786
-2010-03-31,MA,Morocco,-4.6806
-2010-03-31,MK,North Macedonia,1.221
+2010-03-31,LU,Luxembourg,3.9158
+2010-03-31,LV,Latvia,-17.6294
+2010-03-31,MA,Morocco,-0.6924
+2010-03-31,MK,North Macedonia,1.2219
 2010-03-31,MT,Malta,-0.8555
 2010-03-31,MX,Mexico,-2.4198
 2010-03-31,MY,Malaysia,3.7837
-2010-03-31,NL,Netherlands,-4.9397
-2010-03-31,NO,Norway,7.5075
+2010-03-31,NL,Netherlands,-4.9439
+2010-03-31,NO,Norway,7.5265
 2010-03-31,NZ,New Zealand,4.071
 2010-03-31,PE,Peru,20.0185
 2010-03-31,PH,Philippines,-5.486
-2010-03-31,PL,Poland,
-2010-03-31,PT,Portugal,1.6582
+2010-03-31,PT,Portugal,1.6581
 2010-03-31,RO,Romania,-10.8735
 2010-03-31,RS,Serbia,2.7903
 2010-03-31,RU,Russia,-4.7919
-2010-03-31,SE,Sweden,9.4752
-2010-03-31,SG,Singapore,23.9593
-2010-03-31,SI,Slovenia,-2.9816
-2010-03-31,SK,Slovak Republic,-6.1413
-2010-03-31,TH,Thailand,-1.0336
-2010-03-31,TR,Türkiye,
-2010-03-31,US,United States,-2.3573
-2010-03-31,XM,Euro area,-2.675
-2010-03-31,XW,World,1.7861
-2010-03-31,ZA,South Africa,-1.8036
-2010-06-30,4T,Emerging market economies (aggregate),5.4856
-2010-06-30,5R,Advanced economies,0.5243
-2010-06-30,AE,United Arab Emirates,-12.9634
+2010-03-31,SE,Sweden,9.4718
+2010-03-31,SG,Singapore,23.9553
+2010-03-31,SI,Slovenia,-2.9789
+2010-03-31,SK,Slovakia,-5.868
+2010-03-31,TH,Thailand,-1.0335
+2010-03-31,US,United States,-2.3629
+2010-03-31,XM,Euro area,-2.6564
+2010-03-31,XW,World,1.7041
+2010-03-31,ZA,South Africa,-1.9061
+2010-06-30,4T,Emerging market economies (aggregate),5.4577
+2010-06-30,5R,Advanced economies,0.9423
 2010-06-30,AT,Austria,3.5551
-2010-06-30,AU,Australia,12.1316
-2010-06-30,BE,Belgium,1.2372
-2010-06-30,BG,Bulgaria,-11.3577
-2010-06-30,BR,Brazil,19.6627
-2010-06-30,CA,Canada,10.2527
-2010-06-30,CH,Switzerland,2.4365
-2010-06-30,CL,Chile,10.3703
+2010-06-30,AU,Australia,12.2076
+2010-06-30,BE,Belgium,0.3794
+2010-06-30,BG,Bulgaria,-11.3749
+2010-06-30,BR,Brazil,19.6624
+2010-06-30,CA,Canada,10.1977
+2010-06-30,CH,Switzerland,2.4351
+2010-06-30,CL,Chile,10.3702
 2010-06-30,CN,China,7.6983
-2010-06-30,CO,Colombia,5.4226
+2010-06-30,CO,Colombia,4.8968
 2010-06-30,CY,Cyprus,-2.4442
-2010-06-30,CZ,Czechia,-2.5798
+2010-06-30,CZ,Czechia,-2.5761
 2010-06-30,DE,Germany,-0.3362
-2010-06-30,DK,Denmark,0.9645
+2010-06-30,DK,Denmark,1.0206
 2010-06-30,EE,Estonia,-0.5599
-2010-06-30,ES,Spain,-2.5092
+2010-06-30,ES,Spain,-2.509
 2010-06-30,FI,Finland,5.9547
-2010-06-30,FR,France,3.0088
-2010-06-30,GB,United Kingdom,4.5799
-2010-06-30,GR,Greece,-9.3612
+2010-06-30,FR,France,3.0075
+2010-06-30,GB,United Kingdom,4.6243
+2010-06-30,GR,Greece,-9.3613
 2010-06-30,HK,Hong Kong SAR,21.7685
-2010-06-30,HR,Croatia,-7.3832
+2010-06-30,HR,Croatia,-7.3757
 2010-06-30,HU,Hungary,-7.4175
 2010-06-30,ID,Indonesia,-1.4261
-2010-06-30,IE,Ireland,-11.5
-2010-06-30,IL,Israel,16.1159
+2010-06-30,IE,Ireland,-11.4931
+2010-06-30,IL,Israel,16.1153
 2010-06-30,IN,India,7.9579
-2010-06-30,IS,Iceland,-8.2532
-2010-06-30,IT,Italy,-2.4443
+2010-06-30,IS,Iceland,-8.2699
+2010-06-30,IT,Italy,-2.4489
 2010-06-30,JP,Japan,2.9391
-2010-06-30,KR,Korea,0.5862
-2010-06-30,LT,Lithuania,-9.4639
-2010-06-30,LU,Luxembourg,1.6118
-2010-06-30,LV,Latvia,-9.5712
-2010-06-30,MA,Morocco,-1.8519
-2010-06-30,MK,North Macedonia,-0.7627
+2010-06-30,KR,Korea,0.5073
+2010-06-30,LT,Lithuania,-9.4638
+2010-06-30,LU,Luxembourg,1.6108
+2010-06-30,LV,Latvia,-9.5907
+2010-06-30,MA,Morocco,-1.294
+2010-06-30,MK,North Macedonia,-0.6436
 2010-06-30,MT,Malta,0.2469
 2010-06-30,MX,Mexico,-1.8617
 2010-06-30,MY,Malaysia,4.7578
-2010-06-30,NL,Netherlands,-2.3192
-2010-06-30,NO,Norway,6.4091
+2010-06-30,NL,Netherlands,-2.3265
+2010-06-30,NO,Norway,6.3993
 2010-06-30,NZ,New Zealand,1.477
 2010-06-30,PE,Peru,24.7742
 2010-06-30,PH,Philippines,-4.5647
-2010-06-30,PL,Poland,
 2010-06-30,PT,Portugal,0.4261
 2010-06-30,RO,Romania,-7.931
 2010-06-30,RS,Serbia,3.7926
-2010-06-30,RU,Russia,1.5238
-2010-06-30,SE,Sweden,7.3958
-2010-06-30,SG,Singapore,34.1029
-2010-06-30,SI,Slovenia,-1.0347
-2010-06-30,SK,Slovak Republic,-2.765
-2010-06-30,TH,Thailand,-0.4767
-2010-06-30,TR,Türkiye,
-2010-06-30,US,United States,-1.4639
-2010-06-30,XM,Euro area,-0.9764
-2010-06-30,XW,World,2.9483
-2010-06-30,ZA,South Africa,0.6759
-2010-09-30,4T,Emerging market economies (aggregate),4.9697
-2010-09-30,5R,Advanced economies,-0.5557
-2010-09-30,AE,United Arab Emirates,-13.2711
-2010-09-30,AT,Austria,4.3677
-2010-09-30,AU,Australia,6.5087
-2010-09-30,BE,Belgium,0.3957
-2010-09-30,BG,Bulgaria,-9.0034
-2010-09-30,BR,Brazil,19.3163
-2010-09-30,CA,Canada,4.8383
-2010-09-30,CH,Switzerland,4.7604
+2010-06-30,RU,Russia,1.5239
+2010-06-30,SE,Sweden,7.3945
+2010-06-30,SG,Singapore,34.0944
+2010-06-30,SI,Slovenia,-1.0376
+2010-06-30,SK,Slovakia,-2.4819
+2010-06-30,TH,Thailand,-0.4801
+2010-06-30,US,United States,-1.472
+2010-06-30,XM,Euro area,-0.9615
+2010-06-30,XW,World,2.8843
+2010-06-30,ZA,South Africa,0.482
+2010-09-30,4T,Emerging market economies (aggregate),5.2069
+2010-09-30,5R,Advanced economies,-0.1966
+2010-09-30,AT,Austria,4.3678
+2010-09-30,AU,Australia,6.5652
+2010-09-30,BE,Belgium,-0.1785
+2010-09-30,BG,Bulgaria,-9.018
+2010-09-30,BR,Brazil,19.316
+2010-09-30,CA,Canada,4.8994
+2010-09-30,CH,Switzerland,4.7585
 2010-09-30,CL,Chile,5.3017
 2010-09-30,CN,China,5.2652
-2010-09-30,CO,Colombia,3.7536
+2010-09-30,CO,Colombia,4.118
 2010-09-30,CY,Cyprus,-4.026
-2010-09-30,CZ,Czechia,-2.7133
+2010-09-30,CZ,Czechia,-2.7149
 2010-09-30,DE,Germany,0.5413
-2010-09-30,DK,Denmark,0.761
+2010-09-30,DK,Denmark,0.7253
 2010-09-30,EE,Estonia,11.3325
-2010-09-30,ES,Spain,-3.5854
+2010-09-30,ES,Spain,-3.585
 2010-09-30,FI,Finland,5.2567
-2010-09-30,FR,France,4.2431
-2010-09-30,GB,United Kingdom,2.5138
-2010-09-30,GR,Greece,-10.1626
+2010-09-30,FR,France,4.2439
+2010-09-30,GB,United Kingdom,2.5155
+2010-09-30,GR,Greece,-10.1625
 2010-09-30,HK,Hong Kong SAR,19.3192
-2010-09-30,HR,Croatia,-6.9387
+2010-09-30,HR,Croatia,-6.9671
 2010-09-30,HU,Hungary,-4.9874
 2010-09-30,ID,Indonesia,-3.0498
-2010-09-30,IE,Ireland,-11.7332
-2010-09-30,IL,Israel,14.2993
+2010-09-30,IE,Ireland,-11.7075
+2010-09-30,IL,Israel,14.2995
 2010-09-30,IN,India,11.1341
-2010-09-30,IS,Iceland,-5.1697
-2010-09-30,IT,Italy,-2.0543
+2010-09-30,IS,Iceland,-5.1481
+2010-09-30,IT,Italy,-2.0591
 2010-09-30,JP,Japan,2.2794
-2010-09-30,KR,Korea,-0.6639
+2010-09-30,KR,Korea,-0.6557
 2010-09-30,LT,Lithuania,-6.8782
-2010-09-30,LU,Luxembourg,3.9699
-2010-09-30,LV,Latvia,-7.5944
-2010-09-30,MA,Morocco,-0.1752
-2010-09-30,MK,North Macedonia,-0.9229
+2010-09-30,LU,Luxembourg,3.9565
+2010-09-30,LV,Latvia,-7.6237
+2010-09-30,MA,Morocco,-0.1774
+2010-09-30,MK,North Macedonia,-0.9219
 2010-09-30,MT,Malta,1.7438
 2010-09-30,MX,Mexico,-0.5948
 2010-09-30,MY,Malaysia,4.7076
 2010-09-30,NL,Netherlands,-1.9396
-2010-09-30,NO,Norway,4.7091
+2010-09-30,NO,Norway,4.7247
 2010-09-30,NZ,New Zealand,-1.1715
 2010-09-30,PE,Peru,16.8339
 2010-09-30,PH,Philippines,-1.8881
-2010-09-30,PL,Poland,
 2010-09-30,PT,Portugal,-1.3391
 2010-09-30,RO,Romania,-14.295
 2010-09-30,RS,Serbia,5.2898
 2010-09-30,RU,Russia,4.3801
-2010-09-30,SE,Sweden,5.9105
-2010-09-30,SG,Singapore,18.8581
-2010-09-30,SI,Slovenia,-0.6943
-2010-09-30,SK,Slovak Republic,-7.6597
-2010-09-30,TH,Thailand,0.4882
-2010-09-30,TR,Türkiye,
-2010-09-30,US,United States,-3.2949
-2010-09-30,XM,Euro area,-0.4454
-2010-09-30,XW,World,2.1512
-2010-09-30,ZA,South Africa,1.3713
-2010-12-31,4T,Emerging market economies (aggregate),3.3004
-2010-12-31,5R,Advanced economies,-1.7174
-2010-12-31,AE,United Arab Emirates,-14.653
-2010-12-31,AT,Austria,5.1221
-2010-12-31,AU,Australia,1.6333
-2010-12-31,BE,Belgium,1.5614
-2010-12-31,BG,Bulgaria,-8.9133
-2010-12-31,BR,Brazil,16.8766
-2010-12-31,CA,Canada,1.0341
-2010-12-31,CH,Switzerland,6.0288
+2010-09-30,SE,Sweden,5.9069
+2010-09-30,SG,Singapore,18.8519
+2010-09-30,SI,Slovenia,-0.6947
+2010-09-30,SK,Slovakia,-7.3908
+2010-09-30,TH,Thailand,0.4874
+2010-09-30,US,United States,-3.2788
+2010-09-30,XM,Euro area,-0.4356
+2010-09-30,XW,World,2.1283
+2010-09-30,ZA,South Africa,1.1208
+2010-12-31,4T,Emerging market economies (aggregate),3.5315
+2010-12-31,5R,Advanced economies,-1.3428
+2010-12-31,AT,Austria,5.122
+2010-12-31,AU,Australia,1.7182
+2010-12-31,BE,Belgium,0.2077
+2010-12-31,BG,Bulgaria,-8.9091
+2010-12-31,BR,Brazil,16.8762
+2010-12-31,CA,Canada,1.1385
+2010-12-31,CH,Switzerland,6.0278
 2010-12-31,CL,Chile,0.8615
 2010-12-31,CN,China,2.7193
-2010-12-31,CO,Colombia,6.1669
+2010-12-31,CO,Colombia,6.1821
 2010-12-31,CY,Cyprus,-5.51
-2010-12-31,CZ,Czechia,-2.005
+2010-12-31,CZ,Czechia,-1.9992
 2010-12-31,DE,Germany,0.2329
-2010-12-31,DK,Denmark,0.013
+2010-12-31,DK,Denmark,-0.0025
 2010-12-31,EE,Estonia,7.2059
-2010-12-31,ES,Spain,-3.8665
+2010-12-31,ES,Spain,-3.8666
 2010-12-31,FI,Finland,1.6506
-2010-12-31,FR,France,5.0461
-2010-12-31,GB,United Kingdom,-1.9173
+2010-12-31,FR,France,5.0422
+2010-12-31,GB,United Kingdom,-1.7653
 2010-12-31,GR,Greece,-11.485
 2010-12-31,HK,Hong Kong SAR,18.8783
-2010-12-31,HR,Croatia,-5.3416
+2010-12-31,HR,Croatia,-5.3612
 2010-12-31,HU,Hungary,-4.5789
 2010-12-31,ID,Indonesia,-3.2141
-2010-12-31,IE,Ireland,-14.159
-2010-12-31,IL,Israel,11.6738
+2010-12-31,IE,Ireland,-14.2176
+2010-12-31,IL,Israel,11.6734
 2010-12-31,IN,India,6.6565
-2010-12-31,IS,Iceland,-4.0634
-2010-12-31,IT,Italy,-1.4897
+2010-12-31,IS,Iceland,-4.055
+2010-12-31,IT,Italy,-1.4924
 2010-12-31,JP,Japan,2.2885
-2010-12-31,KR,Korea,-1.5353
-2010-12-31,LT,Lithuania,-1.6766
-2010-12-31,LU,Luxembourg,2.8151
-2010-12-31,LV,Latvia,-4.1879
-2010-12-31,MA,Morocco,-2.1302
-2010-12-31,MK,North Macedonia,3.9417
+2010-12-31,KR,Korea,-1.5226
+2010-12-31,LT,Lithuania,-1.6767
+2010-12-31,LU,Luxembourg,2.809
+2010-12-31,LV,Latvia,-4.1236
+2010-12-31,MA,Morocco,-2.6863
+2010-12-31,MK,North Macedonia,4.5643
 2010-12-31,MT,Malta,-2.8557
 2010-12-31,MX,Mexico,0.1509
 2010-12-31,MY,Malaysia,5.7564
-2010-12-31,NL,Netherlands,-2.5556
-2010-12-31,NO,Norway,4.1317
+2010-12-31,NL,Netherlands,-2.5578
+2010-12-31,NO,Norway,4.1322
 2010-12-31,NZ,New Zealand,-5.4192
 2010-12-31,PE,Peru,17.5034
 2010-12-31,PH,Philippines,-0.406
-2010-12-31,PL,Poland,
 2010-12-31,PT,Portugal,-3.1664
 2010-12-31,RO,Romania,-18.6022
 2010-12-31,RS,Serbia,2.0569
 2010-12-31,RU,Russia,4.9118
-2010-12-31,SE,Sweden,4.0103
-2010-12-31,SG,Singapore,13.082
-2010-12-31,SI,Slovenia,-1.7615
-2010-12-31,SK,Slovak Republic,-2.7952
-2010-12-31,TH,Thailand,-1.1551
-2010-12-31,TR,Türkiye,
-2010-12-31,US,United States,-4.7523
-2010-12-31,XM,Euro area,-0.5296
-2010-12-31,XW,World,0.7532
-2010-12-31,ZA,South Africa,0.0377
-2011-03-31,4T,Emerging market economies (aggregate),0.3182
-2011-03-31,5R,Advanced economies,-2.8717
-2011-03-31,AE,United Arab Emirates,-7.9063
+2010-12-31,SE,Sweden,4.0102
+2010-12-31,SG,Singapore,13.076
+2010-12-31,SI,Slovenia,-1.7934
+2010-12-31,SK,Slovakia,-2.5121
+2010-12-31,TH,Thailand,-1.1516
+2010-12-31,US,United States,-4.7495
+2010-12-31,XM,Euro area,-0.5146
+2010-12-31,XW,World,0.7643
+2010-12-31,ZA,South Africa,0.9747
+2011-03-31,4T,Emerging market economies (aggregate),-0.0135
+2011-03-31,5R,Advanced economies,-2.4311
 2011-03-31,AT,Austria,1.7198
-2011-03-31,AU,Australia,-2.7749
-2011-03-31,BE,Belgium,0.7948
-2011-03-31,BG,Bulgaria,-9.4308
-2011-03-31,BR,Brazil,14.8035
-2011-03-31,CA,Canada,0.4648
-2011-03-31,CH,Switzerland,6.5589
+2011-03-31,AU,Australia,-2.8132
+2011-03-31,BE,Belgium,0.3838
+2011-03-31,BG,Bulgaria,-9.376
+2011-03-31,BR,Brazil,14.8034
+2011-03-31,CA,Canada,0.3522
+2011-03-31,CH,Switzerland,6.5587
 2011-03-31,CL,Chile,6.6047
 2011-03-31,CN,China,0.6682
-2011-03-31,CO,Colombia,2.6767
+2011-03-31,CO,Colombia,3.0067
 2011-03-31,CY,Cyprus,-4.5661
-2011-03-31,CZ,Czechia,-1.5274
+2011-03-31,CZ,Czechia,-1.5277
 2011-03-31,DE,Germany,1.0961
-2011-03-31,DK,Denmark,-1.7564
+2011-03-31,DK,Denmark,-1.7293
 2011-03-31,EE,Estonia,1.1585
-2011-03-31,ES,Spain,-6.8054
+2011-03-31,ES,Spain,-6.8056
 2011-03-31,FI,Finland,0.0095
-2011-03-31,FR,France,4.7372
-2011-03-31,GB,United Kingdom,-4.6844
+2011-03-31,FR,France,4.738
+2011-03-31,GB,United Kingdom,-4.5693
 2011-03-31,GR,Greece,-9.6532
 2011-03-31,HK,Hong Kong SAR,19.7896
-2011-03-31,HR,Croatia,-5.0968
-2011-03-31,HU,Hungary,-7.0612
+2011-03-31,HR,Croatia,-5.0527
+2011-03-31,HU,Hungary,-7.0611
 2011-03-31,ID,Indonesia,-2.1948
-2011-03-31,IE,Ireland,-16.3254
-2011-03-31,IL,Israel,9.8072
+2011-03-31,IE,Ireland,-16.2908
+2011-03-31,IL,Israel,9.8077
 2011-03-31,IN,India,8.9505
-2011-03-31,IS,Iceland,1.4086
-2011-03-31,IT,Italy,-1.032
+2011-03-31,IS,Iceland,1.3948
+2011-03-31,IT,Italy,-1.0346
 2011-03-31,JP,Japan,1.3704
-2011-03-31,KR,Korea,-0.9816
+2011-03-31,KR,Korea,-0.9719
 2011-03-31,LT,Lithuania,4.3898
-2011-03-31,LU,Luxembourg,-2.3574
-2011-03-31,LV,Latvia,6.5465
-2011-03-31,MA,Morocco,-0.0177
-2011-03-31,MK,North Macedonia,-7.051
+2011-03-31,LU,Luxembourg,-2.3631
+2011-03-31,LV,Latvia,6.6318
+2011-03-31,MA,Morocco,-1.1787
+2011-03-31,MK,North Macedonia,-7.1399
 2011-03-31,MT,Malta,-5.4823
 2011-03-31,MX,Mexico,2.0722
 2011-03-31,MY,Malaysia,6.5007
-2011-03-31,NL,Netherlands,-2.305
-2011-03-31,NO,Norway,6.9691
+2011-03-31,NL,Netherlands,-2.3125
+2011-03-31,NO,Norway,6.947
 2011-03-31,NZ,New Zealand,-5.6664
 2011-03-31,PE,Peru,15.7832
 2011-03-31,PH,Philippines,-0.3848
 2011-03-31,PL,Poland,-2.6873
-2011-03-31,PT,Portugal,-5.646
+2011-03-31,PT,Portugal,-5.6459
 2011-03-31,RO,Romania,-17.5184
 2011-03-31,RS,Serbia,-4.6021
-2011-03-31,RU,Russia,-28.5625
-2011-03-31,SE,Sweden,2.6821
-2011-03-31,SG,Singapore,8.1467
-2011-03-31,SI,Slovenia,2.3529
-2011-03-31,SK,Slovak Republic,-4.2504
-2011-03-31,TH,Thailand,3.1234
-2011-03-31,TR,Türkiye,2.0868
-2011-03-31,US,United States,-6.3334
-2011-03-31,XM,Euro area,-0.8878
-2011-03-31,XW,World,-1.2955
-2011-03-31,ZA,South Africa,-1.4169
-2011-06-30,4T,Emerging market economies (aggregate),0.0054
-2011-06-30,5R,Advanced economies,-3.7284
-2011-06-30,AE,United Arab Emirates,-5.1304
+2011-03-31,RU,Russia,-28.5699
+2011-03-31,SE,Sweden,2.68
+2011-03-31,SG,Singapore,8.1444
+2011-03-31,SI,Slovenia,2.3544
+2011-03-31,SK,Slovakia,-4.2504
+2011-03-31,TH,Thailand,1.6238
+2011-03-31,TR,Türkiye,3.7367
+2011-03-31,US,United States,-6.323
+2011-03-31,XM,Euro area,-0.8701
+2011-03-31,XW,World,-1.3854
+2011-03-31,ZA,South Africa,-0.4698
+2011-06-30,4T,Emerging market economies (aggregate),-0.4006
+2011-06-30,5R,Advanced economies,-3.1998
 2011-06-30,AT,Austria,-1.9042
-2011-06-30,AU,Australia,-5.557
-2011-06-30,BE,Belgium,0.6783
-2011-06-30,BG,Bulgaria,-10.174
-2011-06-30,BR,Brazil,12.7184
-2011-06-30,CA,Canada,1.3785
-2011-06-30,CH,Switzerland,7.4968
+2011-06-30,AU,Australia,-5.6245
+2011-06-30,BE,Belgium,0.1806
+2011-06-30,BG,Bulgaria,-10.1
+2011-06-30,BR,Brazil,12.7183
+2011-06-30,CA,Canada,1.2152
+2011-06-30,CH,Switzerland,7.4974
 2011-06-30,CL,Chile,7.6688
 2011-06-30,CN,China,-1.5476
-2011-06-30,CO,Colombia,4.6044
+2011-06-30,CO,Colombia,5.2099
 2011-06-30,CY,Cyprus,-6.1987
-2011-06-30,CZ,Czechia,-1.2079
+2011-06-30,CZ,Czechia,-1.2083
 2011-06-30,DE,Germany,0.1341
-2011-06-30,DK,Denmark,-1.9854
+2011-06-30,DK,Denmark,-1.9646
 2011-06-30,EE,Estonia,3.3808
-2011-06-30,ES,Spain,-9.4024
+2011-06-30,ES,Spain,-9.4027
 2011-06-30,FI,Finland,0.8951
-2011-06-30,FR,France,4.4349
-2011-06-30,GB,United Kingdom,-5.9262
+2011-06-30,FR,France,4.4399
+2011-06-30,GB,United Kingdom,-5.9631
 2011-06-30,GR,Greece,-8.3416
 2011-06-30,HK,Hong Kong SAR,20.6263
-2011-06-30,HR,Croatia,-2.2323
-2011-06-30,HU,Hungary,-7.1316
+2011-06-30,HR,Croatia,-2.2451
+2011-06-30,HU,Hungary,-7.1317
 2011-06-30,ID,Indonesia,-1.2755
-2011-06-30,IE,Ireland,-18.3019
-2011-06-30,IL,Israel,8.6007
+2011-06-30,IE,Ireland,-18.3058
+2011-06-30,IL,Israel,8.6003
 2011-06-30,IN,India,12.0833
-2011-06-30,IS,Iceland,0.2867
-2011-06-30,IT,Italy,-0.2914
+2011-06-30,IS,Iceland,0.3006
+2011-06-30,IT,Italy,-0.2892
 2011-06-30,JP,Japan,0.5886
-2011-06-30,KR,Korea,0.6823
+2011-06-30,KR,Korea,0.7551
 2011-06-30,LT,Lithuania,1.4491
-2011-06-30,LU,Luxembourg,1.2688
-2011-06-30,LV,Latvia,7.2113
-2011-06-30,MA,Morocco,-1.1653
-2011-06-30,MK,North Macedonia,-5.9845
+2011-06-30,LU,Luxembourg,1.2662
+2011-06-30,LV,Latvia,7.1597
+2011-06-30,MA,Morocco,0.7339
+2011-06-30,MK,North Macedonia,-5.9288
 2011-06-30,MT,Malta,-3.2863
 2011-06-30,MX,Mexico,2.7439
 2011-06-30,MY,Malaysia,5.2416
-2011-06-30,NL,Netherlands,-3.7695
-2011-06-30,NO,Norway,5.836
+2011-06-30,NL,Netherlands,-3.7673
+2011-06-30,NO,Norway,5.8381
 2011-06-30,NZ,New Zealand,-4.8945
 2011-06-30,PE,Peru,15.9224
 2011-06-30,PH,Philippines,0.9716
@@ -20944,185 +5090,182 @@ date,country_code,country,price
 2011-06-30,PT,Portugal,-8.0627
 2011-06-30,RO,Romania,-18.2351
 2011-06-30,RS,Serbia,-11.0874
-2011-06-30,RU,Russia,-28.0373
-2011-06-30,SE,Sweden,0.8233
-2011-06-30,SG,Singapore,5.2042
-2011-06-30,SI,Slovenia,1.4131
-2011-06-30,SK,Slovak Republic,-5.6326
-2011-06-30,TH,Thailand,2.3652
-2011-06-30,TR,Türkiye,0.9242
-2011-06-30,US,United States,-7.2777
-2011-06-30,XM,Euro area,-1.681
-2011-06-30,XW,World,-1.8571
-2011-06-30,ZA,South Africa,-2.0149
-2011-09-30,4T,Emerging market economies (aggregate),-0.5764
-2011-09-30,5R,Advanced economies,-2.9899
-2011-09-30,AE,United Arab Emirates,0.4064
-2011-09-30,AT,Austria,2.3889
-2011-09-30,AU,Australia,-5.9352
-2011-09-30,BE,Belgium,0.585
-2011-09-30,BG,Bulgaria,-9.1167
-2011-09-30,BR,Brazil,10.4409
-2011-09-30,CA,Canada,4.2032
-2011-09-30,CH,Switzerland,7.8557
+2011-06-30,RU,Russia,-28.0449
+2011-06-30,SE,Sweden,0.827
+2011-06-30,SG,Singapore,5.2008
+2011-06-30,SI,Slovenia,1.4647
+2011-06-30,SK,Slovakia,-5.6326
+2011-06-30,TH,Thailand,1.998
+2011-06-30,TR,Türkiye,3.0617
+2011-06-30,US,United States,-7.2849
+2011-06-30,XM,Euro area,-1.6648
+2011-06-30,XW,World,-1.9651
+2011-06-30,ZA,South Africa,-1.5478
+2011-09-30,4T,Emerging market economies (aggregate),-1.1393
+2011-09-30,5R,Advanced economies,-2.5633
+2011-09-30,AT,Austria,2.3888
+2011-09-30,AU,Australia,-6.0014
+2011-09-30,BE,Belgium,-0.1298
+2011-09-30,BG,Bulgaria,-9.1407
+2011-09-30,BR,Brazil,10.441
+2011-09-30,CA,Canada,4.0555
+2011-09-30,CH,Switzerland,7.858
 2011-09-30,CL,Chile,9.4648
 2011-09-30,CN,China,-2.2226
-2011-09-30,CO,Colombia,6.5998
+2011-09-30,CO,Colombia,6.3495
 2011-09-30,CY,Cyprus,-6.58
-2011-09-30,CZ,Czechia,-1.5495
+2011-09-30,CZ,Czechia,-1.5583
 2011-09-30,DE,Germany,0.2506
-2011-09-30,DK,Denmark,-5.6091
+2011-09-30,DK,Denmark,-5.5899
 2011-09-30,EE,Estonia,1.4665
-2011-09-30,ES,Spain,-10.8006
+2011-09-30,ES,Spain,-10.8002
 2011-09-30,FI,Finland,-0.9406
-2011-09-30,FR,France,3.7051
-2011-09-30,GB,United Kingdom,-6.4727
+2011-09-30,FR,France,3.7081
+2011-09-30,GB,United Kingdom,-6.349
 2011-09-30,GR,Greece,-6.956
 2011-09-30,HK,Hong Kong SAR,12.8257
-2011-09-30,HR,Croatia,-0.3897
-2011-09-30,HU,Hungary,-7.4186
+2011-09-30,HR,Croatia,-0.3661
+2011-09-30,HU,Hungary,-7.4187
 2011-09-30,ID,Indonesia,-0.1068
-2011-09-30,IE,Ireland,-20.5575
-2011-09-30,IL,Israel,6.4864
+2011-09-30,IE,Ireland,-20.5191
+2011-09-30,IL,Israel,6.4861
 2011-09-30,IN,India,8.6342
-2011-09-30,IS,Iceland,1.328
-2011-09-30,IT,Italy,-1.5037
+2011-09-30,IS,Iceland,1.3361
+2011-09-30,IT,Italy,-1.4954
 2011-09-30,JP,Japan,0.0913
-2011-09-30,KR,Korea,1.9791
+2011-09-30,KR,Korea,1.9981
 2011-09-30,LT,Lithuania,2.2147
-2011-09-30,LU,Luxembourg,0.1524
-2011-09-30,LV,Latvia,8.1147
-2011-09-30,MA,Morocco,-0.7279
-2011-09-30,MK,North Macedonia,-2.9419
+2011-09-30,LU,Luxembourg,0.1558
+2011-09-30,LV,Latvia,8.118
+2011-09-30,MA,Morocco,-0.9216
+2011-09-30,MK,North Macedonia,-2.7943
 2011-09-30,MT,Malta,-5.9354
 2011-09-30,MX,Mexico,2.4926
 2011-09-30,MY,Malaysia,6.2356
-2011-09-30,NL,Netherlands,-5.0119
-2011-09-30,NO,Norway,6.7206
+2011-09-30,NL,Netherlands,-5.0114
+2011-09-30,NO,Norway,6.7079
 2011-09-30,NZ,New Zealand,-2.3895
 2011-09-30,PE,Peru,18.9329
 2011-09-30,PH,Philippines,0.71
 2011-09-30,PL,Poland,-4.4175
-2011-09-30,PT,Portugal,-8.3688
+2011-09-30,PT,Portugal,-8.3687
 2011-09-30,RO,Romania,-16.3124
 2011-09-30,RS,Serbia,-16.2339
-2011-09-30,RU,Russia,-26.659
-2011-09-30,SE,Sweden,-0.9706
-2011-09-30,SG,Singapore,2.7929
-2011-09-30,SI,Slovenia,0.8507
-2011-09-30,SK,Slovak Republic,-4.5
-2011-09-30,TH,Thailand,-1.61
-2011-09-30,TR,Türkiye,1.4261
-2011-09-30,US,United States,-5.1768
-2011-09-30,XM,Euro area,-1.945
-2011-09-30,XW,World,-1.7671
-2011-09-30,ZA,South Africa,-1.7092
-2011-12-31,4T,Emerging market economies (aggregate),0.2617
-2011-12-31,5R,Advanced economies,-3.0815
-2011-12-31,AE,United Arab Emirates,6.2906
+2011-09-30,RU,Russia,-26.6529
+2011-09-30,SE,Sweden,-0.9696
+2011-09-30,SG,Singapore,2.7893
+2011-09-30,SI,Slovenia,0.8194
+2011-09-30,SK,Slovakia,-4.5966
+2011-09-30,TH,Thailand,-1.6685
+2011-09-30,TR,Türkiye,2.1895
+2011-09-30,US,United States,-5.2033
+2011-09-30,XM,Euro area,-1.927
+2011-09-30,XW,World,-1.9248
+2011-09-30,ZA,South Africa,-1.2275
+2011-12-31,4T,Emerging market economies (aggregate),-0.1913
+2011-12-31,5R,Advanced economies,-2.7537
 2011-12-31,AT,Austria,1.5491
-2011-12-31,AU,Australia,-6.8421
-2011-12-31,BE,Belgium,-0.1692
-2011-12-31,BG,Bulgaria,-8.6546
-2011-12-31,BR,Brazil,8.9714
-2011-12-31,CA,Canada,5.2345
-2011-12-31,CH,Switzerland,7.1497
-2011-12-31,CL,Chile,10.4965
+2011-12-31,AU,Australia,-6.9321
+2011-12-31,BE,Belgium,-0.2355
+2011-12-31,BG,Bulgaria,-8.6824
+2011-12-31,BR,Brazil,8.9718
+2011-12-31,CA,Canada,5.0218
+2011-12-31,CH,Switzerland,7.1524
+2011-12-31,CL,Chile,10.4966
 2011-12-31,CN,China,-2.2669
-2011-12-31,CO,Colombia,3.4067
+2011-12-31,CO,Colombia,3.4619
 2011-12-31,CY,Cyprus,-8.235
-2011-12-31,CZ,Czechia,-3.1294
+2011-12-31,CZ,Czechia,-3.132
 2011-12-31,DE,Germany,-0.0414
-2011-12-31,DK,Denmark,-8.0008
+2011-12-31,DK,Denmark,-8.0354
 2011-12-31,EE,Estonia,7.374
-2011-12-31,ES,Spain,-15.0827
+2011-12-31,ES,Spain,-15.0825
 2011-12-31,FI,Finland,-0.9105
-2011-12-31,FR,France,1.2348
-2011-12-31,GB,United Kingdom,-5.6507
-2011-12-31,GR,Greece,-9.1501
+2011-12-31,FR,France,1.2401
+2011-12-31,GB,United Kingdom,-5.7446
+2011-12-31,GR,Greece,-9.15
 2011-12-31,HK,Hong Kong SAR,6.1386
-2011-12-31,HR,Croatia,-0.4808
+2011-12-31,HR,Croatia,-0.3785
 2011-12-31,HU,Hungary,-6.726
 2011-12-31,ID,Indonesia,0.9069
-2011-12-31,IE,Ireland,-21.7875
-2011-12-31,IL,Israel,2.81
+2011-12-31,IE,Ireland,-21.731
+2011-12-31,IL,Israel,2.8106
 2011-12-31,IN,India,15.4969
-2011-12-31,IS,Iceland,2.671
-2011-12-31,IT,Italy,-2.7095
+2011-12-31,IS,Iceland,2.6976
+2011-12-31,IT,Italy,-2.7058
 2011-12-31,JP,Japan,-0.6832
-2011-12-31,KR,Korea,2.9178
+2011-12-31,KR,Korea,2.9522
 2011-12-31,LT,Lithuania,1.5215
-2011-12-31,LU,Luxembourg,1.9573
-2011-12-31,LV,Latvia,1.4963
-2011-12-31,MA,Morocco,0.6293
-2011-12-31,MK,North Macedonia,-4.9107
+2011-12-31,LU,Luxembourg,1.9556
+2011-12-31,LV,Latvia,1.5119
+2011-12-31,MA,Morocco,0.141
+2011-12-31,MK,North Macedonia,-5.0306
 2011-12-31,MT,Malta,-1.0647
 2011-12-31,MX,Mexico,1.9277
 2011-12-31,MY,Malaysia,7.7632
-2011-12-31,NL,Netherlands,-5.8056
-2011-12-31,NO,Norway,7.0458
+2011-12-31,NL,Netherlands,-5.8025
+2011-12-31,NO,Norway,6.9772
 2011-12-31,NZ,New Zealand,0.4247
 2011-12-31,PE,Peru,15.2526
 2011-12-31,PH,Philippines,2.0436
 2011-12-31,PL,Poland,-5.1493
-2011-12-31,PT,Portugal,-10.9791
+2011-12-31,PT,Portugal,-10.9792
 2011-12-31,RO,Romania,-16.7233
 2011-12-31,RS,Serbia,-16.3521
-2011-12-31,RU,Russia,-24.6327
-2011-12-31,SE,Sweden,-3.8541
-2011-12-31,SG,Singapore,0.3355
-2011-12-31,SI,Slovenia,-1.1009
-2011-12-31,SK,Slovak Republic,-6.5162
-2011-12-31,TH,Thailand,-1.0565
-2011-12-31,TR,Türkiye,-2.5185
-2011-12-31,US,United States,-4.0312
-2011-12-31,XM,Euro area,-3.472
-2011-12-31,XW,World,-1.3852
-2011-12-31,ZA,South Africa,-1.5977
-2012-03-31,4T,Emerging market economies (aggregate),2.5201
-2012-03-31,5R,Advanced economies,-1.7807
-2012-03-31,AE,United Arab Emirates,6.2561
+2011-12-31,RU,Russia,-24.6231
+2011-12-31,SE,Sweden,-3.8512
+2011-12-31,SG,Singapore,0.3317
+2011-12-31,SI,Slovenia,-1.0704
+2011-12-31,SK,Slovakia,-6.5162
+2011-12-31,TH,Thailand,-0.1357
+2011-12-31,TR,Türkiye,-0.0615
+2011-12-31,US,United States,-4.0617
+2011-12-31,XM,Euro area,-3.4573
+2011-12-31,XW,World,-1.6064
+2011-12-31,ZA,South Africa,-2.0198
+2012-03-31,4T,Emerging market economies (aggregate),2.6088
+2012-03-31,5R,Advanced economies,-1.633
 2012-03-31,AT,Austria,7.9495
-2012-03-31,AU,Australia,-4.1885
-2012-03-31,BE,Belgium,-0.0886
-2012-03-31,BG,Bulgaria,-5.6269
+2012-03-31,AU,Australia,-4.1448
+2012-03-31,BE,Belgium,-0.3371
+2012-03-31,BG,Bulgaria,-5.645
 2012-03-31,BR,Brazil,7.9434
-2012-03-31,CA,Canada,4.9054
-2012-03-31,CH,Switzerland,7.2216
-2012-03-31,CL,Chile,8.1909
+2012-03-31,CA,Canada,4.9124
+2012-03-31,CH,Switzerland,7.2219
+2012-03-31,CL,Chile,8.1908
 2012-03-31,CN,China,-3.5432
-2012-03-31,CO,Colombia,7.3449
+2012-03-31,CO,Colombia,7.4768
 2012-03-31,CY,Cyprus,-7.9541
-2012-03-31,CZ,Czechia,-5.0335
+2012-03-31,CZ,Czechia,-5.033
 2012-03-31,DE,Germany,0.4241
-2012-03-31,DK,Denmark,-7.1788
+2012-03-31,DK,Denmark,-7.2216
 2012-03-31,EE,Estonia,2.7552
-2012-03-31,ES,Spain,-15.8301
+2012-03-31,ES,Spain,-15.8298
 2012-03-31,FI,Finland,-0.352
-2012-03-31,FR,France,-0.5556
-2012-03-31,GB,United Kingdom,-3.81
+2012-03-31,FR,France,-0.5482
+2012-03-31,GB,United Kingdom,-3.8603
 2012-03-31,GR,Greece,-12.3257
 2012-03-31,HK,Hong Kong SAR,0.5426
-2012-03-31,HR,Croatia,0.8976
-2012-03-31,HU,Hungary,-6.8696
+2012-03-31,HR,Croatia,0.8651
+2012-03-31,HU,Hungary,-6.8697
 2012-03-31,ID,Indonesia,-0.0706
-2012-03-31,IE,Ireland,-21.2759
-2012-03-31,IL,Israel,0.3897
+2012-03-31,IE,Ireland,-21.3233
+2012-03-31,IL,Israel,0.3893
 2012-03-31,IN,India,17.0246
-2012-03-31,IS,Iceland,0.8491
-2012-03-31,IT,Italy,-2.575
+2012-03-31,IS,Iceland,0.8582
+2012-03-31,IT,Italy,-2.5748
 2012-03-31,JP,Japan,-0.8128
-2012-03-31,KR,Korea,2.6891
+2012-03-31,KR,Korea,2.7004
 2012-03-31,LT,Lithuania,-2.5835
-2012-03-31,LU,Luxembourg,1.6098
-2012-03-31,LV,Latvia,-0.81
-2012-03-31,MA,Morocco,-0.0376
-2012-03-31,MK,North Macedonia,-0.1915
+2012-03-31,LU,Luxembourg,1.6104
+2012-03-31,LV,Latvia,-0.8608
+2012-03-31,MA,Morocco,0.2411
+2012-03-31,MK,North Macedonia,0.0448
 2012-03-31,MT,Malta,-0.0994
 2012-03-31,MX,Mexico,0.1757
 2012-03-31,MY,Malaysia,10.1718
-2012-03-31,NL,Netherlands,-7.6899
-2012-03-31,NO,Norway,5.4355
+2012-03-31,NL,Netherlands,-7.6858
+2012-03-31,NO,Norway,5.4199
 2012-03-31,NZ,New Zealand,1.514
 2012-03-31,PE,Peru,14.6154
 2012-03-31,PH,Philippines,6.9321
@@ -21130,61 +5273,60 @@ date,country_code,country,price
 2012-03-31,PT,Portugal,-11.2004
 2012-03-31,RO,Romania,-9.6118
 2012-03-31,RS,Serbia,-10.7835
-2012-03-31,RU,Russia,8.2737
-2012-03-31,SE,Sweden,-2.734
-2012-03-31,SG,Singapore,-1.3729
-2012-03-31,SI,Slovenia,-9.3363
-2012-03-31,SK,Slovak Republic,-6.5938
-2012-03-31,TH,Thailand,-1.1448
-2012-03-31,TR,Türkiye,-2.1068
-2012-03-31,US,United States,-1.0609
-2012-03-31,XM,Euro area,-3.6006
-2012-03-31,XW,World,0.4037
-2012-03-31,ZA,South Africa,-1.3075
-2012-06-30,4T,Emerging market economies (aggregate),2.1314
-2012-06-30,5R,Advanced economies,-0.6537
-2012-06-30,AE,United Arab Emirates,12.3982
+2012-03-31,RU,Russia,8.273
+2012-03-31,SE,Sweden,-2.7307
+2012-03-31,SG,Singapore,-1.379
+2012-03-31,SI,Slovenia,-9.3411
+2012-03-31,SK,Slovakia,-6.6903
+2012-03-31,TH,Thailand,0.5459
+2012-03-31,TR,Türkiye,-0.4902
+2012-03-31,US,United States,-1.0527
+2012-03-31,XM,Euro area,-3.5884
+2012-03-31,XW,World,0.2626
+2012-03-31,ZA,South Africa,-1.3415
+2012-06-30,4T,Emerging market economies (aggregate),2.1046
+2012-06-30,5R,Advanced economies,-0.6703
 2012-06-30,AT,Austria,13.024
-2012-06-30,AU,Australia,-2.7451
-2012-06-30,BE,Belgium,-0.1219
-2012-06-30,BG,Bulgaria,-3.1447
-2012-06-30,BR,Brazil,6.933
-2012-06-30,CA,Canada,4.1902
-2012-06-30,CH,Switzerland,7.0425
-2012-06-30,CL,Chile,6.314
+2012-06-30,AU,Australia,-2.7119
+2012-06-30,BE,Belgium,-0.0286
+2012-06-30,BG,Bulgaria,-3.1628
+2012-06-30,BR,Brazil,6.9327
+2012-06-30,CA,Canada,4.2526
+2012-06-30,CH,Switzerland,7.0431
+2012-06-30,CL,Chile,6.3141
 2012-06-30,CN,China,-3.8463
-2012-06-30,CO,Colombia,6.8022
+2012-06-30,CO,Colombia,6.3965
 2012-06-30,CY,Cyprus,-8.2179
-2012-06-30,CZ,Czechia,-5.1818
+2012-06-30,CZ,Czechia,-5.1819
 2012-06-30,DE,Germany,1.5507
-2012-06-30,DK,Denmark,-7.3543
+2012-06-30,DK,Denmark,-7.3876
 2012-06-30,EE,Estonia,3.5346
-2012-06-30,ES,Spain,-17.5803
+2012-06-30,ES,Spain,-17.58
 2012-06-30,FI,Finland,-1.1201
-2012-06-30,FR,France,-2.1472
-2012-06-30,GB,United Kingdom,-2.0562
-2012-06-30,GR,Greece,-12.175
+2012-06-30,FR,France,-2.1498
+2012-06-30,GB,United Kingdom,-1.9516
+2012-06-30,GR,Greece,-12.1749
 2012-06-30,HK,Hong Kong SAR,4.4625
-2012-06-30,HR,Croatia,-3.8627
+2012-06-30,HR,Croatia,-3.8267
 2012-06-30,HU,Hungary,-9.2882
 2012-06-30,ID,Indonesia,-0.6545
-2012-06-30,IE,Ireland,-18.5913
-2012-06-30,IL,Israel,-0.4509
+2012-06-30,IE,Ireland,-18.5968
+2012-06-30,IL,Israel,-0.4503
 2012-06-30,IN,India,14.3117
-2012-06-30,IS,Iceland,1.7979
-2012-06-30,IT,Italy,-5.2639
+2012-06-30,IS,Iceland,1.8065
+2012-06-30,IT,Italy,-5.2612
 2012-06-30,JP,Japan,-1.2742
-2012-06-30,KR,Korea,1.1954
-2012-06-30,LT,Lithuania,-3.5613
-2012-06-30,LU,Luxembourg,1.4851
-2012-06-30,LV,Latvia,-0.2802
-2012-06-30,MA,Morocco,-0.4183
-2012-06-30,MK,North Macedonia,-3.6935
+2012-06-30,KR,Korea,1.1673
+2012-06-30,LT,Lithuania,-3.5612
+2012-06-30,LU,Luxembourg,1.4757
+2012-06-30,LV,Latvia,-0.2078
+2012-06-30,MA,Morocco,-0.2453
+2012-06-30,MK,North Macedonia,-3.6546
 2012-06-30,MT,Malta,-3.5255
 2012-06-30,MX,Mexico,-0.7709
 2012-06-30,MY,Malaysia,11.5464
-2012-06-30,NL,Netherlands,-7.7132
-2012-06-30,NO,Norway,6.4425
+2012-06-30,NL,Netherlands,-7.7082
+2012-06-30,NO,Norway,6.4418
 2012-06-30,NZ,New Zealand,2.8422
 2012-06-30,PE,Peru,15.3495
 2012-06-30,PH,Philippines,5.7098
@@ -21192,123 +5334,121 @@ date,country_code,country,price
 2012-06-30,PT,Portugal,-10.7787
 2012-06-30,RO,Romania,-8.1934
 2012-06-30,RS,Serbia,-6.8441
-2012-06-30,RU,Russia,10.1174
-2012-06-30,SE,Sweden,-0.6915
-2012-06-30,SG,Singapore,-3.1619
-2012-06-30,SI,Slovenia,-7.9462
-2012-06-30,SK,Slovak Republic,-5.7445
-2012-06-30,TH,Thailand,-2.2638
-2012-06-30,TR,Türkiye,0.385
-2012-06-30,US,United States,1.8792
-2012-06-30,XM,Euro area,-4.0429
-2012-06-30,XW,World,0.7744
-2012-06-30,ZA,South Africa,-0.819
-2012-09-30,4T,Emerging market economies (aggregate),2.3708
-2012-09-30,5R,Advanced economies,-0.2405
-2012-09-30,AE,United Arab Emirates,14.3891
-2012-09-30,AT,Austria,9.2752
-2012-09-30,AU,Australia,-1.9646
-2012-09-30,BE,Belgium,-0.843
-2012-09-30,BG,Bulgaria,-4.7486
-2012-09-30,BR,Brazil,5.3677
-2012-09-30,CA,Canada,2.2
-2012-09-30,CH,Switzerland,5.9239
+2012-06-30,RU,Russia,10.1142
+2012-06-30,SE,Sweden,-0.6934
+2012-06-30,SG,Singapore,-3.1671
+2012-06-30,SI,Slovenia,-7.9791
+2012-06-30,SK,Slovakia,-5.8429
+2012-06-30,TH,Thailand,-1.2993
+2012-06-30,TR,Türkiye,0.8579
+2012-06-30,US,United States,1.8393
+2012-06-30,XM,Euro area,-4.0492
+2012-06-30,XW,World,0.5831
+2012-06-30,ZA,South Africa,-0.9137
+2012-09-30,4T,Emerging market economies (aggregate),2.3321
+2012-09-30,5R,Advanced economies,-0.2953
+2012-09-30,AT,Austria,9.2753
+2012-09-30,AU,Australia,-1.9098
+2012-09-30,BE,Belgium,-0.8295
+2012-09-30,BG,Bulgaria,-4.7526
+2012-09-30,BR,Brazil,5.3675
+2012-09-30,CA,Canada,2.2342
+2012-09-30,CH,Switzerland,5.923
 2012-09-30,CL,Chile,6.6637
 2012-09-30,CN,China,-2.955
-2012-09-30,CO,Colombia,5.6848
+2012-09-30,CO,Colombia,5.6959
 2012-09-30,CY,Cyprus,-7.9345
-2012-09-30,CZ,Czechia,-4.6876
+2012-09-30,CZ,Czechia,-4.6843
 2012-09-30,DE,Germany,0.6111
-2012-09-30,DK,Denmark,-4.16
+2012-09-30,DK,Denmark,-4.1898
 2012-09-30,EE,Estonia,4.4659
-2012-09-30,ES,Spain,-18.3561
+2012-09-30,ES,Spain,-18.3565
 2012-09-30,FI,Finland,-0.6072
-2012-09-30,FR,France,-3.4921
-2012-09-30,GB,United Kingdom,-1.776
-2012-09-30,GR,Greece,-13.7323
+2012-09-30,FR,France,-3.4938
+2012-09-30,GB,United Kingdom,-1.9992
+2012-09-30,GR,Greece,-13.7322
 2012-09-30,HK,Hong Kong SAR,10.8447
-2012-09-30,HR,Croatia,-5.8434
+2012-09-30,HR,Croatia,-5.8337
 2012-09-30,HU,Hungary,-9.3533
 2012-09-30,ID,Indonesia,0.1978
-2012-09-30,IE,Ireland,-12.402
+2012-09-30,IE,Ireland,-12.4275
 2012-09-30,IL,Israel,0.7857
 2012-09-30,IN,India,14.2156
-2012-09-30,IS,Iceland,2.1859
-2012-09-30,IT,Italy,-6.6175
+2012-09-30,IS,Iceland,2.1765
+2012-09-30,IT,Italy,-6.6227
 2012-09-30,JP,Japan,-1.0398
-2012-09-30,KR,Korea,0.3045
-2012-09-30,LT,Lithuania,-2.7841
-2012-09-30,LU,Luxembourg,1.6589
-2012-09-30,LV,Latvia,-0.4361
-2012-09-30,MA,Morocco,-0.507
-2012-09-30,MK,North Macedonia,-6.5707
+2012-09-30,KR,Korea,0.2507
+2012-09-30,LT,Lithuania,-2.7842
+2012-09-30,LU,Luxembourg,1.6465
+2012-09-30,LV,Latvia,-0.4467
+2012-09-30,MA,Morocco,-0.8846
+2012-09-30,MK,North Macedonia,-6.5204
 2012-09-30,MT,Malta,3.0068
 2012-09-30,MX,Mexico,-1.6418
 2012-09-30,MY,Malaysia,11.7048
-2012-09-30,NL,Netherlands,-10.9556
-2012-09-30,NO,Norway,6.6921
+2012-09-30,NL,Netherlands,-10.9523
+2012-09-30,NO,Norway,6.6532
 2012-09-30,NZ,New Zealand,3.6628
 2012-09-30,PE,Peru,12.468
 2012-09-30,PH,Philippines,4.6717
 2012-09-30,PL,Poland,-7.3741
-2012-09-30,PT,Portugal,-10.2855
+2012-09-30,PT,Portugal,-10.2856
 2012-09-30,RO,Romania,-8.6233
 2012-09-30,RS,Serbia,-6.2081
-2012-09-30,RU,Russia,9.755
-2012-09-30,SE,Sweden,1.2012
-2012-09-30,SG,Singapore,-2.8512
-2012-09-30,SI,Slovenia,-8.6099
-2012-09-30,SK,Slovak Republic,-5.8763
-2012-09-30,TH,Thailand,-0.1214
-2012-09-30,TR,Türkiye,0.586
-2012-09-30,US,United States,3.6748
-2012-09-30,XM,Euro area,-5.0069
-2012-09-30,XW,World,1.0976
-2012-09-30,ZA,South Africa,0.0658
-2012-12-31,4T,Emerging market economies (aggregate),3.2965
-2012-12-31,5R,Advanced economies,1.0424
-2012-12-31,AE,United Arab Emirates,16.8928
+2012-09-30,RU,Russia,9.7406
+2012-09-30,SE,Sweden,1.2022
+2012-09-30,SG,Singapore,-2.8563
+2012-09-30,SI,Slovenia,-8.5822
+2012-09-30,SK,Slovakia,-5.8787
+2012-09-30,TH,Thailand,-0.1242
+2012-09-30,TR,Türkiye,2.8764
+2012-09-30,US,United States,3.6867
+2012-09-30,XM,Euro area,-5.0297
+2012-09-30,XW,World,0.8899
+2012-09-30,ZA,South Africa,-0.674
+2012-12-31,4T,Emerging market economies (aggregate),3.1197
+2012-12-31,5R,Advanced economies,0.9587
 2012-12-31,AT,Austria,8.471
-2012-12-31,AU,Australia,0.7961
-2012-12-31,BE,Belgium,-1.2757
-2012-12-31,BG,Bulgaria,-5.2817
-2012-12-31,BR,Brazil,4.2322
-2012-12-31,CA,Canada,0.8372
-2012-12-31,CH,Switzerland,5.8921
-2012-12-31,CL,Chile,8.0978
+2012-12-31,AU,Australia,0.7941
+2012-12-31,BE,Belgium,-0.6953
+2012-12-31,BG,Bulgaria,-5.2722
+2012-12-31,BR,Brazil,4.232
+2012-12-31,CA,Canada,0.9884
+2012-12-31,CH,Switzerland,5.8898
+2012-12-31,CL,Chile,8.0977
 2012-12-31,CN,China,-2.4418
-2012-12-31,CO,Colombia,7.5796
+2012-12-31,CO,Colombia,7.2339
 2012-12-31,CY,Cyprus,-5.9753
-2012-12-31,CZ,Czechia,-3.509
+2012-12-31,CZ,Czechia,-3.5106
 2012-12-31,DE,Germany,1.3175
-2012-12-31,DK,Denmark,-0.8302
+2012-12-31,DK,Denmark,-0.785
 2012-12-31,EE,Estonia,2.0435
-2012-12-31,ES,Spain,-15.364
+2012-12-31,ES,Spain,-15.3637
 2012-12-31,FI,Finland,0.4976
-2012-12-31,FR,France,-3.5477
-2012-12-31,GB,United Kingdom,-1.6062
+2012-12-31,FR,France,-3.554
+2012-12-31,GB,United Kingdom,-1.6157
 2012-12-31,GR,Greece,-13.7525
-2012-12-31,HK,Hong Kong SAR,19.5777
-2012-12-31,HR,Croatia,-10.0253
+2012-12-31,HK,Hong Kong SAR,19.5072
+2012-12-31,HR,Croatia,-10.0922
 2012-12-31,HU,Hungary,-10.0146
 2012-12-31,ID,Indonesia,2.805
-2012-12-31,IE,Ireland,-5.8332
-2012-12-31,IL,Israel,5.2952
+2012-12-31,IE,Ireland,-5.81
+2012-12-31,IL,Israel,5.2957
 2012-12-31,IN,India,16.5963
-2012-12-31,IS,Iceland,0.2587
-2012-12-31,IT,Italy,-7.2256
+2012-12-31,IS,Iceland,0.2379
+2012-12-31,IT,Italy,-7.2333
 2012-12-31,JP,Japan,-0.1901
-2012-12-31,KR,Korea,-1.4071
-2012-12-31,LT,Lithuania,-3.96
-2012-12-31,LU,Luxembourg,1.2373
-2012-12-31,LV,Latvia,4.4358
-2012-12-31,MA,Morocco,0.289
-2012-12-31,MK,North Macedonia,-8.8249
+2012-12-31,KR,Korea,-1.4056
+2012-12-31,LT,Lithuania,-3.9599
+2012-12-31,LU,Luxembourg,1.2273
+2012-12-31,LV,Latvia,4.3752
+2012-12-31,MA,Morocco,-0.9404
+2012-12-31,MK,North Macedonia,-9.0021
 2012-12-31,MT,Malta,3.0596
 2012-12-31,MX,Mexico,-1.2798
 2012-12-31,MY,Malaysia,12.8291
-2012-12-31,NL,Netherlands,-9.4664
-2012-12-31,NO,Norway,5.5854
+2012-12-31,NL,Netherlands,-9.4671
+2012-12-31,NO,Norway,5.6725
 2012-12-31,NZ,New Zealand,5.4393
 2012-12-31,PE,Peru,16.2918
 2012-12-31,PH,Philippines,4.8609
@@ -21316,61 +5456,60 @@ date,country_code,country,price
 2012-12-31,PT,Portugal,-5.8736
 2012-12-31,RO,Romania,-5.5611
 2012-12-31,RS,Serbia,-10.3456
-2012-12-31,RU,Russia,9.7006
-2012-12-31,SE,Sweden,3.7535
-2012-12-31,SG,Singapore,-1.1643
-2012-12-31,SI,Slovenia,-11.1145
-2012-12-31,SK,Slovak Republic,-6.1268
-2012-12-31,TH,Thailand,2.3772
-2012-12-31,TR,Türkiye,3.1712
-2012-12-31,US,United States,5.8446
-2012-12-31,XM,Euro area,-4.2565
-2012-12-31,XW,World,2.2104
-2012-12-31,ZA,South Africa,0.0465
-2013-03-31,4T,Emerging market economies (aggregate),3.0031
-2013-03-31,5R,Advanced economies,1.7354
-2013-03-31,AE,United Arab Emirates,15.203
+2012-12-31,RU,Russia,9.6401
+2012-12-31,SE,Sweden,3.7485
+2012-12-31,SG,Singapore,-1.1676
+2012-12-31,SI,Slovenia,-11.1207
+2012-12-31,SK,Slovakia,-6.2262
+2012-12-31,TH,Thailand,1.7371
+2012-12-31,TR,Türkiye,4.0494
+2012-12-31,US,United States,5.8815
+2012-12-31,XM,Euro area,-4.289
+2012-12-31,XW,World,1.9464
+2012-12-31,ZA,South Africa,-0.8733
+2013-03-31,4T,Emerging market economies (aggregate),2.7697
+2013-03-31,5R,Advanced economies,1.6187
 2013-03-31,AT,Austria,2.2715
-2013-03-31,AU,Australia,0.5829
-2013-03-31,BE,Belgium,-0.2131
-2013-03-31,BG,Bulgaria,-5.6353
+2013-03-31,AU,Australia,0.5917
+2013-03-31,BE,Belgium,0.1538
+2013-03-31,BG,Bulgaria,-5.6485
 2013-03-31,BR,Brazil,3.126
-2013-03-31,CA,Canada,-0.2588
-2013-03-31,CH,Switzerland,5.2779
+2013-03-31,CA,Canada,-0.0579
+2013-03-31,CH,Switzerland,5.2766
 2013-03-31,CL,Chile,9.545
 2013-03-31,CN,China,-0.4626
-2013-03-31,CO,Colombia,8.1765
+2013-03-31,CO,Colombia,6.9517
 2013-03-31,CY,Cyprus,-6.604
-2013-03-31,CZ,Czechia,-2.0913
+2013-03-31,CZ,Czechia,-2.0875
 2013-03-31,DE,Germany,1.6097
-2013-03-31,DK,Denmark,1.5051
+2013-03-31,DK,Denmark,1.5296
 2013-03-31,EE,Estonia,4.0597
-2013-03-31,ES,Spain,-15.0411
+2013-03-31,ES,Spain,-15.0407
 2013-03-31,FI,Finland,0.2463
-2013-03-31,FR,France,-3.031
-2013-03-31,GB,United Kingdom,-1.3526
-2013-03-31,GR,Greece,-11.5005
+2013-03-31,FR,France,-3.0352
+2013-03-31,GB,United Kingdom,-1.3656
+2013-03-31,GR,Greece,-11.5004
 2013-03-31,HK,Hong Kong SAR,23.68
-2013-03-31,HR,Croatia,-9.6455
-2013-03-31,HU,Hungary,-8.5269
+2013-03-31,HR,Croatia,-9.6385
+2013-03-31,HU,Hungary,-8.5268
 2013-03-31,ID,Indonesia,6.2351
-2013-03-31,IE,Ireland,-4.1553
-2013-03-31,IL,Israel,8.1823
-2013-03-31,IN,India,13.9357
-2013-03-31,IS,Iceland,0.2384
-2013-03-31,IT,Italy,-8.8808
+2013-03-31,IE,Ireland,-4.0644
+2013-03-31,IL,Israel,8.1828
+2013-03-31,IN,India,14.2841
+2013-03-31,IS,Iceland,0.2424
+2013-03-31,IT,Italy,-8.8769
 2013-03-31,JP,Japan,0.2027
-2013-03-31,KR,Korea,-1.9511
-2013-03-31,LT,Lithuania,-2.2192
-2013-03-31,LU,Luxembourg,3.2027
-2013-03-31,LV,Latvia,4.4133
-2013-03-31,MA,Morocco,-0.477
-2013-03-31,MK,North Macedonia,-8.5473
+2013-03-31,KR,Korea,-1.9806
+2013-03-31,LT,Lithuania,-2.219
+2013-03-31,LU,Luxembourg,3.1962
+2013-03-31,LV,Latvia,4.4364
+2013-03-31,MA,Morocco,-2.0682
+2013-03-31,MK,North Macedonia,-8.6316
 2013-03-31,MT,Malta,-1.0453
 2013-03-31,MX,Mexico,0.0911
 2013-03-31,MY,Malaysia,9.3695
-2013-03-31,NL,Netherlands,-10.3192
-2013-03-31,NO,Norway,4.9739
+2013-03-31,NL,Netherlands,-10.3251
+2013-03-31,NO,Norway,4.9949
 2013-03-31,NZ,New Zealand,6.8248
 2013-03-31,PE,Peru,15.9661
 2013-03-31,PH,Philippines,4.3334
@@ -21378,61 +5517,60 @@ date,country_code,country,price
 2013-03-31,PT,Portugal,-4.7256
 2013-03-31,RO,Romania,-6.2255
 2013-03-31,RS,Serbia,-15.5622
-2013-03-31,RU,Russia,-0.3255
-2013-03-31,SE,Sweden,4.2225
-2013-03-31,SG,Singapore,-0.442
-2013-03-31,SI,Slovenia,-6.4819
-2013-03-31,SK,Slovak Republic,-2.116
-2013-03-31,TH,Thailand,2.2159
-2013-03-31,TR,Türkiye,2.7805
-2013-03-31,US,United States,7.8073
-2013-03-31,XM,Euro area,-4.5321
-2013-03-31,XW,World,2.3934
-2013-03-31,ZA,South Africa,0.3273
-2013-06-30,4T,Emerging market economies (aggregate),3.5806
-2013-06-30,5R,Advanced economies,2.4244
-2013-06-30,AE,United Arab Emirates,15.3496
-2013-06-30,AT,Austria,2.808
-2013-06-30,AU,Australia,2.821
-2013-06-30,BE,Belgium,-0.0478
-2013-06-30,BG,Bulgaria,-4.3188
-2013-06-30,BR,Brazil,2.6687
-2013-06-30,CA,Canada,-0.0672
-2013-06-30,CH,Switzerland,4.8162
+2013-03-31,RU,Russia,-0.3202
+2013-03-31,SE,Sweden,4.2196
+2013-03-31,SG,Singapore,-0.4477
+2013-03-31,SI,Slovenia,-6.4908
+2013-03-31,SK,Slovakia,-2.116
+2013-03-31,TH,Thailand,2.3727
+2013-03-31,TR,Türkiye,3.4352
+2013-03-31,US,United States,7.8051
+2013-03-31,XM,Euro area,-4.5779
+2013-03-31,XW,World,2.1456
+2013-03-31,ZA,South Africa,-0.6611
+2013-06-30,4T,Emerging market economies (aggregate),3.4096
+2013-06-30,5R,Advanced economies,2.2513
+2013-06-30,AT,Austria,2.8081
+2013-06-30,AU,Australia,2.86
+2013-06-30,BE,Belgium,0.4101
+2013-06-30,BG,Bulgaria,-4.3653
+2013-06-30,BR,Brazil,2.6689
+2013-06-30,CA,Canada,0.1306
+2013-06-30,CH,Switzerland,4.8139
 2013-06-30,CL,Chile,9.6362
 2013-06-30,CN,China,2.9101
-2013-06-30,CO,Colombia,7.6052
+2013-06-30,CO,Colombia,7.3346
 2013-06-30,CY,Cyprus,-5.2059
-2013-06-30,CZ,Czechia,-1.4028
+2013-06-30,CZ,Czechia,-1.3969
 2013-06-30,DE,Germany,1.4833
-2013-06-30,DK,Denmark,3.9464
+2013-06-30,DK,Denmark,3.9613
 2013-06-30,EE,Estonia,4.6338
-2013-06-30,ES,Spain,-12.1226
+2013-06-30,ES,Spain,-12.1227
 2013-06-30,FI,Finland,-0.1931
-2013-06-30,FR,France,-2.8805
-2013-06-30,GB,United Kingdom,-1.0686
-2013-06-30,GR,Greece,-11.543
+2013-06-30,FR,France,-2.8782
+2013-06-30,GB,United Kingdom,-1.1386
+2013-06-30,GR,Greece,-11.5429
 2013-06-30,HK,Hong Kong SAR,14.6263
-2013-06-30,HR,Croatia,-6.9557
-2013-06-30,HU,Hungary,-4.0071
+2013-06-30,HR,Croatia,-6.9273
+2013-06-30,HU,Hungary,-4.007
 2013-06-30,ID,Indonesia,6.7129
-2013-06-30,IE,Ireland,-1.4135
-2013-06-30,IL,Israel,8.0665
-2013-06-30,IN,India,8.9032
-2013-06-30,IS,Iceland,1.4971
-2013-06-30,IT,Italy,-7.7601
+2013-06-30,IE,Ireland,-1.4055
+2013-06-30,IL,Israel,8.0663
+2013-06-30,IN,India,9.0782
+2013-06-30,IS,Iceland,1.4851
+2013-06-30,IT,Italy,-7.7613
 2013-06-30,JP,Japan,2.0063
-2013-06-30,KR,Korea,-1.9438
+2013-06-30,KR,Korea,-1.9971
 2013-06-30,LT,Lithuania,1.1311
-2013-06-30,LU,Luxembourg,2.794
-2013-06-30,LV,Latvia,7.9758
-2013-06-30,MA,Morocco,-1.4061
-2013-06-30,MK,North Macedonia,-7.3602
+2013-06-30,LU,Luxembourg,2.7857
+2013-06-30,LV,Latvia,7.9131
+2013-06-30,MA,Morocco,-2.6988
+2013-06-30,MK,North Macedonia,-7.3007
 2013-06-30,MT,Malta,-0.9313
 2013-06-30,MX,Mexico,0.6116
 2013-06-30,MY,Malaysia,9.5078
-2013-06-30,NL,Netherlands,-10.5022
-2013-06-30,NO,Norway,3.721
+2013-06-30,NL,Netherlands,-10.5051
+2013-06-30,NO,Norway,3.6679
 2013-06-30,NZ,New Zealand,8.019
 2013-06-30,PE,Peru,11.7152
 2013-06-30,PH,Philippines,7.2402
@@ -21440,61 +5578,60 @@ date,country_code,country,price
 2013-06-30,PT,Portugal,-3.1286
 2013-06-30,RO,Romania,-5.9887
 2013-06-30,RS,Serbia,-16.2491
-2013-06-30,RU,Russia,-2.0709
-2013-06-30,SE,Sweden,4.8234
-2013-06-30,SG,Singapore,2.4619
-2013-06-30,SI,Slovenia,-6.0743
-2013-06-30,SK,Slovak Republic,-0.4808
-2013-06-30,TH,Thailand,6.2314
-2013-06-30,TR,Türkiye,3.5603
-2013-06-30,US,United States,8.0958
-2013-06-30,XM,Euro area,-3.7204
-2013-06-30,XW,World,3.0273
-2013-06-30,ZA,South Africa,0.5229
-2013-09-30,4T,Emerging market economies (aggregate),4.0411
-2013-09-30,5R,Advanced economies,3.0664
-2013-09-30,AE,United Arab Emirates,20.0813
+2013-06-30,RU,Russia,-2.0593
+2013-06-30,SE,Sweden,4.8282
+2013-06-30,SG,Singapore,2.4554
+2013-06-30,SI,Slovenia,-6.0706
+2013-06-30,SK,Slovakia,-0.4797
+2013-06-30,TH,Thailand,5.2003
+2013-06-30,TR,Türkiye,3.8269
+2013-06-30,US,United States,8.149
+2013-06-30,XM,Euro area,-3.7616
+2013-06-30,XW,World,2.7875
+2013-06-30,ZA,South Africa,0.4335
+2013-09-30,4T,Emerging market economies (aggregate),3.8786
+2013-09-30,5R,Advanced economies,2.8336
 2013-09-30,AT,Austria,2.8556
-2013-09-30,AU,Australia,5.7974
-2013-09-30,BE,Belgium,0.1802
-2013-09-30,BG,Bulgaria,-2.4994
-2013-09-30,BR,Brazil,2.8511
-2013-09-30,CA,Canada,1.1433
-2013-09-30,CH,Switzerland,3.0729
-2013-09-30,CL,Chile,6.8741
+2013-09-30,AU,Australia,5.7501
+2013-09-30,BE,Belgium,0.5846
+2013-09-30,BG,Bulgaria,-2.4577
+2013-09-30,BR,Brazil,2.8512
+2013-09-30,CA,Canada,1.2933
+2013-09-30,CH,Switzerland,3.0707
+2013-09-30,CL,Chile,6.874
 2013-09-30,CN,China,4.6701
-2013-09-30,CO,Colombia,8.1713
+2013-09-30,CO,Colombia,7.8003
 2013-09-30,CY,Cyprus,-6.2228
-2013-09-30,CZ,Czechia,-1.0322
+2013-09-30,CZ,Czechia,-1.0293
 2013-09-30,DE,Germany,1.9298
-2013-09-30,DK,Denmark,3.9396
+2013-09-30,DK,Denmark,3.9562
 2013-09-30,EE,Estonia,8.0579
-2013-09-30,ES,Spain,-7.5409
+2013-09-30,ES,Spain,-7.541
 2013-09-30,FI,Finland,-0.2328
-2013-09-30,FR,France,-2.8064
-2013-09-30,GB,United Kingdom,0.1595
-2013-09-30,GR,Greece,-9.2537
+2013-09-30,FR,France,-2.8031
+2013-09-30,GB,United Kingdom,0.2422
+2013-09-30,GR,Greece,-9.2538
 2013-09-30,HK,Hong Kong SAR,10.2025
-2013-09-30,HR,Croatia,-5.4476
+2013-09-30,HR,Croatia,-5.4262
 2013-09-30,HU,Hungary,-2.7147
 2013-09-30,ID,Indonesia,5.0775
-2013-09-30,IE,Ireland,3.1355
-2013-09-30,IL,Israel,7.7502
-2013-09-30,IN,India,7.7233
-2013-09-30,IS,Iceland,1.9208
-2013-09-30,IT,Italy,-7.3442
+2013-09-30,IE,Ireland,3.1826
+2013-09-30,IL,Israel,7.7499
+2013-09-30,IN,India,7.4945
+2013-09-30,IS,Iceland,1.9242
+2013-09-30,IT,Italy,-7.3397
 2013-09-30,JP,Japan,1.5902
-2013-09-30,KR,Korea,-1.9513
+2013-09-30,KR,Korea,-1.9512
 2013-09-30,LT,Lithuania,-0.8022
-2013-09-30,LU,Luxembourg,3.9202
-2013-09-30,LV,Latvia,6.5474
-2013-09-30,MA,Morocco,-1.2438
-2013-09-30,MK,North Macedonia,-4.6346
+2013-09-30,LU,Luxembourg,3.918
+2013-09-30,LV,Latvia,6.6131
+2013-09-30,MA,Morocco,-1.4297
+2013-09-30,MK,North Macedonia,-4.8144
 2013-09-30,MT,Malta,-3.16
 2013-09-30,MX,Mexico,2.19
 2013-09-30,MY,Malaysia,10.8561
-2013-09-30,NL,Netherlands,-6.3035
-2013-09-30,NO,Norway,0.1326
+2013-09-30,NL,Netherlands,-6.315
+2013-09-30,NO,Norway,0.1325
 2013-09-30,NZ,New Zealand,8.4986
 2013-09-30,PE,Peru,9.1768
 2013-09-30,PH,Philippines,10.565
@@ -21502,61 +5639,60 @@ date,country_code,country,price
 2013-09-30,PT,Portugal,-1.3513
 2013-09-30,RO,Romania,-2.2274
 2013-09-30,RS,Serbia,-12.2405
-2013-09-30,RU,Russia,-3.5913
-2013-09-30,SE,Sweden,5.0412
-2013-09-30,SG,Singapore,2.0261
-2013-09-30,SI,Slovenia,-9.5488
-2013-09-30,SK,Slovak Republic,-0.9513
-2013-09-30,TH,Thailand,7.4619
-2013-09-30,TR,Türkiye,3.1415
-2013-09-30,US,United States,8.4758
-2013-09-30,XM,Euro area,-2.5203
-2013-09-30,XW,World,3.5737
-2013-09-30,ZA,South Africa,0.1712
-2013-12-31,4T,Emerging market economies (aggregate),3.2889
-2013-12-31,5R,Advanced economies,3.4417
-2013-12-31,AE,United Arab Emirates,23.4321
-2013-12-31,AT,Austria,2.4707
-2013-12-31,AU,Australia,7.023
-2013-12-31,BE,Belgium,0.3287
-2013-12-31,BG,Bulgaria,0.2998
+2013-09-30,RU,Russia,-3.5845
+2013-09-30,SE,Sweden,5.0423
+2013-09-30,SG,Singapore,2.0207
+2013-09-30,SI,Slovenia,-9.5841
+2013-09-30,SK,Slovakia,-1.156
+2013-09-30,TH,Thailand,7.7164
+2013-09-30,TR,Türkiye,2.7942
+2013-09-30,US,United States,8.5015
+2013-09-30,XM,Euro area,-2.5609
+2013-09-30,XW,World,3.3144
+2013-09-30,ZA,South Africa,0.8691
+2013-12-31,4T,Emerging market economies (aggregate),3.1505
+2013-12-31,5R,Advanced economies,3.1374
+2013-12-31,AT,Austria,2.4706
+2013-12-31,AU,Australia,7.0899
+2013-12-31,BE,Belgium,0.3218
+2013-12-31,BG,Bulgaria,0.2446
 2013-12-31,BR,Brazil,2.7118
-2013-12-31,CA,Canada,3.0667
-2013-12-31,CH,Switzerland,3.8813
-2013-12-31,CL,Chile,6.6023
+2013-12-31,CA,Canada,3.1682
+2013-12-31,CH,Switzerland,3.8799
+2013-12-31,CL,Chile,6.6024
 2013-12-31,CN,China,5.9846
-2013-12-31,CO,Colombia,6.3354
+2013-12-31,CO,Colombia,6.855
 2013-12-31,CY,Cyprus,-6.629
-2013-12-31,CZ,Czechia,-1.0373
+2013-12-31,CZ,Czechia,-1.0414
 2013-12-31,DE,Germany,0.9597
-2013-12-31,DK,Denmark,2.7913
+2013-12-31,DK,Denmark,2.7827
 2013-12-31,EE,Estonia,13.8853
-2013-12-31,ES,Spain,-6.4098
+2013-12-31,ES,Spain,-6.4104
 2013-12-31,FI,Finland,-1.0724
-2013-12-31,FR,France,-2.1731
-2013-12-31,GB,United Kingdom,2.2591
+2013-12-31,FR,France,-2.1708
+2013-12-31,GB,United Kingdom,2.2183
 2013-12-31,GR,Greece,-7.6123
-2013-12-31,HK,Hong Kong SAR,4.01
-2013-12-31,HR,Croatia,-1.9686
+2013-12-31,HK,Hong Kong SAR,4.0714
+2013-12-31,HR,Croatia,-1.9702
 2013-12-31,HU,Hungary,-1.4356
 2013-12-31,ID,Indonesia,3.2256
-2013-12-31,IE,Ireland,5.3963
-2013-12-31,IL,Israel,5.8228
-2013-12-31,IN,India,1.3839
-2013-12-31,IS,Iceland,4.6767
-2013-12-31,IT,Italy,-6.3649
+2013-12-31,IE,Ireland,5.3223
+2013-12-31,IL,Israel,5.8223
+2013-12-31,IN,India,1.1564
+2013-12-31,IS,Iceland,4.7002
+2013-12-31,IT,Italy,-6.3636
 2013-12-31,JP,Japan,1.3655
-2013-12-31,KR,Korea,-0.9167
+2013-12-31,KR,Korea,-0.946
 2013-12-31,LT,Lithuania,2.5891
-2013-12-31,LU,Luxembourg,2.8998
-2013-12-31,LV,Latvia,8.5205
-2013-12-31,MA,Morocco,-0.2306
-2013-12-31,MK,North Macedonia,-3.9079
+2013-12-31,LU,Luxembourg,2.8993
+2013-12-31,LV,Latvia,8.591
+2013-12-31,MA,Morocco,-0.3214
+2013-12-31,MK,North Macedonia,-3.6081
 2013-12-31,MT,Malta,-1.7907
 2013-12-31,MX,Mexico,2.1331
 2013-12-31,MY,Malaysia,6.1964
-2013-12-31,NL,Netherlands,-5.8873
-2013-12-31,NO,Norway,-1.2502
+2013-12-31,NL,Netherlands,-5.9009
+2013-12-31,NO,Norway,-1.2419
 2013-12-31,NZ,New Zealand,7.2218
 2013-12-31,PE,Peru,6.3826
 2013-12-31,PH,Philippines,11.4275
@@ -21564,61 +5700,60 @@ date,country_code,country,price
 2013-12-31,PT,Portugal,0.6838
 2013-12-31,RO,Romania,-1.7076
 2013-12-31,RS,Serbia,-3.9008
-2013-12-31,RU,Russia,-5.8533
-2013-12-31,SE,Sweden,6.7034
-2013-12-31,SG,Singapore,-0.8732
-2013-12-31,SI,Slovenia,-5.4262
-2013-12-31,SK,Slovak Republic,1.7191
-2013-12-31,TH,Thailand,6.3156
-2013-12-31,TR,Türkiye,4.9223
-2013-12-31,US,United States,8.5589
-2013-12-31,XM,Euro area,-2.1104
-2013-12-31,XW,World,3.3623
-2013-12-31,ZA,South Africa,1.664
-2014-03-31,4T,Emerging market economies (aggregate),3.6424
-2014-03-31,5R,Advanced economies,3.5264
-2014-03-31,AE,United Arab Emirates,35.6562
+2013-12-31,RU,Russia,-5.8038
+2013-12-31,SE,Sweden,6.709
+2013-12-31,SG,Singapore,-0.8787
+2013-12-31,SI,Slovenia,-5.4213
+2013-12-31,SK,Slovakia,1.616
+2013-12-31,TH,Thailand,6.5364
+2013-12-31,TR,Türkiye,4.6008
+2013-12-31,US,United States,8.5547
+2013-12-31,XM,Euro area,-2.1517
+2013-12-31,XW,World,3.1442
+2013-12-31,ZA,South Africa,2.0034
+2014-03-31,4T,Emerging market economies (aggregate),3.3461
+2014-03-31,5R,Advanced economies,3.2387
 2014-03-31,AT,Austria,2.5003
-2014-03-31,AU,Australia,7.6135
-2014-03-31,BE,Belgium,-2.3396
-2014-03-31,BG,Bulgaria,3.1423
+2014-03-31,AU,Australia,7.6036
+2014-03-31,BE,Belgium,-1.4356
+2014-03-31,BG,Bulgaria,3.1321
 2014-03-31,BR,Brazil,2.5114
-2014-03-31,CA,Canada,3.6333
-2014-03-31,CH,Switzerland,2.3769
+2014-03-31,CA,Canada,3.6755
+2014-03-31,CH,Switzerland,2.3764
 2014-03-31,CL,Chile,6.1387
 2014-03-31,CN,China,5.8629
-2014-03-31,CO,Colombia,6.7482
+2014-03-31,CO,Colombia,7.1573
 2014-03-31,CY,Cyprus,-7.0516
-2014-03-31,CZ,Czechia,1.3258
+2014-03-31,CZ,Czechia,1.3218
 2014-03-31,DE,Germany,1.0901
-2014-03-31,DK,Denmark,3.0104
+2014-03-31,DK,Denmark,2.9881
 2014-03-31,EE,Estonia,16.7815
-2014-03-31,ES,Spain,-1.6133
+2014-03-31,ES,Spain,-1.6137
 2014-03-31,FI,Finland,-1.502
-2014-03-31,FR,France,-2.1704
-2014-03-31,GB,United Kingdom,4.6133
+2014-03-31,FR,France,-2.1681
+2014-03-31,GB,United Kingdom,4.7182
 2014-03-31,GR,Greece,-7.8739
 2014-03-31,HK,Hong Kong SAR,-1.244
-2014-03-31,HR,Croatia,-1.9867
-2014-03-31,HU,Hungary,0.9051
+2014-03-31,HR,Croatia,-1.974
+2014-03-31,HU,Hungary,0.9052
 2014-03-31,ID,Indonesia,0.151
-2014-03-31,IE,Ireland,10.3719
-2014-03-31,IL,Israel,6.2383
-2014-03-31,IN,India,4.2615
-2014-03-31,IS,Iceland,7.0836
-2014-03-31,IT,Italy,-4.8196
+2014-03-31,IE,Ireland,10.2699
+2014-03-31,IL,Israel,6.2378
+2014-03-31,IN,India,3.8183
+2014-03-31,IS,Iceland,7.0871
+2014-03-31,IT,Italy,-4.8215
 2014-03-31,JP,Japan,1.537
-2014-03-31,KR,Korea,-0.3202
-2014-03-31,LT,Lithuania,3.6817
-2014-03-31,LU,Luxembourg,1.3733
-2014-03-31,LV,Latvia,10.1232
-2014-03-31,MA,Morocco,0.4923
-2014-03-31,MK,North Macedonia,-2.8572
+2014-03-31,KR,Korea,-0.3278
+2014-03-31,LT,Lithuania,3.6816
+2014-03-31,LU,Luxembourg,1.3727
+2014-03-31,LV,Latvia,10.1038
+2014-03-31,MA,Morocco,0.2136
+2014-03-31,MK,North Macedonia,-2.6558
 2014-03-31,MT,Malta,0.5758
 2014-03-31,MX,Mexico,1.478
 2014-03-31,MY,Malaysia,6.535
-2014-03-31,NL,Netherlands,-2.3279
-2014-03-31,NO,Norway,-1.7404
+2014-03-31,NL,Netherlands,-2.3183
+2014-03-31,NO,Norway,-1.8074
 2014-03-31,NZ,New Zealand,6.0054
 2014-03-31,PE,Peru,3.3765
 2014-03-31,PH,Philippines,9.4389
@@ -21626,61 +5761,60 @@ date,country_code,country,price
 2014-03-31,PT,Portugal,4.1496
 2014-03-31,RO,Romania,-3.9874
 2014-03-31,RS,Serbia,2.6666
-2014-03-31,RU,Russia,-5.1622
-2014-03-31,SE,Sweden,8.6194
-2014-03-31,SG,Singapore,-1.6979
-2014-03-31,SI,Slovenia,-7.0998
-2014-03-31,SK,Slovak Republic,-0.15
-2014-03-31,TH,Thailand,6.3237
-2014-03-31,TR,Türkiye,4.1573
-2014-03-31,US,United States,7.0839
-2014-03-31,XM,Euro area,-0.7003
-2014-03-31,XW,World,3.5882
-2014-03-31,ZA,South Africa,1.9804
-2014-06-30,4T,Emerging market economies (aggregate),2.8759
-2014-06-30,5R,Advanced economies,2.436
-2014-06-30,AE,United Arab Emirates,32.507
-2014-06-30,AT,Austria,3.0191
-2014-06-30,AU,Australia,6.8994
-2014-06-30,BE,Belgium,-1.3544
-2014-06-30,BG,Bulgaria,2.379
+2014-03-31,RU,Russia,-5.173
+2014-03-31,SE,Sweden,8.618
+2014-03-31,SG,Singapore,-1.7045
+2014-03-31,SI,Slovenia,-7.1074
+2014-03-31,SK,Slovakia,-0.3575
+2014-03-31,TH,Thailand,6.351
+2014-03-31,TR,Türkiye,3.497
+2014-03-31,US,United States,7.0909
+2014-03-31,XM,Euro area,-0.7351
+2014-03-31,XW,World,3.2896
+2014-03-31,ZA,South Africa,1.8961
+2014-06-30,4T,Emerging market economies (aggregate),2.6223
+2014-06-30,5R,Advanced economies,2.2411
+2014-06-30,AT,Austria,3.019
+2014-06-30,AU,Australia,6.8449
+2014-06-30,BE,Belgium,-1.3468
+2014-06-30,BG,Bulgaria,2.3975
 2014-06-30,BR,Brazil,1.242
-2014-06-30,CA,Canada,3.0605
-2014-06-30,CH,Switzerland,2.7837
+2014-06-30,CA,Canada,3.228
+2014-06-30,CH,Switzerland,2.7829
 2014-06-30,CL,Chile,5.5267
 2014-06-30,CN,China,3.0163
-2014-06-30,CO,Colombia,4.5548
-2014-06-30,CY,Cyprus,-7.8445
-2014-06-30,CZ,Czechia,1.6363
+2014-06-30,CO,Colombia,4.7182
+2014-06-30,CY,Cyprus,-7.868
+2014-06-30,CZ,Czechia,1.6323
 2014-06-30,DE,Germany,2.1236
-2014-06-30,DK,Denmark,3.213
+2014-06-30,DK,Denmark,3.22
 2014-06-30,EE,Estonia,14.5021
-2014-06-30,ES,Spain,0.6127
+2014-06-30,ES,Spain,0.6126
 2014-06-30,FI,Finland,-1.1117
-2014-06-30,FR,France,-1.7866
-2014-06-30,GB,United Kingdom,6.2479
-2014-06-30,GR,Greece,-6.8467
+2014-06-30,FR,France,-1.7888
+2014-06-30,GB,United Kingdom,6.2273
+2014-06-30,GR,Greece,-6.8468
 2014-06-30,HK,Hong Kong SAR,-0.9762
-2014-06-30,HR,Croatia,-0.3708
+2014-06-30,HR,Croatia,-0.4566
 2014-06-30,HU,Hungary,2.9964
 2014-06-30,ID,Indonesia,0.2912
-2014-06-30,IE,Ireland,16.1979
+2014-06-30,IE,Ireland,16.0833
 2014-06-30,IL,Israel,6.8753
-2014-06-30,IN,India,7.8038
-2014-06-30,IS,Iceland,5.9493
-2014-06-30,IT,Italy,-5.4055
+2014-06-30,IN,India,7.4209
+2014-06-30,IS,Iceland,5.9613
+2014-06-30,IT,Italy,-5.4062
 2014-06-30,JP,Japan,-1.9974
-2014-06-30,KR,Korea,-0.2308
-2014-06-30,LT,Lithuania,6.3844
-2014-06-30,LU,Luxembourg,4.0086
-2014-06-30,LV,Latvia,7.0165
-2014-06-30,MA,Morocco,1.0979
-2014-06-30,MK,North Macedonia,0.8002
+2014-06-30,KR,Korea,-0.2161
+2014-06-30,LT,Lithuania,6.3843
+2014-06-30,LU,Luxembourg,4.0099
+2014-06-30,LV,Latvia,7.0827
+2014-06-30,MA,Morocco,0.5326
+2014-06-30,MK,North Macedonia,1.0487
 2014-06-30,MT,Malta,3.0454
 2014-06-30,MX,Mexico,0.5966
 2014-06-30,MY,Malaysia,6.5642
-2014-06-30,NL,Netherlands,0.2831
-2014-06-30,NO,Norway,-0.4841
+2014-06-30,NL,Netherlands,0.2767
+2014-06-30,NO,Norway,-0.4268
 2014-06-30,NZ,New Zealand,4.731
 2014-06-30,PE,Peru,5.69
 2014-06-30,PH,Philippines,8.1305
@@ -21688,123 +5822,121 @@ date,country_code,country,price
 2014-06-30,PT,Portugal,6.2618
 2014-06-30,RO,Romania,-3.8949
 2014-06-30,RS,Serbia,6.0209
-2014-06-30,RU,Russia,-5.997
-2014-06-30,SE,Sweden,8.6507
-2014-06-30,SG,Singapore,-4.844
-2014-06-30,SI,Slovenia,-10.352
-2014-06-30,SK,Slovak Republic,1.2143
-2014-06-30,TH,Thailand,6.5378
-2014-06-30,TR,Türkiye,2.871
-2014-06-30,US,United States,4.4004
-2014-06-30,XM,Euro area,0.2589
-2014-06-30,XW,World,2.6706
-2014-06-30,ZA,South Africa,1.5682
-2014-09-30,4T,Emerging market economies (aggregate),1.1105
-2014-09-30,5R,Advanced economies,2.2093
-2014-09-30,AE,United Arab Emirates,20.8988
-2014-09-30,AT,Austria,0.7333
-2014-09-30,AU,Australia,6.3184
-2014-09-30,BE,Belgium,-0.9406
-2014-09-30,BG,Bulgaria,2.5914
+2014-06-30,RU,Russia,-6.0042
+2014-06-30,SE,Sweden,8.6483
+2014-06-30,SG,Singapore,-4.8486
+2014-06-30,SI,Slovenia,-10.3824
+2014-06-30,SK,Slovakia,1.1122
+2014-06-30,TH,Thailand,7.9534
+2014-06-30,TR,Türkiye,2.2137
+2014-06-30,US,United States,4.402
+2014-06-30,XM,Euro area,0.2178
+2014-06-30,XW,World,2.4273
+2014-06-30,ZA,South Africa,1.44
+2014-09-30,4T,Emerging market economies (aggregate),0.7952
+2014-09-30,5R,Advanced economies,2.0646
+2014-09-30,AT,Austria,0.7332
+2014-09-30,AU,Australia,6.3721
+2014-09-30,BE,Belgium,-0.7328
+2014-09-30,BG,Bulgaria,2.5988
 2014-09-30,BR,Brazil,-0.0354
-2014-09-30,CA,Canada,3.2338
-2014-09-30,CH,Switzerland,2.5838
+2014-09-30,CA,Canada,3.3389
+2014-09-30,CH,Switzerland,2.5836
 2014-09-30,CL,Chile,11.9486
 2014-09-30,CN,China,-1.4369
-2014-09-30,CO,Colombia,4.7647
+2014-09-30,CO,Colombia,4.7281
 2014-09-30,CY,Cyprus,-7.7063
-2014-09-30,CZ,Czechia,2.1483
+2014-09-30,CZ,Czechia,2.1433
 2014-09-30,DE,Germany,1.9561
-2014-09-30,DK,Denmark,2.7014
+2014-09-30,DK,Denmark,2.7074
 2014-09-30,EE,Estonia,13.8659
-2014-09-30,ES,Spain,0.6106
+2014-09-30,ES,Spain,0.6108
 2014-09-30,FI,Finland,-1.5815
-2014-09-30,FR,France,-1.6464
-2014-09-30,GB,United Kingdom,7.3445
+2014-09-30,FR,France,-1.6528
+2014-09-30,GB,United Kingdom,7.3126
 2014-09-30,GR,Greece,-6.3075
 2014-09-30,HK,Hong Kong SAR,1.464
-2014-09-30,HR,Croatia,-1.7094
-2014-09-30,HU,Hungary,4.6403
+2014-09-30,HR,Croatia,-1.7301
+2014-09-30,HU,Hungary,4.6404
 2014-09-30,ID,Indonesia,2.0847
-2014-09-30,IE,Ireland,18.8927
+2014-09-30,IE,Ireland,18.7985
 2014-09-30,IL,Israel,5.2285
-2014-09-30,IN,India,6.9291
-2014-09-30,IS,Iceland,6.3884
-2014-09-30,IT,Italy,-4.6358
+2014-09-30,IN,India,6.9032
+2014-09-30,IS,Iceland,6.3688
+2014-09-30,IT,Italy,-4.6377
 2014-09-30,JP,Japan,-2.2079
-2014-09-30,KR,Korea,0.4133
+2014-09-30,KR,Korea,0.392
 2014-09-30,LT,Lithuania,9.9916
-2014-09-30,LU,Luxembourg,4.3474
-2014-09-30,LV,Latvia,9.9269
-2014-09-30,MA,Morocco,1.9158
-2014-09-30,MK,North Macedonia,2.7192
+2014-09-30,LU,Luxembourg,4.3502
+2014-09-30,LV,Latvia,9.7359
+2014-09-30,MA,Morocco,0.0406
+2014-09-30,MK,North Macedonia,2.8382
 2014-09-30,MT,Malta,0.2974
 2014-09-30,MX,Mexico,-0.7645
 2014-09-30,MY,Malaysia,5.6591
-2014-09-30,NL,Netherlands,0.3541
-2014-09-30,NO,Norway,1.2976
+2014-09-30,NL,Netherlands,0.3518
+2014-09-30,NO,Norway,1.2986
 2014-09-30,NZ,New Zealand,3.765
 2014-09-30,PE,Peru,0.2292
 2014-09-30,PH,Philippines,6.7217
 2014-09-30,PL,Poland,1.3812
-2014-09-30,PT,Portugal,5.4814
+2014-09-30,PT,Portugal,5.4813
 2014-09-30,RO,Romania,-3.0894
 2014-09-30,RS,Serbia,3.1194
-2014-09-30,RU,Russia,-5.6893
-2014-09-30,SE,Sweden,10.5215
-2014-09-30,SG,Singapore,-4.8458
-2014-09-30,SI,Slovenia,-5.1337
-2014-09-30,SK,Slovak Republic,1.3681
-2014-09-30,TH,Thailand,6.1725
-2014-09-30,TR,Türkiye,4.6857
-2014-09-30,US,United States,3.4722
-2014-09-30,XM,Euro area,0.5131
-2014-09-30,XW,World,1.6353
-2014-09-30,ZA,South Africa,1.298
-2014-12-31,4T,Emerging market economies (aggregate),0.2613
-2014-12-31,5R,Advanced economies,2.4154
-2014-12-31,AE,United Arab Emirates,9.549
-2014-12-31,AT,Austria,1.0127
-2014-12-31,AU,Australia,4.947
-2014-12-31,BE,Belgium,1.0957
-2014-12-31,BG,Bulgaria,3.4403
+2014-09-30,RU,Russia,-5.6803
+2014-09-30,SE,Sweden,10.5225
+2014-09-30,SG,Singapore,-4.853
+2014-09-30,SI,Slovenia,-5.1243
+2014-09-30,SK,Slovakia,1.4759
+2014-09-30,TH,Thailand,6.7426
+2014-09-30,TR,Türkiye,3.1906
+2014-09-30,US,United States,3.4555
+2014-09-30,XM,Euro area,0.4651
+2014-09-30,XW,World,1.4661
+2014-09-30,ZA,South Africa,0.8566
+2014-12-31,4T,Emerging market economies (aggregate),0.0306
+2014-12-31,5R,Advanced economies,2.3408
+2014-12-31,AT,Austria,1.0128
+2014-12-31,AU,Australia,4.9468
+2014-12-31,BE,Belgium,0.8141
+2014-12-31,BG,Bulgaria,3.4579
 2014-12-31,BR,Brazil,-1.4019
-2014-12-31,CA,Canada,3.5613
-2014-12-31,CH,Switzerland,2.9929
-2014-12-31,CL,Chile,9.1028
+2014-12-31,CA,Canada,3.5441
+2014-12-31,CH,Switzerland,2.9922
+2014-12-31,CL,Chile,9.1029
 2014-12-31,CN,China,-5.0078
-2014-12-31,CO,Colombia,3.6833
+2014-12-31,CO,Colombia,3.6092
 2014-12-31,CY,Cyprus,-7.376
-2014-12-31,CZ,Czechia,3.28
+2014-12-31,CZ,Czechia,3.2844
 2014-12-31,DE,Germany,2.7506
-2014-12-31,DK,Denmark,3.8493
+2014-12-31,DK,Denmark,3.8983
 2014-12-31,EE,Estonia,10.586
-2014-12-31,ES,Spain,2.2743
+2014-12-31,ES,Spain,2.2739
 2014-12-31,FI,Finland,-1.3096
-2014-12-31,FR,France,-2.4174
-2014-12-31,GB,United Kingdom,7.5565
+2014-12-31,FR,France,-2.411
+2014-12-31,GB,United Kingdom,7.5326
 2014-12-31,GR,Greece,-3.7725
 2014-12-31,HK,Hong Kong SAR,6.5388
-2014-12-31,HR,Croatia,-1.4806
+2014-12-31,HR,Croatia,-1.4917
 2014-12-31,HU,Hungary,9.1884
 2014-12-31,ID,Indonesia,-0.1797
-2014-12-31,IE,Ireland,19.5361
-2014-12-31,IL,Israel,5.1114
-2014-12-31,IN,India,12.3471
-2014-12-31,IS,Iceland,4.7757
-2014-12-31,IT,Italy,-4.9474
+2014-12-31,IE,Ireland,19.6107
+2014-12-31,IL,Israel,5.1111
+2014-12-31,IN,India,12.3333
+2014-12-31,IS,Iceland,4.7746
+2014-12-31,IT,Italy,-4.9488
 2014-12-31,JP,Japan,-1.9411
-2014-12-31,KR,Korea,1.0829
-2014-12-31,LT,Lithuania,5.242
-2014-12-31,LU,Luxembourg,5.1545
-2014-12-31,LV,Latvia,-5.0112
-2014-12-31,MA,Morocco,-2.3287
-2014-12-31,MK,North Macedonia,-0.8989
+2014-12-31,KR,Korea,1.1033
+2014-12-31,LT,Lithuania,5.2419
+2014-12-31,LU,Luxembourg,5.1571
+2014-12-31,LV,Latvia,-5.047
+2014-12-31,MA,Morocco,-1.3197
+2014-12-31,MK,North Macedonia,-1.08
 2014-12-31,MT,Malta,5.0275
 2014-12-31,MX,Mexico,-0.3265
 2014-12-31,MY,Malaysia,5.7047
-2014-12-31,NL,Netherlands,1.1111
-2014-12-31,NO,Norway,3.6932
+2014-12-31,NL,Netherlands,1.1273
+2014-12-31,NO,Norway,3.6363
 2014-12-31,NZ,New Zealand,6.3518
 2014-12-31,PE,Peru,0.7758
 2014-12-31,PH,Philippines,6.9882
@@ -21812,123 +5944,121 @@ date,country_code,country,price
 2014-12-31,PT,Portugal,2.3167
 2014-12-31,RO,Romania,-1.1731
 2014-12-31,RS,Serbia,2.3377
-2014-12-31,RU,Russia,-6.1428
-2014-12-31,SE,Sweden,10.6452
-2014-12-31,SG,Singapore,-4.0083
-2014-12-31,SI,Slovenia,-4.2936
-2014-12-31,SK,Slovak Republic,3.4327
-2014-12-31,TH,Thailand,6.4044
-2014-12-31,TR,Türkiye,5.6793
-2014-12-31,US,United States,3.5963
-2014-12-31,XM,Euro area,0.7701
-2014-12-31,XW,World,1.2824
-2014-12-31,ZA,South Africa,1.0276
-2015-03-31,4T,Emerging market economies (aggregate),-0.8139
-2015-03-31,5R,Advanced economies,3.4939
-2015-03-31,AE,United Arab Emirates,-6.9206
+2014-12-31,RU,Russia,-6.1476
+2014-12-31,SE,Sweden,10.6419
+2014-12-31,SG,Singapore,-4.0204
+2014-12-31,SI,Slovenia,-4.2896
+2014-12-31,SK,Slovakia,3.3361
+2014-12-31,TH,Thailand,8.9882
+2014-12-31,TR,Türkiye,4.2946
+2014-12-31,US,United States,3.5989
+2014-12-31,XM,Euro area,0.7251
+2014-12-31,XW,World,1.2436
+2014-12-31,ZA,South Africa,0.8261
+2015-03-31,4T,Emerging market economies (aggregate),-0.9455
+2015-03-31,5R,Advanced economies,3.3981
 2015-03-31,AT,Austria,2.6631
-2015-03-31,AU,Australia,5.5161
-2015-03-31,BE,Belgium,0.897
-2015-03-31,BG,Bulgaria,2.7545
+2015-03-31,AU,Australia,5.5336
+2015-03-31,BE,Belgium,1.0086
+2015-03-31,BG,Bulgaria,2.7856
 2015-03-31,BR,Brazil,-4.3481
-2015-03-31,CA,Canada,4.9231
-2015-03-31,CH,Switzerland,4.2308
+2015-03-31,CA,Canada,5.0321
+2015-03-31,CH,Switzerland,4.2302
 2015-03-31,CL,Chile,8.6724
 2015-03-31,CN,China,-6.9355
-2015-03-31,CO,Colombia,2.8246
+2015-03-31,CO,Colombia,3.4181
 2015-03-31,CY,Cyprus,-4.9455
-2015-03-31,CZ,Czechia,3.3699
+2015-03-31,CZ,Czechia,3.4146
 2015-03-31,DE,Germany,4.2395
-2015-03-31,DK,Denmark,6.8404
+2015-03-31,DK,Denmark,6.8451
 2015-03-31,EE,Estonia,9.0629
-2015-03-31,ES,Spain,2.5892
+2015-03-31,ES,Spain,2.5888
 2015-03-31,FI,Finland,-0.4799
-2015-03-31,FR,France,-1.639
-2015-03-31,GB,United Kingdom,6.7157
+2015-03-31,FR,France,-1.6451
+2015-03-31,GB,United Kingdom,6.5384
 2015-03-31,GR,Greece,-1.7767
 2015-03-31,HK,Hong Kong SAR,13.5445
-2015-03-31,HR,Croatia,-1.3225
+2015-03-31,HR,Croatia,-1.3089
 2015-03-31,HU,Hungary,10.3637
 2015-03-31,ID,Indonesia,-0.2568
-2015-03-31,IE,Ireland,18.1717
-2015-03-31,IL,Israel,4.9554
-2015-03-31,IN,India,11.6217
-2015-03-31,IS,Iceland,8.225
-2015-03-31,IT,Italy,-5.4398
+2015-03-31,IE,Ireland,18.2271
+2015-03-31,IL,Israel,4.9553
+2015-03-31,IN,India,11.6067
+2015-03-31,IS,Iceland,8.2316
+2015-03-31,IT,Italy,-5.4404
 2015-03-31,JP,Japan,0.0696
-2015-03-31,KR,Korea,1.4531
-2015-03-31,LT,Lithuania,6.1184
-2015-03-31,LU,Luxembourg,7.0529
-2015-03-31,LV,Latvia,-6.5258
-2015-03-31,MA,Morocco,1.9999
-2015-03-31,MK,North Macedonia,2.3964
+2015-03-31,KR,Korea,1.5035
+2015-03-31,LT,Lithuania,6.1185
+2015-03-31,LU,Luxembourg,7.0545
+2015-03-31,LV,Latvia,-6.4888
+2015-03-31,MA,Morocco,-1.8512
+2015-03-31,MK,North Macedonia,2.3825
 2015-03-31,MT,Malta,2.016
 2015-03-31,MX,Mexico,1.2135
 2015-03-31,MY,Malaysia,8.4775
-2015-03-31,NL,Netherlands,2.4123
-2015-03-31,NO,Norway,5.138
+2015-03-31,NL,Netherlands,2.3013
+2015-03-31,NO,Norway,5.2067
 2015-03-31,NZ,New Zealand,9.124
 2015-03-31,PE,Peru,-3.3063
 2015-03-31,PH,Philippines,8.4043
 2015-03-31,PL,Poland,3.2519
-2015-03-31,PT,Portugal,0.9071
+2015-03-31,PT,Portugal,0.9072
 2015-03-31,RO,Romania,2.4923
 2015-03-31,RS,Serbia,4.8198
-2015-03-31,RU,Russia,-9.657
-2015-03-31,SE,Sweden,11.7726
-2015-03-31,SG,Singapore,-3.5218
-2015-03-31,SI,Slovenia,-1.0153
-2015-03-31,SK,Slovak Republic,5.6288
-2015-03-31,TH,Thailand,6.9535
-2015-03-31,TR,Türkiye,8.4899
-2015-03-31,US,United States,4.9292
-2015-03-31,XM,Euro area,1.4638
-2015-03-31,XW,World,1.2172
-2015-03-31,ZA,South Africa,1.9111
-2015-06-30,4T,Emerging market economies (aggregate),-1.5818
-2015-06-30,5R,Advanced economies,3.7826
-2015-06-30,AE,United Arab Emirates,-13.9564
+2015-03-31,RU,Russia,-9.6504
+2015-03-31,SE,Sweden,11.7725
+2015-03-31,SG,Singapore,-3.5245
+2015-03-31,SI,Slovenia,-0.9868
+2015-03-31,SK,Slovakia,5.645
+2015-03-31,TH,Thailand,10.8301
+2015-03-31,TR,Türkiye,7.3249
+2015-03-31,US,United States,4.9158
+2015-03-31,XM,Euro area,1.4201
+2015-03-31,XW,World,1.3114
+2015-03-31,ZA,South Africa,1.9457
+2015-06-30,4T,Emerging market economies (aggregate),-1.7309
+2015-06-30,5R,Advanced economies,3.7343
 2015-06-30,AT,Austria,0.4106
-2015-06-30,AU,Australia,8.1597
-2015-06-30,BE,Belgium,1.4365
-2015-06-30,BG,Bulgaria,2.249
-2015-06-30,BR,Brazil,-6.7936
-2015-06-30,CA,Canada,6.3923
-2015-06-30,CH,Switzerland,2.9384
+2015-06-30,AU,Australia,8.1474
+2015-06-30,BE,Belgium,1.2576
+2015-06-30,BG,Bulgaria,2.3058
+2015-06-30,BR,Brazil,-6.7953
+2015-06-30,CA,Canada,6.2616
+2015-06-30,CH,Switzerland,2.9399
 2015-06-30,CL,Chile,8.9676
 2015-06-30,CN,China,-7.3296
-2015-06-30,CO,Colombia,5.2823
-2015-06-30,CY,Cyprus,-3.03
-2015-06-30,CZ,Czechia,3.0685
+2015-06-30,CO,Colombia,5.3218
+2015-06-30,CY,Cyprus,-3.0052
+2015-06-30,CZ,Czechia,3.0523
 2015-06-30,DE,Germany,3.3439
-2015-06-30,DK,Denmark,6.0148
+2015-06-30,DK,Denmark,6.0006
 2015-06-30,EE,Estonia,10.5496
-2015-06-30,ES,Spain,4.2842
+2015-06-30,ES,Spain,4.2841
 2015-06-30,FI,Finland,0.0236
-2015-06-30,FR,France,-2.1787
-2015-06-30,GB,United Kingdom,5.282
-2015-06-30,GR,Greece,-2.8868
+2015-06-30,FR,France,-2.183
+2015-06-30,GB,United Kingdom,5.3868
+2015-06-30,GR,Greece,-2.8867
 2015-06-30,HK,Hong Kong SAR,17.4056
-2015-06-30,HR,Croatia,-4.5279
-2015-06-30,HU,Hungary,12.5062
+2015-06-30,HR,Croatia,-4.4856
+2015-06-30,HU,Hungary,12.5063
 2015-06-30,ID,Indonesia,-1.0417
-2015-06-30,IE,Ireland,14.2061
-2015-06-30,IL,Israel,5.3227
-2015-06-30,IN,India,8.9723
-2015-06-30,IS,Iceland,6.2068
-2015-06-30,IT,Italy,-4.7403
+2015-06-30,IE,Ireland,14.3207
+2015-06-30,IL,Israel,5.3232
+2015-06-30,IN,India,8.9857
+2015-06-30,IS,Iceland,6.2171
+2015-06-30,IT,Italy,-4.7384
 2015-06-30,JP,Japan,1.9249
-2015-06-30,KR,Korea,2.366
+2015-06-30,KR,Korea,2.3817
 2015-06-30,LT,Lithuania,4.1868
-2015-06-30,LU,Luxembourg,4.8785
-2015-06-30,LV,Latvia,-5.3696
-2015-06-30,MA,Morocco,-2.6781
-2015-06-30,MK,North Macedonia,0.1649
+2015-06-30,LU,Luxembourg,4.8834
+2015-06-30,LV,Latvia,-5.4257
+2015-06-30,MA,Morocco,-2.1317
+2015-06-30,MK,North Macedonia,-0.231
 2015-06-30,MT,Malta,2.2674
 2015-06-30,MX,Mexico,4.5867
 2015-06-30,MY,Malaysia,4.8501
-2015-06-30,NL,Netherlands,2.1245
-2015-06-30,NO,Norway,4.3037
+2015-06-30,NL,Netherlands,2.1601
+2015-06-30,NO,Norway,4.2647
 2015-06-30,NZ,New Zealand,11.5926
 2015-06-30,PE,Peru,-8.6744
 2015-06-30,PH,Philippines,8.9748
@@ -21936,61 +6066,60 @@ date,country_code,country,price
 2015-06-30,PT,Portugal,2.2036
 2015-06-30,RO,Romania,2.9873
 2015-06-30,RS,Serbia,3.6368
-2015-06-30,RU,Russia,-11.0914
-2015-06-30,SE,Sweden,13.2075
-2015-06-30,SG,Singapore,-3.27
-2015-06-30,SI,Slovenia,4.2336
-2015-06-30,SK,Slovak Republic,5.7133
-2015-06-30,TH,Thailand,5.8491
-2015-06-30,TR,Türkiye,8.7431
-2015-06-30,US,United States,5.4335
-2015-06-30,XM,Euro area,0.9975
-2015-06-30,XW,World,0.9357
-2015-06-30,ZA,South Africa,1.6051
-2015-09-30,4T,Emerging market economies (aggregate),-0.9116
-2015-09-30,5R,Advanced economies,4.0728
-2015-09-30,AE,United Arab Emirates,-14.7385
-2015-09-30,AT,Austria,3.0872
-2015-09-30,AU,Australia,9.0562
-2015-09-30,BE,Belgium,1.9954
-2015-09-30,BG,Bulgaria,2.1022
+2015-06-30,RU,Russia,-11.0815
+2015-06-30,SE,Sweden,13.2081
+2015-06-30,SG,Singapore,-3.2721
+2015-06-30,SI,Slovenia,4.2659
+2015-06-30,SK,Slovakia,5.6225
+2015-06-30,TH,Thailand,8.0293
+2015-06-30,TR,Türkiye,8.201
+2015-06-30,US,United States,5.4216
+2015-06-30,XM,Euro area,0.9687
+2015-06-30,XW,World,1.0984
+2015-06-30,ZA,South Africa,1.4636
+2015-09-30,4T,Emerging market economies (aggregate),-0.997
+2015-09-30,5R,Advanced economies,4.0254
+2015-09-30,AT,Austria,3.0873
+2015-09-30,AU,Australia,9.0721
+2015-09-30,BE,Belgium,1.8892
+2015-09-30,BG,Bulgaria,2.0574
 2015-09-30,BR,Brazil,-9.0621
-2015-09-30,CA,Canada,7.5699
-2015-09-30,CH,Switzerland,3.5879
+2015-09-30,CA,Canada,7.3371
+2015-09-30,CH,Switzerland,3.5892
 2015-09-30,CL,Chile,6.8579
 2015-09-30,CN,China,-4.7993
-2015-09-30,CO,Colombia,4.1324
+2015-09-30,CO,Colombia,4.0934
 2015-09-30,CY,Cyprus,-0.8461
-2015-09-30,CZ,Czechia,3.7598
+2015-09-30,CZ,Czechia,3.77
 2015-09-30,DE,Germany,3.5789
-2015-09-30,DK,Denmark,6.3652
+2015-09-30,DK,Denmark,6.3896
 2015-09-30,EE,Estonia,4.4856
-2015-09-30,ES,Spain,4.9166
+2015-09-30,ES,Spain,4.9165
 2015-09-30,FI,Finland,0.6378
-2015-09-30,FR,France,-1.4506
-2015-09-30,GB,United Kingdom,5.3488
-2015-09-30,GR,Greece,-4.0645
-2015-09-30,HK,Hong Kong SAR,13.8485
-2015-09-30,HR,Croatia,-2.3942
-2015-09-30,HU,Hungary,15.5736
+2015-09-30,FR,France,-1.448
+2015-09-30,GB,United Kingdom,5.2983
+2015-09-30,GR,Greece,-4.1061
+2015-09-30,HK,Hong Kong SAR,13.8983
+2015-09-30,HR,Croatia,-2.4451
+2015-09-30,HU,Hungary,15.5735
 2015-09-30,ID,Indonesia,-1.5197
-2015-09-30,IE,Ireland,8.8143
-2015-09-30,IL,Israel,7.2596
-2015-09-30,IN,India,8.7622
-2015-09-30,IS,Iceland,5.1783
-2015-09-30,IT,Italy,-2.8866
+2015-09-30,IE,Ireland,8.8684
+2015-09-30,IL,Israel,7.26
+2015-09-30,IN,India,8.8633
+2015-09-30,IS,Iceland,5.1719
+2015-09-30,IT,Italy,-2.8879
 2015-09-30,JP,Japan,2.7517
-2015-09-30,KR,Korea,3.1952
-2015-09-30,LT,Lithuania,4.4014
-2015-09-30,LU,Luxembourg,4.9165
-2015-09-30,LV,Latvia,-7.9349
-2015-09-30,MA,Morocco,-3.8331
-2015-09-30,MK,North Macedonia,-3.2579
+2015-09-30,KR,Korea,3.251
+2015-09-30,LT,Lithuania,4.4013
+2015-09-30,LU,Luxembourg,4.9166
+2015-09-30,LV,Latvia,-7.8284
+2015-09-30,MA,Morocco,-1.8465
+2015-09-30,MK,North Macedonia,-3.1941
 2015-09-30,MT,Malta,7.2238
 2015-09-30,MX,Mexico,7.51
 2015-09-30,MY,Malaysia,3.8096
-2015-09-30,NL,Netherlands,3.6692
-2015-09-30,NO,Norway,4.0038
+2015-09-30,NL,Netherlands,3.4309
+2015-09-30,NO,Norway,4.0441
 2015-09-30,NZ,New Zealand,14.9945
 2015-09-30,PE,Peru,-4.9366
 2015-09-30,PH,Philippines,10.0735
@@ -21998,123 +6127,121 @@ date,country_code,country,price
 2015-09-30,PT,Portugal,2.6451
 2015-09-30,RO,Romania,4.9616
 2015-09-30,RS,Serbia,1.8601
-2015-09-30,RU,Russia,-13.3894
-2015-09-30,SE,Sweden,13.5675
-2015-09-30,SG,Singapore,-3.6369
-2015-09-30,SI,Slovenia,1.4941
-2015-09-30,SK,Slovak Republic,6.1385
-2015-09-30,TH,Thailand,5.1124
-2015-09-30,TR,Türkiye,7.392
-2015-09-30,US,United States,5.373
-2015-09-30,XM,Euro area,1.3815
-2015-09-30,XW,World,1.4315
-2015-09-30,ZA,South Africa,1.4072
-2015-12-31,4T,Emerging market economies (aggregate),-0.6919
-2015-12-31,5R,Advanced economies,4.1386
-2015-12-31,AE,United Arab Emirates,-13.6825
-2015-12-31,AT,Austria,6.78
-2015-12-31,AU,Australia,6.8481
-2015-12-31,BE,Belgium,0.0802
-2015-12-31,BG,Bulgaria,4.4584
+2015-09-30,RU,Russia,-13.4027
+2015-09-30,SE,Sweden,13.5676
+2015-09-30,SG,Singapore,-3.6378
+2015-09-30,SI,Slovenia,1.4922
+2015-09-30,SK,Slovakia,6.0477
+2015-09-30,TH,Thailand,6.4692
+2015-09-30,TR,Türkiye,7.6372
+2015-09-30,US,United States,5.3816
+2015-09-30,XM,Euro area,1.3687
+2015-09-30,XW,World,1.5951
+2015-09-30,ZA,South Africa,1.3637
+2015-12-31,4T,Emerging market economies (aggregate),-0.7627
+2015-12-31,5R,Advanced economies,4.0655
+2015-12-31,AT,Austria,6.7799
+2015-12-31,AU,Australia,6.8479
+2015-12-31,BE,Belgium,0.8045
+2015-12-31,BG,Bulgaria,4.5065
 2015-12-31,BR,Brazil,-10.8149
-2015-12-31,CA,Canada,8.4331
-2015-12-31,CH,Switzerland,2.5942
-2015-12-31,CL,Chile,8.9709
+2015-12-31,CA,Canada,8.0437
+2015-12-31,CH,Switzerland,2.5959
+2015-12-31,CL,Chile,8.9708
 2015-12-31,CN,China,-1.7629
-2015-12-31,CO,Colombia,2.2679
+2015-12-31,CO,Colombia,1.5883
 2015-12-31,CY,Cyprus,-0.0802
-2015-12-31,CZ,Czechia,4.4173
+2015-12-31,CZ,Czechia,4.3867
 2015-12-31,DE,Germany,5.3708
-2015-12-31,DK,Denmark,6.6792
+2015-12-31,DK,Denmark,6.6084
 2015-12-31,EE,Estonia,5.6572
-2015-12-31,ES,Spain,4.5861
+2015-12-31,ES,Spain,4.5866
 2015-12-31,FI,Finland,0.6531
-2015-12-31,FR,France,-0.193
-2015-12-31,GB,United Kingdom,6.3615
+2015-12-31,FR,France,-0.1964
+2015-12-31,GB,United Kingdom,6.4027
 2015-12-31,GR,Greece,-4.5294
 2015-12-31,HK,Hong Kong SAR,4.6594
-2015-12-31,HR,Croatia,-1.2709
-2015-12-31,HU,Hungary,14.1335
+2015-12-31,HR,Croatia,-1.2662
+2015-12-31,HU,Hungary,14.1334
 2015-12-31,ID,Indonesia,-0.1891
-2015-12-31,IE,Ireland,7.0494
-2015-12-31,IL,Israel,8.5581
-2015-12-31,IN,India,4.1895
-2015-12-31,IS,Iceland,6.9688
-2015-12-31,IT,Italy,-2.2111
+2015-12-31,IE,Ireland,6.9899
+2015-12-31,IL,Israel,8.5586
+2015-12-31,IN,India,4.2511
+2015-12-31,IS,Iceland,6.9469
+2015-12-31,IT,Italy,-2.2091
 2015-12-31,JP,Japan,1.7154
-2015-12-31,KR,Korea,3.3948
+2015-12-31,KR,Korea,3.3916
 2015-12-31,LT,Lithuania,3.6799
-2015-12-31,LU,Luxembourg,2.8721
-2015-12-31,LV,Latvia,6.4754
-2015-12-31,MA,Morocco,-0.2068
-2015-12-31,MK,North Macedonia,1.5291
+2015-12-31,LU,Luxembourg,2.8718
+2015-12-31,LV,Latvia,6.5196
+2015-12-31,MA,Morocco,-0.5817
+2015-12-31,MK,North Macedonia,1.4955
 2015-12-31,MT,Malta,6.9882
 2015-12-31,MX,Mexico,7.7701
 2015-12-31,MY,Malaysia,3.777
-2015-12-31,NL,Netherlands,3.6754
-2015-12-31,NO,Norway,1.9845
+2015-12-31,NL,Netherlands,3.6954
+2015-12-31,NO,Norway,1.9723
 2015-12-31,NZ,New Zealand,12.53
 2015-12-31,PE,Peru,-7.5948
 2015-12-31,PH,Philippines,9.7193
 2015-12-31,PL,Poland,1.82
-2015-12-31,PT,Portugal,4.4285
+2015-12-31,PT,Portugal,4.4286
 2015-12-31,RO,Romania,3.295
 2015-12-31,RS,Serbia,-0.409
-2015-12-31,RU,Russia,-15.3466
-2015-12-31,SE,Sweden,14.0407
-2015-12-31,SG,Singapore,-2.9703
-2015-12-31,SI,Slovenia,0.6175
-2015-12-31,SK,Slovak Republic,5.3177
-2015-12-31,TH,Thailand,4.5561
-2015-12-31,TR,Türkiye,6.8708
-2015-12-31,US,United States,4.9369
-2015-12-31,XM,Euro area,2.4829
-2015-12-31,XW,World,1.5812
-2015-12-31,ZA,South Africa,1.3224
-2016-03-31,4T,Emerging market economies (aggregate),-0.5346
-2016-03-31,5R,Advanced economies,4.2385
-2016-03-31,AE,United Arab Emirates,-7.7438
+2015-12-31,RU,Russia,-15.3542
+2015-12-31,SE,Sweden,14.0385
+2015-12-31,SG,Singapore,-2.9669
+2015-12-31,SI,Slovenia,0.6419
+2015-12-31,SK,Slovakia,5.3322
+2015-12-31,TH,Thailand,6.8093
+2015-12-31,TR,Türkiye,6.9382
+2015-12-31,US,United States,4.9563
+2015-12-31,XM,Euro area,2.4713
+2015-12-31,XW,World,1.7239
+2015-12-31,ZA,South Africa,1.7693
+2016-03-31,4T,Emerging market economies (aggregate),-0.5547
+2016-03-31,5R,Advanced economies,4.0496
 2016-03-31,AT,Austria,7.0457
-2016-03-31,AU,Australia,5.4159
-2016-03-31,BE,Belgium,1.428
-2016-03-31,BG,Bulgaria,5.2923
-2016-03-31,BR,Brazil,-11.3407
-2016-03-31,CA,Canada,11.1387
-2016-03-31,CH,Switzerland,2.4096
-2016-03-31,CL,Chile,7.3031
+2016-03-31,AU,Australia,5.433
+2016-03-31,BE,Belgium,0.6782
+2016-03-31,BG,Bulgaria,5.2785
+2016-03-31,BR,Brazil,-11.3424
+2016-03-31,CA,Canada,10.4838
+2016-03-31,CH,Switzerland,2.4115
+2016-03-31,CL,Chile,7.3032
 2016-03-31,CN,China,1.2139
-2016-03-31,CO,Colombia,2.6432
+2016-03-31,CO,Colombia,2.298
 2016-03-31,CY,Cyprus,0.5335
-2016-03-31,CZ,Czechia,4.293
+2016-03-31,CZ,Czechia,4.2942
 2016-03-31,DE,Germany,5.8942
-2016-03-31,DK,Denmark,5.0061
+2016-03-31,DK,Denmark,5.0161
 2016-03-31,EE,Estonia,2.4427
-2016-03-31,ES,Spain,6.9829
+2016-03-31,ES,Spain,6.9833
 2016-03-31,FI,Finland,1.0388
-2016-03-31,FR,France,0.3421
-2016-03-31,GB,United Kingdom,7.6235
-2016-03-31,GR,Greece,-3.4691
-2016-03-31,HK,Hong Kong SAR,-7.6135
-2016-03-31,HR,Croatia,1.3861
+2016-03-31,FR,France,0.3384
+2016-03-31,GB,United Kingdom,7.6512
+2016-03-31,GR,Greece,-3.469
+2016-03-31,HK,Hong Kong SAR,-7.5911
+2016-03-31,HR,Croatia,1.3712
 2016-03-31,HU,Hungary,16.4916
 2016-03-31,ID,Indonesia,-0.1755
-2016-03-31,IE,Ireland,7.5777
-2016-03-31,IL,Israel,8.0722
-2016-03-31,IN,India,-1.8606
-2016-03-31,IS,Iceland,4.6903
-2016-03-31,IT,Italy,0.1942
+2016-03-31,IE,Ireland,7.7035
+2016-03-31,IL,Israel,8.0728
+2016-03-31,IN,India,-1.9346
+2016-03-31,IS,Iceland,4.6632
+2016-03-31,IT,Italy,0.1949
 2016-03-31,JP,Japan,1.5849
-2016-03-31,KR,Korea,3.2943
+2016-03-31,KR,Korea,3.24
 2016-03-31,LT,Lithuania,2.368
-2016-03-31,LU,Luxembourg,4.693
-2016-03-31,LV,Latvia,7.5852
-2016-03-31,MA,Morocco,-4.8043
-2016-03-31,MK,North Macedonia,2.4138
+2016-03-31,LU,Luxembourg,4.6956
+2016-03-31,LV,Latvia,7.5446
+2016-03-31,MA,Morocco,-0.4208
+2016-03-31,MK,North Macedonia,2.3559
 2016-03-31,MT,Malta,4.7711
 2016-03-31,MX,Mexico,6.6868
 2016-03-31,MY,Malaysia,3.6746
-2016-03-31,NL,Netherlands,4.0132
-2016-03-31,NO,Norway,1.3664
+2016-03-31,NL,Netherlands,3.787
+2016-03-31,NO,Norway,1.3774
 2016-03-31,NZ,New Zealand,12.6917
 2016-03-31,PE,Peru,-9.7136
 2016-03-31,PH,Philippines,10.2496
@@ -22122,61 +6249,60 @@ date,country_code,country,price
 2016-03-31,PT,Portugal,6.3637
 2016-03-31,RO,Romania,5.737
 2016-03-31,RS,Serbia,-2.9945
-2016-03-31,RU,Russia,-13.0158
-2016-03-31,SE,Sweden,10.2571
-2016-03-31,SG,Singapore,-2.5473
-2016-03-31,SI,Slovenia,1.5445
-2016-03-31,SK,Slovak Republic,5.5731
-2016-03-31,TH,Thailand,3.4135
-2016-03-31,TR,Türkiye,5.1854
-2016-03-31,US,United States,4.254
-2016-03-31,XM,Euro area,3.4727
-2016-03-31,XW,World,1.7085
-2016-03-31,ZA,South Africa,-0.2568
-2016-06-30,4T,Emerging market economies (aggregate),0.8789
-2016-06-30,5R,Advanced economies,4.5873
-2016-06-30,AE,United Arab Emirates,-3.8983
+2016-03-31,RU,Russia,-13.0057
+2016-03-31,SE,Sweden,10.2633
+2016-03-31,SG,Singapore,-2.5482
+2016-03-31,SI,Slovenia,1.5573
+2016-03-31,SK,Slovakia,5.588
+2016-03-31,TH,Thailand,5.4641
+2016-03-31,TR,Türkiye,5.2485
+2016-03-31,US,United States,4.258
+2016-03-31,XM,Euro area,3.4689
+2016-03-31,XW,World,1.8045
+2016-03-31,ZA,South Africa,-0.5764
+2016-06-30,4T,Emerging market economies (aggregate),0.9781
+2016-06-30,5R,Advanced economies,4.3059
 2016-06-30,AT,Austria,8.8977
-2016-06-30,AU,Australia,3.0148
-2016-06-30,BE,Belgium,0.0665
-2016-06-30,BG,Bulgaria,8.5576
-2016-06-30,BR,Brazil,-10.9001
-2016-06-30,CA,Canada,14.3726
-2016-06-30,CH,Switzerland,1.1895
+2016-06-30,AU,Australia,3.0206
+2016-06-30,BE,Belgium,0.1746
+2016-06-30,BG,Bulgaria,8.4683
+2016-06-30,BR,Brazil,-10.8985
+2016-06-30,CA,Canada,13.5581
+2016-06-30,CH,Switzerland,1.1897
 2016-06-30,CL,Chile,3.1176
 2016-06-30,CN,China,3.5591
-2016-06-30,CO,Colombia,1.1507
+2016-06-30,CO,Colombia,0.0903
 2016-06-30,CY,Cyprus,0.5863
-2016-06-30,CZ,Czechia,5.4541
+2016-06-30,CZ,Czechia,5.5169
 2016-06-30,DE,Germany,6.8583
-2016-06-30,DK,Denmark,3.9213
+2016-06-30,DK,Denmark,3.9006
 2016-06-30,EE,Estonia,2.5273
-2016-06-30,ES,Spain,4.8452
+2016-06-30,ES,Spain,4.8458
 2016-06-30,FI,Finland,0.8827
-2016-06-30,FR,France,0.7102
-2016-06-30,GB,United Kingdom,7.657
-2016-06-30,GR,Greece,-1.6012
-2016-06-30,HK,Hong Kong SAR,-10.3302
-2016-06-30,HR,Croatia,2.9829
+2016-06-30,FR,France,0.7156
+2016-06-30,GB,United Kingdom,7.6241
+2016-06-30,GR,Greece,-1.6011
+2016-06-30,HK,Hong Kong SAR,-10.3085
+2016-06-30,HR,Croatia,2.9937
 2016-06-30,HU,Hungary,13.5031
 2016-06-30,ID,Indonesia,-0.0701
-2016-06-30,IE,Ireland,6.1516
-2016-06-30,IL,Israel,8.2525
-2016-06-30,IN,India,1.576
-2016-06-30,IS,Iceland,6.3241
-2016-06-30,IT,Italy,1.0952
+2016-06-30,IE,Ireland,6.1536
+2016-06-30,IL,Israel,8.2522
+2016-06-30,IN,India,1.6272
+2016-06-30,IS,Iceland,6.3231
+2016-06-30,IT,Italy,1.0935
 2016-06-30,JP,Japan,3.3474
-2016-06-30,KR,Korea,2.1363
-2016-06-30,LT,Lithuania,2.6405
-2016-06-30,LU,Luxembourg,5.5512
-2016-06-30,LV,Latvia,10.2396
-2016-06-30,MA,Morocco,-1.3276
-2016-06-30,MK,North Macedonia,1.3491
+2016-06-30,KR,Korea,2.1479
+2016-06-30,LT,Lithuania,2.6404
+2016-06-30,LU,Luxembourg,5.5502
+2016-06-30,LV,Latvia,10.283
+2016-06-30,MA,Morocco,-1.0539
+2016-06-30,MK,North Macedonia,1.5218
 2016-06-30,MT,Malta,6.2956
 2016-06-30,MX,Mexico,5.1012
 2016-06-30,MY,Malaysia,5.0994
-2016-06-30,NL,Netherlands,4.475
-2016-06-30,NO,Norway,1.9762
+2016-06-30,NL,Netherlands,4.7849
+2016-06-30,NO,Norway,2
 2016-06-30,NZ,New Zealand,14.6984
 2016-06-30,PE,Peru,-6.1118
 2016-06-30,PH,Philippines,12.0611
@@ -22184,61 +6310,60 @@ date,country_code,country,price
 2016-06-30,PT,Portugal,5.8264
 2016-06-30,RO,Romania,9.7418
 2016-06-30,RS,Serbia,3.792
-2016-06-30,RU,Russia,-12.4673
-2016-06-30,SE,Sweden,7.7853
-2016-06-30,SG,Singapore,-2.0091
-2016-06-30,SI,Slovenia,0.7163
-2016-06-30,SK,Slovak Republic,6.6108
-2016-06-30,TH,Thailand,2.4708
-2016-06-30,TR,Türkiye,5.928
-2016-06-30,US,United States,4.2379
-2016-06-30,XM,Euro area,3.8843
-2016-06-30,XW,World,2.6307
-2016-06-30,ZA,South Africa,-0.2093
-2016-09-30,4T,Emerging market economies (aggregate),1.6568
-2016-09-30,5R,Advanced economies,4.4094
-2016-09-30,AE,United Arab Emirates,-2.9408
-2016-09-30,AT,Austria,6.3378
-2016-09-30,AU,Australia,2.2028
-2016-09-30,BE,Belgium,0.4068
-2016-09-30,BG,Bulgaria,9.1784
+2016-06-30,RU,Russia,-12.469
+2016-06-30,SE,Sweden,7.7854
+2016-06-30,SG,Singapore,-2.012
+2016-06-30,SI,Slovenia,0.6842
+2016-06-30,SK,Slovakia,6.6281
+2016-06-30,TH,Thailand,5.4427
+2016-06-30,TR,Türkiye,5.4659
+2016-06-30,US,United States,4.256
+2016-06-30,XM,Euro area,3.8792
+2016-06-30,XW,World,2.6962
+2016-06-30,ZA,South Africa,-1.1504
+2016-09-30,4T,Emerging market economies (aggregate),1.8772
+2016-09-30,5R,Advanced economies,4.1318
+2016-09-30,AT,Austria,6.5151
+2016-09-30,AU,Australia,2.1651
+2016-09-30,BE,Belgium,0.0078
+2016-09-30,BG,Bulgaria,9.1889
 2016-09-30,BR,Brazil,-10.6817
-2016-09-30,CA,Canada,15.7688
-2016-09-30,CH,Switzerland,0.108
+2016-09-30,CA,Canada,15.1115
+2016-09-30,CH,Switzerland,0.1084
 2016-09-30,CL,Chile,0.0662
 2016-09-30,CN,China,5.6231
-2016-09-30,CO,Colombia,1.3537
+2016-09-30,CO,Colombia,0.6373
 2016-09-30,CY,Cyprus,-0.8999
-2016-09-30,CZ,Czechia,6.4909
+2016-09-30,CZ,Czechia,6.5081
 2016-09-30,DE,Germany,7.8884
-2016-09-30,DK,Denmark,5.1821
+2016-09-30,DK,Denmark,5.1579
 2016-09-30,EE,Estonia,6.9166
-2016-09-30,ES,Spain,4.2079
+2016-09-30,ES,Spain,4.2075
 2016-09-30,FI,Finland,1.1568
-2016-09-30,FR,France,1.2036
-2016-09-30,GB,United Kingdom,5.9765
-2016-09-30,GR,Greece,-0.7772
-2016-09-30,HK,Hong Kong SAR,-8.2869
-2016-09-30,HR,Croatia,2.7397
-2016-09-30,HU,Hungary,11.6698
+2016-09-30,FR,France,1.2013
+2016-09-30,GB,United Kingdom,6.0102
+2016-09-30,GR,Greece,-0.7307
+2016-09-30,HK,Hong Kong SAR,-8.327
+2016-09-30,HR,Croatia,2.7823
+2016-09-30,HU,Hungary,11.6699
 2016-09-30,ID,Indonesia,-0.2707
-2016-09-30,IE,Ireland,7.3049
-2016-09-30,IL,Israel,8.7922
-2016-09-30,IN,India,2.368
-2016-09-30,IS,Iceland,11.3954
-2016-09-30,IT,Italy,0.02
+2016-09-30,IE,Ireland,7.3415
+2016-09-30,IL,Israel,8.7924
+2016-09-30,IN,India,2.2994
+2016-09-30,IS,Iceland,11.41
+2016-09-30,IT,Italy,0.0163
 2016-09-30,JP,Japan,2.2521
-2016-09-30,KR,Korea,1.272
+2016-09-30,KR,Korea,1.3105
 2016-09-30,LT,Lithuania,4.56
-2016-09-30,LU,Luxembourg,5.5097
-2016-09-30,LV,Latvia,9.3617
-2016-09-30,MA,Morocco,0.5841
-2016-09-30,MK,North Macedonia,0.5503
+2016-09-30,LU,Luxembourg,5.5109
+2016-09-30,LV,Latvia,9.4374
+2016-09-30,MA,Morocco,1.8678
+2016-09-30,MK,North Macedonia,0.4532
 2016-09-30,MT,Malta,3.9743
 2016-09-30,MX,Mexico,3.216
 2016-09-30,MY,Malaysia,5.4021
-2016-09-30,NL,Netherlands,4.9565
-2016-09-30,NO,Norway,3.7704
+2016-09-30,NL,Netherlands,5.5588
+2016-09-30,NO,Norway,3.7295
 2016-09-30,NZ,New Zealand,13.5964
 2016-09-30,PE,Peru,-4.315
 2016-09-30,PH,Philippines,6.9589
@@ -22246,1750 +6371,2264 @@ date,country_code,country,price
 2016-09-30,PT,Portugal,6.9106
 2016-09-30,RO,Romania,7.6118
 2016-09-30,RS,Serbia,18.202
-2016-09-30,RU,Russia,-11.3276
-2016-09-30,SE,Sweden,5.9849
-2016-09-30,SG,Singapore,-2.7166
-2016-09-30,SI,Slovenia,4.8067
-2016-09-30,SK,Slovak Republic,8.3273
-2016-09-30,TH,Thailand,-0.1011
-2016-09-30,TR,Türkiye,5.1365
-2016-09-30,US,United States,4.1358
-2016-09-30,XM,Euro area,4.1141
-2016-09-30,XW,World,2.9588
-2016-09-30,ZA,South Africa,-0.5027
-2016-12-31,4T,Emerging market economies (aggregate),2.7491
-2016-12-31,5R,Advanced economies,3.9774
-2016-12-31,AE,United Arab Emirates,-1.9503
+2016-09-30,RU,Russia,-11.3304
+2016-09-30,SE,Sweden,5.9824
+2016-09-30,SG,Singapore,-2.7196
+2016-09-30,SI,Slovenia,4.8174
+2016-09-30,SK,Slovakia,8.2518
+2016-09-30,TH,Thailand,4.452
+2016-09-30,TR,Türkiye,4.1444
+2016-09-30,US,United States,4.1491
+2016-09-30,XM,Euro area,4.1031
+2016-09-30,XW,World,3.0391
+2016-09-30,ZA,South Africa,-1.076
+2016-12-31,4T,Emerging market economies (aggregate),3.0209
+2016-12-31,5R,Advanced economies,3.7958
 2016-12-31,AT,Austria,3.1971
-2016-12-31,AU,Australia,6.091
-2016-12-31,BE,Belgium,0.7312
-2016-12-31,BG,Bulgaria,8.4515
+2016-12-31,AU,Australia,6.0924
+2016-12-31,BE,Belgium,0.5535
+2016-12-31,BG,Bulgaria,8.4406
 2016-12-31,BR,Brazil,-9.2231
-2016-12-31,CA,Canada,14.499
+2016-12-31,CA,Canada,14.4206
 2016-12-31,CH,Switzerland,-1.1502
 2016-12-31,CL,Chile,0.7492
 2016-12-31,CN,China,7.0826
-2016-12-31,CO,Colombia,3.7648
+2016-12-31,CO,Colombia,3.4108
 2016-12-31,CY,Cyprus,0.0138
-2016-12-31,CZ,Czechia,9.3065
+2016-12-31,CZ,Czechia,9.3835
 2016-12-31,DE,Germany,7.3598
-2016-12-31,DK,Denmark,3.7679
+2016-12-31,DK,Denmark,3.7727
 2016-12-31,EE,Estonia,6.3318
 2016-12-31,ES,Spain,3.405
 2016-12-31,FI,Finland,0.5827
-2016-12-31,FR,France,1.0911
-2016-12-31,GB,United Kingdom,4.0819
-2016-12-31,GR,Greece,-0.5885
+2016-12-31,FR,France,1.0871
+2016-12-31,GB,United Kingdom,4.1704
+2016-12-31,GR,Greece,-0.5852
 2016-12-31,HK,Hong Kong SAR,3.019
-2016-12-31,HR,Croatia,1.0027
-2016-12-31,HU,Hungary,10.3976
+2016-12-31,HR,Croatia,1.0265
+2016-12-31,HU,Hungary,10.3977
 2016-12-31,ID,Indonesia,-0.8944
-2016-12-31,IE,Ireland,8.6931
-2016-12-31,IL,Israel,7.0882
-2016-12-31,IN,India,4.4299
-2016-12-31,IS,Iceland,12.5165
-2016-12-31,IT,Italy,0.0369
+2016-12-31,IE,Ireland,8.6119
+2016-12-31,IL,Israel,7.0874
+2016-12-31,IN,India,4.4191
+2016-12-31,IS,Iceland,12.5232
+2016-12-31,IT,Italy,0.0735
 2016-12-31,JP,Japan,2.2158
-2016-12-31,KR,Korea,0.0535
-2016-12-31,LT,Lithuania,8.1705
-2016-12-31,LU,Luxembourg,6.9955
-2016-12-31,LV,Latvia,6.197
-2016-12-31,MA,Morocco,3.1925
-2016-12-31,MK,North Macedonia,1.6598
+2016-12-31,KR,Korea,0.034
+2016-12-31,LT,Lithuania,8.1706
+2016-12-31,LU,Luxembourg,6.9976
+2016-12-31,LV,Latvia,6.1516
+2016-12-31,MA,Morocco,2.6303
+2016-12-31,MK,North Macedonia,1.8223
 2016-12-31,MT,Malta,4.1612
 2016-12-31,MX,Mexico,2.5425
 2016-12-31,MY,Malaysia,5.2576
-2016-12-31,NL,Netherlands,5.2674
-2016-12-31,NO,Norway,6.3043
+2016-12-31,NL,Netherlands,5.6583
+2016-12-31,NO,Norway,6.3246
 2016-12-31,NZ,New Zealand,12.7658
 2016-12-31,PE,Peru,-1.1195
 2016-12-31,PH,Philippines,5.3994
 2016-12-31,PL,Poland,3.6977
-2016-12-31,PT,Portugal,6.7587
+2016-12-31,PT,Portugal,6.7586
 2016-12-31,RO,Romania,8.611
 2016-12-31,RS,Serbia,21.3983
-2016-12-31,RU,Russia,-9.3035
-2016-12-31,SE,Sweden,4.9786
-2016-12-31,SG,Singapore,-3.1309
-2016-12-31,SI,Slovenia,6.2847
-2016-12-31,SK,Slovak Republic,8.4436
-2016-12-31,TH,Thailand,-1.2277
-2016-12-31,TR,Türkiye,4.2982
-2016-12-31,US,United States,3.5371
-2016-12-31,XM,Euro area,3.7838
-2016-12-31,XW,World,3.3352
-2016-12-31,ZA,South Africa,-1.6965
-2017-03-31,4T,Emerging market economies (aggregate),2.8262
-2017-03-31,5R,Advanced economies,3.4409
-2017-03-31,AE,United Arab Emirates,-3.9413
-2017-03-31,AT,Austria,0.3051
-2017-03-31,AU,Australia,7.9056
-2017-03-31,BE,Belgium,1.7469
-2017-03-31,BG,Bulgaria,7.2041
-2017-03-31,BR,Brazil,-7.1507
-2017-03-31,CA,Canada,15.3632
-2017-03-31,CH,Switzerland,-2.8028
-2017-03-31,CL,Chile,3.1998
+2016-12-31,RU,Russia,-9.306
+2016-12-31,SE,Sweden,4.9852
+2016-12-31,SG,Singapore,-3.1336
+2016-12-31,SI,Slovenia,6.2635
+2016-12-31,SK,Slovakia,8.3716
+2016-12-31,TH,Thailand,2.7754
+2016-12-31,TR,Türkiye,3.8144
+2016-12-31,US,United States,3.5256
+2016-12-31,XM,Euro area,3.7761
+2016-12-31,XW,World,3.4231
+2016-12-31,ZA,South Africa,-2.5795
+2017-03-31,4T,Emerging market economies (aggregate),3.0789
+2017-03-31,5R,Advanced economies,3.323
+2017-03-31,AT,Austria,0.3052
+2017-03-31,AU,Australia,7.887
+2017-03-31,BE,Belgium,1.3085
+2017-03-31,BG,Bulgaria,7.2207
+2017-03-31,BR,Brazil,-7.149
+2017-03-31,CA,Canada,15.3831
+2017-03-31,CH,Switzerland,-2.8027
+2017-03-31,CL,Chile,3.1997
 2017-03-31,CN,China,6.6247
-2017-03-31,CO,Colombia,0.7932
+2017-03-31,CO,Colombia,0.5875
 2017-03-31,CY,Cyprus,-1.2689
-2017-03-31,CZ,Czechia,10.139
+2017-03-31,CZ,Czechia,10.1416
 2017-03-31,DE,Germany,5.0614
-2017-03-31,DK,Denmark,2.6029
+2017-03-31,DK,Denmark,2.6134
 2017-03-31,EE,Estonia,4.5898
-2017-03-31,ES,Spain,2.5023
+2017-03-31,ES,Spain,2.5024
 2017-03-31,FI,Finland,0.2264
-2017-03-31,FR,France,1.5561
-2017-03-31,GB,United Kingdom,2.2178
-2017-03-31,GR,Greece,-3.2357
-2017-03-31,HK,Hong Kong SAR,14.0348
-2017-03-31,HR,Croatia,-1.3645
+2017-03-31,FR,France,1.5654
+2017-03-31,GB,United Kingdom,2.1781
+2017-03-31,GR,Greece,-3.2358
+2017-03-31,HK,Hong Kong SAR,14.0072
+2017-03-31,HR,Croatia,-1.4152
 2017-03-31,HU,Hungary,8.9074
 2017-03-31,ID,Indonesia,-0.9831
-2017-03-31,IE,Ireland,8.8549
-2017-03-31,IL,Israel,4.6989
-2017-03-31,IN,India,6.6473
-2017-03-31,IS,Iceland,15.7181
-2017-03-31,IT,Italy,-2.014
+2017-03-31,IE,Ireland,8.7046
+2017-03-31,IL,Israel,4.6988
+2017-03-31,IN,India,6.7053
+2017-03-31,IS,Iceland,15.7327
+2017-03-31,IT,Italy,-2.0133
 2017-03-31,JP,Japan,3.5533
-2017-03-31,KR,Korea,-0.9442
+2017-03-31,KR,Korea,-0.9299
 2017-03-31,LT,Lithuania,7.2359
-2017-03-31,LU,Luxembourg,5.1492
-2017-03-31,LV,Latvia,5.9145
-2017-03-31,MA,Morocco,5.9688
-2017-03-31,MK,North Macedonia,-4.218
+2017-03-31,LU,Luxembourg,5.1441
+2017-03-31,LV,Latvia,5.9505
+2017-03-31,MA,Morocco,3.9332
+2017-03-31,MK,North Macedonia,-4.3392
 2017-03-31,MT,Malta,3.5996
 2017-03-31,MX,Mexico,2.2723
 2017-03-31,MY,Malaysia,2.4213
-2017-03-31,NL,Netherlands,5.0665
-2017-03-31,NO,Norway,7.3463
+2017-03-31,NL,Netherlands,5.8312
+2017-03-31,NO,Norway,7.3155
 2017-03-31,NZ,New Zealand,9.7245
 2017-03-31,PE,Peru,1.6353
 2017-03-31,PH,Philippines,3.6929
 2017-03-31,PL,Poland,1.2537
-2017-03-31,PT,Portugal,6.4207
+2017-03-31,PT,Portugal,6.4206
 2017-03-31,RO,Romania,4.6605
-2017-03-31,RS,Serbia,10.0427
-2017-03-31,RU,Russia,-8.4084
-2017-03-31,SE,Sweden,6.3388
-2017-03-31,SG,Singapore,-3.3779
-2017-03-31,SI,Slovenia,4.8007
-2017-03-31,SK,Slovak Republic,2.7628
-2017-03-31,TH,Thailand,-2.396
-2017-03-31,TR,Türkiye,1.5179
-2017-03-31,US,United States,2.9192
-2017-03-31,XM,Euro area,2.6256
-2017-03-31,XW,World,3.1163
-2017-03-31,ZA,South Africa,-1.6922
-2017-06-30,4T,Emerging market economies (aggregate),2.9609
-2017-06-30,5R,Advanced economies,3.6308
-2017-06-30,AE,United Arab Emirates,-2.9566
+2017-03-31,RS,Serbia,9.3691
+2017-03-31,RU,Russia,-8.3941
+2017-03-31,SE,Sweden,6.3312
+2017-03-31,SG,Singapore,-3.3796
+2017-03-31,SI,Slovenia,4.7899
+2017-03-31,SK,Slovakia,2.587
+2017-03-31,TH,Thailand,0.2078
+2017-03-31,TR,Türkiye,1.5518
+2017-03-31,US,United States,2.913
+2017-03-31,XM,Euro area,2.6152
+2017-03-31,XW,World,3.1989
+2017-03-31,ZA,South Africa,-2.454
+2017-06-30,4T,Emerging market economies (aggregate),3.158
+2017-06-30,5R,Advanced economies,3.5578
 2017-06-30,AT,Austria,1.6709
-2017-06-30,AU,Australia,8.0608
-2017-06-30,BE,Belgium,0.9393
-2017-06-30,BG,Bulgaria,6.1846
-2017-06-30,BR,Brazil,-5.5962
-2017-06-30,CA,Canada,15.0815
-2017-06-30,CH,Switzerland,-0.3443
+2017-06-30,AU,Australia,8.1016
+2017-06-30,BE,Belgium,1.0839
+2017-06-30,BG,Bulgaria,6.2425
+2017-06-30,BR,Brazil,-5.5944
+2017-06-30,CA,Canada,15.3459
+2017-06-30,CH,Switzerland,-0.3439
 2017-06-30,CL,Chile,5.693
 2017-06-30,CN,China,6.5185
-2017-06-30,CO,Colombia,2.2282
+2017-06-30,CO,Colombia,2.2608
 2017-06-30,CY,Cyprus,0.0671
-2017-06-30,CZ,Czechia,10.8596
+2017-06-30,CZ,Czechia,10.8695
 2017-06-30,DE,Germany,4.3654
-2017-06-30,DK,Denmark,4.2731
+2017-06-30,DK,Denmark,4.2795
 2017-06-30,EE,Estonia,1.6398
-2017-06-30,ES,Spain,3.5181
+2017-06-30,ES,Spain,3.5176
 2017-06-30,FI,Finland,0.7981
-2017-06-30,FR,France,2.3859
-2017-06-30,GB,United Kingdom,1.7218
+2017-06-30,FR,France,2.3848
+2017-06-30,GB,United Kingdom,1.6348
 2017-06-30,GR,Greece,-2.3116
-2017-06-30,HK,Hong Kong SAR,18.7839
-2017-06-30,HR,Croatia,3.1755
-2017-06-30,HU,Hungary,9.8042
+2017-06-30,HK,Hong Kong SAR,18.7077
+2017-06-30,HR,Croatia,3.1688
+2017-06-30,HU,Hungary,9.8043
 2017-06-30,ID,Indonesia,-1.0715
-2017-06-30,IE,Ireland,10.3127
-2017-06-30,IL,Israel,4.2542
-2017-06-30,IN,India,6.3622
-2017-06-30,IS,Iceland,21.0545
-2017-06-30,IT,Italy,-2.364
+2017-06-30,IE,Ireland,10.2947
+2017-06-30,IL,Israel,4.2543
+2017-06-30,IN,India,6.298
+2017-06-30,IS,Iceland,21.0457
+2017-06-30,IT,Italy,-2.3642
 2017-06-30,JP,Japan,1.597
-2017-06-30,KR,Korea,-0.6753
+2017-06-30,KR,Korea,-0.6694
 2017-06-30,LT,Lithuania,6.4842
-2017-06-30,LU,Luxembourg,4.6239
-2017-06-30,LV,Latvia,5.8665
-2017-06-30,MA,Morocco,5.9857
-2017-06-30,MK,North Macedonia,-3.4108
+2017-06-30,LU,Luxembourg,4.6267
+2017-06-30,LV,Latvia,5.8426
+2017-06-30,MA,Morocco,3.8274
+2017-06-30,MK,North Macedonia,-3.5346
 2017-06-30,MT,Malta,4.5203
 2017-06-30,MX,Mexico,1.3042
 2017-06-30,MY,Malaysia,2.8725
-2017-06-30,NL,Netherlands,6.2144
-2017-06-30,NO,Norway,4.7131
+2017-06-30,NL,Netherlands,6.4306
+2017-06-30,NO,Norway,4.6308
 2017-06-30,NZ,New Zealand,4.8524
 2017-06-30,PE,Peru,-1.5232
 2017-06-30,PH,Philippines,-2.5773
 2017-06-30,PL,Poland,2.6897
 2017-06-30,PT,Portugal,6.5049
 2017-06-30,RO,Romania,5.7933
-2017-06-30,RS,Serbia,4.2481
-2017-06-30,RU,Russia,-7.5903
-2017-06-30,SE,Sweden,6.5963
-2017-06-30,SG,Singapore,-3.1774
-2017-06-30,SI,Slovenia,6.7308
-2017-06-30,SK,Slovak Republic,5.6498
-2017-06-30,TH,Thailand,-0.4043
-2017-06-30,TR,Türkiye,-0.5985
-2017-06-30,US,United States,3.8673
-2017-06-30,XM,Euro area,2.7679
-2017-06-30,XW,World,3.2797
-2017-06-30,ZA,South Africa,-0.9957
-2017-09-30,4T,Emerging market economies (aggregate),2.4066
-2017-09-30,5R,Advanced economies,3.5894
-2017-09-30,AE,United Arab Emirates,-3.489
-2017-09-30,AT,Austria,2.3941
-2017-09-30,AU,Australia,6.352
-2017-09-30,BE,Belgium,1.7804
-2017-09-30,BG,Bulgaria,7.2695
-2017-09-30,BR,Brazil,-4.1866
-2017-09-30,CA,Canada,13.1968
-2017-09-30,CH,Switzerland,2.1091
+2017-06-30,RS,Serbia,4.0529
+2017-06-30,RU,Russia,-7.5843
+2017-06-30,SE,Sweden,6.5922
+2017-06-30,SG,Singapore,-3.1783
+2017-06-30,SI,Slovenia,6.7673
+2017-06-30,SK,Slovakia,5.4866
+2017-06-30,TH,Thailand,0.707
+2017-06-30,TR,Türkiye,0.2188
+2017-06-30,US,United States,3.8651
+2017-06-30,XM,Euro area,2.7621
+2017-06-30,XW,World,3.3637
+2017-06-30,ZA,South Africa,-0.9637
+2017-09-30,4T,Emerging market economies (aggregate),2.5502
+2017-09-30,5R,Advanced economies,3.5163
+2017-09-30,AT,Austria,2.2237
+2017-09-30,AU,Australia,6.3781
+2017-09-30,BE,Belgium,2.0979
+2017-09-30,BG,Bulgaria,7.2679
+2017-09-30,BR,Brazil,-4.1829
+2017-09-30,CA,Canada,13.4619
+2017-09-30,CH,Switzerland,2.1093
 2017-09-30,CL,Chile,6.969
 2017-09-30,CN,China,5.2201
-2017-09-30,CO,Colombia,2.9299
+2017-09-30,CO,Colombia,2.8185
 2017-09-30,CY,Cyprus,2.0264
-2017-09-30,CZ,Czechia,9.7386
+2017-09-30,CZ,Czechia,9.7736
 2017-09-30,DE,Germany,4.0128
-2017-09-30,DK,Denmark,2.946
+2017-09-30,DK,Denmark,2.9418
 2017-09-30,EE,Estonia,1.0117
-2017-09-30,ES,Spain,4.9245
+2017-09-30,ES,Spain,4.9256
 2017-09-30,FI,Finland,-0.0911
-2017-09-30,FR,France,2.3324
-2017-09-30,GB,United Kingdom,1.838
-2017-09-30,GR,Greece,-1.6096
+2017-09-30,FR,France,2.335
+2017-09-30,GB,United Kingdom,1.8813
+2017-09-30,GR,Greece,-1.6063
 2017-09-30,HK,Hong Kong SAR,15.618
-2017-09-30,HR,Croatia,2.7084
+2017-09-30,HR,Croatia,2.7254
 2017-09-30,HU,Hungary,9.5694
 2017-09-30,ID,Indonesia,-0.4711
-2017-09-30,IE,Ireland,11.6195
-2017-09-30,IL,Israel,3.962
-2017-09-30,IN,India,4.3444
-2017-09-30,IS,Iceland,18.4377
-2017-09-30,IT,Italy,-2.5917
+2017-09-30,IE,Ireland,11.5147
+2017-09-30,IL,Israel,3.9619
+2017-09-30,IN,India,4.3757
+2017-09-30,IS,Iceland,18.4234
+2017-09-30,IT,Italy,-2.5867
 2017-09-30,JP,Japan,1.8258
-2017-09-30,KR,Korea,-0.7092
-2017-09-30,LT,Lithuania,4.0045
-2017-09-30,LU,Luxembourg,2.9926
-2017-09-30,LV,Latvia,5.7441
-2017-09-30,MA,Morocco,5.2801
-2017-09-30,MK,North Macedonia,-2.3741
+2017-09-30,KR,Korea,-0.7471
+2017-09-30,LT,Lithuania,4.0046
+2017-09-30,LU,Luxembourg,2.9939
+2017-09-30,LV,Latvia,5.7024
+2017-09-30,MA,Morocco,1.595
+2017-09-30,MK,North Macedonia,-2.4162
 2017-09-30,MT,Malta,3.7664
 2017-09-30,MX,Mexico,1.3297
 2017-09-30,MY,Malaysia,2.7566
-2017-09-30,NL,Netherlands,5.9317
-2017-09-30,NO,Norway,0.9569
+2017-09-30,NL,Netherlands,6.6229
+2017-09-30,NO,Norway,0.9188
 2017-09-30,NZ,New Zealand,1.7154
 2017-09-30,PE,Peru,-0.4982
 2017-09-30,PH,Philippines,-0.8593
 2017-09-30,PL,Poland,1.7893
 2017-09-30,PT,Portugal,9.1762
 2017-09-30,RO,Romania,4.1256
-2017-09-30,RS,Serbia,-3.7367
-2017-09-30,RU,Russia,-6.7002
-2017-09-30,SE,Sweden,5.2671
-2017-09-30,SG,Singapore,-0.6619
-2017-09-30,SI,Slovenia,6.898
-2017-09-30,SK,Slovak Republic,5.6583
-2017-09-30,TH,Thailand,2.9421
-2017-09-30,TR,Türkiye,-1.1648
-2017-09-30,US,United States,3.9442
-2017-09-30,XM,Euro area,2.8454
-2017-09-30,XW,World,2.9643
-2017-09-30,ZA,South Africa,-0.6353
-2017-12-31,4T,Emerging market economies (aggregate),1.4407
-2017-12-31,5R,Advanced economies,3.4111
-2017-12-31,AE,United Arab Emirates,-5.8814
+2017-09-30,RS,Serbia,-3.5424
+2017-09-30,RU,Russia,-6.6781
+2017-09-30,SE,Sweden,5.2648
+2017-09-30,SG,Singapore,-0.6611
+2017-09-30,SI,Slovenia,6.9036
+2017-09-30,SK,Slovakia,5.6841
+2017-09-30,TH,Thailand,3.8987
+2017-09-30,TR,Türkiye,-0.4844
+2017-09-30,US,United States,3.9501
+2017-09-30,XM,Euro area,2.8399
+2017-09-30,XW,World,3.0384
+2017-09-30,ZA,South Africa,-0.5869
+2017-12-31,4T,Emerging market economies (aggregate),1.5243
+2017-12-31,5R,Advanced economies,3.3031
 2017-12-31,AT,Austria,2.4134
-2017-12-31,AU,Australia,3.0121
-2017-12-31,BE,Belgium,1.4511
-2017-12-31,BG,Bulgaria,5.2652
-2017-12-31,BR,Brazil,-3.8225
-2017-12-31,CA,Canada,11.8824
-2017-12-31,CH,Switzerland,2.5259
+2017-12-31,AU,Australia,2.97
+2017-12-31,BE,Belgium,1.0281
+2017-12-31,BG,Bulgaria,5.2482
+2017-12-31,BR,Brazil,-3.8152
+2017-12-31,CA,Canada,11.8733
+2017-12-31,CH,Switzerland,2.5263
 2017-12-31,CL,Chile,7.5038
 2017-12-31,CN,China,3.263
-2017-12-31,CO,Colombia,3.0925
+2017-12-31,CO,Colombia,2.7055
 2017-12-31,CY,Cyprus,1.8442
-2017-12-31,CZ,Czechia,5.6714
+2017-12-31,CZ,Czechia,5.6669
 2017-12-31,DE,Germany,4.7637
-2017-12-31,DK,Denmark,3.1906
+2017-12-31,DK,Denmark,3.219
 2017-12-31,EE,Estonia,1.0472
-2017-12-31,ES,Spain,5.6636
+2017-12-31,ES,Spain,5.6642
 2017-12-31,FI,Finland,0.3852
-2017-12-31,FR,France,2.1736
-2017-12-31,GB,United Kingdom,1.6321
-2017-12-31,GR,Greece,-1.2482
+2017-12-31,FR,France,2.1753
+2017-12-31,GB,United Kingdom,1.5434
+2017-12-31,GR,Greece,-1.2483
 2017-12-31,HK,Hong Kong SAR,11.8558
-2017-12-31,HR,Croatia,6.2156
+2017-12-31,HR,Croatia,6.1598
 2017-12-31,HU,Hungary,10.3061
 2017-12-31,ID,Indonesia,0.0073
-2017-12-31,IE,Ireland,11.1088
-2017-12-31,IL,Israel,1.7557
-2017-12-31,IN,India,2.5323
-2017-12-31,IS,Iceland,12.9374
-2017-12-31,IT,Italy,-2.0804
+2017-12-31,IE,Ireland,11.2291
+2017-12-31,IL,Israel,1.7562
+2017-12-31,IN,India,2.4983
+2017-12-31,IS,Iceland,12.9425
+2017-12-31,IT,Italy,-2.1157
 2017-12-31,JP,Japan,1.2281
-2017-12-31,KR,Korea,-0.2158
-2017-12-31,LT,Lithuania,2.5631
-2017-12-31,LU,Luxembourg,2.5666
-2017-12-31,LV,Latvia,5.2349
-2017-12-31,MA,Morocco,0.4494
-2017-12-31,MK,North Macedonia,-2.4505
+2017-12-31,KR,Korea,-0.1796
+2017-12-31,LT,Lithuania,2.563
+2017-12-31,LU,Luxembourg,2.5672
+2017-12-31,LV,Latvia,5.2544
+2017-12-31,MA,Morocco,-1.043
+2017-12-31,MK,North Macedonia,-2.6899
 2017-12-31,MT,Malta,3.6269
 2017-12-31,MX,Mexico,1.8497
 2017-12-31,MY,Malaysia,2.4898
-2017-12-31,NL,Netherlands,7.0349
-2017-12-31,NO,Norway,-0.5963
+2017-12-31,NL,Netherlands,7.4738
+2017-12-31,NO,Norway,-0.575
 2017-12-31,NZ,New Zealand,2.4235
 2017-12-31,PE,Peru,-1.4161
 2017-12-31,PH,Philippines,2.4611
 2017-12-31,PL,Poland,1.5288
 2017-12-31,PT,Portugal,8.8868
 2017-12-31,RO,Romania,2.4017
-2017-12-31,RS,Serbia,-4.5804
-2017-12-31,RU,Russia,-5.4552
-2017-12-31,SE,Sweden,0.9845
-2017-12-31,SG,Singapore,0.6305
-2017-12-31,SI,Slovenia,8.4713
-2017-12-31,SK,Slovak Republic,3.8987
-2017-12-31,TH,Thailand,4.28
-2017-12-31,TR,Türkiye,-2.8456
-2017-12-31,US,United States,3.8166
-2017-12-31,XM,Euro area,3.2359
-2017-12-31,XW,World,2.3665
-2017-12-31,ZA,South Africa,-0.7512
-2018-03-31,4T,Emerging market economies (aggregate),1.5282
-2018-03-31,5R,Advanced economies,3.1155
-2018-03-31,AE,United Arab Emirates,-9.2177
+2017-12-31,RS,Serbia,-4.0385
+2017-12-31,RU,Russia,-5.4543
+2017-12-31,SE,Sweden,0.9781
+2017-12-31,SG,Singapore,0.6304
+2017-12-31,SI,Slovenia,8.4352
+2017-12-31,SK,Slovakia,4.0058
+2017-12-31,TH,Thailand,3.8927
+2017-12-31,TR,Türkiye,-2.3794
+2017-12-31,US,United States,3.8332
+2017-12-31,XM,Euro area,3.2294
+2017-12-31,XW,World,2.4235
+2017-12-31,ZA,South Africa,-0.4353
+2018-03-31,4T,Emerging market economies (aggregate),1.581
+2018-03-31,5R,Advanced economies,3.1077
 2018-03-31,AT,Austria,5.3873
-2018-03-31,AU,Australia,0.1154
-2018-03-31,BE,Belgium,0.9918
-2018-03-31,BG,Bulgaria,4.9838
-2018-03-31,BR,Brazil,-3.15
+2018-03-31,AU,Australia,0.0876
+2018-03-31,BE,Belgium,1.3377
+2018-03-31,BG,Bulgaria,4.926
+2018-03-31,BR,Brazil,-3.1407
 2018-03-31,CA,Canada,5.2778
 2018-03-31,CH,Switzerland,2.2909
 2018-03-31,CL,Chile,6.3465
 2018-03-31,CN,China,2.3376
-2018-03-31,CO,Colombia,3.4852
+2018-03-31,CO,Colombia,2.9104
 2018-03-31,CY,Cyprus,2.6397
-2018-03-31,CZ,Czechia,5.6165
+2018-03-31,CZ,Czechia,5.6027
 2018-03-31,DE,Germany,5.3008
-2018-03-31,DK,Denmark,5.1904
+2018-03-31,DK,Denmark,5.1723
 2018-03-31,EE,Estonia,3.3454
-2018-03-31,ES,Spain,5.244
+2018-03-31,ES,Spain,5.2441
 2018-03-31,FI,Finland,0.247
-2018-03-31,FR,France,1.5454
-2018-03-31,GB,United Kingdom,1.4948
-2018-03-31,GR,Greece,0.5887
+2018-03-31,FR,France,1.5405
+2018-03-31,GB,United Kingdom,1.5867
+2018-03-31,GR,Greece,0.5954
 2018-03-31,HK,Hong Kong SAR,12.8977
-2018-03-31,HR,Croatia,7.3816
-2018-03-31,HU,Hungary,11.194
+2018-03-31,HR,Croatia,7.364
+2018-03-31,HU,Hungary,11.1939
 2018-03-31,ID,Indonesia,0.4005
-2018-03-31,IE,Ireland,11.967
-2018-03-31,IL,Israel,0.1787
-2018-03-31,IN,India,2.0185
-2018-03-31,IS,Iceland,10.4687
-2018-03-31,IT,Italy,-1.2227
+2018-03-31,IE,Ireland,12.0782
+2018-03-31,IL,Israel,0.1783
+2018-03-31,IN,India,2.008
+2018-03-31,IS,Iceland,10.4679
+2018-03-31,IT,Italy,-1.2251
 2018-03-31,JP,Japan,0.24
-2018-03-31,KR,Korea,0.5301
+2018-03-31,KR,Korea,0.5378
 2018-03-31,LT,Lithuania,4.2816
-2018-03-31,LU,Luxembourg,5.2327
-2018-03-31,LV,Latvia,9.2223
-2018-03-31,MA,Morocco,-1.7671
-2018-03-31,MK,North Macedonia,2.4037
+2018-03-31,LU,Luxembourg,5.2333
+2018-03-31,LV,Latvia,9.2122
+2018-03-31,MA,Morocco,-1.9433
+2018-03-31,MK,North Macedonia,2.5225
 2018-03-31,MT,Malta,4.4688
 2018-03-31,MX,Mexico,2.9651
 2018-03-31,MY,Malaysia,2.4733
-2018-03-31,NL,Netherlands,8.0015
-2018-03-31,NO,Norway,-3.0061
+2018-03-31,NL,Netherlands,7.8241
+2018-03-31,NO,Norway,-3.0168
 2018-03-31,NZ,New Zealand,2.4561
 2018-03-31,PE,Peru,-1.6644
 2018-03-31,PH,Philippines,-1.9118
 2018-03-31,PL,Poland,4.2636
 2018-03-31,PT,Portugal,11.3825
 2018-03-31,RO,Romania,1.694
-2018-03-31,RS,Serbia,4.481
-2018-03-31,RU,Russia,-1.9373
-2018-03-31,SE,Sweden,-2.3413
-2018-03-31,SG,Singapore,5.1578
-2018-03-31,SI,Slovenia,8.199
-2018-03-31,SK,Slovak Republic,9.1699
-2018-03-31,TH,Thailand,6.2934
-2018-03-31,TR,Türkiye,-2.0966
-2018-03-31,US,United States,3.9478
-2018-03-31,XM,Euro area,3.6443
-2018-03-31,XW,World,2.2677
-2018-03-31,ZA,South Africa,-0.5165
-2018-06-30,4T,Emerging market economies (aggregate),1.2453
-2018-06-30,5R,Advanced economies,2.4497
-2018-06-30,AE,United Arab Emirates,-10.1528
+2018-03-31,RS,Serbia,6.0374
+2018-03-31,RU,Russia,-1.9574
+2018-03-31,SE,Sweden,-2.3374
+2018-03-31,SG,Singapore,5.1584
+2018-03-31,SI,Slovenia,8.2214
+2018-03-31,SK,Slovakia,9.3993
+2018-03-31,TH,Thailand,5.6332
+2018-03-31,TR,Türkiye,-1.943
+2018-03-31,US,United States,3.94
+2018-03-31,XM,Euro area,3.6366
+2018-03-31,XW,World,2.3445
+2018-03-31,ZA,South Africa,-0.0881
+2018-06-30,4T,Emerging market economies (aggregate),1.27
+2018-06-30,5R,Advanced economies,2.5255
 2018-06-30,AT,Austria,2.9188
-2018-06-30,AU,Australia,-2.6372
-2018-06-30,BE,Belgium,2.0353
-2018-06-30,BG,Bulgaria,4.8004
-2018-06-30,BR,Brazil,-3.0206
+2018-06-30,AU,Australia,-2.653
+2018-06-30,BE,Belgium,2.0141
+2018-06-30,BG,Bulgaria,4.7632
+2018-06-30,BR,Brazil,-3.0095
 2018-06-30,CA,Canada,0.661
 2018-06-30,CH,Switzerland,2.2599
 2018-06-30,CL,Chile,7.3912
 2018-06-30,CN,China,2.2335
-2018-06-30,CO,Colombia,3.8249
+2018-06-30,CO,Colombia,3.8996
 2018-06-30,CY,Cyprus,0.5878
-2018-06-30,CZ,Czechia,5.6629
+2018-06-30,CZ,Czechia,5.6166
 2018-06-30,DE,Germany,4.7916
-2018-06-30,DK,Denmark,3.5928
+2018-06-30,DK,Denmark,3.588
 2018-06-30,EE,Estonia,3.9179
-2018-06-30,ES,Spain,4.9129
+2018-06-30,ES,Spain,4.9126
 2018-06-30,FI,Finland,-0.2017
-2018-06-30,FR,France,0.8896
-2018-06-30,GB,United Kingdom,0.6772
-2018-06-30,GR,Greece,0.7259
-2018-06-30,HK,Hong Kong SAR,12.7108
-2018-06-30,HR,Croatia,2.5462
-2018-06-30,HU,Hungary,10.5452
+2018-06-30,FR,France,0.8866
+2018-06-30,GB,United Kingdom,0.7754
+2018-06-30,GR,Greece,0.7357
+2018-06-30,HK,Hong Kong SAR,12.7558
+2018-06-30,HR,Croatia,2.5684
+2018-06-30,HU,Hungary,10.5451
 2018-06-30,ID,Indonesia,-0.1662
-2018-06-30,IE,Ireland,12.3921
-2018-06-30,IL,Israel,-1.0566
-2018-06-30,IN,India,0.5111
-2018-06-30,IS,Iceland,4.506
-2018-06-30,IT,Italy,-1.3115
+2018-06-30,IE,Ireland,12.421
+2018-06-30,IL,Israel,-1.0564
+2018-06-30,IN,India,0.5367
+2018-06-30,IS,Iceland,4.4935
+2018-06-30,IT,Italy,-1.3102
 2018-06-30,JP,Japan,1.2259
-2018-06-30,KR,Korea,0.4589
+2018-06-30,KR,Korea,0.4806
 2018-06-30,LT,Lithuania,4.6599
-2018-06-30,LU,Luxembourg,3.7491
-2018-06-30,LV,Latvia,6.1802
-2018-06-30,MA,Morocco,-2.1164
-2018-06-30,MK,North Macedonia,0.9846
+2018-06-30,LU,Luxembourg,3.7465
+2018-06-30,LV,Latvia,6.1552
+2018-06-30,MA,Morocco,-2.2876
+2018-06-30,MK,North Macedonia,1.0392
 2018-06-30,MT,Malta,5.0965
 2018-06-30,MX,Mexico,3.9221
 2018-06-30,MY,Malaysia,2.3028
-2018-06-30,NL,Netherlands,7.5866
-2018-06-30,NO,Norway,-0.7252
+2018-06-30,NL,Netherlands,7.7487
+2018-06-30,NO,Norway,-0.6314
 2018-06-30,NZ,New Zealand,2.0826
 2018-06-30,PE,Peru,-1.1533
 2018-06-30,PH,Philippines,-0.1369
 2018-06-30,PL,Poland,4.1873
-2018-06-30,PT,Portugal,10.1529
+2018-06-30,PT,Portugal,10.153
 2018-06-30,RO,Romania,-0.0782
-2018-06-30,RS,Serbia,4.4006
-2018-06-30,RU,Russia,-0.7976
-2018-06-30,SE,Sweden,-3.5001
-2018-06-30,SG,Singapore,8.7219
-2018-06-30,SI,Slovenia,5.7504
-2018-06-30,SK,Slovak Republic,4.04
-2018-06-30,TH,Thailand,4.2139
-2018-06-30,TR,Türkiye,-3.5647
-2018-06-30,US,United States,3.1555
-2018-06-30,XM,Euro area,3.1834
-2018-06-30,XW,World,1.8159
-2018-06-30,ZA,South Africa,-0.7979
-2018-09-30,4T,Emerging market economies (aggregate),1.652
-2018-09-30,5R,Advanced economies,1.9401
-2018-09-30,AE,United Arab Emirates,-11.1496
+2018-06-30,RS,Serbia,5.6291
+2018-06-30,RU,Russia,-0.8102
+2018-06-30,SE,Sweden,-3.4946
+2018-06-30,SG,Singapore,8.7226
+2018-06-30,SI,Slovenia,5.7384
+2018-06-30,SK,Slovakia,4.2361
+2018-06-30,TH,Thailand,4.6747
+2018-06-30,TR,Türkiye,-3.9164
+2018-06-30,US,United States,3.1647
+2018-06-30,XM,Euro area,3.1659
+2018-06-30,XW,World,1.9079
+2018-06-30,ZA,South Africa,-0.9597
+2018-09-30,4T,Emerging market economies (aggregate),1.8303
+2018-09-30,5R,Advanced economies,2.047
 2018-09-30,AT,Austria,5.7108
-2018-09-30,AU,Australia,-3.73
-2018-09-30,BE,Belgium,0.282
-2018-09-30,BG,Bulgaria,2.6527
-2018-09-30,BR,Brazil,-3.4065
+2018-09-30,AU,Australia,-3.7567
+2018-09-30,BE,Belgium,0.3631
+2018-09-30,BG,Bulgaria,2.6497
+2018-09-30,BR,Brazil,-3.3954
 2018-09-30,CA,Canada,-0.7983
-2018-09-30,CH,Switzerland,0.8044
-2018-09-30,CL,Chile,8.7365
+2018-09-30,CH,Switzerland,0.8043
+2018-09-30,CL,Chile,8.7366
 2018-09-30,CN,China,3.6349
-2018-09-30,CO,Colombia,1.4524
+2018-09-30,CO,Colombia,1.6563
 2018-09-30,CY,Cyprus,-0.5982
-2018-09-30,CZ,Czechia,6.2903
+2018-09-30,CZ,Czechia,6.2739
 2018-09-30,DE,Germany,5.0308
-2018-09-30,DK,Denmark,3.6783
+2018-09-30,DK,Denmark,3.6621
 2018-09-30,EE,Estonia,0.5204
-2018-09-30,ES,Spain,4.821
+2018-09-30,ES,Spain,4.8199
 2018-09-30,FI,Finland,-0.3161
-2018-09-30,FR,France,0.4845
-2018-09-30,GB,United Kingdom,0.28
-2018-09-30,GR,Greece,1.2954
+2018-09-30,FR,France,0.4872
+2018-09-30,GB,United Kingdom,0.2537
+2018-09-30,GR,Greece,1.292
 2018-09-30,HK,Hong Kong SAR,13.0111
-2018-09-30,HR,Croatia,4.8831
+2018-09-30,HR,Croatia,4.8248
 2018-09-30,HU,Hungary,11.043
 2018-09-30,ID,Indonesia,-0.1975
-2018-09-30,IE,Ireland,8.2403
-2018-09-30,IL,Israel,-3.0496
-2018-09-30,IN,India,1.7599
-2018-09-30,IS,Iceland,2.2539
-2018-09-30,IT,Italy,-2.2538
+2018-09-30,IE,Ireland,8.2915
+2018-09-30,IL,Israel,-3.0499
+2018-09-30,IN,India,1.8133
+2018-09-30,IS,Iceland,2.2666
+2018-09-30,IT,Italy,-2.254
 2018-09-30,JP,Japan,0.662
-2018-09-30,KR,Korea,0.5646
+2018-09-30,KR,Korea,0.557
 2018-09-30,LT,Lithuania,4.1476
-2018-09-30,LU,Luxembourg,5.7754
-2018-09-30,LV,Latvia,4.2086
-2018-09-30,MA,Morocco,-1.9707
-2018-09-30,MK,North Macedonia,1.4395
+2018-09-30,LU,Luxembourg,5.7696
+2018-09-30,LV,Latvia,4.242
+2018-09-30,MA,Morocco,-1.8051
+2018-09-30,MK,North Macedonia,1.7064
 2018-09-30,MT,Malta,4.2694
 2018-09-30,MX,Mexico,3.9422
 2018-09-30,MY,Malaysia,2.2507
-2018-09-30,NL,Netherlands,7.9558
-2018-09-30,NO,Norway,-0.3156
+2018-09-30,NL,Netherlands,7.5642
+2018-09-30,NO,Norway,-0.2926
 2018-09-30,NZ,New Zealand,1.9246
 2018-09-30,PE,Peru,-0.8928
 2018-09-30,PH,Philippines,-1.8352
 2018-09-30,PL,Poland,4.25
 2018-09-30,PT,Portugal,6.9674
 2018-09-30,RO,Romania,1.3297
-2018-09-30,RS,Serbia,4.4424
-2018-09-30,RU,Russia,0.1882
-2018-09-30,SE,Sweden,-4.1039
-2018-09-30,SG,Singapore,8.0394
-2018-09-30,SI,Slovenia,7.332
-2018-09-30,SK,Slovak Republic,1.5887
-2018-09-30,TH,Thailand,3.8261
-2018-09-30,TR,Türkiye,-10.9906
-2018-09-30,US,United States,2.6673
-2018-09-30,XM,Euro area,2.8042
-2018-09-30,XW,World,1.7909
-2018-09-30,ZA,South Africa,-0.9459
-2018-12-31,4T,Emerging market economies (aggregate),2.2227
-2018-12-31,5R,Advanced economies,1.9151
-2018-12-31,AE,United Arab Emirates,-9.8928
-2018-12-31,AT,Austria,5.2061
-2018-12-31,AU,Australia,-6.8116
-2018-12-31,BE,Belgium,-0.1002
-2018-12-31,BG,Bulgaria,2.3217
-2018-12-31,BR,Brazil,-2.5454
+2018-09-30,RS,Serbia,5.2713
+2018-09-30,RU,Russia,0.1633
+2018-09-30,SE,Sweden,-4.1022
+2018-09-30,SG,Singapore,8.038
+2018-09-30,SI,Slovenia,7.3237
+2018-09-30,SK,Slovakia,1.6029
+2018-09-30,TH,Thailand,4.1265
+2018-09-30,TR,Türkiye,-9.57
+2018-09-30,US,United States,2.692
+2018-09-30,XM,Euro area,2.8037
+2018-09-30,XW,World,1.9437
+2018-09-30,ZA,South Africa,-1.5704
+2018-12-31,4T,Emerging market economies (aggregate),2.4756
+2018-12-31,5R,Advanced economies,1.9884
+2018-12-31,AT,Austria,5.2062
+2018-12-31,AU,Australia,-6.789
+2018-12-31,BE,Belgium,0.102
+2018-12-31,BG,Bulgaria,2.3325
+2018-12-31,BR,Brazil,-2.5345
 2018-12-31,CA,Canada,-0.2621
 2018-12-31,CH,Switzerland,2.7267
 2018-12-31,CL,Chile,7.0403
 2018-12-31,CN,China,4.9987
-2018-12-31,CO,Colombia,0.2954
+2018-12-31,CO,Colombia,-0.2159
 2018-12-31,CY,Cyprus,0.0671
-2018-12-31,CZ,Czechia,7.6467
+2018-12-31,CZ,Czechia,7.6937
 2018-12-31,DE,Germany,4.1777
-2018-12-31,DK,Denmark,3.0314
+2018-12-31,DK,Denmark,3.0242
 2018-12-31,EE,Estonia,1.8906
-2018-12-31,ES,Spain,4.8915
+2018-12-31,ES,Spain,4.8911
 2018-12-31,FI,Finland,-0.2435
-2018-12-31,FR,France,1.3108
-2018-12-31,GB,United Kingdom,0.1071
+2018-12-31,FR,France,1.3103
+2018-12-31,GB,United Kingdom,0.1268
 2018-12-31,GR,Greece,2.0712
 2018-12-31,HK,Hong Kong SAR,3.1857
-2018-12-31,HR,Croatia,3.3105
+2018-12-31,HR,Croatia,3.3711
 2018-12-31,HU,Hungary,11.8146
 2018-12-31,ID,Indonesia,-0.4666
-2018-12-31,IE,Ireland,6.4755
-2018-12-31,IL,Israel,-2.5101
-2018-12-31,IN,India,2.4657
-2018-12-31,IS,Iceland,3.505
-2018-12-31,IT,Italy,-1.8983
+2018-12-31,IE,Ireland,6.474
+2018-12-31,IL,Israel,-2.5099
+2018-12-31,IN,India,2.4831
+2018-12-31,IS,Iceland,3.497
+2018-12-31,IT,Italy,-1.8958
 2018-12-31,JP,Japan,1.625
-2018-12-31,KR,Korea,1.4221
+2018-12-31,KR,Korea,1.3652
 2018-12-31,LT,Lithuania,4.8273
-2018-12-31,LU,Luxembourg,6.9774
-2018-12-31,LV,Latvia,7.9327
-2018-12-31,MA,Morocco,0.1673
-2018-12-31,MK,North Macedonia,0.9244
+2018-12-31,LU,Luxembourg,6.9764
+2018-12-31,LV,Latvia,7.9201
+2018-12-31,MA,Morocco,0.0078
+2018-12-31,MK,North Macedonia,1.159
 2018-12-31,MT,Malta,4.5416
 2018-12-31,MX,Mexico,4.2926
 2018-12-31,MY,Malaysia,2.2088
-2018-12-31,NL,Netherlands,6.9484
-2018-12-31,NO,Norway,-1.0525
+2018-12-31,NL,Netherlands,6.7682
+2018-12-31,NO,Norway,-1.0658
 2018-12-31,NZ,New Zealand,1.4018
 2018-12-31,PE,Peru,-0.5225
 2018-12-31,PH,Philippines,-5.2207
 2018-12-31,PL,Poland,6.0539
 2018-12-31,PT,Portugal,8.4209
 2018-12-31,RO,Romania,1.5758
-2018-12-31,RS,Serbia,5.7266
-2018-12-31,RU,Russia,1.0009
-2018-12-31,SE,Sweden,-1.3395
-2018-12-31,SG,Singapore,7.3366
-2018-12-31,SI,Slovenia,6.2609
-2018-12-31,SK,Slovak Republic,4.569
-2018-12-31,TH,Thailand,2.4244
-2018-12-31,TR,Türkiye,-14.6439
-2018-12-31,US,United States,2.376
-2018-12-31,XM,Euro area,2.852
-2018-12-31,XW,World,2.0838
-2018-12-31,ZA,South Africa,-0.8394
-2019-03-31,4T,Emerging market economies (aggregate),2.548
-2019-03-31,5R,Advanced economies,1.7097
-2019-03-31,AE,United Arab Emirates,-4.9849
+2018-12-31,RS,Serbia,6.386
+2018-12-31,RU,Russia,1.0119
+2018-12-31,SE,Sweden,-1.3379
+2018-12-31,SG,Singapore,7.3361
+2018-12-31,SI,Slovenia,6.2812
+2018-12-31,SK,Slovakia,4.504
+2018-12-31,TH,Thailand,1.534
+2018-12-31,TR,Türkiye,-12.6275
+2018-12-31,US,United States,2.3777
+2018-12-31,XM,Euro area,2.8537
+2018-12-31,XW,World,2.2366
+2018-12-31,ZA,South Africa,-1.5786
+2019-03-31,4T,Emerging market economies (aggregate),2.7599
+2019-03-31,5R,Advanced economies,1.7676
 2019-03-31,AT,Austria,3.1506
-2019-03-31,AU,Australia,-8.5848
-2019-03-31,BE,Belgium,1.4018
-2019-03-31,BG,Bulgaria,3.882
-2019-03-31,BR,Brazil,-1.8693
+2019-03-31,AU,Australia,-8.5595
+2019-03-31,BE,Belgium,1.1928
+2019-03-31,BG,Bulgaria,3.9105
+2019-03-31,BR,Brazil,-1.8604
 2019-03-31,CA,Canada,-1.01
 2019-03-31,CH,Switzerland,4.107
 2019-03-31,CL,Chile,7.5109
 2019-03-31,CN,China,5.6956
-2019-03-31,CO,Colombia,2.4295
+2019-03-31,CO,Colombia,2.2999
 2019-03-31,CY,Cyprus,1.1133
-2019-03-31,CZ,Czechia,6.8618
+2019-03-31,CZ,Czechia,6.8508
 2019-03-31,DE,Germany,3.9074
-2019-03-31,DK,Denmark,1.6349
+2019-03-31,DK,Denmark,1.6484
 2019-03-31,EE,Estonia,3.5451
 2019-03-31,ES,Spain,5.6887
 2019-03-31,FI,Finland,-0.7579
-2019-03-31,FR,France,1.6963
-2019-03-31,GB,United Kingdom,-0.4783
-2019-03-31,GR,Greece,4.7999
+2019-03-31,FR,France,1.6972
+2019-03-31,GB,United Kingdom,-0.4499
+2019-03-31,GR,Greece,4.7964
 2019-03-31,HK,Hong Kong SAR,-0.9006
-2019-03-31,HR,Croatia,6.8929
+2019-03-31,HR,Croatia,6.9725
 2019-03-31,HU,Hungary,15.3891
 2019-03-31,ID,Indonesia,-0.9682
-2019-03-31,IE,Ireland,3.6217
-2019-03-31,IL,Israel,-0.4428
-2019-03-31,IN,India,1.136
+2019-03-31,IE,Ireland,3.5482
+2019-03-31,IL,Israel,-0.4427
+2019-03-31,IN,India,1.1445
 2019-03-31,IS,Iceland,1.2308
-2019-03-31,IT,Italy,-1.8467
+2019-03-31,IT,Italy,-1.8448
 2019-03-31,JP,Japan,2.0026
-2019-03-31,KR,Korea,2.1048
-2019-03-31,LT,Lithuania,5.5977
-2019-03-31,LU,Luxembourg,4.8802
-2019-03-31,LV,Latvia,3.3891
-2019-03-31,MA,Morocco,0.1982
-2019-03-31,MK,North Macedonia,0.5423
+2019-03-31,KR,Korea,2.124
+2019-03-31,LT,Lithuania,5.5976
+2019-03-31,LU,Luxembourg,4.88
+2019-03-31,LV,Latvia,3.4259
+2019-03-31,MA,Morocco,-0.3366
+2019-03-31,MK,North Macedonia,0.4471
 2019-03-31,MT,Malta,4.6179
 2019-03-31,MX,Mexico,4.7356
 2019-03-31,MY,Malaysia,2.8216
-2019-03-31,NL,Netherlands,5.4606
-2019-03-31,NO,Norway,0.0374
+2019-03-31,NL,Netherlands,5.6943
+2019-03-31,NO,Norway,0.0673
 2019-03-31,NZ,New Zealand,1.0895
 2019-03-31,PE,Peru,0.4341
-2019-03-31,PH,Philippines,-0.6273
+2019-03-31,PH,Philippines,-0.7755
 2019-03-31,PL,Poland,6.8011
-2019-03-31,PT,Portugal,8.3881
+2019-03-31,PT,Portugal,8.3882
 2019-03-31,RO,Romania,-0.2904
-2019-03-31,RS,Serbia,6.3849
-2019-03-31,RU,Russia,1.9727
-2019-03-31,SE,Sweden,-0.3444
-2019-03-31,SG,Singapore,2.6139
-2019-03-31,SI,Slovenia,6.1824
-2019-03-31,SK,Slovak Republic,3.2791
-2019-03-31,TH,Thailand,1.3912
-2019-03-31,TR,Türkiye,-14.0012
-2019-03-31,US,United States,2.1162
-2019-03-31,XM,Euro area,2.7112
-2019-03-31,XW,World,2.1588
-2019-03-31,ZA,South Africa,-0.5379
-2019-06-30,4T,Emerging market economies (aggregate),1.7786
-2019-06-30,5R,Advanced economies,1.4686
-2019-06-30,AE,United Arab Emirates,-7.8156
+2019-03-31,RS,Serbia,7.0147
+2019-03-31,RU,Russia,1.9846
+2019-03-31,SE,Sweden,-0.3455
+2019-03-31,SG,Singapore,2.6109
+2019-03-31,SI,Slovenia,6.1593
+2019-03-31,SK,Slovakia,3.2135
+2019-03-31,TH,Thailand,0.2085
+2019-03-31,TR,Türkiye,-13.2002
+2019-03-31,US,United States,2.143
+2019-03-31,XM,Euro area,2.7214
+2019-03-31,XW,World,2.2653
+2019-03-31,ZA,South Africa,-0.8874
+2019-06-30,4T,Emerging market economies (aggregate),2.0295
+2019-06-30,5R,Advanced economies,1.4912
 2019-06-30,AT,Austria,3.8181
-2019-06-30,AU,Australia,-8.8692
-2019-06-30,BE,Belgium,1.0964
-2019-06-30,BG,Bulgaria,1.6274
-2019-06-30,BR,Brazil,-1.3146
+2019-06-30,AU,Australia,-8.8231
+2019-06-30,BE,Belgium,1.1476
+2019-06-30,BG,Bulgaria,1.6319
+2019-06-30,BR,Brazil,-1.313
 2019-06-30,CA,Canada,-1.9146
-2019-06-30,CH,Switzerland,2.9889
+2019-06-30,CH,Switzerland,2.9888
 2019-06-30,CL,Chile,5.0549
 2019-06-30,CN,China,4.4834
-2019-06-30,CO,Colombia,0.0449
+2019-06-30,CO,Colombia,-0.161
 2019-06-30,CY,Cyprus,2.432
-2019-06-30,CZ,Czechia,6.2491
+2019-06-30,CZ,Czechia,6.3191
 2019-06-30,DE,Germany,4.208
-2019-06-30,DK,Denmark,1.9179
+2019-06-30,DK,Denmark,1.9419
 2019-06-30,EE,Estonia,2.7733
-2019-06-30,ES,Spain,4.4445
+2019-06-30,ES,Spain,4.4451
 2019-06-30,FI,Finland,-0.5506
-2019-06-30,FR,France,2.0486
-2019-06-30,GB,United Kingdom,-0.9914
-2019-06-30,GR,Greece,7.2521
-2019-06-30,HK,Hong Kong SAR,-0.1715
-2019-06-30,HR,Croatia,9.5507
+2019-06-30,FR,France,2.0515
+2019-06-30,GB,United Kingdom,-1.0012
+2019-06-30,GR,Greece,7.2451
+2019-06-30,HK,Hong Kong SAR,-0.2052
+2019-06-30,HR,Croatia,9.4742
 2019-06-30,HU,Hungary,15.3456
 2019-06-30,ID,Indonesia,-1.8255
-2019-06-30,IE,Ireland,1.2542
-2019-06-30,IL,Israel,0.0074
-2019-06-30,IN,India,0.3637
-2019-06-30,IS,Iceland,0.7417
+2019-06-30,IE,Ireland,1.3059
+2019-06-30,IL,Israel,0.0071
+2019-06-30,IN,India,0.3136
+2019-06-30,IS,Iceland,0.7487
 2019-06-30,IT,Italy,-0.9411
 2019-06-30,JP,Japan,1.1865
-2019-06-30,KR,Korea,1.2178
+2019-06-30,KR,Korea,1.1903
 2019-06-30,LT,Lithuania,3.8339
-2019-06-30,LU,Luxembourg,9.1699
-2019-06-30,LV,Latvia,4.497
-2019-06-30,MA,Morocco,-0.425
-2019-06-30,MK,North Macedonia,4.2196
+2019-06-30,LU,Luxembourg,9.1681
+2019-06-30,LV,Latvia,4.4917
+2019-06-30,MA,Morocco,-0.7844
+2019-06-30,MK,North Macedonia,4.2921
 2019-06-30,MT,Malta,4.3474
 2019-06-30,MX,Mexico,4.7624
 2019-06-30,MY,Malaysia,1.6836
-2019-06-30,NL,Netherlands,5.5217
-2019-06-30,NO,Norway,-0.4513
+2019-06-30,NL,Netherlands,4.9654
+2019-06-30,NO,Norway,-0.5195
 2019-06-30,NZ,New Zealand,0.322
 2019-06-30,PE,Peru,2.1439
-2019-06-30,PH,Philippines,-2.1603
+2019-06-30,PH,Philippines,2.9629
 2019-06-30,PL,Poland,5.7107
-2019-06-30,PT,Portugal,8.891
+2019-06-30,PT,Portugal,8.8909
 2019-06-30,RO,Romania,-2.2484
-2019-06-30,RS,Serbia,7.3171
-2019-06-30,RU,Russia,1.8337
-2019-06-30,SE,Sweden,0.1399
-2019-06-30,SG,Singapore,0.4226
-2019-06-30,SI,Slovenia,5.6778
-2019-06-30,SK,Slovak Republic,5.6354
-2019-06-30,TH,Thailand,-0.2699
-2019-06-30,TR,Türkiye,-13.7421
-2019-06-30,US,United States,1.7837
-2019-06-30,XM,Euro area,2.9178
-2019-06-30,XW,World,1.6375
-2019-06-30,ZA,South Africa,-0.9184
-2019-09-30,4T,Emerging market economies (aggregate),1.4778
-2019-09-30,5R,Advanced economies,1.7314
-2019-09-30,AE,United Arab Emirates,-5.452
+2019-06-30,RS,Serbia,8.3832
+2019-06-30,RU,Russia,1.8298
+2019-06-30,SE,Sweden,0.1361
+2019-06-30,SG,Singapore,0.4201
+2019-06-30,SI,Slovenia,5.6717
+2019-06-30,SK,Slovakia,5.5768
+2019-06-30,TH,Thailand,0.5438
+2019-06-30,TR,Türkiye,-13.0755
+2019-06-30,US,United States,1.8169
+2019-06-30,XM,Euro area,2.9328
+2019-06-30,XW,World,1.7641
+2019-06-30,ZA,South Africa,-1.7465
+2019-09-30,4T,Emerging market economies (aggregate),1.4787
+2019-09-30,5R,Advanced economies,1.7099
 2019-09-30,AT,Austria,0.8795
-2019-09-30,AU,Australia,-5.2816
-2019-09-30,BE,Belgium,3.3332
-2019-09-30,BG,Bulgaria,2.7886
-2019-09-30,BR,Brazil,0.7135
+2019-09-30,AU,Australia,-5.282
+2019-09-30,BE,Belgium,3.0769
+2019-09-30,BG,Bulgaria,2.7862
+2019-09-30,BR,Brazil,0.7018
 2019-09-30,CA,Canada,-1.7138
-2019-09-30,CH,Switzerland,2.8812
+2019-09-30,CH,Switzerland,2.8813
 2019-09-30,CL,Chile,5.3637
 2019-09-30,CN,China,2.1067
-2019-09-30,CO,Colombia,2.5281
+2019-09-30,CO,Colombia,1.9166
 2019-09-30,CY,Cyprus,3.4578
-2019-09-30,CZ,Czechia,5.7201
+2019-09-30,CZ,Czechia,5.7203
 2019-09-30,DE,Germany,3.8001
-2019-09-30,DK,Denmark,1.9816
+2019-09-30,DK,Denmark,2.0031
 2019-09-30,EE,Estonia,5.7638
 2019-09-30,ES,Spain,4.4711
 2019-09-30,FI,Finland,-0.4534
-2019-09-30,FR,France,2.3787
-2019-09-30,GB,United Kingdom,-1.0886
-2019-09-30,GR,Greece,8.3581
+2019-09-30,FR,France,2.3745
+2019-09-30,GB,United Kingdom,-1.0954
+2019-09-30,GR,Greece,8.3543
 2019-09-30,HK,Hong Kong SAR,-4.4819
-2019-09-30,HR,Croatia,7.1519
+2019-09-30,HR,Croatia,7.1583
 2019-09-30,HU,Hungary,13.1655
 2019-09-30,ID,Indonesia,-2.082
-2019-09-30,IE,Ireland,1.0235
-2019-09-30,IL,Israel,1.4801
-2019-09-30,IN,India,-0.215
-2019-09-30,IS,Iceland,0.2397
-2019-09-30,IT,Italy,0.0496
+2019-09-30,IE,Ireland,1.0297
+2019-09-30,IL,Israel,1.4799
+2019-09-30,IN,India,-0.3084
+2019-09-30,IS,Iceland,0.2393
+2019-09-30,IT,Italy,0.0484
 2019-09-30,JP,Japan,0.9113
-2019-09-30,KR,Korea,1.0566
+2019-09-30,KR,Korea,1.0785
 2019-09-30,LT,Lithuania,3.8457
-2019-09-30,LU,Luxembourg,9.5268
-2019-09-30,LV,Latvia,9.4822
-2019-09-30,MA,Morocco,-0.012
-2019-09-30,MK,North Macedonia,1.3111
+2019-09-30,LU,Luxembourg,9.5273
+2019-09-30,LV,Latvia,9.4742
+2019-09-30,MA,Morocco,-0.2712
+2019-09-30,MK,North Macedonia,1.0571
 2019-09-30,MT,Malta,4.2696
 2019-09-30,MX,Mexico,4.966
 2019-09-30,MY,Malaysia,0.8076
-2019-09-30,NL,Netherlands,3.4897
-2019-09-30,NO,Norway,0.6866
+2019-09-30,NL,Netherlands,3.6147
+2019-09-30,NO,Norway,0.6957
 2019-09-30,NZ,New Zealand,1.6066
 2019-09-30,PE,Peru,-0.0264
-2019-09-30,PH,Philippines,8.922
+2019-09-30,PH,Philippines,5.5587
 2019-09-30,PL,Poland,6.2195
 2019-09-30,PT,Portugal,10.9435
 2019-09-30,RO,Romania,0.349
-2019-09-30,RS,Serbia,8.6678
-2019-09-30,RU,Russia,3.6458
-2019-09-30,SE,Sweden,1.4
-2019-09-30,SG,Singapore,1.7125
-2019-09-30,SI,Slovenia,4.97
-2019-09-30,SK,Slovak Republic,8.3524
-2019-09-30,TH,Thailand,-1.035
-2019-09-30,TR,Türkiye,-5.8679
-2019-09-30,US,United States,2.0457
-2019-09-30,XM,Euro area,3.0945
-2019-09-30,XW,World,1.5941
-2019-09-30,ZA,South Africa,-0.4111
-2019-12-31,4T,Emerging market economies (aggregate),0.4459
-2019-12-31,5R,Advanced economies,2.1392
-2019-12-31,AE,United Arab Emirates,-4.5671
+2019-09-30,RS,Serbia,10.3056
+2019-09-30,RU,Russia,3.6582
+2019-09-30,SE,Sweden,1.4024
+2019-09-30,SG,Singapore,1.7101
+2019-09-30,SI,Slovenia,4.9717
+2019-09-30,SK,Slovakia,8.4664
+2019-09-30,TH,Thailand,-2.1309
+2019-09-30,TR,Türkiye,-7.7104
+2019-09-30,US,United States,2.0492
+2019-09-30,XM,Euro area,3.105
+2019-09-30,XW,World,1.5921
+2019-09-30,ZA,South Africa,-1.9173
+2019-12-31,4T,Emerging market economies (aggregate),0.3755
+2019-12-31,5R,Advanced economies,2.0889
 2019-12-31,AT,Austria,1.7019
-2019-12-31,AU,Australia,0.6476
-2019-12-31,BE,Belgium,4.2118
-2019-12-31,BG,Bulgaria,3.0461
-2019-12-31,BR,Brazil,1.5797
+2019-12-31,AU,Australia,0.6456
+2019-12-31,BE,Belgium,3.6726
+2019-12-31,BG,Bulgaria,3.0835
+2019-12-31,BR,Brazil,1.5477
 2019-12-31,CA,Canada,-0.4445
 2019-12-31,CH,Switzerland,3.5223
 2019-12-31,CL,Chile,5.0607
 2019-12-31,CN,China,-0.6327
-2019-12-31,CO,Colombia,2.5089
+2019-12-31,CO,Colombia,2.5917
 2019-12-31,CY,Cyprus,2.4103
-2019-12-31,CZ,Czechia,5.7356
+2019-12-31,CZ,Czechia,5.6777
 2019-12-31,DE,Germany,5.2275
-2019-12-31,DK,Denmark,1.8588
+2019-12-31,DK,Denmark,1.8726
 2019-12-31,EE,Estonia,6.368
-2019-12-31,ES,Spain,3.2398
+2019-12-31,ES,Spain,3.2403
 2019-12-31,FI,Finland,-0.6793
-2019-12-31,FR,France,2.6614
-2019-12-31,GB,United Kingdom,-0.567
-2019-12-31,GR,Greece,7.3772
+2019-12-31,FR,France,2.6678
+2019-12-31,GB,United Kingdom,-0.5342
+2019-12-31,GR,Greece,7.3807
 2019-12-31,HK,Hong Kong SAR,0.3048
-2019-12-31,HR,Croatia,9.0472
+2019-12-31,HR,Croatia,9.041
 2019-12-31,HU,Hungary,9.137
 2019-12-31,ID,Indonesia,-1.6576
-2019-12-31,IE,Ireland,-0.1811
-2019-12-31,IL,Israel,3.1196
-2019-12-31,IN,India,-2.7036
-2019-12-31,IS,Iceland,1.7484
-2019-12-31,IT,Italy,-0.0892
+2019-12-31,IE,Ireland,-0.2396
+2019-12-31,IL,Israel,3.1192
+2019-12-31,IN,India,-2.679
+2019-12-31,IS,Iceland,1.748
+2019-12-31,IT,Italy,-0.0916
 2019-12-31,JP,Japan,0.4545
-2019-12-31,KR,Korea,-0.2114
+2019-12-31,KR,Korea,-0.2294
 2019-12-31,LT,Lithuania,4.3888
-2019-12-31,LU,Luxembourg,9.261
-2019-12-31,LV,Latvia,6.488
-2019-12-31,MA,Morocco,-1.3393
-2019-12-31,MK,North Macedonia,3.2787
+2019-12-31,LU,Luxembourg,9.258
+2019-12-31,LV,Latvia,6.4883
+2019-12-31,MA,Morocco,-1.6158
+2019-12-31,MK,North Macedonia,3.1684
 2019-12-31,MT,Malta,4.3744
 2019-12-31,MX,Mexico,4.5829
 2019-12-31,MY,Malaysia,0.792
-2019-12-31,NL,Netherlands,3.746
-2019-12-31,NO,Norway,0.9533
+2019-12-31,NL,Netherlands,3.7517
+2019-12-31,NO,Norway,0.9733
 2019-12-31,NZ,New Zealand,2.8692
 2019-12-31,PE,Peru,-2.4593
-2019-12-31,PH,Philippines,8.9424
+2019-12-31,PH,Philippines,7.3238
 2019-12-31,PL,Poland,6.6358
-2019-12-31,PT,Portugal,10.0994
+2019-12-31,PT,Portugal,10.0995
 2019-12-31,RO,Romania,0.4243
-2019-12-31,RS,Serbia,8.449
-2019-12-31,RU,Russia,3.011
-2019-12-31,SE,Sweden,1.5321
-2019-12-31,SG,Singapore,2.0297
-2019-12-31,SI,Slovenia,3.234
-2019-12-31,SK,Slovak Republic,7.7199
-2019-12-31,TH,Thailand,1.0482
-2019-12-31,TR,Türkiye,-0.2777
-2019-12-31,US,United States,2.3864
-2019-12-31,XM,Euro area,3.2732
-2019-12-31,XW,World,1.2205
-2019-12-31,ZA,South Africa,-0.4236
-2020-03-31,4T,Emerging market economies (aggregate),0.0728
-2020-03-31,5R,Advanced economies,2.6921
-2020-03-31,AE,United Arab Emirates,-6.3215
+2019-12-31,RS,Serbia,10.4103
+2019-12-31,RU,Russia,3.0201
+2019-12-31,SE,Sweden,1.5346
+2019-12-31,SG,Singapore,2.0273
+2019-12-31,SI,Slovenia,3.228
+2019-12-31,SK,Slovakia,7.8289
+2019-12-31,TH,Thailand,1.6647
+2019-12-31,TR,Türkiye,-2.3043
+2019-12-31,US,United States,2.4016
+2019-12-31,XM,Euro area,3.2805
+2019-12-31,XW,World,1.2168
+2019-12-31,ZA,South Africa,-1.6361
+2020-03-31,4T,Emerging market economies (aggregate),0.044
+2020-03-31,5R,Advanced economies,2.6304
 2020-03-31,AT,Austria,1.4599
-2020-03-31,AU,Australia,5.0618
-2020-03-31,BE,Belgium,2.4742
-2020-03-31,BG,Bulgaria,1.0577
-2020-03-31,BR,Brazil,2.2555
+2020-03-31,AU,Australia,5.0177
+2020-03-31,BE,Belgium,2.7498
+2020-03-31,BG,Bulgaria,1.0358
+2020-03-31,BR,Brazil,2.1948
 2020-03-31,CA,Canada,2.4148
 2020-03-31,CH,Switzerland,1.7845
-2020-03-31,CL,Chile,5.191
+2020-03-31,CL,Chile,5.0807
 2020-03-31,CN,China,-2.1002
-2020-03-31,CO,Colombia,1.8829
+2020-03-31,CO,Colombia,1.2852
 2020-03-31,CY,Cyprus,0.7421
-2020-03-31,CZ,Czechia,4.8232
+2020-03-31,CZ,Czechia,4.8609
 2020-03-31,DE,Germany,5.2865
-2020-03-31,DK,Denmark,1.4432
+2020-03-31,DK,Denmark,1.431
 2020-03-31,EE,Estonia,9.8315
-2020-03-31,ES,Spain,2.6694
+2020-03-31,ES,Spain,2.6695
 2020-03-31,FI,Finland,0.3429
-2020-03-31,FR,France,3.6431
-2020-03-31,GB,United Kingdom,0.1014
-2020-03-31,GR,Greece,6.3479
+2020-03-31,FR,France,3.6427
+2020-03-31,GB,United Kingdom,0.0842
+2020-03-31,GR,Greece,6.3444
 2020-03-31,HK,Hong Kong SAR,0.369
-2020-03-31,HR,Croatia,7.6436
+2020-03-31,HR,Croatia,7.623
 2020-03-31,HU,Hungary,3.8219
-2020-03-31,ID,Indonesia,-1.6625
-2020-03-31,IE,Ireland,-0.019
-2020-03-31,IL,Israel,3.3459
-2020-03-31,IN,India,-2.5799
-2020-03-31,IS,Iceland,3.3626
-2020-03-31,IT,Italy,1.4433
+2020-03-31,ID,Indonesia,-1.6885
+2020-03-31,IE,Ireland,-0.059
+2020-03-31,IL,Israel,3.3463
+2020-03-31,IN,India,-2.6033
+2020-03-31,IS,Iceland,3.3642
+2020-03-31,IT,Italy,1.4408
 2020-03-31,JP,Japan,-1.0956
-2020-03-31,KR,Korea,0.1183
+2020-03-31,KR,Korea,0.1235
 2020-03-31,LT,Lithuania,3.6462
-2020-03-31,LU,Luxembourg,12.488
-2020-03-31,LV,Latvia,6.6737
-2020-03-31,MA,Morocco,-2.1425
-2020-03-31,MK,North Macedonia,1.5795
+2020-03-31,LU,Luxembourg,12.4861
+2020-03-31,LV,Latvia,6.6504
+2020-03-31,MA,Morocco,-1.9861
+2020-03-31,MK,North Macedonia,1.6819
 2020-03-31,MT,Malta,4.361
 2020-03-31,MX,Mexico,3.5232
 2020-03-31,MY,Malaysia,0.9683
-2020-03-31,NL,Netherlands,4.6216
-2020-03-31,NO,Norway,0.746
+2020-03-31,NL,Netherlands,5.1639
+2020-03-31,NO,Norway,0.6872
 2020-03-31,NZ,New Zealand,4.8979
 2020-03-31,PE,Peru,-2.1391
-2020-03-31,PH,Philippines,9.7877
+2020-03-31,PH,Philippines,5.0618
 2020-03-31,PL,Poland,6.4308
 2020-03-31,PT,Portugal,10.1467
 2020-03-31,RO,Romania,4.9437
-2020-03-31,RS,Serbia,7.6913
-2020-03-31,RU,Russia,4.5877
-2020-03-31,SE,Sweden,3.5248
-2020-03-31,SG,Singapore,1.9792
-2020-03-31,SI,Slovenia,3.1816
-2020-03-31,SK,Slovak Republic,10.1304
-2020-03-31,TH,Thailand,3.4077
-2020-03-31,TR,Türkiye,2.6043
-2020-03-31,US,United States,2.9791
-2020-03-31,XM,Euro area,3.946
-2020-03-31,XW,World,1.2585
-2020-03-31,ZA,South Africa,-2.4451
-2020-06-30,4T,Emerging market economies (aggregate),1.177
-2020-06-30,5R,Advanced economies,3.878
-2020-06-30,AE,United Arab Emirates,-4.8947
-2020-06-30,AT,Austria,4.0991
-2020-06-30,AU,Australia,6.6029
-2020-06-30,BE,Belgium,3.9213
-2020-06-30,BG,Bulgaria,1.3453
-2020-06-30,BR,Brazil,5.0842
+2020-03-31,RS,Serbia,9.9222
+2020-03-31,RU,Russia,4.5956
+2020-03-31,SE,Sweden,3.5235
+2020-03-31,SG,Singapore,1.9756
+2020-03-31,SI,Slovenia,3.1807
+2020-03-31,SK,Slovakia,10.095
+2020-03-31,TH,Thailand,3.7494
+2020-03-31,TR,Türkiye,2.5311
+2020-03-31,US,United States,3.0546
+2020-03-31,XM,Euro area,3.9542
+2020-03-31,XW,World,1.3022
+2020-03-31,ZA,South Africa,-3.11
+2020-06-30,4T,Emerging market economies (aggregate),0.9049
+2020-06-30,5R,Advanced economies,3.7866
+2020-06-30,AT,Austria,4.0992
+2020-06-30,AU,Australia,6.5792
+2020-06-30,BE,Belgium,3.6969
+2020-06-30,BG,Bulgaria,1.3844
+2020-06-30,BR,Brazil,4.9868
 2020-06-30,CA,Canada,5.6472
 2020-06-30,CH,Switzerland,3.7748
-2020-06-30,CL,Chile,6.3335
+2020-06-30,CL,Chile,6.3505
 2020-06-30,CN,China,-0.5564
-2020-06-30,CO,Colombia,-1.6629
+2020-06-30,CO,Colombia,-1.7452
 2020-06-30,CY,Cyprus,3.8472
-2020-06-30,CZ,Czechia,4.499
+2020-06-30,CZ,Czechia,4.5024
 2020-06-30,DE,Germany,5.764
-2020-06-30,DK,Denmark,1.3339
+2020-06-30,DK,Denmark,1.3449
 2020-06-30,EE,Estonia,5.2711
-2020-06-30,ES,Spain,2.8578
+2020-06-30,ES,Spain,2.8575
 2020-06-30,FI,Finland,0.8832
-2020-06-30,FR,France,4.8798
-2020-06-30,GB,United Kingdom,0.5628
-2020-06-30,GR,Greece,5.7525
-2020-06-30,HK,Hong Kong SAR,-4.2359
-2020-06-30,HR,Croatia,8.6091
+2020-06-30,FR,France,4.8834
+2020-06-30,GB,United Kingdom,0.5506
+2020-06-30,GR,Greece,5.749
+2020-06-30,HK,Hong Kong SAR,-4.2035
+2020-06-30,HR,Croatia,8.7177
 2020-06-30,HU,Hungary,0.0895
-2020-06-30,ID,Indonesia,-0.8295
-2020-06-30,IE,Ireland,0.6703
+2020-06-30,ID,Indonesia,-0.8316
+2020-06-30,IE,Ireland,0.6269
 2020-06-30,IL,Israel,3.3965
-2020-06-30,IN,India,-3.5159
+2020-06-30,IN,India,-3.4948
 2020-06-30,IS,Iceland,4.0938
-2020-06-30,IT,Italy,3.4639
+2020-06-30,IT,Italy,3.4613
 2020-06-30,JP,Japan,-0.833
-2020-06-30,KR,Korea,2.4209
+2020-06-30,KR,Korea,2.3838
 2020-06-30,LT,Lithuania,6.1475
-2020-06-30,LU,Luxembourg,12.6683
-2020-06-30,LV,Latvia,1.9289
-2020-06-30,MA,Morocco,-0.8764
-2020-06-30,MK,North Macedonia,0.9918
+2020-06-30,LU,Luxembourg,12.6762
+2020-06-30,LV,Latvia,1.9707
+2020-06-30,MA,Morocco,-5.4562
+2020-06-30,MK,North Macedonia,1.0006
 2020-06-30,MT,Malta,3.1491
 2020-06-30,MX,Mexico,2.9137
 2020-06-30,MY,Malaysia,4.0768
-2020-06-30,NL,Netherlands,5.6854
-2020-06-30,NO,Norway,1.5334
+2020-06-30,NL,Netherlands,6.5631
+2020-06-30,NO,Norway,1.6002
 2020-06-30,NZ,New Zealand,5.2768
 2020-06-30,PE,Peru,-1.8398
-2020-06-30,PH,Philippines,24.2821
+2020-06-30,PH,Philippines,6.6559
 2020-06-30,PL,Poland,7.4983
 2020-06-30,PT,Portugal,10.0334
 2020-06-30,RO,Romania,3.9339
-2020-06-30,RS,Serbia,8.1586
-2020-06-30,RU,Russia,4.8162
-2020-06-30,SE,Sweden,3.1348
-2020-06-30,SG,Singapore,1.915
-2020-06-30,SI,Slovenia,6.2016
-2020-06-30,SK,Slovak Republic,7.598
-2020-06-30,TH,Thailand,8.0605
-2020-06-30,TR,Türkiye,12.5601
-2020-06-30,US,United States,4.5728
-2020-06-30,XM,Euro area,4.8594
-2020-06-30,XW,World,2.4044
-2020-06-30,ZA,South Africa,-0.9191
-2020-09-30,4T,Emerging market economies (aggregate),1.0136
-2020-09-30,5R,Advanced economies,4.6824
-2020-09-30,AE,United Arab Emirates,-5.3912
+2020-06-30,RS,Serbia,10.4683
+2020-06-30,RU,Russia,4.8142
+2020-06-30,SE,Sweden,3.136
+2020-06-30,SG,Singapore,1.9068
+2020-06-30,SI,Slovenia,6.2003
+2020-06-30,SK,Slovakia,7.6262
+2020-06-30,TH,Thailand,7.1381
+2020-06-30,TR,Türkiye,7.1177
+2020-06-30,US,United States,4.6845
+2020-06-30,XM,Euro area,4.8709
+2020-06-30,XW,World,2.309
+2020-06-30,ZA,South Africa,-1.1436
+2020-09-30,4T,Emerging market economies (aggregate),0.9237
+2020-09-30,5R,Advanced economies,4.5913
 2020-09-30,AT,Austria,7.8381
-2020-09-30,AU,Australia,3.7701
-2020-09-30,BE,Belgium,2.3191
-2020-09-30,BG,Bulgaria,4.0052
-2020-09-30,BR,Brazil,5.5991
+2020-09-30,AU,Australia,3.816
+2020-09-30,BE,Belgium,2.3523
+2020-09-30,BG,Bulgaria,4.0017
+2020-09-30,BR,Brazil,5.465
 2020-09-30,CA,Canada,6.6237
 2020-09-30,CH,Switzerland,3.4799
-2020-09-30,CL,Chile,1.0906
+2020-09-30,CL,Chile,1.1676
 2020-09-30,CN,China,-0.0397
-2020-09-30,CO,Colombia,-0.598
+2020-09-30,CO,Colombia,-0.6905
 2020-09-30,CY,Cyprus,2.4349
-2020-09-30,CZ,Czechia,4.8963
+2020-09-30,CZ,Czechia,4.8773
 2020-09-30,DE,Germany,8.8797
-2020-09-30,DK,Denmark,5.5937
+2020-09-30,DK,Denmark,5.5944
 2020-09-30,EE,Estonia,4.8961
 2020-09-30,ES,Spain,2.3364
 2020-09-30,FI,Finland,1.4038
-2020-09-30,FR,France,4.5344
-2020-09-30,GB,United Kingdom,1.9072
+2020-09-30,FR,France,4.5349
+2020-09-30,GB,United Kingdom,1.924
 2020-09-30,GR,Greece,5.8866
 2020-09-30,HK,Hong Kong SAR,0.6914
-2020-09-30,HR,Croatia,7.0239
+2020-09-30,HR,Croatia,7.1065
 2020-09-30,HU,Hungary,1.1032
-2020-09-30,ID,Indonesia,-0.0355
-2020-09-30,IE,Ireland,0.0471
-2020-09-30,IL,Israel,3.5028
-2020-09-30,IN,India,-5.419
-2020-09-30,IS,Iceland,4.3726
-2020-09-30,IT,Italy,1.5041
+2020-09-30,ID,Indonesia,-0.0558
+2020-09-30,IE,Ireland,0.1198
+2020-09-30,IL,Israel,3.5032
+2020-09-30,IN,India,-5.4164
+2020-09-30,IS,Iceland,4.3716
+2020-09-30,IT,Italy,1.5028
 2020-09-30,JP,Japan,-0.1508
-2020-09-30,KR,Korea,3.7773
+2020-09-30,KR,Korea,3.7734
 2020-09-30,LT,Lithuania,5.3428
-2020-09-30,LU,Luxembourg,13.0046
-2020-09-30,LV,Latvia,1.7455
-2020-09-30,MA,Morocco,-1.5778
-2020-09-30,MK,North Macedonia,1.343
+2020-09-30,LU,Luxembourg,13.0072
+2020-09-30,LV,Latvia,1.7284
+2020-09-30,MA,Morocco,-1.9501
+2020-09-30,MK,North Macedonia,1.4753
 2020-09-30,MT,Malta,2.2782
 2020-09-30,MX,Mexico,1.0988
 2020-09-30,MY,Malaysia,1.5918
-2020-09-30,NL,Netherlands,7.1111
-2020-09-30,NO,Norway,3.3108
+2020-09-30,NL,Netherlands,7.2184
+2020-09-30,NO,Norway,3.3008
 2020-09-30,NZ,New Zealand,8.4223
 2020-09-30,PE,Peru,-1.2618
-2020-09-30,PH,Philippines,-2.6279
+2020-09-30,PH,Philippines,3.9201
 2020-09-30,PL,Poland,7.6531
 2020-09-30,PT,Portugal,6.9224
 2020-09-30,RO,Romania,-1.0003
-2020-09-30,RS,Serbia,6.6116
-2020-09-30,RU,Russia,5.8539
-2020-09-30,SE,Sweden,3.1268
-2020-09-30,SG,Singapore,0.9301
-2020-09-30,SI,Slovenia,3.3581
-2020-09-30,SK,Slovak Republic,6.8735
-2020-09-30,TH,Thailand,6.1671
-2020-09-30,TR,Türkiye,13.943
-2020-09-30,US,United States,5.8359
-2020-09-30,XM,Euro area,5.2426
-2020-09-30,XW,World,2.667
-2020-09-30,ZA,South Africa,-0.3052
-2020-12-31,4T,Emerging market economies (aggregate),2.1975
-2020-12-31,5R,Advanced economies,6.563
-2020-12-31,AE,United Arab Emirates,-4.3062
+2020-09-30,RS,Serbia,9.0314
+2020-09-30,RU,Russia,5.8643
+2020-09-30,SE,Sweden,3.126
+2020-09-30,SG,Singapore,0.9183
+2020-09-30,SI,Slovenia,3.3577
+2020-09-30,SK,Slovakia,6.7496
+2020-09-30,TH,Thailand,5.4568
+2020-09-30,TR,Türkiye,14.97
+2020-09-30,US,United States,5.8704
+2020-09-30,XM,Euro area,5.2485
+2020-09-30,XW,World,2.6991
+2020-09-30,ZA,South Africa,-0.2749
+2020-12-31,4T,Emerging market economies (aggregate),2.0394
+2020-12-31,5R,Advanced economies,6.4578
 2020-12-31,AT,Austria,8.5923
-2020-12-31,AU,Australia,2.7395
-2020-12-31,BE,Belgium,5.1406
-2020-12-31,BG,Bulgaria,4.9599
-2020-12-31,BR,Brazil,4.6743
+2020-12-31,AU,Australia,2.7326
+2020-12-31,BE,Belgium,5.2801
+2020-12-31,BG,Bulgaria,4.9125
+2020-12-31,BR,Brazil,4.5025
 2020-12-31,CA,Canada,7.5167
 2020-12-31,CH,Switzerland,3.8453
-2020-12-31,CL,Chile,1.6451
+2020-12-31,CL,Chile,1.574
 2020-12-31,CN,China,2.2697
-2020-12-31,CO,Colombia,0.3114
+2020-12-31,CO,Colombia,0.1361
 2020-12-31,CY,Cyprus,1.6208
-2020-12-31,CZ,Czechia,6.1604
+2020-12-31,CZ,Czechia,6.1327
 2020-12-31,DE,Germany,8.8549
-2020-12-31,DK,Denmark,10.3254
+2020-12-31,DK,Denmark,10.3152
 2020-12-31,EE,Estonia,6.031
-2020-12-31,ES,Spain,2.4182
+2020-12-31,ES,Spain,2.4178
 2020-12-31,FI,Finland,3.3822
-2020-12-31,FR,France,5.7754
-2020-12-31,GB,United Kingdom,5.2963
-2020-12-31,GR,Greece,5.3366
+2020-12-31,FR,France,5.7666
+2020-12-31,GB,United Kingdom,5.239
+2020-12-31,GR,Greece,5.3297
 2020-12-31,HK,Hong Kong SAR,0.4869
-2020-12-31,HR,Croatia,6.8307
+2020-12-31,HR,Croatia,6.8097
 2020-12-31,HU,Hungary,1.3346
-2020-12-31,ID,Indonesia,-0.4113
-2020-12-31,IE,Ireland,1.9028
-2020-12-31,IL,Israel,4.408
-2020-12-31,IN,India,-3.9233
-2020-12-31,IS,Iceland,4.065
-2020-12-31,IT,Italy,1.754
+2020-12-31,ID,Indonesia,-0.4351
+2020-12-31,IE,Ireland,1.8804
+2020-12-31,IL,Israel,4.4084
+2020-12-31,IN,India,-3.9013
+2020-12-31,IS,Iceland,4.0657
+2020-12-31,IT,Italy,1.7577
 2020-12-31,JP,Japan,2.5223
-2020-12-31,KR,Korea,6.6525
-2020-12-31,LT,Lithuania,8.8306
-2020-12-31,LU,Luxembourg,16.0594
-2020-12-31,LV,Latvia,2.855
-2020-12-31,MA,Morocco,0.8266
-2020-12-31,MK,North Macedonia,-0.3447
+2020-12-31,KR,Korea,6.6839
+2020-12-31,LT,Lithuania,8.8307
+2020-12-31,LU,Luxembourg,16.0592
+2020-12-31,LV,Latvia,2.8971
+2020-12-31,MA,Morocco,1.12
+2020-12-31,MK,North Macedonia,-0.2961
 2020-12-31,MT,Malta,1.3369
 2020-12-31,MX,Mexico,1.7933
 2020-12-31,MY,Malaysia,2.7781
-2020-12-31,NL,Netherlands,7.6599
-2020-12-31,NO,Norway,6.1794
+2020-12-31,NL,Netherlands,7.5671
+2020-12-31,NO,Norway,6.1454
 2020-12-31,NZ,New Zealand,14.4218
 2020-12-31,PE,Peru,1.8636
-2020-12-31,PH,Philippines,-1.9896
+2020-12-31,PH,Philippines,1.0089
 2020-12-31,PL,Poland,5.9979
-2020-12-31,PT,Portugal,8.1433
+2020-12-31,PT,Portugal,8.1432
 2020-12-31,RO,Romania,0.2467
-2020-12-31,RS,Serbia,6.7385
-2020-12-31,RU,Russia,9.1336
-2020-12-31,SE,Sweden,4.9391
-2020-12-31,SG,Singapore,2.3306
-2020-12-31,SI,Slovenia,5.9173
-2020-12-31,SK,Slovak Republic,5.6207
-2020-12-31,TH,Thailand,4.3333
-2020-12-31,TR,Türkiye,14.8687
-2020-12-31,US,United States,8.1781
-2020-12-31,XM,Euro area,6.2271
-2020-12-31,XW,World,4.1524
-2020-12-31,ZA,South Africa,0.6348
-2021-03-31,4T,Emerging market economies (aggregate),2.4583
-2021-03-31,5R,Advanced economies,7.1156
-2021-03-31,AE,United Arab Emirates,-1.8567
+2020-12-31,RS,Serbia,9.2236
+2020-12-31,RU,Russia,9.1346
+2020-12-31,SE,Sweden,4.9362
+2020-12-31,SG,Singapore,2.3141
+2020-12-31,SI,Slovenia,5.9202
+2020-12-31,SK,Slovakia,5.4968
+2020-12-31,TH,Thailand,1.5159
+2020-12-31,TR,Türkiye,15.7176
+2020-12-31,US,United States,8.1962
+2020-12-31,XM,Euro area,6.2339
+2020-12-31,XW,World,4.1669
+2020-12-31,ZA,South Africa,0.9574
+2021-03-31,4T,Emerging market economies (aggregate),2.1765
+2021-03-31,5R,Advanced economies,7.0422
 2021-03-31,AT,Austria,10.8586
-2021-03-31,AU,Australia,6.2909
-2021-03-31,BE,Belgium,6.3579
-2021-03-31,BG,Bulgaria,7.5141
-2021-03-31,BR,Brazil,3.8471
+2021-03-31,AU,Australia,6.3339
+2021-03-31,BE,Belgium,5.6565
+2021-03-31,BG,Bulgaria,7.5603
+2021-03-31,BR,Brazil,3.6425
 2021-03-31,CA,Canada,7.2045
 2021-03-31,CH,Switzerland,4.3094
-2021-03-31,CL,Chile,4.7994
+2021-03-31,CL,Chile,5.0838
 2021-03-31,CN,China,3.1668
-2021-03-31,CO,Colombia,0.5894
+2021-03-31,CO,Colombia,0.6519
 2021-03-31,CY,Cyprus,2.34
-2021-03-31,CZ,Czechia,10.9276
+2021-03-31,CZ,Czechia,10.9297
 2021-03-31,DE,Germany,7.6968
-2021-03-31,DK,Denmark,13.2165
+2021-03-31,DK,Denmark,13.2505
 2021-03-31,EE,Estonia,5.9096
-2021-03-31,ES,Spain,0.3502
+2021-03-31,ES,Spain,0.3501
 2021-03-31,FI,Finland,3.0606
-2021-03-31,FR,France,4.753
-2021-03-31,GB,United Kingdom,7.6182
-2021-03-31,GR,Greece,6.2619
+2021-03-31,FR,France,4.7556
+2021-03-31,GB,United Kingdom,7.0111
+2021-03-31,GR,Greece,6.2618
 2021-03-31,HK,Hong Kong SAR,0.9903
-2021-03-31,HR,Croatia,4.1918
-2021-03-31,HU,Hungary,6.3219
-2021-03-31,ID,Indonesia,-0.4664
-2021-03-31,IE,Ireland,3.2087
-2021-03-31,IL,Israel,4.7017
-2021-03-31,IN,India,-2.1071
-2021-03-31,IS,Iceland,4.1377
-2021-03-31,IT,Italy,1.1204
+2021-03-31,HR,Croatia,4.1895
+2021-03-31,HU,Hungary,6.3218
+2021-03-31,ID,Indonesia,-0.4682
+2021-03-31,IE,Ireland,3.2727
+2021-03-31,IL,Israel,4.7013
+2021-03-31,IN,India,-2.1144
+2021-03-31,IS,Iceland,4.1367
+2021-03-31,IT,Italy,1.1236
 2021-03-31,JP,Japan,3.8961
-2021-03-31,KR,Korea,8.7425
+2021-03-31,KR,Korea,8.7036
 2021-03-31,LT,Lithuania,11.0447
-2021-03-31,LU,Luxembourg,15.7178
-2021-03-31,LV,Latvia,2.998
-2021-03-31,MA,Morocco,-0.3056
-2021-03-31,MK,North Macedonia,1.1227
+2021-03-31,LU,Luxembourg,15.7185
+2021-03-31,LV,Latvia,2.9719
+2021-03-31,MA,Morocco,0.4092
+2021-03-31,MK,North Macedonia,1.0006
 2021-03-31,MT,Malta,4.242
 2021-03-31,MX,Mexico,2.4808
 2021-03-31,MY,Malaysia,0.2078
-2021-03-31,NL,Netherlands,9.3498
-2021-03-31,NO,Norway,7.9372
+2021-03-31,NL,Netherlands,8.4331
+2021-03-31,NO,Norway,8.0201
 2021-03-31,NZ,New Zealand,20.9016
 2021-03-31,PE,Peru,-0.4149
-2021-03-31,PH,Philippines,-7.9157
+2021-03-31,PH,Philippines,0.0748
 2021-03-31,PL,Poland,4.2458
-2021-03-31,PT,Portugal,6.1752
+2021-03-31,PT,Portugal,6.1751
 2021-03-31,RO,Romania,-2.2295
-2021-03-31,RS,Serbia,7.2118
-2021-03-31,RU,Russia,5.228
-2021-03-31,SE,Sweden,5.6106
-2021-03-31,SG,Singapore,5.8378
-2021-03-31,SI,Slovenia,7.8408
-2021-03-31,SK,Slovak Republic,0.9638
-2021-03-31,TH,Thailand,0.8845
-2021-03-31,TR,Türkiye,14.174
-2021-03-31,US,United States,9.3439
-2021-03-31,XM,Euro area,5.1062
-2021-03-31,XW,World,4.5352
-2021-03-31,ZA,South Africa,1.5448
-2021-06-30,4T,Emerging market economies (aggregate),1.914
-2021-06-30,5R,Advanced economies,8.2917
-2021-06-30,AE,United Arab Emirates,2.6272
+2021-03-31,RS,Serbia,9.6756
+2021-03-31,RU,Russia,5.2229
+2021-03-31,SE,Sweden,5.6093
+2021-03-31,SG,Singapore,5.8255
+2021-03-31,SI,Slovenia,7.8412
+2021-03-31,SK,Slovakia,0.9704
+2021-03-31,TH,Thailand,1.5118
+2021-03-31,TR,Türkiye,13.7145
+2021-03-31,US,United States,9.2622
+2021-03-31,XM,Euro area,5.0687
+2021-03-31,XW,World,4.5044
+2021-03-31,ZA,South Africa,3.1201
+2021-06-30,4T,Emerging market economies (aggregate),1.6853
+2021-06-30,5R,Advanced economies,8.1515
 2021-06-30,AT,Austria,9.0194
-2021-06-30,AU,Australia,12.4353
-2021-06-30,BE,Belgium,5.8831
-2021-06-30,BG,Bulgaria,6.5486
-2021-06-30,BR,Brazil,1.1029
+2021-06-30,AU,Australia,12.4699
+2021-06-30,BE,Belgium,5.4874
+2021-06-30,BG,Bulgaria,6.4801
+2021-06-30,BR,Brazil,0.8827
 2021-06-30,CA,Canada,9.7893
-2021-06-30,CH,Switzerland,4.1977
-2021-06-30,CL,Chile,6.3405
+2021-06-30,CH,Switzerland,4.1978
+2021-06-30,CL,Chile,6.531
 2021-06-30,CN,China,2.4499
-2021-06-30,CO,Colombia,4.8451
+2021-06-30,CO,Colombia,4.2414
 2021-06-30,CY,Cyprus,-2.0905
-2021-06-30,CZ,Czechia,13.9241
+2021-06-30,CZ,Czechia,13.8466
 2021-06-30,DE,Germany,9.0768
-2021-06-30,DK,Denmark,13.4953
+2021-06-30,DK,Denmark,13.4874
 2021-06-30,EE,Estonia,12.5745
-2021-06-30,ES,Spain,0.7061
+2021-06-30,ES,Spain,0.7063
 2021-06-30,FI,Finland,3.3
-2021-06-30,FR,France,4.6149
-2021-06-30,GB,United Kingdom,7.9111
-2021-06-30,GR,Greece,6.5607
+2021-06-30,FR,France,4.6142
+2021-06-30,GB,United Kingdom,7.2169
+2021-06-30,GR,Greece,6.5606
 2021-06-30,HK,Hong Kong SAR,1.6791
-2021-06-30,HR,Croatia,4.2597
+2021-06-30,HR,Croatia,4.2012
 2021-06-30,HU,Hungary,11.1137
-2021-06-30,ID,Indonesia,-0.5141
-2021-06-30,IE,Ireland,4.1214
-2021-06-30,IL,Israel,6.2651
-2021-06-30,IN,India,-3.4296
+2021-06-30,ID,Indonesia,-0.5132
+2021-06-30,IE,Ireland,4.083
+2021-06-30,IL,Israel,6.2654
+2021-06-30,IN,India,-3.4374
 2021-06-30,IS,Iceland,7.8599
-2021-06-30,IT,Italy,-0.7984
+2021-06-30,IT,Italy,-0.7995
 2021-06-30,JP,Japan,6.2476
-2021-06-30,KR,Korea,10.2629
+2021-06-30,KR,Korea,10.2658
 2021-06-30,LT,Lithuania,9.7261
-2021-06-30,LU,Luxembourg,10.929
-2021-06-30,LV,Latvia,9.5549
-2021-06-30,MA,Morocco,-5.8947
-2021-06-30,MK,North Macedonia,1.2556
+2021-06-30,LU,Luxembourg,10.9268
+2021-06-30,LV,Latvia,9.5194
+2021-06-30,MA,Morocco,0.6936
+2021-06-30,MK,North Macedonia,1.3194
 2021-06-30,MT,Malta,4.0756
 2021-06-30,MX,Mexico,1.6934
 2021-06-30,MY,Malaysia,-3.0006
-2021-06-30,NL,Netherlands,10.7887
-2021-06-30,NO,Norway,9.2943
+2021-06-30,NL,Netherlands,10.3094
+2021-06-30,NO,Norway,9.2927
 2021-06-30,NZ,New Zealand,24.3592
 2021-06-30,PE,Peru,-1.2252
-2021-06-30,PH,Philippines,-12.8502
+2021-06-30,PH,Philippines,-1.5581
 2021-06-30,PL,Poland,3.7347
 2021-06-30,PT,Portugal,6.9931
 2021-06-30,RO,Romania,-0.5478
-2021-06-30,RS,Serbia,5.8442
-2021-06-30,RU,Russia,7.8632
-2021-06-30,SE,Sweden,8.9641
-2021-06-30,SG,Singapore,4.7418
-2021-06-30,SI,Slovenia,8.0479
-2021-06-30,SK,Slovak Republic,2.5008
-2021-06-30,TH,Thailand,-1.8297
-2021-06-30,TR,Türkiye,10.3852
-2021-06-30,US,United States,10.5287
-2021-06-30,XM,Euro area,5.4373
-2021-06-30,XW,World,4.7399
-2021-06-30,ZA,South Africa,-0.0417
-2021-09-30,4T,Emerging market economies (aggregate),2.2312
-2021-09-30,5R,Advanced economies,9.0653
-2021-09-30,AE,United Arab Emirates,7.1912
+2021-06-30,RS,Serbia,8.2089
+2021-06-30,RU,Russia,7.8973
+2021-06-30,SE,Sweden,8.9649
+2021-06-30,SG,Singapore,4.7311
+2021-06-30,SI,Slovenia,8.0508
+2021-06-30,SK,Slovakia,2.4474
+2021-06-30,TH,Thailand,-1.4849
+2021-06-30,TR,Türkiye,14.7096
+2021-06-30,US,United States,10.2619
+2021-06-30,XM,Euro area,5.4173
+2021-06-30,XW,World,4.7605
+2021-06-30,ZA,South Africa,2.7593
+2021-09-30,4T,Emerging market economies (aggregate),1.6302
+2021-09-30,5R,Advanced economies,8.9095
 2021-09-30,AT,Austria,7.0629
-2021-09-30,AU,Australia,18.1327
-2021-09-30,BE,Belgium,5.4304
-2021-09-30,BG,Bulgaria,4.7092
-2021-09-30,BR,Brazil,-1.6276
+2021-09-30,AU,Australia,18.033
+2021-09-30,BE,Belgium,4.8056
+2021-09-30,BG,Bulgaria,4.7397
+2021-09-30,BR,Brazil,-1.8409
 2021-09-30,CA,Canada,9.8983
-2021-09-30,CH,Switzerland,6.0608
-2021-09-30,CL,Chile,8.0612
+2021-09-30,CH,Switzerland,6.0607
+2021-09-30,CL,Chile,8.046
 2021-09-30,CN,China,2.4326
-2021-09-30,CO,Colombia,2.4622
+2021-09-30,CO,Colombia,1.9785
 2021-09-30,CY,Cyprus,-3.0743
-2021-09-30,CZ,Czechia,17.2997
+2021-09-30,CZ,Czechia,17.3309
 2021-09-30,DE,Germany,8.5633
-2021-09-30,DK,Denmark,9.1814
+2021-09-30,DK,Denmark,9.1995
 2021-09-30,EE,Estonia,11.1421
-2021-09-30,ES,Spain,0.7467
+2021-09-30,ES,Spain,0.7471
 2021-09-30,FI,Finland,2.546
-2021-09-30,FR,France,5.3143
-2021-09-30,GB,United Kingdom,6.1671
+2021-09-30,FR,France,5.3181
+2021-09-30,GB,United Kingdom,5.3914
 2021-09-30,GR,Greece,6.86
 2021-09-30,HK,Hong Kong SAR,1.4453
-2021-09-30,HR,Croatia,5.7288
+2021-09-30,HR,Croatia,5.6974
 2021-09-30,HU,Hungary,11.1282
-2021-09-30,ID,Indonesia,-0.5393
-2021-09-30,IE,Ireland,7.5107
-2021-09-30,IL,Israel,7.2421
-2021-09-30,IN,India,-2.5641
-2021-09-30,IS,Iceland,9.9292
-2021-09-30,IT,Italy,1.8917
+2021-09-30,ID,Indonesia,-0.5395
+2021-09-30,IE,Ireland,7.4203
+2021-09-30,IL,Israel,7.242
+2021-09-30,IN,India,-2.5511
+2021-09-30,IS,Iceland,9.9301
+2021-09-30,IT,Italy,1.8931
 2021-09-30,JP,Japan,8.3252
-2021-09-30,KR,Korea,12.2699
+2021-09-30,KR,Korea,12.2353
 2021-09-30,LT,Lithuania,12.7721
-2021-09-30,LU,Luxembourg,10.4646
-2021-09-30,LV,Latvia,8.2888
-2021-09-30,MA,Morocco,-7.3169
-2021-09-30,MK,North Macedonia,2.126
+2021-09-30,LU,Luxembourg,10.4635
+2021-09-30,LV,Latvia,8.2884
+2021-09-30,MA,Morocco,-6.7624
+2021-09-30,MK,North Macedonia,2.0042
 2021-09-30,MT,Malta,3.811
 2021-09-30,MX,Mexico,2.7076
 2021-09-30,MY,Malaysia,-1.065
-2021-09-30,NL,Netherlands,14.2834
-2021-09-30,NO,Norway,6.7147
+2021-09-30,NL,Netherlands,13.7213
+2021-09-30,NO,Norway,6.7021
 2021-09-30,NZ,New Zealand,22.6206
 2021-09-30,PE,Peru,-5.1009
-2021-09-30,PH,Philippines,2.1381
+2021-09-30,PH,Philippines,0.8757
 2021-09-30,PL,Poland,3.3337
-2021-09-30,PT,Portugal,9.8751
+2021-09-30,PT,Portugal,9.8752
 2021-09-30,RO,Romania,0.8103
-2021-09-30,RS,Serbia,5.6306
-2021-09-30,RU,Russia,7.2246
-2021-09-30,SE,Sweden,9.1746
-2021-09-30,SG,Singapore,4.8702
-2021-09-30,SI,Slovenia,10.5047
-2021-09-30,SK,Slovak Republic,3.9678
-2021-09-30,TH,Thailand,1.2944
-2021-09-30,TR,Türkiye,13.6827
-2021-09-30,US,United States,11.1874
-2021-09-30,XM,Euro area,6.2668
-2021-09-30,XW,World,5.2481
-2021-09-30,ZA,South Africa,-1.0611
-2021-12-31,4T,Emerging market economies (aggregate),1.6896
-2021-12-31,5R,Advanced economies,7.6083
-2021-12-31,AE,United Arab Emirates,7.3148
+2021-09-30,RS,Serbia,7.9864
+2021-09-30,RU,Russia,7.208
+2021-09-30,SE,Sweden,9.1741
+2021-09-30,SG,Singapore,4.8576
+2021-09-30,SI,Slovenia,10.4984
+2021-09-30,SK,Slovakia,3.9934
+2021-09-30,TH,Thailand,3.4977
+2021-09-30,TR,Türkiye,11.7533
+2021-09-30,US,United States,10.8222
+2021-09-30,XM,Euro area,6.2113
+2021-09-30,XW,World,5.0731
+2021-09-30,ZA,South Africa,2.0244
+2021-12-31,4T,Emerging market economies (aggregate),0.6822
+2021-12-31,5R,Advanced economies,7.5394
 2021-12-31,AT,Austria,8.1391
-2021-12-31,AU,Australia,19.4917
-2021-12-31,BE,Belgium,0.8275
-2021-12-31,BG,Bulgaria,2.1897
-2021-12-31,BR,Brazil,-3.7325
+2021-12-31,AU,Australia,19.5166
+2021-12-31,BE,Belgium,0.7
+2021-12-31,BG,Bulgaria,2.1945
+2021-12-31,BR,Brazil,-3.905
 2021-12-31,CA,Canada,8.7934
 2021-12-31,CH,Switzerland,5.7958
-2021-12-31,CL,Chile,8.6896
+2021-12-31,CL,Chile,8.2586
 2021-12-31,CN,China,-0.1139
-2021-12-31,CO,Colombia,1.8416
+2021-12-31,CO,Colombia,1.3464
 2021-12-31,CY,Cyprus,-1.7688
-2021-12-31,CZ,Czechia,18.5047
+2021-12-31,CZ,Czechia,18.4954
 2021-12-31,DE,Germany,7.532
-2021-12-31,DK,Denmark,3.4051
+2021-12-31,DK,Denmark,3.4186
 2021-12-31,EE,Estonia,10.1028
-2021-12-31,ES,Spain,0.4572
+2021-12-31,ES,Spain,0.457
 2021-12-31,FI,Finland,0.3514
-2021-12-31,FR,France,4.0455
-2021-12-31,GB,United Kingdom,3.172
+2021-12-31,FR,France,4.0458
+2021-12-31,GB,United Kingdom,2.2577
 2021-12-31,GR,Greece,5.359
 2021-12-31,HK,Hong Kong SAR,1.5886
-2021-12-31,HR,Croatia,4.1223
-2021-12-31,HU,Hungary,14.6675
-2021-12-31,ID,Indonesia,-0.566
-2021-12-31,IE,Ireland,8.0691
-2021-12-31,IL,Israel,9.0203
-2021-12-31,IN,India,-1.797
+2021-12-31,HR,Croatia,4.1267
+2021-12-31,HU,Hungary,14.6676
+2021-12-31,ID,Indonesia,-0.5657
+2021-12-31,IE,Ireland,8.1234
+2021-12-31,IL,Israel,9.0204
+2021-12-31,IN,India,-1.8225
 2021-12-31,IS,Iceland,10.5231
-2021-12-31,IT,Italy,0.4397
+2021-12-31,IT,Italy,0.4351
 2021-12-31,JP,Japan,6.2902
-2021-12-31,KR,Korea,11.7368
+2021-12-31,KR,Korea,11.7854
 2021-12-31,LT,Lithuania,9.6738
-2021-12-31,LU,Luxembourg,7.7065
-2021-12-31,LV,Latvia,8.394
-2021-12-31,MA,Morocco,-9.6922
-2021-12-31,MK,North Macedonia,6.4508
+2021-12-31,LU,Luxembourg,7.7139
+2021-12-31,LV,Latvia,8.3333
+2021-12-31,MA,Morocco,-9.4036
+2021-12-31,MK,North Macedonia,6.5247
 2021-12-31,MT,Malta,2.0328
 2021-12-31,MX,Mexico,1.4569
 2021-12-31,MY,Malaysia,-1.232
-2021-12-31,NL,Netherlands,13.3216
-2021-12-31,NO,Norway,3.1975
+2021-12-31,NL,Netherlands,13.146
+2021-12-31,NO,Norway,3.1976
 2021-12-31,NZ,New Zealand,18.8565
 2021-12-31,PE,Peru,-8.4536
-2021-12-31,PH,Philippines,1.2887
+2021-12-31,PH,Philippines,2.6867
 2021-12-31,PL,Poland,3.8745
-2021-12-31,PT,Portugal,8.986
+2021-12-31,PT,Portugal,8.9861
 2021-12-31,RO,Romania,-0.1518
-2021-12-31,RS,Serbia,4.224
-2021-12-31,RU,Russia,6.1326
-2021-12-31,SE,Sweden,7.3403
-2021-12-31,SG,Singapore,6.6443
-2021-12-31,SI,Slovenia,11.1447
-2021-12-31,SK,Slovak Republic,4.9259
-2021-12-31,TH,Thailand,-0.0168
-2021-12-31,TR,Türkiye,26.9114
-2021-12-31,US,United States,10.0396
-2021-12-31,XM,Euro area,4.749
-2021-12-31,XW,World,4.3003
-2021-12-31,ZA,South Africa,-1.8653
-2022-03-31,4T,Emerging market economies (aggregate),1.5832
-2022-03-31,5R,Advanced economies,7.5906
-2022-03-31,AE,United Arab Emirates,7.8137
+2021-12-31,RS,Serbia,6.5005
+2021-12-31,RU,Russia,6.1282
+2021-12-31,SE,Sweden,7.3373
+2021-12-31,SG,Singapore,6.6336
+2021-12-31,SI,Slovenia,11.1485
+2021-12-31,SK,Slovakia,4.9593
+2021-12-31,TH,Thailand,0.5999
+2021-12-31,TR,Türkiye,18.5497
+2021-12-31,US,United States,9.5846
+2021-12-31,XM,Euro area,4.6887
+2021-12-31,XW,World,3.9154
+2021-12-31,ZA,South Africa,0.477
+2022-03-31,4T,Emerging market economies (aggregate),0.7004
+2022-03-31,5R,Advanced economies,7.1492
 2022-03-31,AT,Austria,6.1627
-2022-03-31,AU,Australia,14.7484
-2022-03-31,BE,Belgium,-1.406
-2022-03-31,BG,Bulgaria,0.8889
-2022-03-31,BR,Brazil,-5.4862
-2022-03-31,CA,Canada,18.6327
-2022-03-31,CH,Switzerland,4.8124
-2022-03-31,CL,Chile,-0.3385
+2022-03-31,AU,Australia,14.7257
+2022-03-31,BE,Belgium,-1.6331
+2022-03-31,BG,Bulgaria,0.8739
+2022-03-31,BR,Brazil,-5.5581
+2022-03-31,CA,Canada,18.5475
+2022-03-31,CH,Switzerland,4.8125
+2022-03-31,CL,Chile,-0.8457
 2022-03-31,CN,China,-1.106
-2022-03-31,CO,Colombia,0.6516
+2022-03-31,CO,Colombia,0.1657
 2022-03-31,CY,Cyprus,-2.9887
-2022-03-31,CZ,Czechia,11.9323
-2022-03-31,DE,Germany,6.5069
-2022-03-31,DK,Denmark,-0.6582
+2022-03-31,CZ,Czechia,11.9228
+2022-03-31,DE,Germany,7.0636
+2022-03-31,DK,Denmark,-0.6656
 2022-03-31,EE,Estonia,7.204
-2022-03-31,ES,Spain,0.6214
-2022-03-31,FI,Finland,-1.5495
-2022-03-31,FR,France,3.2125
-2022-03-31,GB,United Kingdom,2.4634
+2022-03-31,ES,Spain,0.6217
+2022-03-31,FI,Finland,-1.8128
+2022-03-31,FR,France,3.2115
+2022-03-31,GB,United Kingdom,1.8588
 2022-03-31,GR,Greece,2.4055
 2022-03-31,HK,Hong Kong SAR,-1.5736
-2022-03-31,HR,Croatia,6.6125
+2022-03-31,HR,Croatia,6.629
 2022-03-31,HU,Hungary,13.8025
-2022-03-31,ID,Indonesia,-0.6965
-2022-03-31,IE,Ireland,8.6725
-2022-03-31,IL,Israel,11.457
-2022-03-31,IN,India,-4.2761
+2022-03-31,ID,Indonesia,-0.6985
+2022-03-31,IE,Ireland,8.6583
+2022-03-31,IL,Israel,11.4574
+2022-03-31,IN,India,-4.2775
 2022-03-31,IS,Iceland,12.1514
-2022-03-31,IT,Italy,-1.06
+2022-03-31,IT,Italy,-1.0595
 2022-03-31,JP,Japan,8.1216
-2022-03-31,KR,Korea,8.4602
-2022-03-31,LT,Lithuania,4.4126
-2022-03-31,LU,Luxembourg,4.5543
-2022-03-31,LV,Latvia,7.4779
-2022-03-31,MA,Morocco,-9.0962
-2022-03-31,MK,North Macedonia,4.3381
+2022-03-31,KR,Korea,8.3696
+2022-03-31,LT,Lithuania,4.4127
+2022-03-31,LU,Luxembourg,4.5576
+2022-03-31,LV,Latvia,7.4977
+2022-03-31,MA,Morocco,-8.9273
+2022-03-31,MK,North Macedonia,4.4029
 2022-03-31,MT,Malta,2.5217
 2022-03-31,MX,Mexico,0.4413
 2022-03-31,MY,Malaysia,0.1522
-2022-03-31,NL,Netherlands,11.0396
-2022-03-31,NO,Norway,3.2554
+2022-03-31,NL,Netherlands,10.7802
+2022-03-31,NO,Norway,3.2189
 2022-03-31,NZ,New Zealand,6.2316
 2022-03-31,PE,Peru,-7.8402
-2022-03-31,PH,Philippines,2.3183
+2022-03-31,PH,Philippines,5.5537
 2022-03-31,PL,Poland,3.5145
-2022-03-31,PT,Portugal,8.3017
+2022-03-31,PT,Portugal,8.3018
 2022-03-31,RO,Romania,-1.9655
-2022-03-31,RS,Serbia,4.3426
-2022-03-31,RU,Russia,18.7874
-2022-03-31,SE,Sweden,5.4118
-2022-03-31,SG,Singapore,3.0536
-2022-03-31,SI,Slovenia,10.3915
-2022-03-31,SK,Slovak Republic,4.4615
-2022-03-31,TH,Thailand,-0.5463
-2022-03-31,TR,Türkiye,35.7183
-2022-03-31,US,United States,10.3595
-2022-03-31,XM,Euro area,3.4872
-2022-03-31,XW,World,4.2275
-2022-03-31,ZA,South Africa,-1.6649
-2022-06-30,4T,Emerging market economies (aggregate),-0.2024
-2022-06-30,5R,Advanced economies,4.721
-2022-06-30,AE,United Arab Emirates,3.9866
+2022-03-31,RS,Serbia,6.4613
+2022-03-31,RU,Russia,18.7713
+2022-03-31,SE,Sweden,5.413
+2022-03-31,SG,Singapore,3.0415
+2022-03-31,SI,Slovenia,10.3944
+2022-03-31,SK,Slovakia,4.5045
+2022-03-31,TH,Thailand,-1.8375
+2022-03-31,TR,Türkiye,24.2038
+2022-03-31,US,United States,9.394
+2022-03-31,XM,Euro area,3.6202
+2022-03-31,XW,World,3.7399
+2022-03-31,ZA,South Africa,-0.5393
+2022-06-30,4T,Emerging market economies (aggregate),-1.043
+2022-06-30,5R,Advanced economies,4.2303
 2022-06-30,AT,Austria,4.8801
-2022-06-30,AU,Australia,6.7769
-2022-06-30,BE,Belgium,-2.791
-2022-06-30,BG,Bulgaria,-0.8731
-2022-06-30,BR,Brazil,-7.9162
-2022-06-30,CA,Canada,7.2101
+2022-06-30,AU,Australia,6.7312
+2022-06-30,BE,Belgium,-2.7945
+2022-06-30,BG,Bulgaria,-0.8397
+2022-06-30,BR,Brazil,-7.8113
+2022-06-30,CA,Canada,6.5235
 2022-06-30,CH,Switzerland,4.3927
-2022-06-30,CL,Chile,-2.56
+2022-06-30,CL,Chile,-3.901
 2022-06-30,CN,China,-4.2636
-2022-06-30,CO,Colombia,-1.7561
+2022-06-30,CO,Colombia,-2.1629
 2022-06-30,CY,Cyprus,-4.1358
-2022-06-30,CZ,Czechia,5.633
-2022-06-30,DE,Germany,2.7697
-2022-06-30,DK,Denmark,-4.5107
+2022-06-30,CZ,Czechia,5.7179
+2022-06-30,DE,Germany,3.3495
+2022-06-30,DK,Denmark,-4.5083
 2022-06-30,EE,Estonia,5.8939
-2022-06-30,ES,Spain,-0.9599
-2022-06-30,FI,Finland,-4.2076
-2022-06-30,FR,France,1.4119
-2022-06-30,GB,United Kingdom,0.361
-2022-06-30,GR,Greece,-0.2884
+2022-06-30,ES,Spain,-0.9595
+2022-06-30,FI,Finland,-4.4602
+2022-06-30,FR,France,1.4092
+2022-06-30,GB,United Kingdom,-0.213
+2022-06-30,GR,Greece,-0.2883
 2022-06-30,HK,Hong Kong SAR,-3.6789
-2022-06-30,HR,Croatia,2.5448
-2022-06-30,HU,Hungary,12.8677
-2022-06-30,ID,Indonesia,-2.0617
-2022-06-30,IE,Ireland,5.8357
-2022-06-30,IL,Israel,12.7739
-2022-06-30,IN,India,-3.6566
+2022-06-30,HR,Croatia,2.5444
+2022-06-30,HU,Hungary,12.8676
+2022-06-30,ID,Indonesia,-2.0604
+2022-06-30,IE,Ireland,5.8247
+2022-06-30,IL,Israel,12.7734
+2022-06-30,IN,India,-3.6263
 2022-06-30,IS,Iceland,13.8956
-2022-06-30,IT,Italy,-1.6448
+2022-06-30,IT,Italy,-1.6434
 2022-06-30,JP,Japan,6.6587
-2022-06-30,KR,Korea,3.7633
+2022-06-30,KR,Korea,3.8046
 2022-06-30,LT,Lithuania,2.6413
-2022-06-30,LU,Luxembourg,4.3134
-2022-06-30,LV,Latvia,-0.0697
-2022-06-30,MA,Morocco,-6.2714
-2022-06-30,MK,North Macedonia,3.7475
+2022-06-30,LU,Luxembourg,4.3079
+2022-06-30,LV,Latvia,-0.0156
+2022-06-30,MA,Morocco,-7.7508
+2022-06-30,MK,North Macedonia,3.7591
 2022-06-30,MT,Malta,1.5313
 2022-06-30,MX,Mexico,0.1795
 2022-06-30,MY,Malaysia,-0.2189
-2022-06-30,NL,Netherlands,8.4532
-2022-06-30,NO,Norway,0.4986
+2022-06-30,NL,Netherlands,7.8482
+2022-06-30,NO,Norway,0.4576
 2022-06-30,NZ,New Zealand,-2.0431
 2022-06-30,PE,Peru,-9.1972
-2022-06-30,PH,Philippines,-2.7076
+2022-06-30,PH,Philippines,3.9629
 2022-06-30,PL,Poland,-1.4084
-2022-06-30,PT,Portugal,4.8057
+2022-06-30,PT,Portugal,4.8058
 2022-06-30,RO,Romania,-5.4438
-2022-06-30,RS,Serbia,3.6817
-2022-06-30,RU,Russia,10.7048
-2022-06-30,SE,Sweden,-0.3558
-2022-06-30,SG,Singapore,4.4753
-2022-06-30,SI,Slovenia,6.5031
-2022-06-30,SK,Slovak Republic,3.6588
-2022-06-30,TH,Thailand,-1.1486
-2022-06-30,TR,Türkiye,49.754
-2022-06-30,US,United States,7.7751
-2022-06-30,XM,Euro area,1.0977
-2022-06-30,XW,World,1.9704
-2022-06-30,ZA,South Africa,-2.6438
-2022-09-30,4T,Emerging market economies (aggregate),-0.6869
-2022-09-30,5R,Advanced economies,0.5468
-2022-09-30,AE,United Arab Emirates,0.9409
+2022-06-30,RS,Serbia,5.287
+2022-06-30,RU,Russia,10.6801
+2022-06-30,SE,Sweden,-0.3582
+2022-06-30,SG,Singapore,4.4622
+2022-06-30,SI,Slovenia,6.5009
+2022-06-30,SK,Slovakia,3.6493
+2022-06-30,TH,Thailand,-2.7222
+2022-06-30,TR,Türkiye,39.7534
+2022-06-30,US,United States,6.7423
+2022-06-30,XM,Euro area,1.2791
+2022-06-30,XW,World,1.4493
+2022-06-30,ZA,South Africa,-1.9897
+2022-09-30,4T,Emerging market economies (aggregate),-0.7852
+2022-09-30,5R,Advanced economies,0.3044
 2022-09-30,AT,Austria,0.9063
-2022-09-30,AU,Australia,-2.8888
-2022-09-30,BE,Belgium,-4.4736
-2022-09-30,BG,Bulgaria,-1.9522
-2022-09-30,BR,Brazil,-6.3389
-2022-09-30,CA,Canada,-4.0411
-2022-09-30,CH,Switzerland,2.8391
-2022-09-30,CL,Chile,-5.0772
+2022-09-30,AU,Australia,-2.8424
+2022-09-30,BE,Belgium,-4.4214
+2022-09-30,BG,Bulgaria,-1.9933
+2022-09-30,BR,Brazil,-5.9354
+2022-09-30,CA,Canada,-4.8314
+2022-09-30,CH,Switzerland,2.8392
+2022-09-30,CL,Chile,-4.8688
 2022-09-30,CN,China,-5.788
-2022-09-30,CO,Colombia,-3.0415
+2022-09-30,CO,Colombia,-3.593
 2022-09-30,CY,Cyprus,-2.9335
-2022-09-30,CZ,Czechia,-1.6865
-2022-09-30,DE,Germany,-2.7744
-2022-09-30,DK,Denmark,-10.3257
+2022-09-30,CZ,Czechia,-1.7004
+2022-09-30,DE,Germany,-2.1718
+2022-09-30,DK,Denmark,-10.3178
 2022-09-30,EE,Estonia,0.3384
 2022-09-30,ES,Spain,-2.1993
-2022-09-30,FI,Finland,-5.9798
-2022-09-30,FR,France,0.5385
-2022-09-30,GB,United Kingdom,1.1375
+2022-09-30,FI,Finland,-6.1471
+2022-09-30,FR,France,0.5368
+2022-09-30,GB,United Kingdom,0.8499
 2022-09-30,GR,Greece,0.8469
 2022-09-30,HK,Hong Kong SAR,-9.8403
-2022-09-30,HR,Croatia,2.1117
+2022-09-30,HR,Croatia,2.0998
 2022-09-30,HU,Hungary,6.5599
-2022-09-30,ID,Indonesia,-3.0959
-2022-09-30,IE,Ireland,2.9428
-2022-09-30,IL,Israel,14.106
-2022-09-30,IN,India,-2.3336
+2022-09-30,ID,Indonesia,-3.096
+2022-09-30,IE,Ireland,2.9372
+2022-09-30,IL,Israel,14.1062
+2022-09-30,IN,India,-0.3242
 2022-09-30,IS,Iceland,11.8158
-2022-09-30,IT,Italy,-5.0757
+2022-09-30,IT,Italy,-5.0731
 2022-09-30,JP,Japan,4.8469
-2022-09-30,KR,Korea,-0.5827
+2022-09-30,KR,Korea,-0.5422
 2022-09-30,LT,Lithuania,-2.8045
-2022-09-30,LU,Luxembourg,3.9581
-2022-09-30,LV,Latvia,-6.6898
-2022-09-30,MA,Morocco,-6.3788
-2022-09-30,MK,North Macedonia,3.5024
+2022-09-30,LU,Luxembourg,3.9559
+2022-09-30,LV,Latvia,-6.6577
+2022-09-30,MA,Morocco,-6.0053
+2022-09-30,MK,North Macedonia,3.5929
 2022-09-30,MT,Malta,-0.7277
 2022-09-30,MX,Mexico,0.8364
 2022-09-30,MY,Malaysia,0.6078
-2022-09-30,NL,Netherlands,-0.1015
-2022-09-30,NO,Norway,-1.7854
+2022-09-30,NL,Netherlands,-0.1735
+2022-09-30,NO,Norway,-1.7339
 2022-09-30,NZ,New Zealand,-10.1446
 2022-09-30,PE,Peru,-7.7783
-2022-09-30,PH,Philippines,-0.0104
+2022-09-30,PH,Philippines,6.9271
 2022-09-30,PL,Poland,-3.6476
-2022-09-30,PT,Portugal,3.713
+2022-09-30,PT,Portugal,3.7129
 2022-09-30,RO,Romania,-7.5172
-2022-09-30,RS,Serbia,1.8342
-2022-09-30,RU,Russia,10.9363
-2022-09-30,SE,Sweden,-7.813
-2022-09-30,SG,Singapore,5.8503
-2022-09-30,SI,Slovenia,4.0787
-2022-09-30,SK,Slovak Republic,0.5317
-2022-09-30,TH,Thailand,-3.4441
-2022-09-30,TR,Türkiye,59.6276
-2022-09-30,US,United States,2.7129
-2022-09-30,XM,Euro area,-2.3439
-2022-09-30,XW,World,-0.1316
-2022-09-30,ZA,South Africa,-4.0523
-2022-12-31,4T,Emerging market economies (aggregate),-1.3083
-2022-12-31,5R,Advanced economies,-2.7842
-2022-12-31,AE,United Arab Emirates,2.9228
-2022-12-31,AT,Austria,-4.8376
-2022-12-31,AU,Australia,-10.1387
-2022-12-31,BE,Belgium,-5.68
-2022-12-31,BG,Bulgaria,-3.1932
-2022-12-31,BR,Brazil,-4.8556
-2022-12-31,CA,Canada,-9.8407
+2022-09-30,RS,Serbia,2.8105
+2022-09-30,RU,Russia,10.9506
+2022-09-30,SE,Sweden,-7.8157
+2022-09-30,SG,Singapore,5.8461
+2022-09-30,SI,Slovenia,4.082
+2022-09-30,SK,Slovakia,0.571
+2022-09-30,TH,Thailand,-5.5104
+2022-09-30,TR,Türkiye,54.8972
+2022-09-30,US,United States,2.1451
+2022-09-30,XM,Euro area,-2.133
+2022-09-30,XW,World,-0.2567
+2022-09-30,ZA,South Africa,-3.2817
+2022-12-31,4T,Emerging market economies (aggregate),-0.9818
+2022-12-31,5R,Advanced economies,-2.9474
+2022-12-31,AT,Austria,-4.8375
+2022-12-31,AU,Australia,-10.137
+2022-12-31,BE,Belgium,-5.822
+2022-12-31,BG,Bulgaria,-3.2195
+2022-12-31,BR,Brazil,-3.9975
+2022-12-31,CA,Canada,-10.6321
 2022-12-31,CH,Switzerland,1.822
-2022-12-31,CL,Chile,-7.3537
+2022-12-31,CL,Chile,-7.1488
 2022-12-31,CN,China,-5.4411
-2022-12-31,CO,Colombia,-5.9356
+2022-12-31,CO,Colombia,-6.3668
 2022-12-31,CY,Cyprus,-1.7304
-2022-12-31,CZ,Czechia,-7.5802
-2022-12-31,DE,Germany,-11.1917
-2022-12-31,DK,Denmark,-14.3759
+2022-12-31,CZ,Czechia,-7.5424
+2022-12-31,DE,Germany,-10.1759
+2022-12-31,DK,Denmark,-14.392
 2022-12-31,EE,Estonia,-2.9702
 2022-12-31,ES,Spain,-1.0549
 2022-12-31,FI,Finland,-10.2767
-2022-12-31,FR,France,-1.2831
-2022-12-31,GB,United Kingdom,-1.4937
-2022-12-31,GR,Greece,5.2663
+2022-12-31,FR,France,-1.2801
+2022-12-31,GB,United Kingdom,-1.5613
+2022-12-31,GR,Greece,5.5146
 2022-12-31,HK,Hong Kong SAR,-15.1046
-2022-12-31,HR,Croatia,3.5696
-2022-12-31,HU,Hungary,-4.5223
-2022-12-31,ID,Indonesia,-3.3535
-2022-12-31,IE,Ireland,-0.1885
+2022-12-31,HR,Croatia,3.6105
+2022-12-31,HU,Hungary,-4.263
+2022-12-31,ID,Indonesia,-3.3548
+2022-12-31,IE,Ireland,-0.185
 2022-12-31,IL,Israel,10.9517
-2022-12-31,IN,India,-3.1205
+2022-12-31,IN,India,-1.5347
 2022-12-31,IS,Iceland,9.8988
-2022-12-31,IT,Italy,-8.1022
+2022-12-31,IT,Italy,-8.0997
 2022-12-31,JP,Japan,3.5329
-2022-12-31,KR,Korea,-5.0489
+2022-12-31,KR,Korea,-5.0416
 2022-12-31,LT,Lithuania,-5.458
-2022-12-31,LU,Luxembourg,-0.5071
-2022-12-31,LV,Latvia,-10.5744
-2022-12-31,MA,Morocco,-7.5412
-2022-12-31,MK,North Macedonia,0.9797
+2022-12-31,LU,Luxembourg,-0.5146
+2022-12-31,LV,Latvia,-10.554
+2022-12-31,MA,Morocco,-6.6667
+2022-12-31,MK,North Macedonia,0.904
 2022-12-31,MT,Malta,-1.3192
 2022-12-31,MX,Mexico,2.224
 2022-12-31,MY,Malaysia,-0.0194
-2022-12-31,NL,Netherlands,-5.3011
-2022-12-31,NO,Norway,-3.7706
+2022-12-31,NL,Netherlands,-5.0299
+2022-12-31,NO,Norway,-3.7831
 2022-12-31,NZ,New Zealand,-16.7944
 2022-12-31,PE,Peru,-6.3231
-2022-12-31,PH,Philippines,-0.1611
+2022-12-31,PH,Philippines,4.6637
 2022-12-31,PL,Poland,-6.8844
 2022-12-31,PT,Portugal,1.3183
 2022-12-31,RO,Romania,-8.2902
-2022-12-31,RS,Serbia,-0.0421
-2022-12-31,RU,Russia,9.6895
-2022-12-31,SE,Sweden,-13.6733
-2022-12-31,SG,Singapore,1.8709
-2022-12-31,SI,Slovenia,1.4025
-2022-12-31,SK,Slovak Republic,-4.7511
-2022-12-31,TH,Thailand,-0.9897
-2022-12-31,TR,Türkiye,51.0185
-2022-12-31,US,United States,-0.0601
-2022-12-31,XM,Euro area,-6.3887
-2022-12-31,XW,World,-1.9552
-2022-12-31,ZA,South Africa,-3.9617
-2023-03-31,4T,Emerging market economies (aggregate),-1.7666
-2023-03-31,5R,Advanced economies,-4.8785
-2023-03-31,AE,United Arab Emirates,7.868
+2022-12-31,RS,Serbia,0.3375
+2022-12-31,RU,Russia,9.6827
+2022-12-31,SE,Sweden,-13.6686
+2022-12-31,SG,Singapore,1.8617
+2022-12-31,SI,Slovenia,1.3998
+2022-12-31,SK,Slovakia,-4.7777
+2022-12-31,TH,Thailand,-1.4562
+2022-12-31,TR,Türkiye,52.4898
+2022-12-31,US,United States,-0.1887
+2022-12-31,XM,Euro area,-6.136
+2022-12-31,XW,World,-1.9109
+2022-12-31,ZA,South Africa,-3.5945
+2023-03-31,4T,Emerging market economies (aggregate),-1.714
+2023-03-31,5R,Advanced economies,-4.9374
 2023-03-31,AT,Austria,-8.4897
-2023-03-31,AU,Australia,-12.3176
-2023-03-31,BE,Belgium,-2.5668
-2023-03-31,BG,Bulgaria,-5.2526
-2023-03-31,BR,Brazil,-4.5913
-2023-03-31,CA,Canada,-18.8814
+2023-03-31,AU,Australia,-12.2785
+2023-03-31,BE,Belgium,-3.0313
+2023-03-31,BG,Bulgaria,-5.2606
+2023-03-31,BR,Brazil,-3.1128
+2023-03-31,CA,Canada,-19.5888
 2023-03-31,CH,Switzerland,0.7023
-2023-03-31,CL,Chile,-3.3063
+2023-03-31,CL,Chile,-3.0905
 2023-03-31,CN,China,-4.562
-2023-03-31,CO,Colombia,-3.8929
+2023-03-31,CO,Colombia,-4.8016
 2023-03-31,CY,Cyprus,1.0859
-2023-03-31,CZ,Czechia,-13.4624
-2023-03-31,DE,Germany,-13.8884
-2023-03-31,DK,Denmark,-14.1889
+2023-03-31,CZ,Czechia,-13.4872
+2023-03-31,DE,Germany,-13.4714
+2023-03-31,DK,Denmark,-10.4901
 2023-03-31,EE,Estonia,-6.7696
-2023-03-31,ES,Spain,-1.4356
-2023-03-31,FI,Finland,-12.4227
-2023-03-31,FR,France,-2.9369
-2023-03-31,GB,United Kingdom,-5.8154
-2023-03-31,GR,Greece,8.9557
+2023-03-31,ES,Spain,-1.4359
+2023-03-31,FI,Finland,-12.765
+2023-03-31,FR,France,-2.9398
+2023-03-31,GB,United Kingdom,-5.6189
+2023-03-31,GR,Greece,9.2016
 2023-03-31,HK,Hong Kong SAR,-11.9553
-2023-03-31,HR,Croatia,1.9724
-2023-03-31,HU,Hungary,-11.9767
-2023-03-31,ID,Indonesia,-3.2747
-2023-03-31,IE,Ireland,-2.6519
+2023-03-31,HR,Croatia,1.9915
+2023-03-31,HU,Hungary,-11.217
+2023-03-31,ID,Indonesia,-3.2063
+2023-03-31,IE,Ireland,-2.6437
 2023-03-31,IL,Israel,5.7597
-2023-03-31,IN,India,-1.531
+2023-03-31,IN,India,-1.745
 2023-03-31,IS,Iceland,3.0638
-2023-03-31,IT,Italy,-7.2191
+2023-03-31,IT,Italy,-7.2189
 2023-03-31,JP,Japan,1.0671
-2023-03-31,KR,Korea,-8.6584
-2023-03-31,LT,Lithuania,-4.4707
-2023-03-31,LU,Luxembourg,-5.681
-2023-03-31,LV,Latvia,-11.504
-2023-03-31,MA,Morocco,-7.9775
-2023-03-31,MK,North Macedonia,2.3205
-2023-03-31,MT,Malta,-0.3918
+2023-03-31,KR,Korea,-8.532
+2023-03-31,LT,Lithuania,-4.4708
+2023-03-31,LU,Luxembourg,-5.6869
+2023-03-31,LV,Latvia,-11.5459
+2023-03-31,MA,Morocco,-7.7124
+2023-03-31,MK,North Macedonia,2.4921
+2023-03-31,MT,Malta,0.2772
 2023-03-31,MX,Mexico,3.9297
 2023-03-31,MY,Malaysia,1.1727
-2023-03-31,NL,Netherlands,-6.3471
-2023-03-31,NO,Norway,-6.2726
+2023-03-31,NL,Netherlands,-6.1378
+2023-03-31,NO,Norway,-6.2604
 2023-03-31,NZ,New Zealand,-17.1852
 2023-03-31,PE,Peru,-7.227
-2023-03-31,PH,Philippines,1.7777
+2023-03-31,PH,Philippines,1.6751
 2023-03-31,PL,Poland,-10.1443
 2023-03-31,PT,Portugal,0.6505
 2023-03-31,RO,Romania,-9.3462
-2023-03-31,RS,Serbia,-2.3061
-2023-03-31,RU,Russia,-6.8822
-2023-03-31,SE,Sweden,-16.4521
-2023-03-31,SG,Singapore,4.9883
-2023-03-31,SI,Slovenia,-1.0234
-2023-03-31,SK,Slovak Republic,-6.4998
-2023-03-31,TH,Thailand,0.8924
-2023-03-31,TR,Türkiye,50.8685
-2023-03-31,US,United States,-2.2442
-2023-03-31,XM,Euro area,-7.0097
-2023-03-31,XW,World,-3.1525
-2023-03-31,ZA,South Africa,-4.0817
-2023-06-30,4T,Emerging market economies (aggregate),-0.437
-2023-06-30,5R,Advanced economies,-4.7146
-2023-06-30,AE,United Arab Emirates,12.9115
+2023-03-31,RS,Serbia,-2.0641
+2023-03-31,RU,Russia,-6.8846
+2023-03-31,SE,Sweden,-16.2763
+2023-03-31,SG,Singapore,4.9771
+2023-03-31,SI,Slovenia,-0.8614
+2023-03-31,SK,Slovakia,-6.6831
+2023-03-31,TH,Thailand,0.8289
+2023-03-31,TR,Türkiye,57.2373
+2023-03-31,US,United States,-2.0142
+2023-03-31,XM,Euro area,-6.9649
+2023-03-31,XW,World,-3.2526
+2023-03-31,ZA,South Africa,-4.1088
+2023-06-30,4T,Emerging market economies (aggregate),-0.277
+2023-06-30,5R,Advanced economies,-4.7717
 2023-06-30,AT,Austria,-10.2016
-2023-06-30,AU,Australia,-9.3287
-2023-06-30,BE,Belgium,-3.0929
-2023-06-30,BG,Bulgaria,0.4864
-2023-06-30,BR,Brazil,-3.2392
-2023-06-30,CA,Canada,-11.7102
+2023-06-30,AU,Australia,-9.2714
+2023-06-30,BE,Belgium,-3.0372
+2023-06-30,BG,Bulgaria,0.4896
+2023-06-30,BR,Brazil,-0.9436
+2023-06-30,CA,Canada,-11.9276
 2023-06-30,CH,Switzerland,0.2447
-2023-06-30,CL,Chile,-0.8023
-2023-06-30,CN,China,-2.7707
-2023-06-30,CO,Colombia,-4.7275
+2023-06-30,CL,Chile,-0.6287
+2023-06-30,CN,China,-2.7652
+2023-06-30,CO,Colombia,-5.7333
 2023-06-30,CY,Cyprus,4.4461
-2023-06-30,CZ,Czechia,-12.4689
-2023-06-30,DE,Germany,-15.1932
-2023-06-30,DK,Denmark,-9.7989
+2023-06-30,CZ,Czechia,-12.5606
+2023-06-30,DE,Germany,-14.9989
+2023-06-30,DK,Denmark,-8.0398
 2023-06-30,EE,Estonia,-5.6564
 2023-06-30,ES,Spain,0.6416
-2023-06-30,FI,Finland,-11.7064
-2023-06-30,FR,France,-4.2774
-2023-06-30,GB,United Kingdom,-7.029
-2023-06-30,GR,Greece,11.6518
+2023-06-30,FI,Finland,-12.2142
+2023-06-30,FR,France,-4.2683
+2023-06-30,GB,United Kingdom,-6.9328
+2023-06-30,GR,Greece,12.0198
 2023-06-30,HK,Hong Kong SAR,-10.5075
-2023-06-30,HR,Croatia,5.2311
-2023-06-30,HU,Hungary,-13.8692
-2023-06-30,ID,Indonesia,-1.943
-2023-06-30,IE,Ireland,-3.6797
-2023-06-30,IL,Israel,0.4374
-2023-06-30,IN,India,0.4984
+2023-06-30,HR,Croatia,5.2122
+2023-06-30,HU,Hungary,-12.6792
+2023-06-30,ID,Indonesia,-1.9818
+2023-06-30,IE,Ireland,-3.6627
+2023-06-30,IL,Israel,0.4379
+2023-06-30,IN,India,-0.8537
 2023-06-30,IS,Iceland,-1.3868
-2023-06-30,IT,Italy,-6.283
+2023-06-30,IT,Italy,-6.2825
 2023-06-30,JP,Japan,-0.1293
-2023-06-30,KR,Korea,-9.7321
+2023-06-30,KR,Korea,-9.7401
 2023-06-30,LT,Lithuania,-2.0944
-2023-06-30,LU,Luxembourg,-9.0711
-2023-06-30,LV,Latvia,-5.6161
-2023-06-30,MA,Morocco,-6.8014
-2023-06-30,MK,North Macedonia,1.611
-2023-06-30,MT,Malta,-1.0637
+2023-06-30,LU,Luxembourg,-9.0703
+2023-06-30,LV,Latvia,-5.6431
+2023-06-30,MA,Morocco,-6.0134
+2023-06-30,MK,North Macedonia,1.6432
+2023-06-30,MT,Malta,-0.3434
 2023-06-30,MX,Mexico,5.5057
 2023-06-30,MY,Malaysia,1.4731
-2023-06-30,NL,Netherlands,-9.449
-2023-06-30,NO,Norway,-6.2215
+2023-06-30,NL,Netherlands,-9.1749
+2023-06-30,NO,Norway,-6.1842
 2023-06-30,NZ,New Zealand,-14.0762
 2023-06-30,PE,Peru,-5.9478
-2023-06-30,PH,Philippines,7.6341
+2023-06-30,PH,Philippines,4.2048
 2023-06-30,PL,Poland,-5.4766
 2023-06-30,PT,Portugal,4.1869
 2023-06-30,RO,Romania,-9.6653
-2023-06-30,RS,Serbia,-3.2823
-2023-06-30,RU,Russia,-1.8476
-2023-06-30,SE,Sweden,-15.1238
-2023-06-30,SG,Singapore,2.2482
-2023-06-30,SI,Slovenia,-0.7794
-2023-06-30,SK,Slovak Republic,-12.5579
-2023-06-30,TH,Thailand,2.1806
-2023-06-30,TR,Türkiye,39.5446
-2023-06-30,US,United States,-2.2605
-2023-06-30,XM,Euro area,-7.2738
-2023-06-30,XW,World,-2.3413
-2023-06-30,ZA,South Africa,-3.9454
-2023-09-30,4T,Emerging market economies (aggregate),
-2023-09-30,5R,Advanced economies,-2.697
-2023-09-30,AE,United Arab Emirates,16.7713
+2023-06-30,RS,Serbia,-2.7058
+2023-06-30,RU,Russia,-1.8398
+2023-06-30,SE,Sweden,-15.0838
+2023-06-30,SG,Singapore,2.2401
+2023-06-30,SI,Slovenia,-0.6341
+2023-06-30,SK,Slovakia,-12.7607
+2023-06-30,TH,Thailand,1.7265
+2023-06-30,TR,Türkiye,46.2898
+2023-06-30,US,United States,-1.7047
+2023-06-30,XM,Euro area,-7.2831
+2023-06-30,XW,World,-2.42
+2023-06-30,ZA,South Africa,-4.2795
+2023-09-30,4T,Emerging market economies (aggregate),-1.3581
+2023-09-30,5R,Advanced economies,-3.2114
 2023-09-30,AT,Austria,-9.0924
-2023-09-30,AU,Australia,-3.0516
-2023-09-30,BE,Belgium,-2.2919
-2023-09-30,BG,Bulgaria,1.5855
-2023-09-30,BR,Brazil,-3.9844
-2023-09-30,CA,Canada,-3.5862
+2023-09-30,AU,Australia,-2.7837
+2023-09-30,BE,Belgium,-2.4451
+2023-09-30,BG,Bulgaria,1.5899
+2023-09-30,BR,Brazil,-0.8
+2023-09-30,CA,Canada,-3.8626
 2023-09-30,CH,Switzerland,-0.2912
-2023-09-30,CL,Chile,
-2023-09-30,CN,China,-3.1003
-2023-09-30,CO,Colombia,-3.9253
+2023-09-30,CL,Chile,2.191
+2023-09-30,CN,China,-3.1151
+2023-09-30,CO,Colombia,-2.7649
 2023-09-30,CY,Cyprus,4.7247
-2023-09-30,CZ,Czechia,-10.6939
-2023-09-30,DE,Germany,-14.991
-2023-09-30,DK,Denmark,-2.3776
+2023-09-30,CZ,Czechia,-10.6943
+2023-09-30,DE,Germany,-14.98
+2023-09-30,DK,Denmark,-1.6854
 2023-09-30,EE,Estonia,-1.1581
 2023-09-30,ES,Spain,1.6652
-2023-09-30,FI,Finland,
-2023-09-30,FR,France,-5.8948
-2023-09-30,GB,United Kingdom,-6.7222
-2023-09-30,GR,Greece,9.4386
-2023-09-30,HK,Hong Kong SAR,-10.2482
-2023-09-30,HR,Croatia,3.3893
-2023-09-30,HU,Hungary,-12.0181
-2023-09-30,ID,Indonesia,-0.8908
-2023-09-30,IE,Ireland,-4.5287
-2023-09-30,IL,Israel,-3.8486
-2023-09-30,IN,India,
+2023-09-30,FI,Finland,-12.8873
+2023-09-30,FR,France,-5.9656
+2023-09-30,GB,United Kingdom,-7.3078
+2023-09-30,GR,Greece,10.2632
+2023-09-30,HK,Hong Kong SAR,-10.266
+2023-09-30,HR,Croatia,3.3652
+2023-09-30,HU,Hungary,-10.1392
+2023-09-30,ID,Indonesia,-0.9606
+2023-09-30,IE,Ireland,-4.5481
+2023-09-30,IL,Israel,-3.8084
+2023-09-30,IN,India,-3.6046
 2023-09-30,IS,Iceland,-5.1169
-2023-09-30,IT,Italy,-3.5927
-2023-09-30,JP,Japan,-1.0238
-2023-09-30,KR,Korea,-10.1307
+2023-09-30,IT,Italy,-3.6836
+2023-09-30,JP,Japan,-0.975
+2023-09-30,KR,Korea,-10.1449
 2023-09-30,LT,Lithuania,2.8238
-2023-09-30,LU,Luxembourg,-16.9578
-2023-09-30,LV,Latvia,-1.7896
-2023-09-30,MA,Morocco,-4.8693
-2023-09-30,MK,North Macedonia,3.0035
-2023-09-30,MT,Malta,0.3532
+2023-09-30,LU,Luxembourg,-17.2522
+2023-09-30,LV,Latvia,-1.9387
+2023-09-30,MA,Morocco,-4.6038
+2023-09-30,MK,North Macedonia,3.1907
+2023-09-30,MT,Malta,1.3768
 2023-09-30,MX,Mexico,5.5015
-2023-09-30,MY,Malaysia,-1.8464
-2023-09-30,NL,Netherlands,-6.1794
-2023-09-30,NO,Norway,-5.5301
-2023-09-30,NZ,New Zealand,-9.4125
-2023-09-30,PE,Peru,-3.5928
-2023-09-30,PH,Philippines,7.1124
+2023-09-30,MY,Malaysia,1.293
+2023-09-30,NL,Netherlands,-6.1319
+2023-09-30,NO,Norway,-5.5404
+2023-09-30,NZ,New Zealand,-9.1918
+2023-09-30,PE,Peru,-4.1761
+2023-09-30,PH,Philippines,1.8863
 2023-09-30,PL,Poland,-0.1254
-2023-09-30,PT,Portugal,
-2023-09-30,RO,Romania,
-2023-09-30,RS,Serbia,-2.8735
-2023-09-30,RU,Russia,
-2023-09-30,SE,Sweden,-11.0911
-2023-09-30,SG,Singapore,0.2666
-2023-09-30,SI,Slovenia,-0.7932
-2023-09-30,SK,Slovak Republic,-11.661
-2023-09-30,TH,Thailand,3.0651
-2023-09-30,TR,Türkiye,21.1295
-2023-09-30,US,United States,1.0205
-2023-09-30,XM,Euro area,-6.7272
-2023-09-30,XW,World,
-2023-09-30,ZA,South Africa,-3.9712
+2023-09-30,PT,Portugal,3.9732
+2023-09-30,RO,Romania,-3.9686
+2023-09-30,RS,Serbia,-2.1029
+2023-09-30,RU,Russia,-3.2379
+2023-09-30,SE,Sweden,-11.0355
+2023-09-30,SG,Singapore,0.2519
+2023-09-30,SI,Slovenia,-0.8704
+2023-09-30,SK,Slovakia,-11.9171
+2023-09-30,TH,Thailand,2.6649
+2023-09-30,TR,Türkiye,24.0616
+2023-09-30,US,United States,1.1097
+2023-09-30,XM,Euro area,-6.8324
+2023-09-30,XW,World,-2.235
+2023-09-30,ZA,South Africa,-3.9034
+2023-12-31,4T,Emerging market economies (aggregate),-1.2731
+2023-12-31,5R,Advanced economies,-1.4174
+2023-12-31,AT,Austria,-7.3811
+2023-12-31,AU,Australia,3.0692
+2023-12-31,BE,Belgium,1.9331
+2023-12-31,BG,Bulgaria,4.5567
+2023-12-31,BR,Brazil,0.0553
+2023-12-31,CA,Canada,-2.6586
+2023-12-31,CH,Switzerland,-0.3632
+2023-12-31,CL,Chile,2.9106
+2023-12-31,CN,China,-3.3968
+2023-12-31,CO,Colombia,-4.6288
+2023-12-31,CY,Cyprus,5.9284
+2023-12-31,CZ,Czechia,-7.9791
+2023-12-31,DE,Germany,-10.8169
+2023-12-31,DK,Denmark,8.5291
+2023-12-31,EE,Estonia,1.4005
+2023-12-31,ES,Spain,0.9944
+2023-12-31,FI,Finland,-9.0717
+2023-12-31,FR,France,-7.0537
+2023-12-31,GB,United Kingdom,-6.3557
+2023-12-31,GR,Greece,8.8719
+2023-12-31,HK,Hong Kong SAR,-9.5712
+2023-12-31,HR,Croatia,4.185
+2023-12-31,HU,Hungary,-0.3508
+2023-12-31,ID,Indonesia,-1.0389
+2023-12-31,IE,Ireland,-1.3106
+2023-12-31,IL,Israel,-4.8046
+2023-12-31,IN,India,-2.2716
+2023-12-31,IS,Iceland,-3.3805
+2023-12-31,IT,Italy,0.789
+2023-12-31,JP,Japan,-0.8633
+2023-12-31,KR,Korea,-8.7184
+2023-12-31,LT,Lithuania,6.201
+2023-12-31,LU,Luxembourg,-17.1405
+2023-12-31,LV,Latvia,-0.3902
+2023-12-31,MA,Morocco,-3.9032
+2023-12-31,MK,North Macedonia,3.3501
+2023-12-31,MT,Malta,2.9886
+2023-12-31,MX,Mexico,5.4083
+2023-12-31,MY,Malaysia,2.2114
+2023-12-31,NL,Netherlands,-0.6519
+2023-12-31,NO,Norway,-4.9883
+2023-12-31,NZ,New Zealand,-5.0357
+2023-12-31,PE,Peru,-0.7747
+2023-12-31,PH,Philippines,-1.0681
+2023-12-31,PL,Poland,6.5353
+2023-12-31,PT,Portugal,6.0447
+2023-12-31,RO,Romania,-3.4782
+2023-12-31,RS,Serbia,-0.8164
+2023-12-31,RU,Russia,-3.6862
+2023-12-31,SE,Sweden,-7.9678
+2023-12-31,SG,Singapore,2.7035
+2023-12-31,SI,Slovenia,1.5342
+2023-12-31,SK,Slovakia,-7.3316
+2023-12-31,TH,Thailand,3.0725
+2023-12-31,TR,Türkiye,15.0813
+2023-12-31,US,United States,2.1798
+2023-12-31,XM,Euro area,-3.8886
+2023-12-31,XW,World,-1.3376
+2023-12-31,ZA,South Africa,-4.4243
+2024-03-31,4T,Emerging market economies (aggregate),-0.5662
+2024-03-31,5R,Advanced economies,-0.6802
+2024-03-31,AT,Austria,-6.5853
+2024-03-31,AU,Australia,5.7289
+2024-03-31,BE,Belgium,0.4773
+2024-03-31,BG,Bulgaria,12.2043
+2024-03-31,BR,Brazil,1.2428
+2024-03-31,CA,Canada,-2.0546
+2024-03-31,CH,Switzerland,0.3107
+2024-03-31,CL,Chile,3.4052
+2024-03-31,CN,China,-5.1559
+2024-03-31,CO,Colombia,0.1207
+2024-03-31,CY,Cyprus,6.1285
+2024-03-31,CZ,Czechia,-0.876
+2024-03-31,DE,Germany,-7.4925
+2024-03-31,DK,Denmark,0.1999
+2024-03-31,EE,Estonia,3.4085
+2024-03-31,ES,Spain,3.1526
+2024-03-31,FI,Finland,-6.6568
+2024-03-31,FR,France,-7.3474
+2024-03-31,GB,United Kingdom,-4.6943
+2024-03-31,GR,Greece,7.4881
+2024-03-31,HK,Hong Kong SAR,-13.2111
+2024-03-31,HR,Croatia,4.7756
+2024-03-31,HU,Hungary,7.992
+2024-03-31,ID,Indonesia,-0.8852
+2024-03-31,IE,Ireland,2.7604
+2024-03-31,IL,Israel,-1.4971
+2024-03-31,IN,India,1.7547
+2024-03-31,IS,Iceland,0.2569
+2024-03-31,IT,Italy,0.6587
+2024-03-31,JP,Japan,-0.0346
+2024-03-31,KR,Korea,-5.6419
+2024-03-31,LT,Lithuania,9.3555
+2024-03-31,LU,Luxembourg,-13.9907
+2024-03-31,LV,Latvia,2.8961
+2024-03-31,MA,Morocco,-1.7193
+2024-03-31,MK,North Macedonia,1.1252
+2024-03-31,MT,Malta,4.1726
+2024-03-31,MX,Mexico,4.8799
+2024-03-31,MY,Malaysia,1.8213
+2024-03-31,NL,Netherlands,0.6554
+2024-03-31,NO,Norway,-3.0688
+2024-03-31,NZ,New Zealand,-1.8667
+2024-03-31,PE,Peru,-1.5415
+2024-03-31,PH,Philippines,3.9833
+2024-03-31,PL,Poland,14.5902
+2024-03-31,PT,Portugal,4.677
+2024-03-31,RO,Romania,-1.4973
+2024-03-31,RS,Serbia,0.1918
+2024-03-31,RU,Russia,10.5383
+2024-03-31,SE,Sweden,-5.9809
+2024-03-31,SG,Singapore,1.5896
+2024-03-31,SI,Slovenia,3.831
+2024-03-31,SK,Slovakia,-5.9492
+2024-03-31,TH,Thailand,1.3912
+2024-03-31,TR,Türkiye,-2.0867
+2024-03-31,US,United States,2.0744
+2024-03-31,XM,Euro area,-2.7714
+2024-03-31,XW,World,-0.6172
+2024-03-31,ZA,South Africa,-4.2067
+2024-06-30,4T,Emerging market economies (aggregate),-1.9949
+2024-06-30,5R,Advanced economies,-0.1295
+2024-06-30,AT,Austria,-5.5675
+2024-06-30,AU,Australia,4.8545
+2024-06-30,BE,Belgium,-0.2091
+2024-06-30,BG,Bulgaria,12.4091
+2024-06-30,BR,Brazil,2.1071
+2024-06-30,CA,Canada,-5.3872
+2024-06-30,CH,Switzerland,0.0141
+2024-06-30,CL,Chile,2.8793
+2024-06-30,CN,China,-7.6261
+2024-06-30,CO,Colombia,0.5382
+2024-06-30,CY,Cyprus,5.1682
+2024-06-30,CZ,Czechia,1.6151
+2024-06-30,DE,Germany,-4.6574
+2024-06-30,DK,Denmark,2.2335
+2024-06-30,EE,Estonia,3.8484
+2024-06-30,ES,Spain,4.3258
+2024-06-30,FI,Finland,-5.8603
+2024-06-30,FR,France,-6.6156
+2024-06-30,GB,United Kingdom,-1.67
+2024-06-30,GR,Greece,7.0032
+2024-06-30,HK,Hong Kong SAR,-13.8329
+2024-06-30,HR,Croatia,6.6158
+2024-06-30,HU,Hungary,8.7939
+2024-06-30,ID,Indonesia,-0.9937
+2024-06-30,IE,Ireland,5.8226
+2024-06-30,IL,Israel,1.6427
+2024-06-30,IN,India,2.5539
+2024-06-30,IS,Iceland,0.2489
+2024-06-30,IT,Italy,2.1173
+2024-06-30,JP,Japan,0.0417
+2024-06-30,KR,Korea,-3.5419
+2024-06-30,LT,Lithuania,9.8648
+2024-06-30,LU,Luxembourg,-10.5508
+2024-06-30,LV,Latvia,-0.1179
+2024-06-30,MA,Morocco,-1.0658
+2024-06-30,MK,North Macedonia,7.181
+2024-06-30,MT,Malta,5.3502
+2024-06-30,MX,Mexico,4.3744
+2024-06-30,MY,Malaysia,2.1182
+2024-06-30,NL,Netherlands,4.6217
+2024-06-30,NO,Norway,-1.5218
+2024-06-30,NZ,New Zealand,-2.0607
+2024-06-30,PE,Peru,-1.755
+2024-06-30,PH,Philippines,3.9415
+2024-06-30,PL,Poland,14.668
+2024-06-30,PT,Portugal,4.9933
+2024-06-30,RO,Romania,1.4957
+2024-06-30,RS,Serbia,0.8566
+2024-06-30,RU,Russia,10.1659
+2024-06-30,SE,Sweden,-4.0208
+2024-06-30,SG,Singapore,3.1734
+2024-06-30,SI,Slovenia,4.5147
+2024-06-30,SK,Slovakia,1.8573
+2024-06-30,TH,Thailand,0.4692
+2024-06-30,TR,Türkiye,-13.1102
+2024-06-30,US,United States,1.5419
+2024-06-30,XM,Euro area,-1.0577
+2024-06-30,XW,World,-1.1332
+2024-06-30,ZA,South Africa,-4.3225
+2024-09-30,4T,Emerging market economies (aggregate),-2.8668
+2024-09-30,5R,Advanced economies,0.3503
+2024-09-30,AT,Austria,-4.4952
+2024-09-30,AU,Australia,4.4556
+2024-09-30,BE,Belgium,0.361
+2024-09-30,BG,Bulgaria,14.3453
+2024-09-30,BR,Brazil,1.8264
+2024-09-30,CA,Canada,-5.9425
+2024-09-30,CH,Switzerland,0.675
+2024-09-30,CL,Chile,2.2077
+2024-09-30,CN,China,-9.0289
+2024-09-30,CO,Colombia,1.0652
+2024-09-30,CY,Cyprus,5.004
+2024-09-30,CZ,Czechia,3.7227
+2024-09-30,DE,Germany,-2.0614
+2024-09-30,DK,Denmark,3.8974
+2024-09-30,EE,Estonia,3.1177
+2024-09-30,ES,Spain,5.9635
+2024-09-30,FI,Finland,-2.906
+2024-09-30,FR,France,-5.1319
+2024-09-30,GB,United Kingdom,-1.1342
+2024-09-30,GR,Greece,5.5224
+2024-09-30,HK,Hong Kong SAR,-15.1415
+2024-09-30,HR,Croatia,10.2149
+2024-09-30,HU,Hungary,9.8103
+2024-09-30,ID,Indonesia,-0.5604
+2024-09-30,IE,Ireland,8.2508
+2024-09-30,IL,Israel,2.6633
+2024-09-30,IN,India,2.6121
+2024-09-30,IS,Iceland,5.6534
+2024-09-30,IT,Italy,2.7189
+2024-09-30,JP,Japan,0.4514
+2024-09-30,KR,Korea,-2.3315
+2024-09-30,LT,Lithuania,8.128
+2024-09-30,LU,Luxembourg,-3.4856
+2024-09-30,LV,Latvia,4.2367
+2024-09-30,MA,Morocco,-1.534
+2024-09-30,MK,North Macedonia,5.2257
+2024-09-30,MT,Malta,5.5211
+2024-09-30,MX,Mexico,3.9427
+2024-09-30,MY,Malaysia,2.3714
+2024-09-30,NL,Netherlands,6.5777
+2024-09-30,NO,Norway,0.4227
+2024-09-30,NZ,New Zealand,-3.0816
+2024-09-30,PE,Peru,-1.8652
+2024-09-30,PH,Philippines,4.2376
+2024-09-30,PL,Poland,9.3
+2024-09-30,PT,Portugal,7.4762
+2024-09-30,RO,Romania,-0.9939
+2024-09-30,RS,Serbia,0.9511
+2024-09-30,RU,Russia,8.0479
+2024-09-30,SE,Sweden,-1.7833
+2024-09-30,SG,Singapore,2.2152
+2024-09-30,SI,Slovenia,7.143
+2024-09-30,SK,Slovakia,3.4034
+2024-09-30,TH,Thailand,2.4283
+2024-09-30,TR,Türkiye,-13.512
+2024-09-30,US,United States,1.0946
+2024-09-30,XM,Euro area,0.6147
+2024-09-30,XW,World,-1.3934
+2024-09-30,ZA,South Africa,-3.482
+2024-12-31,4T,Emerging market economies (aggregate),-3.0631
+2024-12-31,5R,Advanced economies,0.7809
+2024-12-31,AT,Austria,-2.9419
+2024-12-31,AU,Australia,3.2824
+2024-12-31,BE,Belgium,-0.3543
+2024-12-31,BG,Bulgaria,15.9377
+2024-12-31,BR,Brazil,1.2176
+2024-12-31,CA,Canada,-3.6694
+2024-12-31,CH,Switzerland,1.6975
+2024-12-31,CL,Chile,2.8485
+2024-12-31,CN,China,-8.7494
+2024-12-31,CO,Colombia,4.6911
+2024-12-31,CY,Cyprus,2.9459
+2024-12-31,CZ,Czechia,5.4103
+2024-12-31,DE,Germany,-0.3653
+2024-12-31,DK,Denmark,1.9653
+2024-12-31,EE,Estonia,-0.3143
+2024-12-31,ES,Spain,8.7997
+2024-12-31,FI,Finland,-2.7663
+2024-12-31,FR,France,-3.0961
+2024-12-31,GB,United Kingdom,-0.0499
+2024-12-31,GR,Greece,4.8498
+2024-12-31,HK,Hong Kong SAR,-9.3817
+2024-12-31,HR,Croatia,7.1383
+2024-12-31,HU,Hungary,11.8562
+2024-12-31,ID,Indonesia,-0.2173
+2024-12-31,IE,Ireland,8.2455
+2024-12-31,IL,Israel,3.9981
+2024-12-31,IN,India,1.1551
+2024-12-31,IS,Iceland,3.667
+2024-12-31,IT,Italy,3.2075
+2024-12-31,JP,Japan,-0.1393
+2024-12-31,KR,Korea,-1.7069
+2024-12-31,LT,Lithuania,8.4549
+2024-12-31,LU,Luxembourg,0.4857
+2024-12-31,LV,Latvia,4.6237
+2024-12-31,MA,Morocco,0.9776
+2024-12-31,MK,North Macedonia,6.2839
+2024-12-31,MT,Malta,4.8905
+2024-12-31,MX,Mexico,4.0256
+2024-12-31,MY,Malaysia,2.5772
+2024-12-31,NL,Netherlands,6.6926
+2024-12-31,NO,Norway,2.3391
+2024-12-31,NZ,New Zealand,-3.7319
+2024-12-31,PE,Peru,-3.5053
+2024-12-31,PH,Philippines,7.0312
+2024-12-31,PL,Poland,5.2083
+2024-12-31,PT,Portugal,8.7256
+2024-12-31,RO,Romania,-0.9765
+2024-12-31,RS,Serbia,1.0256
+2024-12-31,RU,Russia,7.4482
+2024-12-31,SE,Sweden,0.7952
+2024-12-31,SG,Singapore,2.4686
+2024-12-31,SI,Slovenia,6.3442
+2024-12-31,SK,Slovakia,4.7718
+2024-12-31,TH,Thailand,1.5627
+2024-12-31,TR,Türkiye,-12.3403
+2024-12-31,US,United States,0.6962
+2024-12-31,XM,Euro area,1.8855
+2024-12-31,XW,World,-1.307
+2024-12-31,ZA,South Africa,-1.7572
+2025-03-31,4T,Emerging market economies (aggregate),-2.6316
+2025-03-31,5R,Advanced economies,0.9762
+2025-03-31,AT,Austria,-2.6793
+2025-03-31,AU,Australia,2.0183
+2025-03-31,BE,Belgium,-0.8143
+2025-03-31,BG,Bulgaria,10.7127
+2025-03-31,BR,Brazil,0.6112
+2025-03-31,CA,Canada,-3.6908
+2025-03-31,CH,Switzerland,3.7601
+2025-03-31,CL,Chile,1.9731
+2025-03-31,CN,China,-7.4249
+2025-03-31,CO,Colombia,-0.9849
+2025-03-31,CY,Cyprus,2.7858
+2025-03-31,CZ,Czechia,7.0268
+2025-03-31,DE,Germany,1.2272
+2025-03-31,DK,Denmark,6.9672
+2025-03-31,EE,Estonia,0.0893
+2025-03-31,ES,Spain,9.3129
+2025-03-31,FI,Finland,-2.4174
+2025-03-31,FR,France,-0.667
+2025-03-31,GB,United Kingdom,1.3569
+2025-03-31,GR,Greece,4.7817
+2025-03-31,HK,Hong Kong SAR,-8.0107
+2025-03-31,HR,Croatia,9.1123
+2025-03-31,HU,Hungary,11.203
+2025-03-31,ID,Indonesia,0.5081
+2025-03-31,IE,Ireland,5.9115
+2025-03-31,IL,Israel,2.3171
+2025-03-31,IN,India,0.1226
+2025-03-31,IS,Iceland,2.6841
+2025-03-31,IT,Italy,2.7154
+2025-03-31,JP,Japan,0.8836
+2025-03-31,KR,Korea,-2.2129
+2025-03-31,LT,Lithuania,4.8811
+2025-03-31,LU,Luxembourg,-0.6452
+2025-03-31,LV,Latvia,2.0119
+2025-03-31,MA,Morocco,-1.5926
+2025-03-31,MK,North Macedonia,14.6353
+2025-03-31,MT,Malta,3.9694
+2025-03-31,MX,Mexico,4.2734
+2025-03-31,MY,Malaysia,1.9644
+2025-03-31,NL,Netherlands,6.9897
+2025-03-31,NO,Norway,3.5824
+2025-03-31,NZ,New Zealand,-4.3211
+2025-03-31,PE,Peru,-0.7789
+2025-03-31,PH,Philippines,5.2121
+2025-03-31,PL,Poland,1.1048
+2025-03-31,PT,Portugal,13.72
+2025-03-31,RO,Romania,0.2388
+2025-03-31,RS,Serbia,1.0191
+2025-03-31,RU,Russia,6.2956
+2025-03-31,SE,Sweden,1.1989
+2025-03-31,SG,Singapore,2.3112
+2025-03-31,SI,Slovenia,1.2855
+2025-03-31,SK,Slovakia,8.9637
+2025-03-31,TH,Thailand,2.3857
+2025-03-31,TR,Türkiye,-5.6297
+2025-03-31,US,United States,-0.0689
+2025-03-31,XM,Euro area,2.9129
+2025-03-31,XW,World,-0.981
+2025-03-31,ZA,South Africa,-1.2074
+2025-06-30,4T,Emerging market economies (aggregate),-2.0004
+2025-06-30,5R,Advanced economies,0.5833
+2025-06-30,AT,Austria,-3.0018
+2025-06-30,AU,Australia,1.9305
+2025-06-30,BE,Belgium,0.615
+2025-06-30,BG,Bulgaria,11.2253
+2025-06-30,BR,Brazil,-0.2171
+2025-06-30,CA,Canada,-4.6034
+2025-06-30,CH,Switzerland,4.9506
+2025-06-30,CL,Chile,2.0328
+2025-06-30,CN,China,-6.3758
+2025-06-30,CO,Colombia,4.7037
+2025-06-30,CY,Cyprus,4.8267
+2025-06-30,CZ,Czechia,7.922
+2025-06-30,DE,Germany,1.0289
+2025-06-30,DK,Denmark,5.6113
+2025-06-30,EE,Estonia,0.7945
+2025-06-30,ES,Spain,10.3945
+2025-06-30,FI,Finland,-1.7648
+2025-06-30,FR,France,-0.181
+2025-06-30,GB,United Kingdom,-1.3197
+2025-06-30,GR,Greece,5.4592
+2025-06-30,HK,Hong Kong SAR,-7.9531
+2025-06-30,HR,Croatia,9.4751
+2025-06-30,HU,Hungary,9.0779
+2025-06-30,ID,Indonesia,-0.8914
+2025-06-30,IE,Ireland,5.771
+2025-06-30,IL,Israel,-0.6275
+2025-06-30,IN,India,0.734
+2025-06-30,IS,Iceland,1.7404
+2025-06-30,IT,Italy,2.1786
+2025-06-30,JP,Japan,0.2537
+2025-06-30,KR,Korea,-1.9026
+2025-06-30,LT,Lithuania,4.8548
+2025-06-30,LU,Luxembourg,2.4965
+2025-06-30,LV,Latvia,2.6126
+2025-06-30,MA,Morocco,-0.2215
+2025-06-30,MK,North Macedonia,15.8804
+2025-06-30,MT,Malta,3.0902
+2025-06-30,MX,Mexico,4.3083
+2025-06-30,MY,Malaysia,1.7354
+2025-06-30,NL,Netherlands,5.9342
+2025-06-30,NO,Norway,1.6383
+2025-06-30,NZ,New Zealand,-3.6784
+2025-06-30,PE,Peru,0.5492
+2025-06-30,PH,Philippines,6.1108
+2025-06-30,PL,Poland,0.2592
+2025-06-30,PT,Portugal,14.6616
+2025-06-30,RO,Romania,-0.7603
+2025-06-30,RS,Serbia,1.486
+2025-06-30,RU,Russia,5.846
+2025-06-30,SE,Sweden,0.1804
+2025-06-30,SG,Singapore,2.6158
+2025-06-30,SI,Slovenia,3.3892
+2025-06-30,SK,Slovakia,6.9553
+2025-06-30,TH,Thailand,3.1889
+2025-06-30,TR,Türkiye,-2.5202
+2025-06-30,US,United States,-0.5504
+2025-06-30,XM,Euro area,3.0724
+2025-06-30,XW,World,-0.8115
+2025-06-30,ZA,South Africa,0.4063
+2025-09-30,4T,Emerging market economies (aggregate),-1.2293
+2025-09-30,5R,Advanced economies,0.2709
+2025-09-30,AT,Austria,-2.3372
+2025-09-30,AU,Australia,1.7436
+2025-09-30,BE,Belgium,1.6403
+2025-09-30,BG,Bulgaria,9.518
+2025-09-30,BR,Brazil,-0.4394
+2025-09-30,CA,Canada,-5.0726
+2025-09-30,CH,Switzerland,5.0142
+2025-09-30,CL,Chile,2.78
+2025-09-30,CN,China,-5.2998
+2025-09-30,CO,Colombia,3.1311
+2025-09-30,CY,Cyprus,5.9011
+2025-09-30,CZ,Czechia,8.1305
+2025-09-30,DE,Germany,0.8742
+2025-09-30,DK,Denmark,4.1002
+2025-09-30,EE,Estonia,-0.4029
+2025-09-30,ES,Spain,9.7602
+2025-09-30,FI,Finland,-3.5395
+2025-09-30,FR,France,-0.3
+2025-09-30,GB,United Kingdom,-1.2839
+2025-09-30,GR,Greece,5.4853
+2025-09-30,HK,Hong Kong SAR,-1.8821
+2025-09-30,HR,Croatia,9.34
+2025-09-30,HU,Hungary,15.9779
+2025-09-30,ID,Indonesia,-1.5639
+2025-09-30,IE,Ireland,5.2579
+2025-09-30,IL,Israel,-2.0766
+2025-09-30,IN,India,1.8298
+2025-09-30,IS,Iceland,-1.0877
+2025-09-30,IT,Italy,2.0955
+2025-09-30,JP,Japan,1.4084
+2025-09-30,KR,Korea,-1.57
+2025-09-30,LT,Lithuania,6.6493
+2025-09-30,LU,Luxembourg,-1.5644
+2025-09-30,LV,Latvia,3.7875
+2025-09-30,MA,Morocco,1.5767
+2025-09-30,MK,North Macedonia,19.8227
+2025-09-30,MT,Malta,3.0644
+2025-09-30,MX,Mexico,5.067
+2025-09-30,MY,Malaysia,0.9758
+2025-09-30,NL,Netherlands,4.6134
+2025-09-30,NO,Norway,1.5219
+2025-09-30,NZ,New Zealand,-3.4711
+2025-09-30,PE,Peru,2.6441
+2025-09-30,PH,Philippines,0.486
+2025-09-30,PL,Poland,0.8721
+2025-09-30,PT,Portugal,14.6942
+2025-09-30,RO,Romania,-2.5508
+2025-09-30,RS,Serbia,1.5294
+2025-09-30,RU,Russia,7.1157
+2025-09-30,SE,Sweden,-0.6072
+2025-09-30,SG,Singapore,4.4374
+2025-09-30,SI,Slovenia,-0.1085
+2025-09-30,SK,Slovakia,8.7342
+2025-09-30,TH,Thailand,1.1471
+2025-09-30,TR,Türkiye,-0.8428
+2025-09-30,US,United States,-1.5537
+2025-09-30,XM,Euro area,2.8833
+2025-09-30,XW,World,-0.5454
+2025-09-30,ZA,South Africa,1.4371
+2025-12-31,5R,Advanced economies,0.3653
+2025-12-31,AT,Austria,-1.7427
+2025-12-31,AU,Australia,4.0487
+2025-12-31,BE,Belgium,1.282
+2025-12-31,BG,Bulgaria,7.0384
+2025-12-31,BR,Brazil,-0.0889
+2025-12-31,CA,Canada,-5.5075
+2025-12-31,CH,Switzerland,3.8781
+2025-12-31,CN,China,-6.2713
+2025-12-31,CO,Colombia,7.2007
+2025-12-31,CY,Cyprus,7.5719
+2025-12-31,CZ,Czechia,7.9612
+2025-12-31,DE,Germany,0.8506
+2025-12-31,DK,Denmark,5.4726
+2025-12-31,EE,Estonia,0.9948
+2025-12-31,ES,Spain,9.5689
+2025-12-31,FR,France,0.15
+2025-12-31,GB,United Kingdom,-0.8816
+2025-12-31,GR,Greece,5.1684
+2025-12-31,HK,Hong Kong SAR,1.1681
+2025-12-31,HR,Croatia,12.0103
+2025-12-31,HU,Hungary,16.8257
+2025-12-31,IE,Ireland,3.9129
+2025-12-31,IL,Israel,-2.5961
+2025-12-31,IN,India,2.9968
+2025-12-31,IS,Iceland,-0.4967
+2025-12-31,IT,Italy,2.866
+2025-12-31,JP,Japan,2.3085
+2025-12-31,KR,Korea,-1.6388
+2025-12-31,LT,Lithuania,6.7937
+2025-12-31,LU,Luxembourg,-2.8069
+2025-12-31,LV,Latvia,6.9145
+2025-12-31,MA,Morocco,0.4452
+2025-12-31,MK,North Macedonia,19.9632
+2025-12-31,MX,Mexico,5.0514
+2025-12-31,MY,Malaysia,0.0712
+2025-12-31,NO,Norway,2.793
+2025-12-31,NZ,New Zealand,-4.2399
+2025-12-31,PE,Peru,4.6278
+2025-12-31,PH,Philippines,-0.0837
+2025-12-31,PL,Poland,1.7853
+2025-12-31,PT,Portugal,16.2843
+2025-12-31,RO,Romania,-2.528
+2025-12-31,RS,Serbia,2.8578
+2025-12-31,RU,Russia,7.1556
+2025-12-31,SE,Sweden,0.69
+2025-12-31,SG,Singapore,2.1235
+2025-12-31,SI,Slovenia,2.9834
+2025-12-31,SK,Slovakia,8.6449
+2025-12-31,TH,Thailand,1.1453
+2025-12-31,TR,Türkiye,-0.7502
+2025-12-31,US,United States,-1.773
+2025-12-31,XM,Euro area,3.0123
+2025-12-31,ZA,South Africa,1.7435

--- a/datapackage.json
+++ b/datapackage.json
@@ -13,7 +13,7 @@
     {
       "name": "bis-selected-property-prices",
       "title": "BIS Selected Residential Property Prices",
-      "path": "https://www.bis.org/statistics/full_spp_csv.zip"
+      "path": "https://stats.bis.org/api/v2/data/dataflow/BIS/WS_SPP/1.0?format=csv&labels=both"
     }
   ],
   "resources": [
@@ -166,5 +166,5 @@
       }
     }
   ],
-  "collection": "property-prices"
+"collection": "property-prices"
 }

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -1,82 +1,61 @@
-import urllib.request
-import zipfile
 import csv
+import io
 import os
-from frictionless import Resource
+import urllib.request
 
-source_url = 'https://www.bis.org/statistics/full_spp_csv.zip'
+source_url = 'https://stats.bis.org/api/v2/data/dataflow/BIS/WS_SPP/1.0?format=csv&labels=both'
 
-def download_source():
-    """ Downloads and unzip the source csv file
-    :return: filename """
-    os.makedirs('archive', exist_ok=True)
-    
-    with urllib.request.urlopen(source_url) as u, open('archive/source.zip', 'wb') as f:
-        f.write(u.read())
-    
-    with zipfile.ZipFile('archive/source.zip', 'r') as zfile:
-        zfile.extractall('archive/')
-        return 'archive/' + zfile.namelist()[0]
 
 def parse_date(date):
-    """ Transforms date from quartals '1999-Q1' to usual '1999-03-31' """
+    """Transforms BIS quarter format '1999-Q1' to ISO date '1999-03-31'."""
     return date.replace('Q1', '03-31').replace('Q2', '06-30').replace('Q3', '09-30').replace('Q4', '12-31')
 
-def parse(filename):
-    """ Read csv file and parse it into 4 different csv files with unpivoted data."""
-    resource = Resource(filename)
-    data = resource.read_rows()
-    headers = resource.header
-    dates = headers[12:]
+
+def fetch():
+    with urllib.request.urlopen(source_url) as response:
+        return response.read().decode('utf-8')
+
+
+def parse(content):
+    """Read long-format CSV from the BIS SDMX API and split into 4 output files."""
+    buckets = {
+        'nominal_index': [],
+        'nominal_year': [],
+        'real_index': [],
+        'real_year': [],
+    }
+
+    for row in csv.DictReader(io.StringIO(content)):
+        value = row['Value']
+        unit = row['Unit of measure']
+
+        if 'Nominal' in value and 'Index' in unit:
+            category = 'nominal_index'
+        elif 'Nominal' in value and 'Year' in unit:
+            category = 'nominal_year'
+        elif 'Real' in value and 'Index' in unit:
+            category = 'real_index'
+        elif 'Real' in value and 'Year' in unit:
+            category = 'real_year'
+        else:
+            continue
+
+        buckets[category].append((
+            parse_date(row['TIME_PERIOD']),
+            row['REF_AREA'],
+            row['Reference area'],
+            row['OBS_VALUE'],
+        ))
 
     os.makedirs('data', exist_ok=True)
-    
-    output = {
-        "nominal_index": csv.writer(open('data/nominal_index.csv', 'w', newline='')),
-        "nominal_year": csv.writer(open('data/nominal_year.csv', 'w', newline='')),
-        "real_index": csv.writer(open('data/real_index.csv', 'w', newline='')),
-        "real_year": csv.writer(open('data/real_year.csv', 'w', newline=''))
-    }
-    
-    for csv_file in output.values():
-        csv_file.writerow(['date', 'country_code', 'country', 'price'])
-    
-    for date in dates:
-        for row in data:
-            country_code = row['REF_AREA']
-            country = row['Reference area']
-            value = row['Value']
-            unit = row['Unit of measure']
-            price = row[date]
-            
-            category = ''
-            if 'Nominal' in value and 'Index' in unit:
-                category = 'nominal_index'
-            elif 'Nominal' in value and 'Year' in unit:
-                category = 'nominal_year'
-            elif 'Real' in value and 'Index' in unit:
-                category = 'real_index'
-            elif 'Real' in value and 'Year' in unit:
-                category = 'real_year'
-            
-            if category:
-                output[category].writerow([parse_date(date), country_code, country, price])
 
-def extract_csv_structure():
-    """Helper function"""
-    from frictionless import Package
-    import json
-    
-    with open('structure.txt', 'w') as file:
-        file.write(
-            json.dumps(
-                Package('data').to_descriptor(),
-                indent=2,
-                sort_keys=True
-            )
-        )
+    for name, rows in buckets.items():
+        rows.sort()  # sorts by (date, country_code)
+        with open(f'data/{name}.csv', 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['date', 'country_code', 'country', 'price'])
+            writer.writerows(rows)
 
-if __name__ == "__main__":
-    data_file = download_source()
-    print(data_file)
-    parse(data_file)
+
+if __name__ == '__main__':
+    parse(fetch())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,0 @@
-frictionless==5.18.0


### PR DESCRIPTION
## Summary

The BIS zip file (`full_spp_csv.zip`) stopped receiving quarterly updates after Q3 2023. BIS now distributes live data via their SDMX REST API.

## Script changes (`scripts/process.py`)

- **New source URL**: `https://stats.bis.org/api/v2/data/dataflow/BIS/WS_SPP/1.0?format=csv&labels=both`
- Data now arrives in long format (one row per observation) — the old zip used a wide/pivoted format, so the loop structure was rewritten accordingly
- Category detection logic (`Nominal`/`Real` × `Index`/`Year-on-year`) is **unchanged** — the API returns the same `Value` and `Unit of measure` label strings
- Output rows are sorted by `(date, country_code)` for stable future diffs
- `frictionless` dependency removed (no longer needed); `requirements.txt` is now empty

## Data changes

- Extended from Q3 2023 → **Q4 2025** (~2 years of missing quarters restored)
- Row order normalized to `(date, country_code)` sort

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>